### PR TITLE
Drop junit.framework dependency from AWS::RDS::DBInstance

### DIFF
--- a/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/TranslatorTest.java
+++ b/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/TranslatorTest.java
@@ -1,6 +1,6 @@
 package software.amazon.rds.dbinstance;
 
-import junit.framework.Assert;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.Test;
 
@@ -18,7 +18,7 @@ class TranslatorTest extends AbstractTestBase {
                 .build();
         final Boolean isRollback = false;
         final ModifyDbInstanceRequest request = Translator.modifyDbInstanceRequest(previousModel, desiredModel, isRollback);
-        Assert.assertEquals(request.allocatedStorage(), ALLOCATED_STORAGE_INCR);
+        assertThat(request.allocatedStorage()).isEqualTo(ALLOCATED_STORAGE_INCR);
     }
 
     @Test
@@ -31,7 +31,7 @@ class TranslatorTest extends AbstractTestBase {
                 .build();
         final Boolean isRollback = false;
         final ModifyDbInstanceRequest request = Translator.modifyDbInstanceRequest(previousModel, desiredModel, isRollback);
-        Assert.assertEquals(request.allocatedStorage(), ALLOCATED_STORAGE_DECR);
+        assertThat(request.allocatedStorage()).isEqualTo(ALLOCATED_STORAGE_DECR);
     }
 
     @Test
@@ -44,7 +44,7 @@ class TranslatorTest extends AbstractTestBase {
                 .build();
         final Boolean isRollback = true;
         final ModifyDbInstanceRequest request = Translator.modifyDbInstanceRequest(previousModel, desiredModel, isRollback);
-        Assert.assertEquals(request.allocatedStorage(), ALLOCATED_STORAGE_INCR);
+        assertThat(request.allocatedStorage()).isEqualTo(ALLOCATED_STORAGE_INCR);
     }
 
     @Test
@@ -57,7 +57,7 @@ class TranslatorTest extends AbstractTestBase {
                 .build();
         final Boolean isRollback = true;
         final ModifyDbInstanceRequest request = Translator.modifyDbInstanceRequest(previousModel, desiredModel, isRollback);
-        Assert.assertEquals(request.allocatedStorage(), ALLOCATED_STORAGE); // should stay unchanged
+        assertThat(request.allocatedStorage()).isEqualTo(ALLOCATED_STORAGE); // should stay unchanged
     }
 
     @Test
@@ -70,7 +70,7 @@ class TranslatorTest extends AbstractTestBase {
                 .build();
         final Boolean isRollback = false;
         final ModifyDbInstanceRequest request = Translator.modifyDbInstanceRequest(previousModel, desiredModel, isRollback);
-        Assert.assertEquals(request.iops(), IOPS_INCR);
+        assertThat(request.iops()).isEqualTo(IOPS_INCR);
     }
 
     @Test
@@ -83,7 +83,7 @@ class TranslatorTest extends AbstractTestBase {
                 .build();
         final Boolean isRollback = false;
         final ModifyDbInstanceRequest request = Translator.modifyDbInstanceRequest(previousModel, desiredModel, isRollback);
-        Assert.assertEquals(request.iops(), IOPS_DECR);
+        assertThat(request.iops()).isEqualTo(IOPS_DECR);
     }
 
     @Test
@@ -96,7 +96,7 @@ class TranslatorTest extends AbstractTestBase {
                 .build();
         final Boolean isRollback = true;
         final ModifyDbInstanceRequest request = Translator.modifyDbInstanceRequest(previousModel, desiredModel, isRollback);
-        Assert.assertEquals(request.iops(), IOPS_INCR);
+        assertThat(request.iops()).isEqualTo(IOPS_INCR);
     }
 
     @Test
@@ -109,6 +109,6 @@ class TranslatorTest extends AbstractTestBase {
                 .build();
         final Boolean isRollback = true;
         final ModifyDbInstanceRequest request = Translator.modifyDbInstanceRequest(previousModel, desiredModel, isRollback);
-        Assert.assertEquals(request.iops(), IOPS_DEFAULT);
+        assertThat(request.iops()).isEqualTo(IOPS_DEFAULT);
     }
 }


### PR DESCRIPTION
This commit drops junit.framework test dependency from DBInstance. The dependency was added mechanically with no reasons and we should have favoured an already existing dependency on org.assertj.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Signed-off-by: Oleg Sidorov <sidorovo@amazon.com>