### PR TITLE
fix duplicate delete call

### DIFF
--- a/aws-rds-globalcluster/src/main/java/software/amazon/rds/globalcluster/CallbackContext.java
+++ b/aws-rds-globalcluster/src/main/java/software/amazon/rds/globalcluster/CallbackContext.java
@@ -9,4 +9,5 @@ import software.amazon.cloudformation.proxy.StdCallbackContext;
 public class CallbackContext extends StdCallbackContext {
     private boolean globalClusterCreated;
     private boolean removed;
+    private boolean isDeleting;
 }

--- a/aws-rds-globalcluster/src/main/java/software/amazon/rds/globalcluster/DeleteHandler.java
+++ b/aws-rds-globalcluster/src/main/java/software/amazon/rds/globalcluster/DeleteHandler.java
@@ -1,8 +1,8 @@
 package software.amazon.rds.globalcluster;
 
-import java.util.function.Function;
-
 import software.amazon.awssdk.services.rds.RdsClient;
+import software.amazon.awssdk.services.rds.model.DeleteGlobalClusterRequest;
+import software.amazon.awssdk.services.rds.model.DeleteGlobalClusterResponse;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.Logger;
 import software.amazon.cloudformation.proxy.ProgressEvent;
@@ -10,44 +10,47 @@ import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 
 public class DeleteHandler extends BaseHandlerStd {
+
     protected ProgressEvent<ResourceModel, CallbackContext> handleRequest(final AmazonWebServicesClientProxy proxy,
                                                                           final ResourceHandlerRequest<ResourceModel> request,
                                                                           final CallbackContext callbackContext,
                                                                           final ProxyClient<RdsClient> proxyClient,
                                                                           final Logger logger) {
+
         ResourceModel model = request.getDesiredResourceState();
 
         ProgressEvent<ResourceModel, CallbackContext> result;
 
-        if (callbackContext.isDeleting()) {
-            result = ProgressEvent.progress(model, callbackContext)
-                    .then(progress -> proxy.initiate("rds::stabilize-dbcluster" + getClass().getSimpleName(), proxyClient, progress.getResourceModel(), progress.getCallbackContext())
-                            .translateToServiceRequest(Function.identity())
-                            .makeServiceCall(EMPTY_CALL)
-                            .stabilize((deleteGlobalClusterRequest, deleteGlobalClusterResponse, stabilizeProxy, stabilizeModel, context)
-                                    -> isDeleted(stabilizeModel, stabilizeProxy))
-                            .success());
-        } else {
-            result = ProgressEvent.progress(model, callbackContext)
-                    .then(progress -> removeFromGlobalCluster(proxy, proxyClient, progress))
-                    .then(progress -> waitForDBClusterAvailableStatus(proxy, proxyClient, progress))
-                    .then(progress -> proxy.initiate("rds::delete-global-cluster", proxyClient, request.getDesiredResourceState(), callbackContext)
-                            .translateToServiceRequest(Translator::deleteGlobalClusterRequest)
-                            .backoffDelay(BACKOFF_STRATEGY)
-                            .makeServiceCall((deleteGlobalClusterRequest, proxyInvocation)
-                                    -> proxyInvocation.injectCredentialsAndInvokeV2(deleteGlobalClusterRequest, proxyInvocation.client()::deleteGlobalCluster))
-                            // wait until deleted
-                            .stabilize((deleteGlobalClusterRequest, deleteGlobalClusterResponse, stabilizeProxy, stabilizeModel, context)
-                                    -> isDeleted(stabilizeModel, stabilizeProxy))
-                            .success());
-
-            callbackContext.setDeleting(true);
-        }
+        result = ProgressEvent.progress(model, callbackContext)
+                .then(progress -> removeFromGlobalCluster(proxy, proxyClient, progress))
+                .then(progress -> waitForDBClusterAvailableStatus(proxy, proxyClient, progress))
+                .then(progress -> proxy.initiate("rds::delete-global-cluster", proxyClient, request.getDesiredResourceState(), callbackContext)
+                        .translateToServiceRequest(Translator::deleteGlobalClusterRequest)
+                        .backoffDelay(BACKOFF_STRATEGY)
+                        .makeServiceCall((deleteGlobalClusterRequest1, proxyInvocation) -> deleteGlobalCluster(deleteGlobalClusterRequest1, proxyInvocation, callbackContext))
+                        // wait until deleted
+                        .stabilize((deleteGlobalClusterRequest, deleteGlobalClusterResponse, stabilizeProxy, stabilizeModel, context)
+                                -> isDeleted(stabilizeModel, stabilizeProxy))
+                        .success());
 
         if (result.isSuccess()) {
             result.setResourceModel(null);
         }
 
         return result;
+    }
+
+    private static DeleteGlobalClusterResponse deleteGlobalCluster(DeleteGlobalClusterRequest deleteGlobalClusterRequest, ProxyClient<RdsClient> proxyInvocation, CallbackContext callbackContext) {
+        DeleteGlobalClusterResponse deleteResponse;
+
+        if (callbackContext.isDeleting()) {
+            deleteResponse = callbackContext.response("rds::delete-global-cluster");
+        } else {
+            deleteResponse = proxyInvocation.injectCredentialsAndInvokeV2(deleteGlobalClusterRequest, proxyInvocation.client()::deleteGlobalCluster);
+
+            callbackContext.setDeleting(true);
+        }
+
+        return deleteResponse;
     }
 }

--- a/aws-rds-globalcluster/src/test/java/software/amazon/rds/globalcluster/DeleteHandlerWithProgressTest.java
+++ b/aws-rds-globalcluster/src/test/java/software/amazon/rds/globalcluster/DeleteHandlerWithProgressTest.java
@@ -122,7 +122,7 @@ public class DeleteHandlerWithProgressTest extends AbstractTestBase {
         assertThat(response.getMessage()).isNull();
         assertThat(response.getErrorCode()).isNull();
 
-        verify(proxyRdsClient.client(), times(1)).describeGlobalClusters(any(DescribeGlobalClustersRequest.class));
+        verify(proxyRdsClient.client(), times(2)).describeGlobalClusters(any(DescribeGlobalClustersRequest.class));
 
         verify(rds).serviceName();
         verifyNoMoreInteractions(rds);

--- a/aws-rds-globalcluster/src/test/java/software/amazon/rds/globalcluster/DeleteHandlerWithProgressTest.java
+++ b/aws-rds-globalcluster/src/test/java/software/amazon/rds/globalcluster/DeleteHandlerWithProgressTest.java
@@ -1,0 +1,152 @@
+package software.amazon.rds.globalcluster;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import java.time.Duration;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import software.amazon.awssdk.awscore.exception.AwsErrorDetails;
+import software.amazon.awssdk.http.SdkHttpResponse;
+import software.amazon.awssdk.services.rds.RdsClient;
+import software.amazon.awssdk.services.rds.model.DeleteGlobalClusterRequest;
+import software.amazon.awssdk.services.rds.model.DeleteGlobalClusterResponse;
+import software.amazon.awssdk.services.rds.model.DescribeGlobalClustersRequest;
+import software.amazon.awssdk.services.rds.model.DescribeGlobalClustersResponse;
+import software.amazon.awssdk.services.rds.model.GlobalClusterNotFoundException;
+import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
+import software.amazon.cloudformation.proxy.DelayFactory;
+import software.amazon.cloudformation.proxy.HandlerErrorCode;
+import software.amazon.cloudformation.proxy.OperationStatus;
+import software.amazon.cloudformation.proxy.ProgressEvent;
+import software.amazon.cloudformation.proxy.ProxyClient;
+import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
+import software.amazon.cloudformation.proxy.WaitStrategy;
+
+@ExtendWith(MockitoExtension.class)
+public class DeleteHandlerWithProgressTest extends AbstractTestBase {
+
+    @Mock
+    private AmazonWebServicesClientProxy proxy;
+
+    @Mock
+    private ProxyClient<RdsClient> proxyRdsClient;
+
+    @Mock
+    RdsClient rds;
+
+    private DeleteHandler handler;
+
+    @BeforeEach
+    public void setup() {
+        handler = new DeleteHandler();
+        rds = mock(RdsClient.class);
+        proxy = new AmazonWebServicesClientProxy(logger, MOCK_CREDENTIALS, DelayFactory.CONSTANT_DEFAULT_DELAY_FACTORY,
+                WaitStrategy.scheduleForCallbackStrategy());
+        proxyRdsClient = MOCK_PROXY(proxy, rds);
+    }
+
+    @Test
+    public void handleRequest_SimpleSuccess() {
+        final DeleteGlobalClusterResponse deleteGlobalClusterResponse = DeleteGlobalClusterResponse.builder().build();
+        when(proxyRdsClient.client().deleteGlobalCluster(any(DeleteGlobalClusterRequest.class))).thenReturn(deleteGlobalClusterResponse);
+        when(proxyRdsClient.client().describeGlobalClusters(any(DescribeGlobalClustersRequest.class))).thenThrow(GlobalClusterNotFoundException.class);
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder().desiredResourceState(RESOURCE_MODEL).build();
+        final ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyRdsClient, logger);
+
+        assertThat(response).isNotNull();
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
+        assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
+        assertThat(response.getResourceModel()).isNull();
+        assertThat(response.getResourceModels()).isNull();
+        assertThat(response.getMessage()).isNull();
+        assertThat(response.getErrorCode()).isNull();
+
+        verify(proxyRdsClient.client()).deleteGlobalCluster(any(DeleteGlobalClusterRequest.class));
+        verify(proxyRdsClient.client(), times(2)).describeGlobalClusters(any(DescribeGlobalClustersRequest.class));
+
+        verify(rds).serviceName();
+        verifyNoMoreInteractions(rds);
+    }
+
+    @Test
+    public void handleRequest_ReturnsInProgress_WhenGlobalClusterIsStillDeleting() {
+        DescribeGlobalClustersResponse describeResponse = DescribeGlobalClustersResponse.builder().build();
+        final DeleteGlobalClusterResponse deleteGlobalClusterResponse = DeleteGlobalClusterResponse.builder().build();
+        when(proxyRdsClient.client().deleteGlobalCluster(any(DeleteGlobalClusterRequest.class))).thenReturn(deleteGlobalClusterResponse);
+        when(proxyRdsClient.client().describeGlobalClusters(any(DescribeGlobalClustersRequest.class))).thenReturn(describeResponse);
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder().desiredResourceState(RESOURCE_MODEL).build();
+
+        final CallbackContext callbackContext = new CallbackContext();
+
+        final ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, callbackContext, proxyRdsClient, logger);
+
+        assertThat(response).isNotNull();
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.IN_PROGRESS);
+        assertThat(response.getCallbackDelaySeconds()).isEqualTo(30);
+        assertThat(response.getResourceModel()).isSameAs(RESOURCE_MODEL);
+        assertThat(response.getMessage()).isNull();
+        assertThat(response.getErrorCode()).isNull();
+
+        verify(proxyRdsClient.client()).deleteGlobalCluster(any(DeleteGlobalClusterRequest.class));
+        verify(proxyRdsClient.client(), times(2)).describeGlobalClusters(any(DescribeGlobalClustersRequest.class));
+
+        verify(rds).serviceName();
+        verifyNoMoreInteractions(rds);
+    }
+
+    @Test
+    public void handleRequest_ReturnsSuccess_WhenGlobalClusterDeletingFinishesAfterInProgressResponse() {
+        when(proxyRdsClient.client().describeGlobalClusters(any(DescribeGlobalClustersRequest.class))).thenThrow(GlobalClusterNotFoundException.class);
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder().desiredResourceState(RESOURCE_MODEL).build();
+
+        final CallbackContext callbackContext = new CallbackContext();
+        callbackContext.setDeleting(true);
+
+        final ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, callbackContext, proxyRdsClient, logger);
+
+        assertThat(response).isNotNull();
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
+        assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
+        assertThat(response.getResourceModel()).isNull();
+        assertThat(response.getMessage()).isNull();
+        assertThat(response.getErrorCode()).isNull();
+
+        verify(proxyRdsClient.client(), times(1)).describeGlobalClusters(any(DescribeGlobalClustersRequest.class));
+
+        verify(rds).serviceName();
+        verifyNoMoreInteractions(rds);
+    }
+
+    @Test
+    public void handleRequest_ReturnsFailedResponse_WhenRdsClientThrowsClusterNotFoundException() {
+        AwsErrorDetails awsErr = AwsErrorDetails.builder().sdkHttpResponse(SdkHttpResponse.builder().statusCode(404).build()).build();
+
+        GlobalClusterNotFoundException exception = GlobalClusterNotFoundException.builder().awsErrorDetails(awsErr).build();
+
+        when(proxyRdsClient.client().deleteGlobalCluster(any(DeleteGlobalClusterRequest.class))).thenThrow(exception);
+        when(proxyRdsClient.client().describeGlobalClusters(any(DescribeGlobalClustersRequest.class))).thenThrow(GlobalClusterNotFoundException.class);
+
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder().desiredResourceState(RESOURCE_MODEL).build();
+        final ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyRdsClient, logger);
+
+        assertThat(response).isNotNull();
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.FAILED);
+        assertThat(response.getResourceModels()).isNull();
+        assertThat(response.getErrorCode()).isEqualTo(HandlerErrorCode.NotFound);
+
+        verify(proxyRdsClient.client()).deleteGlobalCluster(any(DeleteGlobalClusterRequest.class));
+        verify(rds).serviceName();
+        verifyNoMoreInteractions(rds);
+    }
+}


### PR DESCRIPTION
*AURORA-5700*

*Adds handler for IN_PROGRESS Response*

When DescribeGlobalCluster after deletion returns IN_PROGRESS the delete handler should not attempt to delete the global cluster again. Instead it should check repeatedly into the progress and return SUCCESS when the cluster is no longer present.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
