### PR TITLE
Fix DBInstance DBSnapshotIdentifier validation

### DIFF
--- a/aws-rds-dbinstance/aws-rds-dbinstance.json
+++ b/aws-rds-dbinstance/aws-rds-dbinstance.json
@@ -382,7 +382,7 @@
     }
   },
   "additionalProperties": false,
-  "oneOf": [
+  "anyOf": [
     {
       "required": [
         "DBInstanceClass",


### PR DESCRIPTION
This commit fixes DBInstance validation: at the moment, providing both
`Engine` and `DBSnapshotIdentifier` would cause a validation error. The
reason be: the validation group is concatenated with a strict `oneOf`
statement. This commit changes it to `anyOf` as providing both
aforementioned attributes is legal from RDS API perspective.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Signed-off-by: Oleg Sidorov <sidorovo@amazon.com>