### PR TITLE
Removing Translator unused method from AWS::RDS::DbParamterGroup

### DIFF
--- a/.github/workflows/maven-verify.yml
+++ b/.github/workflows/maven-verify.yml
@@ -36,12 +36,11 @@ jobs:
         cd "${GITHUB_WORKSPACE}/aws-rds-dbclusterparametergroup"
         mvn clean verify --no-transfer-progress
         cat rpdk.log
-        # TODO: uncomment this resource once the code coverage is fixed.
-        #- name: Verify AWS::RDS::DBParameterGroup
-        #  run: |
-        #    cd "${GITHUB_WORKSPACE}/aws-rds-dbparametergroup"
-        #    mvn clean verify --no-transfer-progress
-        #    cat rpdk.log
+    - name: Verify AWS::RDS::DBParameterGroup
+      run: |
+        cd "${GITHUB_WORKSPACE}/aws-rds-dbparametergroup"
+        mvn clean verify --no-transfer-progress
+        cat rpdk.log
     - name: Verify AWS::RDS::DBSubnetGroup
       run: |
         cd "${GITHUB_WORKSPACE}/aws-rds-dbsubnetgroup"

--- a/aws-rds-dbparametergroup/src/main/java/software/amazon/rds/dbparametergroup/Configuration.java
+++ b/aws-rds-dbparametergroup/src/main/java/software/amazon/rds/dbparametergroup/Configuration.java
@@ -1,12 +1,12 @@
 package software.amazon.rds.dbparametergroup;
 
+import java.util.Collections;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import org.json.JSONObject;
 import org.json.JSONTokener;
-
-import com.amazonaws.util.CollectionUtils;
 
 class Configuration extends BaseConfiguration {
 
@@ -20,12 +20,9 @@ class Configuration extends BaseConfiguration {
     }
 
     public Map<String, String> resourceDefinedTags(final ResourceModel model) {
-        if (CollectionUtils.isNullOrEmpty(model.getTags())) {
-            return null;
-        }
-
-        return model.getTags()
+        return Optional.ofNullable(model.getTags())
+                .orElse(Collections.emptyList())
                 .stream()
-                .collect(Collectors.toMap(Tag::getKey, Tag::getValue, (value1, value2) -> value2));
+                .collect(Collectors.toMap(Tag::getKey, Tag::getValue, (v1, v2) -> v2));
     }
 }

--- a/aws-rds-dbparametergroup/src/main/java/software/amazon/rds/dbparametergroup/Translator.java
+++ b/aws-rds-dbparametergroup/src/main/java/software/amazon/rds/dbparametergroup/Translator.java
@@ -7,7 +7,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import software.amazon.awssdk.services.rds.model.AddTagsToResourceRequest;
 import software.amazon.awssdk.services.rds.model.ApplyMethod;
@@ -174,9 +173,4 @@ public class Translator {
                 .build();
     }
 
-    private static <T> Stream<T> streamOfOrEmpty(final Collection<T> collection) {
-        return Optional.ofNullable(collection)
-                .map(Collection::stream)
-                .orElseGet(Stream::empty);
-    }
 }


### PR DESCRIPTION
Removing Translator unused method and adding resource to Maven verify pipeline

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Signed-off-by: Moataz Mohamed <azmoataz@amazon.com>