### PR TITLE
add tests for update and delete handlers and translator

### DIFF
--- a/aws-rds-globalcluster/README.md
+++ b/aws-rds-globalcluster/README.md
@@ -10,3 +10,9 @@ The RPDK will automatically generate the correct resource model from the schema 
 > Please don't modify files under `target/generated-sources/rpdk`, as they will be automatically overwritten.
 
 The code uses [Lombok](https://projectlombok.org/), and [you may have to install IDE integrations](https://projectlombok.org/setup/overview) to enable auto-complete for Lombok-annotated classes.
+
+## Contract Testing
+
+sam local start-lambda
+cfn test
+cfn test -- -k contract_create_delete

--- a/aws-rds-globalcluster/aws-rds-globalcluster.json
+++ b/aws-rds-globalcluster/aws-rds-globalcluster.json
@@ -57,7 +57,8 @@
   "additionalProperties": false,
   "createOnlyProperties": [
     "/properties/GlobalClusterIdentifier",
-    "/properties/SourceDBClusterIdentifier"
+    "/properties/SourceDBClusterIdentifier",
+    "/properties/StorageEncrypted"
   ],
   "primaryIdentifier": [
     "/properties/GlobalClusterIdentifier"

--- a/aws-rds-globalcluster/src/main/java/software/amazon/rds/globalcluster/DeleteHandler.java
+++ b/aws-rds-globalcluster/src/main/java/software/amazon/rds/globalcluster/DeleteHandler.java
@@ -24,8 +24,8 @@ public class DeleteHandler extends BaseHandlerStd {
                         .makeServiceCall((deleteGlobalClusterRequest, proxyInvocation)
                                 -> proxyInvocation.injectCredentialsAndInvokeV2(deleteGlobalClusterRequest, proxyInvocation.client()::deleteGlobalCluster))
                         // wait until deleted
-                        .stabilize(((deleteGlobalClusterRequest, deleteGlobalClusterResponse, stabilizeProxy, stabilizeModel, context)
-                                -> isDeleted(stabilizeModel, stabilizeProxy)))
+                        .stabilize((deleteGlobalClusterRequest, deleteGlobalClusterResponse, stabilizeProxy, stabilizeModel, context)
+                                -> isDeleted(stabilizeModel, stabilizeProxy))
                         .success());
 
         result.setResourceModel(null);

--- a/aws-rds-globalcluster/src/main/java/software/amazon/rds/globalcluster/Translator.java
+++ b/aws-rds-globalcluster/src/main/java/software/amazon/rds/globalcluster/Translator.java
@@ -18,22 +18,13 @@ import software.amazon.awssdk.services.rds.model.RemoveFromGlobalClusterRequest;
 public class Translator {
 
   static CreateGlobalClusterRequest createGlobalClusterRequest(final ResourceModel model) {
-    return CreateGlobalClusterRequest.builder()
-            .engine(model.getEngine())
-            .engineVersion(model.getEngineVersion())
-            .storageEncrypted(model.getStorageEncrypted())
-            .deletionProtection(model.getDeletionProtection())
-            .globalClusterIdentifier(model.getGlobalClusterIdentifier())
-            .sourceDBClusterIdentifier(model.getSourceDBClusterIdentifier())
-            .storageEncrypted(model.getStorageEncrypted())
-            .build();
+    return createGlobalClusterRequest(model, null);
   }
 
   static CreateGlobalClusterRequest createGlobalClusterRequest(final ResourceModel model, String dbClusterArn) {
     return CreateGlobalClusterRequest.builder()
             .engine(model.getEngine())
             .engineVersion(model.getEngineVersion())
-            .storageEncrypted(model.getStorageEncrypted())
             .deletionProtection(model.getDeletionProtection())
             .globalClusterIdentifier(model.getGlobalClusterIdentifier())
             .sourceDBClusterIdentifier(dbClusterArn)

--- a/aws-rds-globalcluster/src/test/java/software/amazon/rds/globalcluster/DeleteHandlerTest.java
+++ b/aws-rds-globalcluster/src/test/java/software/amazon/rds/globalcluster/DeleteHandlerTest.java
@@ -1,22 +1,34 @@
 package software.amazon.rds.globalcluster;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
 import java.time.Duration;
-import org.junit.jupiter.api.AfterEach;
-import software.amazon.awssdk.services.rds.RdsClient;
-import software.amazon.awssdk.services.rds.model.*;
-import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
-import software.amazon.cloudformation.proxy.OperationStatus;
-import software.amazon.cloudformation.proxy.ProgressEvent;
-import software.amazon.cloudformation.proxy.ProxyClient;
-import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.*;
+import software.amazon.awssdk.awscore.exception.AwsErrorDetails;
+import software.amazon.awssdk.http.SdkHttpResponse;
+import software.amazon.awssdk.services.rds.RdsClient;
+import software.amazon.awssdk.services.rds.model.DeleteGlobalClusterRequest;
+import software.amazon.awssdk.services.rds.model.DeleteGlobalClusterResponse;
+import software.amazon.awssdk.services.rds.model.DescribeGlobalClustersRequest;
+import software.amazon.awssdk.services.rds.model.GlobalClusterNotFoundException;
+import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
+import software.amazon.cloudformation.proxy.HandlerErrorCode;
+import software.amazon.cloudformation.proxy.OperationStatus;
+import software.amazon.cloudformation.proxy.ProgressEvent;
+import software.amazon.cloudformation.proxy.ProxyClient;
+import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 
 @ExtendWith(MockitoExtension.class)
 public class DeleteHandlerTest extends AbstractTestBase {
@@ -31,12 +43,6 @@ public class DeleteHandlerTest extends AbstractTestBase {
     RdsClient rds;
 
     private DeleteHandler handler;
-
-    @AfterEach
-    public void post_execute() {
-        verify(rds, atLeastOnce()).serviceName();
-        verifyNoMoreInteractions(rds);
-    }
 
     @BeforeEach
     public void setup() {
@@ -63,5 +69,30 @@ public class DeleteHandlerTest extends AbstractTestBase {
 
         verify(proxyRdsClient.client()).deleteGlobalCluster(any(DeleteGlobalClusterRequest.class));
         verify(proxyRdsClient.client(), times(2)).describeGlobalClusters(any(DescribeGlobalClustersRequest.class));
+
+        verify(rds).serviceName();
+        verifyNoMoreInteractions(rds);
+    }
+
+    @Test
+    public void handleRequest_ReturnsFailedResponse_WhenRdsClientThrowsClusterNotFoundException() {
+        AwsErrorDetails awsErr = AwsErrorDetails.builder().sdkHttpResponse(SdkHttpResponse.builder().statusCode(404).build()).build();
+
+        GlobalClusterNotFoundException exception = GlobalClusterNotFoundException.builder().awsErrorDetails(awsErr).build();
+
+        when(proxyRdsClient.client().deleteGlobalCluster(any(DeleteGlobalClusterRequest.class))).thenThrow(exception);
+        when(proxyRdsClient.client().describeGlobalClusters(any(DescribeGlobalClustersRequest.class))).thenThrow(GlobalClusterNotFoundException.class);
+
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder().desiredResourceState(RESOURCE_MODEL).build();
+        final ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyRdsClient, logger);
+
+        assertThat(response).isNotNull();
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.FAILED);
+        assertThat(response.getResourceModels()).isNull();
+        assertThat(response.getErrorCode()).isEqualTo(HandlerErrorCode.NotFound);
+
+        verify(proxyRdsClient.client()).deleteGlobalCluster(any(DeleteGlobalClusterRequest.class));
+        verify(rds).serviceName();
+        verifyNoMoreInteractions(rds);
     }
 }

--- a/aws-rds-globalcluster/src/test/java/software/amazon/rds/globalcluster/TranslatorTest.java
+++ b/aws-rds-globalcluster/src/test/java/software/amazon/rds/globalcluster/TranslatorTest.java
@@ -1,0 +1,64 @@
+package software.amazon.rds.globalcluster;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import software.amazon.awssdk.services.rds.model.CreateGlobalClusterRequest;
+
+public class TranslatorTest {
+
+    @Test
+    public void createGlobalClusterRequest_setsGlobalClusterIdentifier() {
+        ResourceModel model = ResourceModel.builder().globalClusterIdentifier("foo").build();
+
+        CreateGlobalClusterRequest globalClusterRequest = Translator.createGlobalClusterRequest(model, null);
+
+        assertThat(globalClusterRequest.globalClusterIdentifier()).isEqualTo("foo");
+    }
+
+    @Test
+    public void createGlobalClusterRequest_setsEngine() {
+        ResourceModel model = ResourceModel.builder().engine("aurora-mysql").build();
+
+        CreateGlobalClusterRequest globalClusterRequest = Translator.createGlobalClusterRequest(model, null);
+
+        assertThat(globalClusterRequest.engine()).isEqualTo("aurora-mysql");
+    }
+
+    @Test
+    public void createGlobalClusterRequest_setsEngineVersion() {
+        ResourceModel model = ResourceModel.builder().engineVersion("5.7.mysql_aurora.2.07.2").build();
+
+        CreateGlobalClusterRequest globalClusterRequest = Translator.createGlobalClusterRequest(model, null);
+
+        assertThat(globalClusterRequest.engineVersion()).isEqualTo("5.7.mysql_aurora.2.07.2");
+    }
+
+    @Test
+    public void createGlobalClusterRequest_setsDeletionProtection() {
+        ResourceModel model = ResourceModel.builder().deletionProtection(true).build();
+
+        CreateGlobalClusterRequest globalClusterRequest = Translator.createGlobalClusterRequest(model, null);
+
+        assertThat(globalClusterRequest.deletionProtection()).isEqualTo(true);
+    }
+
+    @Test
+    public void createGlobalClusterRequest_setsStorageEncryption() {
+        ResourceModel model = ResourceModel.builder().storageEncrypted(true).build();
+
+        CreateGlobalClusterRequest globalClusterRequest = Translator.createGlobalClusterRequest(model, null);
+
+        assertThat(globalClusterRequest.storageEncrypted()).isEqualTo(true);
+    }
+
+    @Test
+    public void createGlobalClusterRequest_setsArn() {
+        ResourceModel model = ResourceModel.builder().build();
+
+        CreateGlobalClusterRequest globalClusterRequest = Translator.createGlobalClusterRequest(model, "arn:aws:rds::111111111111:global-cluster:cf-contract-test-global-cluster-0");
+
+        assertThat(globalClusterRequest.sourceDBClusterIdentifier()).isEqualTo("arn:aws:rds::111111111111:global-cluster:cf-contract-test-global-cluster-0");
+    }
+}


### PR DESCRIPTION
verify that handlers return NotFound error code
when global cluster does not exist

verify that translator copies all properties
from model into request

add StorageEncrypted to the list of create only properties

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
