### PR TITLE
Drop AZ from DBInstance contract tests

### DIFF
--- a/aws-rds-dbinstance/inputs/inputs_1_create.json
+++ b/aws-rds-dbinstance/inputs/inputs_1_create.json
@@ -1,7 +1,6 @@
 {
   "AllocatedStorage": "5",
   "AutoMinorVersionUpgrade": false,
-  "AvailabilityZone": "us-east-1b",
   "DBInstanceIdentifier": "test-db-instance",
   "DBInstanceClass": "db.t3.micro",
   "DBName": "testdbname",

--- a/aws-rds-dbinstance/inputs/inputs_1_update.json
+++ b/aws-rds-dbinstance/inputs/inputs_1_update.json
@@ -1,7 +1,6 @@
 {
   "AllocatedStorage": "5",
   "AutoMinorVersionUpgrade": false,
-  "AvailabilityZone": "us-east-1b",
   "DBInstanceIdentifier": "test-db-instance",
   "DBInstanceClass": "db.t3.micro",
   "DBName": "testdbname",


### PR DESCRIPTION
This commit removes specific AZ from DBInstance contract tests.

The motivation is to make the tests region-independent and let RDS choose the AZ automatically.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Signed-off-by: Oleg Sidorov <sidorovo@amazon.com>