### PR TITLE
AWS::RDS::OptionGroup supports system tags

### DIFF
--- a/aws-rds-optiongroup/.rpdk-config
+++ b/aws-rds-optiongroup/.rpdk-config
@@ -1,5 +1,4 @@
 {
-    "artifact_type": "RESOURCE",
     "typeName": "AWS::RDS::OptionGroup",
     "language": "java",
     "runtime": "java8",
@@ -14,6 +13,5 @@
         ],
         "codegen_template_path": "guided_aws",
         "protocolVersion": "2.0.0"
-    },
-    "executableEntrypoint": "software.amazon.rds.optiongroup.HandlerWrapperExecutable"
+    }
 }

--- a/aws-rds-optiongroup/pom.xml
+++ b/aws-rds-optiongroup/pom.xml
@@ -22,7 +22,7 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>rds</artifactId>
-            <version>2.15.74</version>
+            <version>2.16.54</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/software.amazon.cloudformation/aws-cloudformation-rpdk-java-plugin -->
         <dependency>

--- a/aws-rds-optiongroup/src/main/java/software/amazon/rds/optiongroup/CreateHandler.java
+++ b/aws-rds-optiongroup/src/main/java/software/amazon/rds/optiongroup/CreateHandler.java
@@ -38,7 +38,7 @@ public class CreateHandler extends BaseHandlerStd {
                 .then(progress -> proxy.initiate("rds::create-option-group", proxyClient, progress.getResourceModel(), progress.getCallbackContext())
                         .translateToServiceRequest(model -> Translator.createOptionGroupRequest(
                                 model,
-                                request.getDesiredResourceTags()
+                                mergeMaps(request.getSystemTags(), request.getDesiredResourceTags())
                         ))
                         .backoffDelay(BACKOFF_DELAY)
                         .makeServiceCall((createRequest, proxyInvocation) -> proxyInvocation.injectCredentialsAndInvokeV2(

--- a/aws-rds-optiongroup/src/main/java/software/amazon/rds/optiongroup/ReadHandler.java
+++ b/aws-rds-optiongroup/src/main/java/software/amazon/rds/optiongroup/ReadHandler.java
@@ -3,8 +3,6 @@ package software.amazon.rds.optiongroup;
 import java.util.List;
 
 import software.amazon.awssdk.services.rds.RdsClient;
-import software.amazon.awssdk.services.rds.model.ListTagsForResourceRequest;
-import software.amazon.awssdk.services.rds.model.ListTagsForResourceResponse;
 import software.amazon.awssdk.services.rds.model.OptionGroup;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.Logger;
@@ -34,7 +32,7 @@ public class ReadHandler extends BaseHandlerStd {
                 .done((describeRequest, describeResponse, proxyInvocation, model, context) -> {
                     final OptionGroup optionGroup = describeResponse.optionGroupsList().stream().findFirst().get();
                     final List<OptionConfiguration> optionConfigurations = Translator.translateOptionConfigurationsFromSdk(optionGroup.options());
-                    final List<Tag> tags = listTagsSoftFailOnAccessDenied(proxyInvocation, optionGroup.optionGroupArn());
+                    final List<Tag> tags = listTags(proxyInvocation, optionGroup.optionGroupArn());
                     return ProgressEvent.success(
                             ResourceModel.builder()
                                     .optionGroupName(optionGroup.optionGroupName())

--- a/aws-rds-optiongroup/src/test/java/software/amazon/rds/optiongroup/UpdateHandlerTest.java
+++ b/aws-rds-optiongroup/src/test/java/software/amazon/rds/optiongroup/UpdateHandlerTest.java
@@ -115,7 +115,7 @@ public class UpdateHandlerTest extends AbstractTestBase {
 
         verify(proxyClient.client()).modifyOptionGroup(any(ModifyOptionGroupRequest.class));
         verify(proxyClient.client(), times(2)).describeOptionGroups(any(DescribeOptionGroupsRequest.class));
-        verify(proxyClient.client(), times(2)).listTagsForResource(any(ListTagsForResourceRequest.class));
+        verify(proxyClient.client()).listTagsForResource(any(ListTagsForResourceRequest.class));
     }
 
     @Test
@@ -168,7 +168,7 @@ public class UpdateHandlerTest extends AbstractTestBase {
         // no modifyOptionGroup invocation is expected here
         verify(proxyClient.client(), times(0)).modifyOptionGroup(any(ModifyOptionGroupRequest.class));
         verify(proxyClient.client(), times(2)).describeOptionGroups(any(DescribeOptionGroupsRequest.class));
-        verify(proxyClient.client(), times(2)).listTagsForResource(any(ListTagsForResourceRequest.class));
+        verify(proxyClient.client()).listTagsForResource(any(ListTagsForResourceRequest.class));
         verify(proxyClient.client()).removeTagsFromResource(any(RemoveTagsFromResourceRequest.class));
         verify(proxyClient.client()).addTagsToResource(any(AddTagsToResourceRequest.class));
     }
@@ -235,7 +235,7 @@ public class UpdateHandlerTest extends AbstractTestBase {
 
         verify(proxyClient.client()).modifyOptionGroup(any(ModifyOptionGroupRequest.class));
         verify(proxyClient.client(), times(2)).describeOptionGroups(any(DescribeOptionGroupsRequest.class));
-        verify(proxyClient.client(), times(2)).listTagsForResource(any(ListTagsForResourceRequest.class));
+        verify(proxyClient.client()).listTagsForResource(any(ListTagsForResourceRequest.class));
     }
 
     @Test
@@ -299,7 +299,7 @@ public class UpdateHandlerTest extends AbstractTestBase {
 
         verify(proxyClient.client()).modifyOptionGroup(any(ModifyOptionGroupRequest.class));
         verify(proxyClient.client(), times(2)).describeOptionGroups(any(DescribeOptionGroupsRequest.class));
-        verify(proxyClient.client(), times(2)).listTagsForResource(any(ListTagsForResourceRequest.class));
+        verify(proxyClient.client()).listTagsForResource(any(ListTagsForResourceRequest.class));
     }
 
     @Test
@@ -365,7 +365,7 @@ public class UpdateHandlerTest extends AbstractTestBase {
         // in this case we expect no ModifyOptionGroup call at all
         verify(proxyClient.client(), times(0)).modifyOptionGroup(any(ModifyOptionGroupRequest.class));
         verify(proxyClient.client(), times(2)).describeOptionGroups(any(DescribeOptionGroupsRequest.class));
-        verify(proxyClient.client(), times(2)).listTagsForResource(any(ListTagsForResourceRequest.class));
+        verify(proxyClient.client()).listTagsForResource(any(ListTagsForResourceRequest.class));
     }
 
     @Test


### PR DESCRIPTION
This commit adds a support for system tags. Prior to that, OptionGroup
was supporting resource-level tags only. RDS API makes no distinction
between system- and resource-level tags, so the tags are merged into a
single collection before invoking the corresponding RDS API call.

Apart from this change, OptionGroup drops a support for tagging
soft-failing. As it was concluded internally, soft failing on tagging is
considered to be a deprecated mode, therefore it is not making its way
to the new implementation.

AWS SDK version was bumped to 2.16.54.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Signed-off-by: Oleg Sidorov <sidorovo@amazon.com>