### PR TITLE
Fix OptionGroup contract tests

### DIFF
--- a/aws-rds-optiongroup/.rpdk-config
+++ b/aws-rds-optiongroup/.rpdk-config
@@ -1,4 +1,5 @@
 {
+    "artifact_type": "RESOURCE",
     "typeName": "AWS::RDS::OptionGroup",
     "language": "java",
     "runtime": "java8",
@@ -13,5 +14,6 @@
         ],
         "codegen_template_path": "guided_aws",
         "protocolVersion": "2.0.0"
-    }
+    },
+    "executableEntrypoint": "software.amazon.rds.optiongroup.HandlerWrapperExecutable"
 }

--- a/aws-rds-optiongroup/aws-rds-optiongroup.json
+++ b/aws-rds-optiongroup/aws-rds-optiongroup.json
@@ -22,7 +22,6 @@
         "OptionSettings": {
           "description": "The option settings to include in an option group.",
           "type": "array",
-          "uniqueItems": true,
           "items": {
             "$ref": "#/definitions/OptionSetting"
           }
@@ -124,7 +123,6 @@
     "OptionConfigurations": {
       "description": "Indicates what options are available in the option group.",
       "type": "array",
-      "uniqueItems": true,
       "items": {
         "$ref": "#/definitions/OptionConfiguration"
       }

--- a/aws-rds-optiongroup/inputs/inputs_1_create.json
+++ b/aws-rds-optiongroup/inputs/inputs_1_create.json
@@ -1,4 +1,5 @@
 {
+  "OptionGroupName": "test-option-group",
   "OptionGroupDescription": "A test option group",
   "EngineName": "mysql",
   "MajorEngineVersion": "5.6",
@@ -6,64 +7,6 @@
     {
       "OptionName": "MEMCACHED",
       "Port": 1234,
-      "OptionSettings": [
-        {
-          "Name": "BACKLOG_QUEUE_LIMIT",
-          "Value": "1024"
-        },
-        {
-          "Name": "BINDING_PROTOCOL",
-          "Value": "ascii"
-        },
-        {
-          "Name": "CAS_DISABLED",
-          "Value": "0"
-        },
-        {
-          "Name": "CHUNK_SIZE",
-          "Value": "32"
-        },
-        {
-          "Name": "CHUNK_SIZE_GROWTH_FACTOR",
-          "Value": "1.25"
-        },
-        {
-          "Name": "DAEMON_MEMCACHED_R_BATCH_SIZE",
-          "Value": "1"
-        },
-        {
-          "Name": "DAEMON_MEMCACHED_W_BATCH_SIZE",
-          "Value": "1"
-        },
-        {
-          "Name": "ERROR_ON_MEMORY_EXHAUSTED",
-          "Value": "0"
-        },
-        {
-          "Name": "INNODB_API_BK_COMMIT_INTERVAL",
-          "Value": "5"
-        },
-        {
-          "Name": "INNODB_API_DISABLE_ROWLOCK",
-          "Value": "0"
-        },
-        {
-          "Name": "INNODB_API_ENABLE_MDL",
-          "Value": "0"
-        },
-        {
-          "Name": "INNODB_API_TRX_LEVEL",
-          "Value": "0"
-        },
-        {
-          "Name": "MAX_SIMULTANEOUS_CONNECTIONS",
-          "Value": "1024"
-        },
-        {
-          "Name": "VERBOSITY",
-          "Value": "v"
-        }
-      ],
       "DBSecurityGroupMemberships": [
         "default"
       ],

--- a/aws-rds-optiongroup/inputs/inputs_1_invalid.json
+++ b/aws-rds-optiongroup/inputs/inputs_1_invalid.json
@@ -1,19 +1,10 @@
 {
-  "EngineName": "mysql",
+  "OptionGroupName": "test-option-group",
   "OptionGroupDescription": "A test option group",
+  "EngineName": "mysql",
   "OptionConfigurations": [
     {
       "Port": 1234,
-      "OptionSettings": [
-        {
-          "Name": "CHUNK_SIZE",
-          "Value": "32"
-        },
-        {
-          "Name": "BINDING_PROTOCOL",
-          "Value": "ascii"
-        }
-      ],
       "DBSecurityGroupMemberships": [
         "default"
       ],

--- a/aws-rds-optiongroup/inputs/inputs_1_update.json
+++ b/aws-rds-optiongroup/inputs/inputs_1_update.json
@@ -1,69 +1,12 @@
 {
+  "OptionGroupName": "test-option-group",
+  "OptionGroupDescription": "A test option group",
   "EngineName": "mysql",
   "MajorEngineVersion": "5.6",
-  "OptionGroupDescription": "A test option group",
   "OptionConfigurations": [
     {
       "OptionName": "MEMCACHED",
       "Port": 4567,
-      "OptionSettings": [
-        {
-          "Name": "BACKLOG_QUEUE_LIMIT",
-          "Value": "1024"
-        },
-        {
-          "Name": "INNODB_API_ENABLE_MDL",
-          "Value": "0"
-        },
-        {
-          "Name": "DAEMON_MEMCACHED_R_BATCH_SIZE",
-          "Value": "1"
-        },
-        {
-          "Name": "DAEMON_MEMCACHED_W_BATCH_SIZE",
-          "Value": "1"
-        },
-        {
-          "Name": "CAS_DISABLED",
-          "Value": "0"
-        },
-        {
-          "Name": "INNODB_API_TRX_LEVEL",
-          "Value": "0"
-        },
-        {
-          "Name": "INNODB_API_DISABLE_ROWLOCK",
-          "Value": "0"
-        },
-        {
-          "Name": "VERBOSITY",
-          "Value": "v"
-        },
-        {
-          "Name": "CHUNK_SIZE_GROWTH_FACTOR",
-          "Value": "1.25"
-        },
-        {
-          "Name": "INNODB_API_BK_COMMIT_INTERVAL",
-          "Value": "5"
-        },
-        {
-          "Name": "MAX_SIMULTANEOUS_CONNECTIONS",
-          "Value": "1024"
-        },
-        {
-          "Name": "ERROR_ON_MEMORY_EXHAUSTED",
-          "Value": "0"
-        },
-        {
-          "Name": "CHUNK_SIZE",
-          "Value": "64"
-        },
-        {
-          "Name": "BINDING_PROTOCOL",
-          "Value": "ascii"
-        }
-      ],
       "DBSecurityGroupMemberships": [
         "default"
       ],

--- a/aws-rds-optiongroup/src/main/java/software/amazon/rds/optiongroup/BaseHandlerStd.java
+++ b/aws-rds-optiongroup/src/main/java/software/amazon/rds/optiongroup/BaseHandlerStd.java
@@ -21,6 +21,10 @@ import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 import software.amazon.cloudformation.proxy.delay.Constant;
 
 public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
+
+    protected static final String STACK_NAME = "rds";
+    protected static final String RESOURCE_IDENTIFIER = "optiongroup";
+
     protected static final Constant BACKOFF_DELAY = Constant.of()
             .timeout(Duration.ofSeconds(150L))
             .delay(Duration.ofSeconds(5L))

--- a/aws-rds-optiongroup/src/main/java/software/amazon/rds/optiongroup/CreateHandler.java
+++ b/aws-rds-optiongroup/src/main/java/software/amazon/rds/optiongroup/CreateHandler.java
@@ -27,8 +27,8 @@ public class CreateHandler extends BaseHandlerStd {
                     final ResourceModel model = request.getDesiredResourceState();
                     if (StringUtils.isNullOrEmpty(model.getOptionGroupName())) {
                         model.setOptionGroupName(IdentifierUtils.generateResourceIdentifier(
-                                request.getStackId(),
-                                Optional.ofNullable(request.getLogicalResourceIdentifier()).orElse("optiongroup"),
+                                Optional.ofNullable(request.getStackId()).orElse(STACK_NAME),
+                                Optional.ofNullable(request.getLogicalResourceIdentifier()).orElse(RESOURCE_IDENTIFIER),
                                 request.getClientRequestToken(),
                                 MAX_LENGTH_OPTION_GROUP
                         ).toLowerCase());


### PR DESCRIPTION
This commit introduces minor changes in OptionGroup contract test fixtures. `OptionSettings` is not being provided on object creation and update.

The reason is: `ModifyOptionGroup` RDS API call changes the order of the `OptionSettings` list and CFN CLI tool expects all collections to be preserved in exactly the same order as they are provided in the input
fixtures even if `insertionOrder=false` is set. This behavior is confirmed to be unexpected and the corresponding corrective action is on CFN CLI team backlog.

For the time being, we stick to providing no `OptionSettings` in the test fixtures.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Signed-off-by: Oleg Sidorov <sidorovo@amazon.com>