### PR TITLE
Add DBClusterResourceId as read-only attribute (#43)

### DIFF
--- a/aws-rds-dbcluster/aws-rds-dbcluster.json
+++ b/aws-rds-dbcluster/aws-rds-dbcluster.json
@@ -9,6 +9,10 @@
     "ReadEndpoint": {
       "$ref": "#/definitions/ReadEndpoint"
     },
+    "DBClusterResourceId": {
+      "description": "The AWS Region-unique, immutable identifier for the DB cluster.",
+      "type": "string"
+    },
     "AssociatedRoles": {
       "description": "Provides a list of the AWS Identity and Access Management (IAM) roles that are associated with the DB cluster. IAM roles that are associated with a DB cluster grant permission for the DB cluster to access other AWS services on your behalf.",
       "type": "array",
@@ -333,7 +337,8 @@
   "additionalProperties": false,
   "readOnlyProperties": [
     "/properties/Endpoint",
-    "/properties/ReadEndpoint"
+    "/properties/ReadEndpoint",
+    "/properties/DBClusterResourceId"
   ],
   "createOnlyProperties": [
     "/properties/AvailabilityZones",

--- a/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/ReadHandler.java
+++ b/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/ReadHandler.java
@@ -39,6 +39,7 @@ public class ReadHandler extends BaseHandlerStd {
                                     .port(targetDBCluster.port().toString()).build())
                             .readEndpoint(ReadEndpoint.builder()
                                     .address(targetDBCluster.readerEndpoint()).build())
+                            .dBClusterResourceId(targetDBCluster.dbClusterResourceId())
 
                             .associatedRoles(targetDBCluster.associatedRoles().stream().map(roleTransform).collect(Collectors.toList()))
                             .availabilityZones(targetDBCluster.availabilityZones())


### PR DESCRIPTION
Issue #43 

Changes as title; this is a very simple change. Currently has no test associated with it, as I couldn't see any place to add one.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
