### PR TITLE
Fix AWS::RDS::OptionGroup on empty option configurations

### DIFF
--- a/aws-rds-optiongroup/src/main/java/software/amazon/rds/optiongroup/UpdateHandler.java
+++ b/aws-rds-optiongroup/src/main/java/software/amazon/rds/optiongroup/UpdateHandler.java
@@ -40,8 +40,14 @@ public class UpdateHandler extends BaseHandlerStd {
         final Collection<OptionConfiguration> optionsToInclude = getOptionsToInclude(previousOptions, desiredOptions);
         final Collection<OptionConfiguration> optionsToRemove = getOptionsToRemove(previousOptions, desiredOptions);
 
-        final Map<String, String> previousTags = mergeMaps(request.getPreviousSystemTags(), request.getPreviousResourceTags());
-        final Map<String, String> desiredTags = mergeMaps(request.getSystemTags(), request.getDesiredResourceTags());
+        final Map<String, String> previousTags = mergeMaps(
+                request.getPreviousSystemTags(),
+                request.getPreviousResourceTags()
+        );
+        final Map<String, String> desiredTags = mergeMaps(
+                request.getSystemTags(),
+                request.getDesiredResourceTags()
+        );
 
         // Here we explicitly use some immutability properties of an OptionGroup resource.
         // In fact, ModifyOptionGroupRequest only passes optionConfigurations, the rest is immutable.

--- a/aws-rds-optiongroup/src/test/java/software/amazon/rds/optiongroup/AbstractTestBase.java
+++ b/aws-rds-optiongroup/src/test/java/software/amazon/rds/optiongroup/AbstractTestBase.java
@@ -26,6 +26,7 @@ public class AbstractTestBase {
     protected static final LoggerProxy logger;
 
     protected static final ResourceModel RESOURCE_MODEL;
+    protected static final ResourceModel RESOURCE_MODEL_NO_OPTION_CONFIGURATIONS;
     protected static final OptionGroup OPTION_GROUP_ACTIVE;
     protected static final Set<Tag> TAG_SET;
 
@@ -44,6 +45,13 @@ public class AbstractTestBase {
                                 .optionVersion("1.2.3")
                                 .build()
                 ))
+                .build();
+
+        RESOURCE_MODEL_NO_OPTION_CONFIGURATIONS = ResourceModel.builder()
+                .optionGroupName("testOptionGroup")
+                .optionGroupDescription("test option group description")
+                .engineName("testEngineVersion")
+                .majorEngineVersion("testMajorVersionName")
                 .build();
 
         OPTION_GROUP_ACTIVE = OptionGroup.builder()


### PR DESCRIPTION
This commit changes OptionGroup Create handler behavior on a case when the
option configurations collection is empty. The old behavior used to call
UpdateOptionGroup anyways, which resulted in a 400 response from the API
backend. This commits turns this update into a conditional operation by checking
if the underlying collection of option configurations is non-empty.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Signed-off-by: Oleg Sidorov <sidorovo@amazon.com>