### PR TITLE
Pin `six` python package version to ~>1.15

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -5,6 +5,7 @@ phases:
         java: openjdk8
         python: 3.7
     commands:
+      -  pip install --upgrade 'six~=1.15'
       -  pip install pre-commit cloudformation-cli-java-plugin
   build:
     commands:


### PR DESCRIPTION
This commit updates the build spec in order to provide an explicit
version range for `six` pip package to ~>1.15 (>=1.15.0, <1.16.0).

The current pipeline comes with pip version 1.14.0, which is incompatible
with the new cfn-cli tool and breaks the build pipeline.

An example of a failing pipeline:
```
ERROR: aws-sam-translator 1.34.0 has requirement six~=1.15, but you'll have six 1.14.0 which is incompatible.
```

Providing a patch-level version range allows the pipeline to receive
patch versions with no need to change the spec again.

The version range must be bumped again upon an incompatible update
landing on cfn-cli side.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Signed-off-by: Oleg Sidorov <sidorovo@amazon.com>