### PR TITLE
Cannot RestoreToPointInTime into specified subnets

### DIFF
--- a/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/Translator.java
+++ b/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/Translator.java
@@ -61,6 +61,7 @@ public class Translator {
     static RestoreDbClusterToPointInTimeRequest restoreDbClusterToPointInTimeRequest(final ResourceModel model) {
         return RestoreDbClusterToPointInTimeRequest.builder()
                 .dbClusterIdentifier(model.getDBClusterIdentifier())
+                .dbSubnetGroupName(model.getDBSubnetGroupName())
                 .sourceDBClusterIdentifier(model.getSourceDBClusterIdentifier())
                 .useLatestRestorableTime(model.getUseLatestRestorableTime())
                 .restoreType(model.getRestoreType())

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -5,8 +5,9 @@ phases:
         java: openjdk8
         python: 3.7
     commands:
-      -  pip install --upgrade 'six~=1.15'
-      -  pip install pre-commit cloudformation-cli cloudformation-cli-java-plugin
+      - pip install --upgrade 'six~=1.15'
+      - pip install --upgrade 'pyyaml~=5.4'
+      - pip install pre-commit cloudformation-cli cloudformation-cli-java-plugin
   build:
     commands:
       - pre-commit run --all-files

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -6,7 +6,7 @@ phases:
         python: 3.7
     commands:
       -  pip install --upgrade 'six~=1.15'
-      -  pip install pre-commit cloudformation-cli-java-plugin
+      -  pip install pre-commit cloudformation-cli cloudformation-cli-java-plugin
   build:
     commands:
       - pre-commit run --all-files


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-cloudformation/aws-cloudformation-resource-providers-rds/issues/15

*Also see linked issue:*
https://github.com/aws-cloudformation/aws-cloudformation-coverage-roadmap/issues/336

*Description of changes:*
This occurs as the dbSubnetGroupName field isn't included in translator function: restoreDbClusterToPointInTimeRequest.
The appropriate course of action here is to simply add the missing field.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
