### PR TITLE
Fix DBInstance schema: RebootDBInstance permission typo

### DIFF
--- a/aws-rds-dbinstance/aws-rds-dbinstance.json
+++ b/aws-rds-dbinstance/aws-rds-dbinstance.json
@@ -430,8 +430,8 @@
     "/properties/StorageType"
   ],
   "deprecatedProperties": [
-    "TdeCredentialArn",
-    "TdeCredentialPassword"
+    "/properties/TdeCredentialArn",
+    "/properties/TdeCredentialPassword"
   ],
   "writeOnlyProperties": [
     "/properties/MasterUserPassword",
@@ -455,7 +455,7 @@
         "rds:CreateDBInstance",
         "rds:DescribeDBInstances",
         "rds:ModifyDBInstance",
-        "rds::RebootDBInstance"
+        "rds:RebootDBInstance"
       ]
     },
     "read": {

--- a/aws-rds-dbinstance/resource-role.yaml
+++ b/aws-rds-dbinstance/resource-role.yaml
@@ -24,7 +24,6 @@ Resources:
               - Effect: Allow
                 Action:
                 - "ec2:DescribeSecurityGroups"
-                - "rds::RebootDBInstance"
                 - "rds:AddRoleToDBInstance"
                 - "rds:AddTagsToResource"
                 - "rds:CreateDBInstance"
@@ -32,6 +31,7 @@ Resources:
                 - "rds:DescribeDBInstances"
                 - "rds:ListTagsForResource"
                 - "rds:ModifyDBInstance"
+                - "rds:RebootDBInstance"
                 - "rds:RemoveRoleFromDBInstance"
                 - "rds:RemoveTagsFromResource"
                 Resource: "*"


### PR DESCRIPTION
This commit fixes a typo in DBInstance schema definition: rds::RebootDBInstance should rather be spelled as rds:RebootDBInstace (singular colon).

Apart from that, 2 deprecation directives were missing a prefix:
  * TdeCredentialArn -> /properties/TdeCredentialArn
  * TdeCredentialPassword -> /properties/TdeCredentialPassport

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Signed-off-by: Oleg Sidorov <sidorovo@amazon.com>