### PR TITLE
Fix DBInstance permissions

### DIFF
--- a/aws-rds-dbinstance/aws-rds-dbinstance.json
+++ b/aws-rds-dbinstance/aws-rds-dbinstance.json
@@ -430,8 +430,8 @@
     "/properties/StorageType"
   ],
   "deprecatedProperties": [
-    "TdeCredentialArn",
-    "TdeCredentialPassword"
+    "/properties/TdeCredentialArn",
+    "/properties/TdeCredentialPassword"
   ],
   "writeOnlyProperties": [
     "/properties/MasterUserPassword",
@@ -453,22 +453,25 @@
       "permissions": [
         "rds:AddRoleToDBInstance",
         "rds:CreateDBInstance",
+        "rds:CreateDbInstanceReadReplica",
         "rds:DescribeDBInstances",
         "rds:ModifyDBInstance",
-        "rds::RebootDBInstance"
+        "rds:RebootDBInstance",
+        "rds:RestoreDbInstanceFromDbSnapshot"
       ]
     },
     "read": {
       "permissions": [
-        "rds:DescribeDBInstances",
-        "rds:ListTagsForResource"
+        "rds:DescribeDBInstances"
       ]
     },
     "update": {
       "permissions": [
         "rds:AddRoleToDBInstance",
         "rds:AddTagsToResource",
+        "rds:DescribeDbEngineVersions",
         "rds:DescribeDBInstances",
+        "rds:DescribeDbParameterGroups",
         "rds:ModifyDBInstance",
         "rds:RemoveRoleFromDBInstance",
         "rds:RemoveTagsFromResource",

--- a/aws-rds-dbinstance/resource-role.yaml
+++ b/aws-rds-dbinstance/resource-role.yaml
@@ -24,16 +24,19 @@ Resources:
               - Effect: Allow
                 Action:
                 - "ec2:DescribeSecurityGroups"
-                - "rds::RebootDBInstance"
                 - "rds:AddRoleToDBInstance"
                 - "rds:AddTagsToResource"
                 - "rds:CreateDBInstance"
+                - "rds:CreateDbInstanceReadReplica"
                 - "rds:DeleteDBInstance"
                 - "rds:DescribeDBInstances"
-                - "rds:ListTagsForResource"
+                - "rds:DescribeDbEngineVersions"
+                - "rds:DescribeDbParameterGroups"
                 - "rds:ModifyDBInstance"
+                - "rds:RebootDBInstance"
                 - "rds:RemoveRoleFromDBInstance"
                 - "rds:RemoveTagsFromResource"
+                - "rds:RestoreDbInstanceFromDbSnapshot"
                 Resource: "*"
 Outputs:
   ExecutionRoleArn:


### PR DESCRIPTION
This commit fixes permissions for DBInstance schema:

Adds:
+ rds:CreateDbInstanceReadReplica
+ rds:RebootDBInstance
+ rds:RestoreDbInstanceFromDbSnapshot
+ rds:DescribeDbEngineVersions
+ rds:DescribeDbParameterGroups

Removes:
* rds:ListTagsForResource

The motivation for this change is to align it with the current method
set that is being used in the codebase.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Signed-off-by: Oleg Sidorov <sidorovo@amazon.com>