### PR TITLE
Cannot RestoreToPointInTime into specified subnets

### DIFF
--- a/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/Translator.java
+++ b/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/Translator.java
@@ -61,6 +61,7 @@ public class Translator {
     static RestoreDbClusterToPointInTimeRequest restoreDbClusterToPointInTimeRequest(final ResourceModel model) {
         return RestoreDbClusterToPointInTimeRequest.builder()
                 .dbClusterIdentifier(model.getDBClusterIdentifier())
+                .dbSubnetGroupName(model.getDBSubnetGroupName())
                 .sourceDBClusterIdentifier(model.getSourceDBClusterIdentifier())
                 .useLatestRestorableTime(model.getUseLatestRestorableTime())
                 .restoreType(model.getRestoreType())


### PR DESCRIPTION
Re-creating PR: #52 

Issue #, if available: #15 

Also see linked issue:
aws-cloudformation/aws-cloudformation-coverage-roadmap#336

Description of changes:
This occurs as the dbSubnetGroupName field isn't included in translator function: restoreDbClusterToPointInTimeRequest.
The appropriate course of action here is to simply add the missing field.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Thanks for your patience