### PR TITLE
Migrate DBParameterGroup to ErrorRuleSet

### DIFF
--- a/aws-rds-dbparametergroup/aws-rds-dbparametergroup.json
+++ b/aws-rds-dbparametergroup/aws-rds-dbparametergroup.json
@@ -48,6 +48,9 @@
     "Tags": {
       "description": "An array of key-value pairs to apply to this resource.",
       "type": "array",
+      "maxItems": 50,
+      "uniqueItems": false,
+      "insertionOrder": false,
       "items": {
         "$ref": "#/definitions/Tag"
       }

--- a/aws-rds-dbparametergroup/pom.xml
+++ b/aws-rds-dbparametergroup/pom.xml
@@ -66,6 +66,12 @@
             <version>2.26.0</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>software.amazon.rds.common</groupId>
+            <artifactId>aws-rds-cfn-common</artifactId>
+            <version>1.0</version>
+            <scope>compile</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/aws-rds-dbparametergroup/src/main/java/software/amazon/rds/dbparametergroup/BaseHandlerStd.java
+++ b/aws-rds-dbparametergroup/src/main/java/software/amazon/rds/dbparametergroup/BaseHandlerStd.java
@@ -8,12 +8,11 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
-import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Maps;
-import software.amazon.awssdk.core.exception.RetryableException;
+import lombok.Setter;
 import software.amazon.awssdk.services.rds.RdsClient;
 import software.amazon.awssdk.services.rds.model.DbParameterGroupAlreadyExistsException;
 import software.amazon.awssdk.services.rds.model.DbParameterGroupNotFoundException;
@@ -21,7 +20,6 @@ import software.amazon.awssdk.services.rds.model.DbParameterGroupQuotaExceededEx
 import software.amazon.awssdk.services.rds.model.InvalidDbParameterGroupStateException;
 import software.amazon.awssdk.services.rds.model.Parameter;
 import software.amazon.cloudformation.exceptions.CfnAccessDeniedException;
-import software.amazon.cloudformation.exceptions.CfnGeneralServiceException;
 import software.amazon.cloudformation.exceptions.CfnInvalidRequestException;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.HandlerErrorCode;
@@ -30,13 +28,33 @@ import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 import software.amazon.cloudformation.proxy.delay.Constant;
+import software.amazon.rds.common.error.ErrorRuleSet;
+import software.amazon.rds.common.error.ErrorStatus;
+import software.amazon.rds.common.handler.Commons;
 
 public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
+    protected static final Constant CONSTANT = Constant.of().timeout(Duration.ofMinutes(120L))
+            .delay(Duration.ofSeconds(30L)).build();
+    protected static final ErrorRuleSet DEFAULT_DB_PARAMETER_GROUP_ERROR_RULE_SET = ErrorRuleSet.builder()
+            .withErrorClasses(ErrorStatus.failWith(HandlerErrorCode.ResourceConflict),
+                    InvalidDbParameterGroupStateException.class)
+            .withErrorClasses(ErrorStatus.failWith(HandlerErrorCode.AlreadyExists),
+                    DbParameterGroupAlreadyExistsException.class)
+            .withErrorClasses(ErrorStatus.failWith(HandlerErrorCode.NotFound),
+                    DbParameterGroupNotFoundException.class)
+            .withErrorClasses(ErrorStatus.failWith(HandlerErrorCode.ServiceLimitExceeded),
+                    DbParameterGroupQuotaExceededException.class)
+            .build()
+            .orElse(Commons.DEFAULT_ERROR_RULE_SET);
+    protected static final ErrorRuleSet SOFT_FAIL_TAG_DB_PARAMETER_GROUP_ERROR_RULE_SET = ErrorRuleSet.builder()
+            .withErrorClasses(ErrorStatus.ignore(), CfnAccessDeniedException.class)
+            .build()
+            .orElse(DEFAULT_DB_PARAMETER_GROUP_ERROR_RULE_SET);
     protected static int MAX_LENGTH_GROUP_NAME = 255;
     protected static int NO_CALLBACK_DELAY = 0;
     protected static int MAX_PARAMETERS_PER_REQUEST = 20;
-    protected static final Constant CONSTANT = Constant.of().timeout(Duration.ofMinutes(120L))
-            .delay(Duration.ofSeconds(30L)).build();
+    @Setter
+    private Logger logger;
 
     @Override
     public final ProgressEvent<ResourceModel, CallbackContext> handleRequest(
@@ -53,42 +71,6 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
         );
     }
 
-    protected ProgressEvent<ResourceModel, CallbackContext> softFailAccessDenied(
-            final Supplier<ProgressEvent<
-                    ResourceModel, CallbackContext>> eventSupplier, final ResourceModel model,
-            final CallbackContext callbackContext) {
-        try {
-            return eventSupplier.get();
-        } catch (final CfnAccessDeniedException e) {
-            return ProgressEvent.progress(model, callbackContext);
-        }
-    }
-
-    public ProgressEvent<ResourceModel, CallbackContext> handleException(final Exception e) {
-        if (
-                e instanceof DbParameterGroupAlreadyExistsException
-        ) {
-            return ProgressEvent.defaultFailureHandler(e, HandlerErrorCode.AlreadyExists);
-        } else if (
-                e instanceof DbParameterGroupQuotaExceededException
-        ) {
-            return ProgressEvent.defaultFailureHandler(e, HandlerErrorCode.ServiceLimitExceeded);
-        } else if (
-                e instanceof DbParameterGroupNotFoundException
-        ) {
-            return ProgressEvent.defaultFailureHandler(e, HandlerErrorCode.NotFound);
-        } else if (
-                e instanceof InvalidDbParameterGroupStateException
-        ) {
-            throw RetryableException.builder().cause(e).build(); // current behaviour is retry on InvalidDbParameterGroupState exception
-        } else if (
-                e.getMessage().equals("Rate exceeded")
-        ) {
-            return ProgressEvent.defaultFailureHandler(e, HandlerErrorCode.Throttling); //Request throttled from rds service
-        }
-        throw new CfnGeneralServiceException(e);
-    }
-
     protected ProgressEvent<ResourceModel, CallbackContext> applyParameters(final AmazonWebServicesClientProxy proxy,
                                                                             final ProxyClient<RdsClient> proxyClient,
                                                                             final ResourceModel model,
@@ -102,142 +84,196 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
         Map<String, Parameter> currentDBParameters = Maps.newHashMap();
 
         return ProgressEvent.progress(model, callbackContext)
-            .then(progressEvent -> describeDefaultEngineParametersCall(progressEvent, defaultEngineParameters, proxy, proxyClient))
-            .then(progressEvent -> validateModelParameters(progressEvent, defaultEngineParameters))
-            .then(progressEvent -> describeCurrentDBParametersCall(progressEvent, currentDBParameters, proxy, proxyClient))
-            .then(progressEvent -> resetParameters(progressEvent, defaultEngineParameters, currentDBParameters, proxy,proxyClient))
-            .then(progressEvent -> modifyParameters(progressEvent, currentDBParameters, proxy, proxyClient));
+                .then(progressEvent -> describeDefaultEngineParameters(progressEvent, defaultEngineParameters, proxy, proxyClient))
+                .then(progressEvent -> validateModelParameters(progressEvent, defaultEngineParameters))
+                .then(progressEvent -> describeCurrentDBParameters(progressEvent, currentDBParameters, proxy, proxyClient))
+                .then(progressEvent -> resetParameters(progressEvent, defaultEngineParameters, currentDBParameters, proxy, proxyClient))
+                .then(progressEvent -> modifyParameters(progressEvent, currentDBParameters, proxy, proxyClient));
     }
 
-    private ProgressEvent<ResourceModel, CallbackContext> resetParameters(ProgressEvent<ResourceModel, CallbackContext> progress, Map<String, Parameter> defaultEngineParameters, Map<String, Parameter> currentDBParameters, AmazonWebServicesClientProxy proxy, ProxyClient<RdsClient> proxyClient){
+    private ProgressEvent<ResourceModel, CallbackContext> resetParameters(final ProgressEvent<ResourceModel, CallbackContext> progress,
+                                                                          final Map<String, Parameter> defaultEngineParameters,
+                                                                          final Map<String, Parameter> currentDBParameters,
+                                                                          final AmazonWebServicesClientProxy proxy,
+                                                                          final ProxyClient<RdsClient> proxyClient) {
         ResourceModel model = progress.getResourceModel();
         CallbackContext callbackContext = progress.getCallbackContext();
         Map<String, Parameter> parametersToReset = getParametersToReset(model, defaultEngineParameters, currentDBParameters);
         for (List<Parameter> paramsPartition : Iterables.partition(parametersToReset.values(), MAX_PARAMETERS_PER_REQUEST)) {  //modify api call is limited to 20 parameter per request
-            progress = makeResetParametersCall(proxy, proxyClient, model, callbackContext, paramsPartition);
-            if (progress.isFailed()) return progress;
+            ProgressEvent<ResourceModel, CallbackContext> progressEvent = resetParameters(proxy, model, callbackContext, paramsPartition, proxyClient);
+            if (progressEvent.isFailed()) return progressEvent;
         }
         return ProgressEvent.progress(model, callbackContext);
     }
 
-    private ProgressEvent<ResourceModel, CallbackContext> modifyParameters(ProgressEvent<ResourceModel, CallbackContext> progress,Map<String, Parameter> currentDBParameters, AmazonWebServicesClientProxy proxy, ProxyClient<RdsClient> proxyClient){
+    private ProgressEvent<ResourceModel, CallbackContext> modifyParameters(final ProgressEvent<ResourceModel, CallbackContext> progress,
+                                                                           final Map<String, Parameter> currentDBParameters,
+                                                                           final AmazonWebServicesClientProxy proxy,
+                                                                           final ProxyClient<RdsClient> proxyClient) {
         ResourceModel model = progress.getResourceModel();
         CallbackContext callbackContext = progress.getCallbackContext();
         Map<String, Parameter> parametersToModify = getModifiableParameters(model, currentDBParameters);
         for (List<Parameter> paramsPartition : Iterables.partition(parametersToModify.values(), MAX_PARAMETERS_PER_REQUEST)) {  //modify api call is limited to 20 parameter per request
-            ProgressEvent<ResourceModel, CallbackContext> progressEvent = makeModifyParametersCall(proxy, proxyClient, model, callbackContext, paramsPartition);
+            ProgressEvent<ResourceModel, CallbackContext> progressEvent = modifyParameters(proxyClient, proxy, callbackContext, paramsPartition, model);
             if (progressEvent.isFailed()) return progressEvent;
         }
         return ProgressEvent.progress(model, callbackContext);
 
     }
 
-    private ProgressEvent<ResourceModel, CallbackContext> makeModifyParametersCall(AmazonWebServicesClientProxy proxy, ProxyClient<RdsClient> proxyClient, ResourceModel model, CallbackContext callbackContext, List<Parameter> paramsPartition) { ProgressEvent<ResourceModel, CallbackContext> progress;
+    private ProgressEvent<ResourceModel, CallbackContext> modifyParameters(final ProxyClient<RdsClient> proxyClient,
+                                                                           final AmazonWebServicesClientProxy proxy,
+                                                                           final CallbackContext callbackContext,
+                                                                           final List<Parameter> paramsPartition,
+                                                                           final ResourceModel model) {
+        logger.log(String.format("Modifying parameters: %s (total: %d)",
+                paramsPartition.stream().map(Parameter::parameterName).collect(Collectors.joining(" , ")),
+                paramsPartition.size()));
         return proxy.initiate("rds::modify-db-parameter-group", proxyClient, model, callbackContext)
-            .translateToServiceRequest((resourceModel) -> Translator.modifyDbParameterGroupRequest(resourceModel, paramsPartition))
-            .makeServiceCall((request, proxyInvocation) -> proxyInvocation.injectCredentialsAndInvokeV2(request, proxyInvocation.client()::modifyDBParameterGroup))
-            .handleError((describeDbParameterGroupsRequest, exception, client, resourceModel, ctx) -> handleException(exception))
-            .progress();
+                .translateToServiceRequest((resourceModel) -> Translator.modifyDbParameterGroupRequest(resourceModel, paramsPartition))
+                .makeServiceCall((request, proxyInvocation) -> proxyInvocation.injectCredentialsAndInvokeV2(request, proxyInvocation.client()::modifyDBParameterGroup))
+                .handleError((describeDbParameterGroupsRequest, exception, client, resourceModel, ctx) ->
+                        Commons.handleException(
+                                ProgressEvent.progress(resourceModel, ctx),
+                                exception,
+                                DEFAULT_DB_PARAMETER_GROUP_ERROR_RULE_SET))
+                .progress();
     }
 
-    private ProgressEvent<ResourceModel, CallbackContext> makeResetParametersCall(AmazonWebServicesClientProxy proxy, ProxyClient<RdsClient> proxyClient, ResourceModel model, CallbackContext callbackContext, List<Parameter> paramsPartition) {
-        ProgressEvent<ResourceModel, CallbackContext> progress;
+    private ProgressEvent<ResourceModel, CallbackContext> resetParameters(final AmazonWebServicesClientProxy proxy,
+                                                                          final ResourceModel model,
+                                                                          final CallbackContext callbackContext,
+                                                                          final List<Parameter> paramsPartition,
+                                                                          final ProxyClient<RdsClient> proxyClient) {
+        logger.log(String.format("Reset parameters: %s (total: %d)",
+                paramsPartition.stream().map(Parameter::parameterName).collect(Collectors.joining(" , ")),
+                paramsPartition.size()));
         return proxy.initiate("rds::reset-db-parameter-group", proxyClient, model, callbackContext)
-            .translateToServiceRequest((resourceModel) -> Translator.resetDbParametersRequest(resourceModel, paramsPartition))
-            .makeServiceCall((request, proxyInvocation) -> proxyInvocation.injectCredentialsAndInvokeV2(request, proxyInvocation.client()::resetDBParameterGroup))
-            .handleError((describeDbParameterGroupsRequest, exception, client, resourceModel, ctx) -> handleException(exception))
-            .progress();
+                .translateToServiceRequest((resourceModel) -> Translator.resetDbParametersRequest(resourceModel, paramsPartition))
+                .makeServiceCall((request, proxyInvocation) -> proxyInvocation.injectCredentialsAndInvokeV2(request, proxyInvocation.client()::resetDBParameterGroup))
+                .handleError((describeDbParameterGroupsRequest, exception, client, resourceModel, ctx) ->
+                        Commons.handleException(
+                                ProgressEvent.progress(resourceModel, ctx),
+                                exception,
+                                DEFAULT_DB_PARAMETER_GROUP_ERROR_RULE_SET))
+                .progress();
     }
 
-    private Map<String, Parameter> getModifiableParameters(ResourceModel model, Map<String, Parameter> currentDBParameters) {
+    private Map<String, Parameter> getModifiableParameters(final ResourceModel model,
+                                                           final Map<String, Parameter> currentDBParameters) {
         Map<String, Parameter> parametersToModify = Maps.newHashMap(currentDBParameters);
         parametersToModify.keySet().retainAll(model.getParameters().keySet());
         return parametersToModify.entrySet()
-            .stream()
-            //filter to parameters want to modify and its value is different from already exist value
-            .filter(entry -> {
-                String parameterName = entry.getKey();
-                String currentParameterValue = entry.getValue().parameterValue();
-                String newParameterValue = String.valueOf(model.getParameters().get(parameterName));
-                return !newParameterValue.equals(currentParameterValue);
-            })
-            .collect(Collectors.toMap(Map.Entry::getKey,
-                entry -> {
+                .stream()
+                //filter to parameters want to modify and its value is different from already exist value
+                .filter(entry -> {
                     String parameterName = entry.getKey();
-                    String newValue = String.valueOf(model.getParameters().get(parameterName));
-                    Parameter defaultParameter = entry.getValue();
-                    return Translator.buildParameterWithNewValue(newValue, defaultParameter);
+                    String currentParameterValue = entry.getValue().parameterValue();
+                    String newParameterValue = String.valueOf(model.getParameters().get(parameterName));
+                    return !newParameterValue.equals(currentParameterValue);
                 })
-            );
+                .collect(Collectors.toMap(Map.Entry::getKey,
+                        entry -> {
+                            String parameterName = entry.getKey();
+                            String newValue = String.valueOf(model.getParameters().get(parameterName));
+                            Parameter defaultParameter = entry.getValue();
+                            return Translator.buildParameterWithNewValue(newValue, defaultParameter);
+                        })
+                );
     }
 
-    private ProgressEvent<ResourceModel, CallbackContext> validateModelParameters(ProgressEvent<ResourceModel, CallbackContext> progress, Map<String, Parameter> defaultEngineParameters) {
+    private ProgressEvent<ResourceModel, CallbackContext> validateModelParameters(final ProgressEvent<ResourceModel, CallbackContext> progress,
+                                                                                  final Map<String, Parameter> defaultEngineParameters) {
         Set<String> invalidParameters = progress.getResourceModel().getParameters().entrySet().stream()
-            .filter(entry -> {
-                String parameterName = entry.getKey();
-                String newParameterValue = String.valueOf(entry.getValue());
-                Parameter defaultParameter = defaultEngineParameters.get(parameterName);
-                if (!defaultEngineParameters.containsKey(parameterName)) return true;
-                //Parameter is not modifiable and input model contains different value from default value
-                if (!defaultParameter.isModifiable() && !defaultParameter.parameterValue().equals(newParameterValue)) return true;
-                return false;
-            })
-            .map(Map.Entry::getKey)
-            .collect(Collectors.toSet());
+                .filter(entry -> {
+                    String parameterName = entry.getKey();
+                    String newParameterValue = String.valueOf(entry.getValue());
+                    Parameter defaultParameter = defaultEngineParameters.get(parameterName);
+                    if (!defaultEngineParameters.containsKey(parameterName)) return true;
+                    //Parameter is not modifiable and input model contains different value from default value
+                    return !defaultParameter.isModifiable() && !defaultParameter.parameterValue().equals(newParameterValue);
+                })
+                .map(Map.Entry::getKey)
+                .collect(Collectors.toSet());
 
-        if (!invalidParameters.isEmpty())
-            return ProgressEvent.defaultFailureHandler(new CfnInvalidRequestException("Invalid / unmodifiable / Unsupported DB Parameter: " + invalidParameters.stream().findFirst().get()),
-                HandlerErrorCode.InvalidRequest);
+        if (!invalidParameters.isEmpty()) {
+            logger.log(String.format(
+                    "Invalid parameters: %s\nDefault engine parameters: %s",
+                    invalidParameters.stream().collect(Collectors.joining(" , ")),
+                    defaultEngineParameters.entrySet().stream()
+                            .map(entry -> String.format("%s -> %s", entry.getKey(), entry.getValue().isModifiable()))
+                            .collect(Collectors.joining(" , "))));
+            return ProgressEvent.defaultFailureHandler(
+                    new CfnInvalidRequestException("Invalid / unmodifiable / Unsupported DB Parameter: " + invalidParameters.stream().findFirst().get()),
+                    HandlerErrorCode.InvalidRequest
+            );
+        }
         return ProgressEvent.progress(progress.getResourceModel(), progress.getCallbackContext());
     }
 
-    private Map<String, Parameter> getParametersToReset(ResourceModel model, Map<String, Parameter> defaultEngineParameters, Map<String, Parameter> currentParameters) {
+    private Map<String, Parameter> getParametersToReset(final ResourceModel model,
+                                                        final Map<String, Parameter> defaultEngineParameters,
+                                                        final Map<String, Parameter> currentParameters) {
         return currentParameters.entrySet()
-            .stream()
-            .filter(entry -> {
-                String parameterName = entry.getKey();
-                String currentParameterValue = entry.getValue().parameterValue();
-                String defaultParameterValue = defaultEngineParameters.get(parameterName).parameterValue();
-                Map<String, Object> parametersToModify = model.getParameters();
-                return parametersToModify != null && currentParameterValue != null
-                    && !currentParameterValue.equals(defaultParameterValue)
-                    && !parametersToModify.containsKey(parameterName);
-            })
-            .collect(Collectors.toMap(entry -> entry.getKey(), entry -> entry.getValue()));
+                .stream()
+                .filter(entry -> {
+                    String parameterName = entry.getKey();
+                    String currentParameterValue = entry.getValue().parameterValue();
+                    String defaultParameterValue = defaultEngineParameters.get(parameterName).parameterValue();
+                    Map<String, Object> parametersToModify = model.getParameters();
+                    return parametersToModify != null && currentParameterValue != null
+                            && !currentParameterValue.equals(defaultParameterValue)
+                            && !parametersToModify.containsKey(parameterName);
+                })
+                .collect(Collectors.toMap(entry -> entry.getKey(), entry -> entry.getValue()));
     }
 
-    private ProgressEvent<ResourceModel, CallbackContext> describeCurrentDBParametersCall(ProgressEvent<ResourceModel, CallbackContext> progress, final Map<String, Parameter> currentDBParameters, AmazonWebServicesClientProxy proxy, ProxyClient<RdsClient> proxyClient) {
+    private ProgressEvent<ResourceModel, CallbackContext> describeCurrentDBParameters(final ProgressEvent<ResourceModel, CallbackContext> progress,
+                                                                                      final Map<String, Parameter> currentDBParameters,
+                                                                                      final AmazonWebServicesClientProxy proxy,
+                                                                                      ProxyClient<RdsClient> proxyClient) {
         return proxy.initiate("rds::describe-db-parameters", proxyClient, progress.getResourceModel(), progress.getCallbackContext())
-            .translateToServiceRequest((resourceModel) -> Translator.describeDbParametersRequest(resourceModel))
-            .makeServiceCall((request, proxyInvocation) -> proxyInvocation.injectCredentialsAndInvokeIterableV2(request, proxyInvocation.client()::describeDBParametersPaginator))
-            .handleError((describeDBParametersPaginatorRequest, exception, client, resourceModel, ctx) -> handleException(exception))
-            .done((describeDbParameterGroupsRequest, describeDbParameterGroupsResponse, proxyInvocation, resourceModel, context) -> {
-                 currentDBParameters.putAll(
-                     describeDbParameterGroupsResponse.stream()
-                    .flatMap(describeDbParametersResponse -> describeDbParametersResponse.parameters().stream())
-                    .collect(Collectors.toMap(Parameter::parameterName, Function.identity()))
-                 );
-                return ProgressEvent.progress(resourceModel, context);
-            });
+                .translateToServiceRequest((resourceModel) -> Translator.describeDbParametersRequest(resourceModel))
+                .makeServiceCall((request, proxyInvocation) -> proxyInvocation.injectCredentialsAndInvokeIterableV2(request, proxyInvocation.client()::describeDBParametersPaginator))
+                .handleError((describeDBParametersPaginatorRequest, exception, client, resourceModel, ctx) ->
+                        Commons.handleException(
+                                ProgressEvent.progress(resourceModel, ctx),
+                                exception,
+                                DEFAULT_DB_PARAMETER_GROUP_ERROR_RULE_SET))
+                .done((describeDbParameterGroupsRequest, describeDbParameterGroupsResponse, proxyInvocation, resourceModel, context) -> {
+                    currentDBParameters.putAll(
+                            describeDbParameterGroupsResponse.stream()
+                                    .flatMap(describeDbParametersResponse -> describeDbParametersResponse.parameters().stream())
+                                    .collect(Collectors.toMap(Parameter::parameterName, Function.identity()))
+                    );
+                    return ProgressEvent.progress(resourceModel, context);
+                });
     }
 
-    private ProgressEvent<ResourceModel, CallbackContext> describeDefaultEngineParametersCall(ProgressEvent<ResourceModel, CallbackContext> progress, final Map<String, Parameter> defaultEngineParameters, AmazonWebServicesClientProxy proxy, ProxyClient<RdsClient> proxyClient) {
+    private ProgressEvent<ResourceModel, CallbackContext> describeDefaultEngineParameters(final ProgressEvent<ResourceModel, CallbackContext> progress,
+                                                                                          final Map<String, Parameter> defaultEngineParameters,
+                                                                                          final AmazonWebServicesClientProxy proxy,
+                                                                                          final ProxyClient<RdsClient> proxyClient) {
         return proxy.initiate("rds::default-engine-db-parameters", proxyClient, progress.getResourceModel(), progress.getCallbackContext())
-            .translateToServiceRequest((resourceModel) -> Translator.describeEngineDefaultParametersRequest(resourceModel))
-            .makeServiceCall((request, proxyInvocation) -> proxyInvocation.injectCredentialsAndInvokeIterableV2(request, proxyInvocation.client()::describeEngineDefaultParametersPaginator))
-            .handleError((describeEngineDefaultParametersPaginatorRequest, exception, client, resourceModel, ctx) -> handleException(exception))
-            .done((describeEngineDefaultParametersRequest, describeEngineDefaultParametersResponse, proxyInvocation, resourceModel, context) -> {
-                defaultEngineParameters.putAll(
-                    describeEngineDefaultParametersResponse.stream()
-                    .flatMap(describeDbParametersResponse -> describeDbParametersResponse.engineDefaults().parameters().stream())
-                    .collect(Collectors.toMap(Parameter::parameterName, Function.identity()))
-                );
-                return ProgressEvent.progress(resourceModel, context);
-            });
+                .translateToServiceRequest((resourceModel) -> Translator.describeEngineDefaultParametersRequest(resourceModel))
+                .makeServiceCall((request, proxyInvocation) -> proxyInvocation.injectCredentialsAndInvokeIterableV2(request, proxyInvocation.client()::describeEngineDefaultParametersPaginator))
+                .handleError((describeEngineDefaultParametersPaginatorRequest, exception, client, resourceModel, ctx) ->
+                        Commons.handleException(
+                                ProgressEvent.progress(resourceModel, ctx),
+                                exception,
+                                DEFAULT_DB_PARAMETER_GROUP_ERROR_RULE_SET))
+                .done((describeEngineDefaultParametersRequest, describeEngineDefaultParametersResponse, proxyInvocation, resourceModel, context) -> {
+                    defaultEngineParameters.putAll(
+                            describeEngineDefaultParametersResponse.stream()
+                                    .flatMap(describeDbParametersResponse -> describeDbParametersResponse.engineDefaults().parameters().stream())
+                                    .collect(Collectors.toMap(Parameter::parameterName, Function.identity()))
+                    );
+                    return ProgressEvent.progress(resourceModel, context);
+                });
 
     }
 
-    protected <K, V> Map<K, V> mergeMaps(Map<K, V> m1, Map<K, V> m2) {
+    protected <K, V> Map<K, V> mergeMaps(final Map<K, V> m1, final Map<K, V> m2) {
         final Map<K, V> result = new HashMap<>();
         result.putAll(Optional.ofNullable(m1).orElse(Collections.emptyMap()));
         result.putAll(Optional.ofNullable(m2).orElse(Collections.emptyMap()));

--- a/aws-rds-dbparametergroup/src/main/java/software/amazon/rds/dbparametergroup/Configuration.java
+++ b/aws-rds-dbparametergroup/src/main/java/software/amazon/rds/dbparametergroup/Configuration.java
@@ -1,12 +1,12 @@
 package software.amazon.rds.dbparametergroup;
 
-import java.util.Collections;
 import java.util.Map;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 import org.json.JSONObject;
 import org.json.JSONTokener;
+
+import com.amazonaws.util.CollectionUtils;
 
 class Configuration extends BaseConfiguration {
 
@@ -20,8 +20,11 @@ class Configuration extends BaseConfiguration {
     }
 
     public Map<String, String> resourceDefinedTags(final ResourceModel model) {
-        return Optional.ofNullable(model.getTags())
-                .orElse(Collections.emptyList())
+        if (CollectionUtils.isNullOrEmpty(model.getTags())) {
+            return null;
+        }
+
+        return model.getTags()
                 .stream()
                 .collect(Collectors.toMap(Tag::getKey, Tag::getValue, (v1, v2) -> v2));
     }

--- a/aws-rds-dbparametergroup/src/main/java/software/amazon/rds/dbparametergroup/DeleteHandler.java
+++ b/aws-rds-dbparametergroup/src/main/java/software/amazon/rds/dbparametergroup/DeleteHandler.java
@@ -6,6 +6,7 @@ import software.amazon.cloudformation.proxy.Logger;
 import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
+import software.amazon.rds.common.handler.Commons;
 
 public class DeleteHandler extends BaseHandlerStd {
 
@@ -15,11 +16,15 @@ public class DeleteHandler extends BaseHandlerStd {
             final CallbackContext callbackContext,
             final ProxyClient<RdsClient> proxyClient,
             final Logger logger) {
-
+        setLogger(logger);
         return proxy.initiate("rds::delete-db-parameter-group", proxyClient, request.getDesiredResourceState(), callbackContext)
                 .translateToServiceRequest(Translator::deleteDbParameterGroupRequest)
                 .makeServiceCall((deleteGroupRequest, proxyInvocation) -> proxyInvocation.injectCredentialsAndInvokeV2(deleteGroupRequest, proxyInvocation.client()::deleteDBParameterGroup))
-                .handleError((deleteGroupRequest, exception, client, resourceModel, cxt) -> handleException(exception))
+                .handleError((deleteGroupRequest, exception, client, resourceModel, ctx) ->
+                        Commons.handleException(
+                                ProgressEvent.progress(resourceModel, ctx),
+                                exception,
+                                DEFAULT_DB_PARAMETER_GROUP_ERROR_RULE_SET))
                 .done((deleteGroupRequest, deleteGroupResponse, proxyInvocation, resourceModel, context) -> ProgressEvent.defaultSuccessHandler(null));
     }
 }

--- a/aws-rds-dbparametergroup/src/main/java/software/amazon/rds/dbparametergroup/ListHandler.java
+++ b/aws-rds-dbparametergroup/src/main/java/software/amazon/rds/dbparametergroup/ListHandler.java
@@ -3,6 +3,7 @@ package software.amazon.rds.dbparametergroup;
 import java.util.stream.Collectors;
 
 import software.amazon.awssdk.services.rds.RdsClient;
+import software.amazon.awssdk.services.rds.model.DescribeDbParameterGroupsRequest;
 import software.amazon.awssdk.services.rds.model.DescribeDbParameterGroupsResponse;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.Logger;
@@ -10,6 +11,7 @@ import software.amazon.cloudformation.proxy.OperationStatus;
 import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
+import software.amazon.rds.common.handler.Commons;
 
 public class ListHandler extends BaseHandlerStd {
 
@@ -20,13 +22,17 @@ public class ListHandler extends BaseHandlerStd {
             final CallbackContext callbackContext,
             final ProxyClient<RdsClient> proxyClient,
             final Logger logger) {
-
+        setLogger(logger);
         DescribeDbParameterGroupsResponse describeDBParameterGroupsResponse = null;
+        DescribeDbParameterGroupsRequest describeDbParameterGroupsRequest = Translator.describeDbParameterGroupsRequest(request.getNextToken());
         try {
-            describeDBParameterGroupsResponse = proxy.injectCredentialsAndInvokeV2(Translator.describeDbParameterGroupsRequest(request.getNextToken()),
+            describeDBParameterGroupsResponse = proxy.injectCredentialsAndInvokeV2(describeDbParameterGroupsRequest,
                     proxyClient.client()::describeDBParameterGroups);
-        } catch (Exception e) {
-            handleException(e);
+        } catch (Exception exception) {
+            return Commons.handleException(
+                    ProgressEvent.progress(request.getDesiredResourceState(), callbackContext),
+                    exception,
+                    DEFAULT_DB_PARAMETER_GROUP_ERROR_RULE_SET);
         }
 
         return ProgressEvent.<ResourceModel, CallbackContext>builder()

--- a/aws-rds-dbparametergroup/src/main/java/software/amazon/rds/dbparametergroup/ParameterType.java
+++ b/aws-rds-dbparametergroup/src/main/java/software/amazon/rds/dbparametergroup/ParameterType.java
@@ -4,7 +4,7 @@ public enum ParameterType {
     Static("static"),
     Dynamic("dynamic");
 
-    private String value;
+    private final String value;
 
     ParameterType(String value) {
         this.value = value;

--- a/aws-rds-dbparametergroup/src/main/java/software/amazon/rds/dbparametergroup/ReadHandler.java
+++ b/aws-rds-dbparametergroup/src/main/java/software/amazon/rds/dbparametergroup/ReadHandler.java
@@ -1,45 +1,48 @@
 package software.amazon.rds.dbparametergroup;
 
+import java.util.Set;
+
 import software.amazon.awssdk.services.rds.RdsClient;
 import software.amazon.awssdk.services.rds.model.DBParameterGroup;
+import software.amazon.awssdk.services.rds.model.Tag;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.Logger;
 import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
+import software.amazon.rds.common.handler.Commons;
+import software.amazon.rds.common.handler.Tagging;
 
 public class ReadHandler extends BaseHandlerStd {
-    private Logger logger;
 
     protected ProgressEvent<ResourceModel, CallbackContext> handleRequest(
             final AmazonWebServicesClientProxy proxy,
             final ResourceHandlerRequest<ResourceModel> request,
             final CallbackContext callbackContext,
             final ProxyClient<RdsClient> proxyClient,
-            final Logger logger) {
-
-        this.logger = logger;
+            final Logger logger
+    ) {
+        setLogger(logger);
         return proxy.initiate("rds::read-db-parameter-group", proxyClient, request.getDesiredResourceState(), callbackContext)
                 .translateToServiceRequest(Translator::describeDbParameterGroupsRequest)
                 .backoffDelay(CONSTANT)
                 .makeServiceCall((describeDbParameterGroupsRequest, proxyInvocation) -> proxyInvocation.injectCredentialsAndInvokeV2(describeDbParameterGroupsRequest, proxyInvocation.client()::describeDBParameterGroups))
-                .handleError((describeDbParameterGroupsRequest, exception, client, resourceModel, ctx) -> handleException(exception))
+                .handleError((describeDbParameterGroupsRequest, exception, client, resourceModel, ctx) ->
+                        Commons.handleException(
+                                ProgressEvent.progress(resourceModel, ctx),
+                                exception,
+                                DEFAULT_DB_PARAMETER_GROUP_ERROR_RULE_SET))
                 .done((describeDbParameterGroupsRequest, describeDbParameterGroupsResponse, proxyInvocation, model, context) -> {
-                    final DBParameterGroup dBParameterGroup = describeDbParameterGroupsResponse.dbParameterGroups().stream().findFirst().get();
-                    callbackContext.setDbParameterGroupArn(dBParameterGroup.dbParameterGroupArn());
-                    return ProgressEvent.progress(Translator.translateFromDBParameterGroup(dBParameterGroup), callbackContext);
-                })
-                .then(progress -> softFailAccessDenied(() ->
-                                proxy.initiate("rds::read-db-parameter-group-tags", proxyClient, request.getDesiredResourceState(), callbackContext)
-                                        .translateToServiceRequest(resourceModel -> Translator.listTagsForResourceRequest(callbackContext.getDbParameterGroupArn()))
-                                        .makeServiceCall((listTagsForResourceRequest, proxyInvocation) ->
-                                                proxyInvocation.injectCredentialsAndInvokeV2(listTagsForResourceRequest, proxyInvocation.client()::listTagsForResource))
-                                        .done((listTagsForResourceRequest, listTagsForResourceResponse, proxyInvocation, model, context) -> {
-                                            progress.getResourceModel().setTags(Translator.translateTagsFromSdk(listTagsForResourceResponse.tagList()));
-                                            return ProgressEvent.progress(progress.getResourceModel(), callbackContext);
-                                        }),
-                        progress.getResourceModel(), progress.getCallbackContext()))
-                .then(progress -> ProgressEvent.success(progress.getResourceModel(), progress.getCallbackContext()));
-
+                    try {
+                        final DBParameterGroup dBParameterGroup = describeDbParameterGroupsResponse.dbParameterGroups().stream().findFirst().get();
+                        final Set<Tag> tags = Tagging.listTagsForResource(proxyInvocation, dBParameterGroup.dbParameterGroupArn());
+                        return ProgressEvent.success(Translator.translateFromDBParameterGroup(dBParameterGroup, tags), context);
+                    } catch (Exception exception) {
+                        return Commons.handleException(
+                                ProgressEvent.progress(model, context),
+                                exception,
+                                SOFT_FAIL_TAG_DB_PARAMETER_GROUP_ERROR_RULE_SET);
+                    }
+                });
     }
 }

--- a/aws-rds-dbparametergroup/src/main/java/software/amazon/rds/dbparametergroup/UpdateHandler.java
+++ b/aws-rds-dbparametergroup/src/main/java/software/amazon/rds/dbparametergroup/UpdateHandler.java
@@ -1,15 +1,15 @@
 package software.amazon.rds.dbparametergroup;
 
 import java.util.Map;
-import java.util.Set;
 
-import com.google.common.collect.Sets;
 import software.amazon.awssdk.services.rds.RdsClient;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.Logger;
 import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
+import software.amazon.rds.common.handler.Commons;
+import software.amazon.rds.common.handler.Tagging;
 
 public class UpdateHandler extends BaseHandlerStd {
 
@@ -17,30 +17,28 @@ public class UpdateHandler extends BaseHandlerStd {
             final AmazonWebServicesClientProxy proxy,
             final ProxyClient<RdsClient> proxyClient,
             final ProgressEvent<ResourceModel, CallbackContext> progress,
-            final ResourceModel model,
-            final CallbackContext callbackContext,
-            final Map<String, String> tags) {
-        return softFailAccessDenied(
-                () -> proxy.initiate("rds::tag-db-parameter-group", proxyClient, progress.getResourceModel(), progress.getCallbackContext())
-                        .translateToServiceRequest(Translator::describeDbParameterGroupsRequest)
-                        .makeServiceCall(((describeDbGroupsRequest, proxyInvocation) ->
-                                proxyInvocation.injectCredentialsAndInvokeV2(describeDbGroupsRequest, proxyInvocation.client()::describeDBParameterGroups)))
-                        .done((describeDbParameterGroupsRequest, describeDbParameterGroupsResponse, invocation, resourceModel, context) -> {
-                            final String arn = describeDbParameterGroupsResponse.dbParameterGroups().stream().findFirst().get().dbParameterGroupArn();
-                            final Set<Tag> currentTags = Sets.newHashSet(Translator.translateTagsToModelResource(tags));
-                            final Set<Tag> existingTags = Sets.newHashSet(Translator.translateTagsFromSdk(proxyClient.injectCredentialsAndInvokeV2(Translator.listTagsForResourceRequest(arn), proxyClient.client()::listTagsForResource).tagList()));
-                            final Set<Tag> tagsToRemove = Sets.difference(existingTags, currentTags);
-                            final Set<Tag> tagsToAdd = Sets.difference(currentTags, existingTags);
-                            invocation.injectCredentialsAndInvokeV2(
-                                    Translator.removeTagsFromResourceRequest(arn, tagsToRemove),
-                                    invocation.client()::removeTagsFromResource
-                            );
-                            invocation.injectCredentialsAndInvokeV2(
-                                    Translator.addTagsToResourceRequest(arn, tagsToAdd),
-                                    invocation.client()::addTagsToResource
-                            );
-                            return ProgressEvent.progress(resourceModel, context);
-                        }), model, callbackContext);
+            final Map<String, String> previousTags,
+            final Map<String, String> desiredTags
+    ) {
+        return proxy.initiate("rds::tag-db-parameter-group", proxyClient, progress.getResourceModel(), progress.getCallbackContext())
+                .translateToServiceRequest(Translator::describeDbParameterGroupsRequest)
+                .makeServiceCall(((describeDbGroupsRequest, proxyInvocation) -> proxyInvocation.injectCredentialsAndInvokeV2(
+                        describeDbGroupsRequest,
+                        proxyInvocation.client()::describeDBParameterGroups)))
+                .handleError((describeDbParameterGroupsRequest, exception, client, resourceModel, ctx) -> Commons.handleException(
+                        ProgressEvent.progress(resourceModel, ctx),
+                        exception,
+                        DEFAULT_DB_PARAMETER_GROUP_ERROR_RULE_SET))
+                .done((describeDbParameterGroupsRequest, describeDbParameterGroupsResponse, invocation, resourceModel, context) -> {
+                    final String arn = describeDbParameterGroupsResponse.dbParameterGroups().stream().findFirst().get().dbParameterGroupArn();
+                    return Tagging.updateTags(
+                            invocation,
+                            arn,
+                            ProgressEvent.progress(resourceModel, context),
+                            previousTags,
+                            desiredTags,
+                            SOFT_FAIL_TAG_DB_PARAMETER_GROUP_ERROR_RULE_SET);
+                });
     }
 
     protected ProgressEvent<ResourceModel, CallbackContext> handleRequest(
@@ -48,13 +46,22 @@ public class UpdateHandler extends BaseHandlerStd {
             final ResourceHandlerRequest<ResourceModel> request,
             final CallbackContext callbackContext,
             final ProxyClient<RdsClient> proxyClient,
-            final Logger logger) {
+            final Logger logger
+    ) {
+        setLogger(logger);
+        final Map<String, String> previousTags = Tagging.mergeTags(
+                request.getPreviousSystemTags(),
+                request.getPreviousResourceTags()
+        );
+        final Map<String, String> desiredTags = Tagging.mergeTags(
+                request.getSystemTags(),
+                request.getDesiredResourceTags()
+        );
 
         final ResourceModel model = request.getDesiredResourceState();
         return ProgressEvent.progress(model, callbackContext)
-            .then(progress -> applyParameters(proxy, proxyClient, progress.getResourceModel(), progress.getCallbackContext()))
-            .then(progress -> tagResource(proxy, proxyClient, progress, model, callbackContext, mergeMaps(request.getSystemTags(), request.getDesiredResourceTags())))
-            .then(progress -> new ReadHandler().handleRequest(proxy, request, callbackContext, proxyClient, logger));
-
+                .then(progress -> applyParameters(proxy, proxyClient, progress.getResourceModel(), progress.getCallbackContext()))
+                .then(progress -> tagResource(proxy, proxyClient, progress, previousTags, desiredTags))
+                .then(progress -> new ReadHandler().handleRequest(proxy, request, callbackContext, proxyClient, logger));
     }
 }

--- a/aws-rds-dbparametergroup/src/test/java/software/amazon/rds/dbparametergroup/ConfigurationTest.java
+++ b/aws-rds-dbparametergroup/src/test/java/software/amazon/rds/dbparametergroup/ConfigurationTest.java
@@ -1,0 +1,41 @@
+package software.amazon.rds.dbparametergroup;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Arrays;
+import java.util.Map;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class ConfigurationTest {
+
+    @Test
+    public void duplicateTagKeysLastWins() {
+        final Configuration configuration = new Configuration();
+        final String tagKeyA = "TagKeyA";
+        final String tagValue1 = "TagValue1";
+        final String tagValue2 = "TagValue2";
+
+        final String tagKeyB = "TagKey3";
+        final String tagValue3 = "TagValue3";
+
+        final Map<String, String> tags = configuration.resourceDefinedTags(ResourceModel.builder().tags(Arrays.asList(
+                new Tag(tagKeyA, tagValue1),
+                new Tag(tagKeyA, tagValue2),
+                new Tag(tagKeyB, tagValue3))).build());
+
+        assertThat(tags).hasSize(2);
+        assertThat(tags).containsExactly(
+                Assertions.entry(tagKeyA, tagValue2),
+                Assertions.entry(tagKeyB, tagValue3));
+    }
+
+    @Test
+    public void noTags() {
+        final Configuration configuration = new Configuration();
+        final Map<String, String> tags = configuration.resourceDefinedTags(ResourceModel.builder().build());
+
+        assertThat(tags).isNull();
+    }
+}

--- a/aws-rds-dbparametergroup/src/test/java/software/amazon/rds/dbparametergroup/CreateHandlerTest.java
+++ b/aws-rds-dbparametergroup/src/test/java/software/amazon/rds/dbparametergroup/CreateHandlerTest.java
@@ -85,12 +85,12 @@ public class CreateHandlerTest extends AbstractTestBase {
         callbackContext.setParametersApplied(true);
 
         ResourceModel EMPTY_NAME_RESOURCE_MODEL = ResourceModel.builder()
-            .dBParameterGroupName("")
-            .description("test DB Parameter group description")
-            .family("testFamily")
-            .tags(Collections.emptyList())
-            .parameters(PARAMS)
-            .build();
+                .dBParameterGroupName("")
+                .description("test DB Parameter group description")
+                .family("testFamily")
+                .tags(Collections.emptyList())
+                .parameters(PARAMS)
+                .build();
 
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
                 .logicalResourceIdentifier(LOGICAL_RESOURCE_IDENTIFIER)
@@ -157,10 +157,10 @@ public class CreateHandlerTest extends AbstractTestBase {
         mockDescribeDbParametersResponse("static", "dynamic", false);
 
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
-            .clientRequestToken(getClientRequestToken())
-            .desiredResourceState(RESOURCE_MODEL)
-            .desiredResourceTags(translateTagsToMap(TAG_SET))
-            .logicalResourceIdentifier(LOGICAL_RESOURCE_IDENTIFIER).build();
+                .clientRequestToken(getClientRequestToken())
+                .desiredResourceState(RESOURCE_MODEL)
+                .desiredResourceTags(translateTagsToMap(TAG_SET))
+                .logicalResourceIdentifier(LOGICAL_RESOURCE_IDENTIFIER).build();
         try {
             handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);
         } catch (CfnInvalidRequestException e) {
@@ -252,43 +252,43 @@ public class CreateHandlerTest extends AbstractTestBase {
 
     private void mockDescribeDbParametersResponse(String firstParamApplyType, String secondParamApplyType, boolean isModifiable) {
         Parameter param1 = Parameter.builder()
-            .parameterName("param1")
-            .parameterValue("system_value")
-            .isModifiable(isModifiable)
-            .applyType(firstParamApplyType)
-            .build();
+                .parameterName("param1")
+                .parameterValue("system_value")
+                .isModifiable(isModifiable)
+                .applyType(firstParamApplyType)
+                .build();
         Parameter param2 = Parameter.builder()
-            .parameterName("param2")
-            .parameterValue("system_value")
-            .isModifiable(isModifiable)
-            .applyType(secondParamApplyType)
-            .build();
+                .parameterName("param2")
+                .parameterValue("system_value")
+                .isModifiable(isModifiable)
+                .applyType(secondParamApplyType)
+                .build();
 
         DescribeEngineDefaultParametersIterable describeEngineDefaultParametersResponses = mock(DescribeEngineDefaultParametersIterable.class);
         final DescribeEngineDefaultParametersResponse describeEngineDefaultParametersResponse = DescribeEngineDefaultParametersResponse.builder()
-            .engineDefaults(EngineDefaults.builder()
-                .parameters(param1, param2)
-                .build()
-            ).build();
+                .engineDefaults(EngineDefaults.builder()
+                        .parameters(param1, param2)
+                        .build()
+                ).build();
         when(describeEngineDefaultParametersResponses.stream())
-            .thenReturn(Stream.<DescribeEngineDefaultParametersResponse>builder().
-                add(describeEngineDefaultParametersResponse)
-                .build()
-            );
+                .thenReturn(Stream.<DescribeEngineDefaultParametersResponse>builder().
+                        add(describeEngineDefaultParametersResponse)
+                        .build()
+                );
         when(proxyClient.client().describeEngineDefaultParametersPaginator(any(DescribeEngineDefaultParametersRequest.class))).thenReturn(describeEngineDefaultParametersResponses);
 
-        if(!isModifiable)
+        if (!isModifiable)
             return;
 
         final DescribeDbParametersResponse describeDbParametersResponse = DescribeDbParametersResponse.builder().marker(null)
-            .parameters(param1, param2).build();
+                .parameters(param1, param2).build();
 
         final DescribeDBParametersIterable describeDbParametersIterable = mock(DescribeDBParametersIterable.class);
         when(describeDbParametersIterable.stream())
-            .thenReturn(Stream.<DescribeDbParametersResponse>builder()
-                .add(describeDbParametersResponse)
-                .build()
-            );
+                .thenReturn(Stream.<DescribeDbParametersResponse>builder()
+                        .add(describeDbParametersResponse)
+                        .build()
+                );
         when(proxyClient.client().describeDBParametersPaginator(any(DescribeDbParametersRequest.class))).thenReturn(describeDbParametersIterable);
     }
 }

--- a/aws-rds-dbparametergroup/src/test/java/software/amazon/rds/dbparametergroup/DeleteHandlerTest.java
+++ b/aws-rds-dbparametergroup/src/test/java/software/amazon/rds/dbparametergroup/DeleteHandlerTest.java
@@ -20,8 +20,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import software.amazon.awssdk.services.rds.RdsClient;
 import software.amazon.awssdk.services.rds.model.DbParameterGroupNotFoundException;
-import software.amazon.awssdk.services.rds.model.DeleteDbParameterGroupResponse;
 import software.amazon.awssdk.services.rds.model.DeleteDbParameterGroupRequest;
+import software.amazon.awssdk.services.rds.model.DeleteDbParameterGroupResponse;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.HandlerErrorCode;
 import software.amazon.cloudformation.proxy.OperationStatus;
@@ -78,7 +78,6 @@ public class DeleteHandlerTest extends AbstractTestBase {
 
     @Test
     public void handleRequest_SimpleSuccessNotFound() {
-        final DeleteDbParameterGroupResponse deleteDBParameterGroupResponse = DeleteDbParameterGroupResponse.builder().build();
         when(rdsClient.deleteDBParameterGroup(any(DeleteDbParameterGroupRequest.class)))
                 .thenThrow(DbParameterGroupNotFoundException.class);
 
@@ -91,7 +90,6 @@ public class DeleteHandlerTest extends AbstractTestBase {
 
         assertThat(response).isNotNull();
         assertThat(response.getStatus()).isEqualTo(OperationStatus.FAILED);
-        assertThat(response.getCallbackContext()).isNull();
         assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
         assertThat(response.getResourceModels()).isNull();
         assertThat(response.getMessage()).isNull();

--- a/aws-rds-dbparametergroup/src/test/java/software/amazon/rds/dbparametergroup/UpdateHandlerTest.java
+++ b/aws-rds-dbparametergroup/src/test/java/software/amazon/rds/dbparametergroup/UpdateHandlerTest.java
@@ -28,8 +28,6 @@ import software.amazon.awssdk.services.rds.model.ListTagsForResourceRequest;
 import software.amazon.awssdk.services.rds.model.ListTagsForResourceResponse;
 import software.amazon.awssdk.services.rds.model.RemoveTagsFromResourceRequest;
 import software.amazon.awssdk.services.rds.model.RemoveTagsFromResourceResponse;
-import software.amazon.awssdk.services.rds.model.ResetDbParameterGroupRequest;
-import software.amazon.awssdk.services.rds.model.ResetDbParameterGroupResponse;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.OperationStatus;
 import software.amazon.cloudformation.proxy.ProgressEvent;
@@ -40,14 +38,11 @@ import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 public class UpdateHandlerTest extends AbstractTestBase {
 
     @Mock
+    RdsClient rdsClient;
+    @Mock
     private AmazonWebServicesClientProxy proxy;
-
     @Mock
     private ProxyClient<RdsClient> proxyRdsClient;
-
-    @Mock
-    RdsClient rdsClient;
-
     private DBParameterGroup simpleDbParameterGroup;
     private ResourceModel previousResourceModel;
 
@@ -104,9 +99,6 @@ public class UpdateHandlerTest extends AbstractTestBase {
         final ListTagsForResourceResponse listTagsForResourceResponse = ListTagsForResourceResponse.builder().build();
         when(rdsClient.listTagsForResource(any(ListTagsForResourceRequest.class))).thenReturn(listTagsForResourceResponse);
 
-        final RemoveTagsFromResourceResponse removeTagsFromResourceResponse = RemoveTagsFromResourceResponse.builder().build();
-        when(rdsClient.removeTagsFromResource(any(RemoveTagsFromResourceRequest.class))).thenReturn(removeTagsFromResourceResponse);
-
         final AddTagsToResourceResponse addTagsToResourceResponse = AddTagsToResourceResponse.builder().build();
         when(rdsClient.addTagsToResource(any(AddTagsToResourceRequest.class))).thenReturn(addTagsToResourceResponse);
 
@@ -120,8 +112,7 @@ public class UpdateHandlerTest extends AbstractTestBase {
         assertThat(response.getErrorCode()).isNull();
 
         verify(proxyRdsClient.client(), times(2)).describeDBParameterGroups(any(DescribeDbParameterGroupsRequest.class));
-        verify(proxyRdsClient.client(), times(2)).listTagsForResource(any(ListTagsForResourceRequest.class));
-        verify(proxyRdsClient.client()).removeTagsFromResource(any(RemoveTagsFromResourceRequest.class));
+        verify(proxyRdsClient.client(), times(1)).listTagsForResource(any(ListTagsForResourceRequest.class));
         verify(proxyRdsClient.client()).addTagsToResource(any(AddTagsToResourceRequest.class));
     }
 
@@ -138,8 +129,6 @@ public class UpdateHandlerTest extends AbstractTestBase {
 
         final ListTagsForResourceResponse listTagsForResourceResponse = ListTagsForResourceResponse.builder().build();
         when(rdsClient.listTagsForResource(any(ListTagsForResourceRequest.class))).thenReturn(listTagsForResourceResponse);
-        final RemoveTagsFromResourceResponse removeTagsFromResourceResponse = RemoveTagsFromResourceResponse.builder().build();
-        when(rdsClient.removeTagsFromResource(any(RemoveTagsFromResourceRequest.class))).thenReturn(removeTagsFromResourceResponse);
         final AddTagsToResourceResponse addTagsToResourceResponse = AddTagsToResourceResponse.builder().build();
         when(rdsClient.addTagsToResource(any(AddTagsToResourceRequest.class))).thenReturn(addTagsToResourceResponse);
 
@@ -153,8 +142,7 @@ public class UpdateHandlerTest extends AbstractTestBase {
         assertThat(response.getErrorCode()).isNull();
 
         verify(proxyRdsClient.client(), times(2)).describeDBParameterGroups(any(DescribeDbParameterGroupsRequest.class));
-        verify(proxyRdsClient.client(), times(2)).listTagsForResource(any(ListTagsForResourceRequest.class));
-        verify(proxyRdsClient.client()).removeTagsFromResource(any(RemoveTagsFromResourceRequest.class));
+        verify(proxyRdsClient.client(), times(1)).listTagsForResource(any(ListTagsForResourceRequest.class));
         verify(proxyRdsClient.client()).addTagsToResource(any(AddTagsToResourceRequest.class));
     }
 }

--- a/aws-rds-dbsubnetgroup/aws-rds-dbsubnetgroup.json
+++ b/aws-rds-dbsubnetgroup/aws-rds-dbsubnetgroup.json
@@ -20,7 +20,7 @@
     "Tags": {
       "type": "array",
       "maxItems": 50,
-      "uniqueItems": true,
+      "uniqueItems": false,
       "insertionOrder": false,
       "description": "An array of key-value pairs to apply to this resource.",
       "items": {

--- a/aws-rds-dbsubnetgroup/src/main/java/software/amazon/rds/dbsubnetgroup/Configuration.java
+++ b/aws-rds-dbsubnetgroup/src/main/java/software/amazon/rds/dbsubnetgroup/Configuration.java
@@ -18,6 +18,6 @@ class Configuration extends BaseConfiguration {
 
         return resourceModel.getTags()
                 .stream()
-                .collect(Collectors.toMap(Tag::getKey, Tag::getValue));
+                .collect(Collectors.toMap(Tag::getKey, Tag::getValue, (v1, v2) -> v2));
     }
 }

--- a/aws-rds-dbsubnetgroup/src/main/java/software/amazon/rds/dbsubnetgroup/Translator.java
+++ b/aws-rds-dbsubnetgroup/src/main/java/software/amazon/rds/dbsubnetgroup/Translator.java
@@ -1,22 +1,25 @@
 package software.amazon.rds.dbsubnetgroup;
 
 import java.util.Collection;
-import java.util.Collections;
+import java.util.List;
 import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
 import java.util.stream.Collectors;
 
+import com.amazonaws.util.CollectionUtils;
 import software.amazon.awssdk.services.rds.model.CreateDbSubnetGroupRequest;
+import software.amazon.awssdk.services.rds.model.DBSubnetGroup;
 import software.amazon.awssdk.services.rds.model.DeleteDbSubnetGroupRequest;
 import software.amazon.awssdk.services.rds.model.DescribeDbSubnetGroupsRequest;
 import software.amazon.awssdk.services.rds.model.ModifyDbSubnetGroupRequest;
-import software.amazon.awssdk.services.rds.model.Tag;
+import software.amazon.awssdk.services.rds.model.Subnet;
+import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.rds.common.handler.Tagging;
 
 public class Translator {
-    static CreateDbSubnetGroupRequest createDbSubnetGroupRequest(final ResourceModel model,
-                                                                 final Map<String, String> tags) {
+    static CreateDbSubnetGroupRequest createDbSubnetGroupRequest(
+            final ResourceModel model,
+            final Map<String, String> tags
+    ) {
         return CreateDbSubnetGroupRequest.builder()
                 .dbSubnetGroupName(model.getDBSubnetGroupName())
                 .dbSubnetGroupDescription(model.getDBSubnetGroupDescription())
@@ -50,12 +53,23 @@ public class Translator {
                 .build();
     }
 
-    static Set<software.amazon.rds.dbsubnetgroup.Tag> translateTagsFromSdk(final Collection<Tag> tags) {
-        return Optional.ofNullable(tags).orElse(Collections.emptySet())
-                .stream()
-                .map(tag -> software.amazon.rds.dbsubnetgroup.Tag.builder()
+    static ProgressEvent<ResourceModel, CallbackContext> translateToModel(
+            final DBSubnetGroup dbSubnetGroup,
+            final Collection<software.amazon.awssdk.services.rds.model.Tag> rdsTags
+    ) {
+        List<Tag> tags = CollectionUtils.isNullOrEmpty(rdsTags) ? null
+                : rdsTags.stream()
+                .map(tag -> Tag.builder()
                         .key(tag.key())
-                        .value(tag.value()).build())
-                .collect(Collectors.toSet());
+                        .value(tag.value())
+                        .build())
+                .collect(Collectors.toList());
+
+        return ProgressEvent.defaultSuccessHandler(ResourceModel.builder()
+                .dBSubnetGroupName(dbSubnetGroup.dbSubnetGroupName())
+                .dBSubnetGroupDescription(dbSubnetGroup.dbSubnetGroupDescription())
+                .subnetIds(dbSubnetGroup.subnets().stream().map(Subnet::subnetIdentifier).collect(Collectors.toList()))
+                .tags(tags)
+                .build());
     }
 }

--- a/aws-rds-dbsubnetgroup/src/test/java/software/amazon/rds/dbsubnetgroup/ConfigurationTest.java
+++ b/aws-rds-dbsubnetgroup/src/test/java/software/amazon/rds/dbsubnetgroup/ConfigurationTest.java
@@ -1,0 +1,41 @@
+package software.amazon.rds.dbsubnetgroup;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Arrays;
+import java.util.Map;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class ConfigurationTest {
+
+    @Test
+    public void duplicateTagKeysLastWins() {
+        final Configuration configuration = new Configuration();
+        final String tagKeyA = "TagKeyA";
+        final String tagValue1 = "TagValue1";
+        final String tagValue2 = "TagValue2";
+
+        final String tagKeyB = "TagKey3";
+        final String tagValue3 = "TagValue3";
+
+        final Map<String, String> tags = configuration.resourceDefinedTags(ResourceModel.builder().tags(Arrays.asList(
+                new Tag(tagKeyA, tagValue1),
+                new Tag(tagKeyA, tagValue2),
+                new Tag(tagKeyB, tagValue3))).build());
+
+        assertThat(tags).hasSize(2);
+        assertThat(tags).containsExactly(
+                Assertions.entry(tagKeyA, tagValue2),
+                Assertions.entry(tagKeyB, tagValue3));
+    }
+
+    @Test
+    public void noTags() {
+        final Configuration configuration = new Configuration();
+        final Map<String, String> tags = configuration.resourceDefinedTags(ResourceModel.builder().build());
+
+        assertThat(tags).isNull();
+    }
+}

--- a/aws-rds-dbsubnetgroup/src/test/java/software/amazon/rds/dbsubnetgroup/ReadHandlerTest.java
+++ b/aws-rds-dbsubnetgroup/src/test/java/software/amazon/rds/dbsubnetgroup/ReadHandlerTest.java
@@ -24,6 +24,7 @@ import software.amazon.awssdk.services.rds.model.DescribeDbSubnetGroupsRequest;
 import software.amazon.awssdk.services.rds.model.DescribeDbSubnetGroupsResponse;
 import software.amazon.awssdk.services.rds.model.ListTagsForResourceRequest;
 import software.amazon.awssdk.services.rds.model.ListTagsForResourceResponse;
+import software.amazon.awssdk.services.rds.model.Tag;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.HandlerErrorCode;
 import software.amazon.cloudformation.proxy.OperationStatus;
@@ -64,7 +65,9 @@ public class ReadHandlerTest extends AbstractTestBase {
 
         final DescribeDbSubnetGroupsResponse describeActiveDbSubnetGroupsResponse = DescribeDbSubnetGroupsResponse.builder().dbSubnetGroups(DB_SUBNET_GROUP_ACTIVE).build();
         when(proxyRdsClient.client().describeDBSubnetGroups(any(DescribeDbSubnetGroupsRequest.class))).thenReturn(describeActiveDbSubnetGroupsResponse);
-        final ListTagsForResourceResponse listTagsForResourceResponse = ListTagsForResourceResponse.builder().build();
+        final ListTagsForResourceResponse listTagsForResourceResponse = ListTagsForResourceResponse.builder()
+                .tagList(Tag.builder().key("key").value("value").build())
+                .build();
         when(proxyRdsClient.client().listTagsForResource(any(ListTagsForResourceRequest.class))).thenReturn(listTagsForResourceResponse);
 
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()

--- a/aws-rds-dbsubnetgroup/template.yml
+++ b/aws-rds-dbsubnetgroup/template.yml
@@ -5,7 +5,7 @@ Description: AWS SAM template for the AWS::RDS::DBSubnetGroup resource type
 Globals:
   Function:
     Timeout: 180  # docker start-up times can be long for SAM CLI
-    MemorySize: 256
+    MemorySize: 512
 
 Resources:
   TypeFunction:

--- a/aws-rds-eventsubscription/aws-rds-eventsubscription.json
+++ b/aws-rds-eventsubscription/aws-rds-eventsubscription.json
@@ -28,10 +28,10 @@
   },
   "properties": {
     "Tags": {
-      "description": "The list of tags for the cluster parameter group.",
+      "description": "An array of key-value pairs to apply to this resource.",
       "type": "array",
       "maxItems": 50,
-      "uniqueItems": true,
+      "uniqueItems": false,
       "insertionOrder": false,
       "items": {
         "$ref": "#/definitions/Tag"

--- a/aws-rds-eventsubscription/docs/README.md
+++ b/aws-rds-eventsubscription/docs/README.md
@@ -44,7 +44,7 @@ Properties:
 
 #### Tags
 
-The list of tags for the cluster parameter group.
+An array of key-value pairs to apply to this resource.
 
 _Required_: No
 

--- a/aws-rds-eventsubscription/src/main/java/software/amazon/rds/eventsubscription/Configuration.java
+++ b/aws-rds-eventsubscription/src/main/java/software/amazon/rds/eventsubscription/Configuration.java
@@ -3,7 +3,7 @@ package software.amazon.rds.eventsubscription;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import software.amazon.awssdk.utils.CollectionUtils;
+import com.amazonaws.util.CollectionUtils;
 
 class Configuration extends BaseConfiguration {
 
@@ -17,6 +17,6 @@ class Configuration extends BaseConfiguration {
 
         return resourceModel.getTags()
                 .stream()
-                .collect(Collectors.toMap(Tag::getKey, Tag::getValue));
+                .collect(Collectors.toMap(Tag::getKey, Tag::getValue, (v1, v2) -> v2));
     }
 }

--- a/aws-rds-eventsubscription/src/main/java/software/amazon/rds/eventsubscription/CreateHandler.java
+++ b/aws-rds-eventsubscription/src/main/java/software/amazon/rds/eventsubscription/CreateHandler.java
@@ -41,7 +41,7 @@ public class CreateHandler extends BaseHandlerStd {
                 .makeServiceCall((createEventSubscriptionRequest, proxyInvocation) -> proxyInvocation.injectCredentialsAndInvokeV2(createEventSubscriptionRequest, proxyInvocation.client()::createEventSubscription))
                 .stabilize((createEventSubscriptionRequest, createEventSubscriptionResponse, proxyInvocation, resourceModel, context) ->
                         isStabilized(resourceModel, proxyInvocation))
-                .handleError((deleteRequest, exception, client, resourceModel, ctx) -> Commons.handleException(
+                .handleError((createRequest, exception, client, resourceModel, ctx) -> Commons.handleException(
                         ProgressEvent.progress(resourceModel, ctx),
                         exception,
                         DEFAULT_EVENT_SUBSCRIPTION_ERROR_RULE_SET))

--- a/aws-rds-eventsubscription/src/main/java/software/amazon/rds/eventsubscription/UpdateHandler.java
+++ b/aws-rds-eventsubscription/src/main/java/software/amazon/rds/eventsubscription/UpdateHandler.java
@@ -42,7 +42,7 @@ public class UpdateHandler extends BaseHandlerStd {
                 .makeServiceCall((modifyEventSubscriptionRequest, proxyInvocation) -> proxyInvocation.injectCredentialsAndInvokeV2(modifyEventSubscriptionRequest, proxyInvocation.client()::modifyEventSubscription))
                 .stabilize((modifyEventSubscriptionRequest, modifyEventSubscriptionResponse, proxyInvocation, resourceModel, context) ->
                         isStabilized(resourceModel, proxyInvocation))
-                .handleError((deleteRequest, exception, client, resourceModel, ctx) -> Commons.handleException(
+                .handleError((modifyRequest, exception, client, resourceModel, ctx) -> Commons.handleException(
                         ProgressEvent.progress(resourceModel, ctx),
                         exception,
                         DEFAULT_EVENT_SUBSCRIPTION_ERROR_RULE_SET))

--- a/aws-rds-eventsubscription/src/test/java/software/amazon/rds/eventsubscription/ConfigurationTest.java
+++ b/aws-rds-eventsubscription/src/test/java/software/amazon/rds/eventsubscription/ConfigurationTest.java
@@ -1,0 +1,41 @@
+package software.amazon.rds.eventsubscription;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Arrays;
+import java.util.Map;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class ConfigurationTest {
+
+    @Test
+    public void duplicateTagKeysLastWins() {
+        final Configuration configuration = new Configuration();
+        final String tagKeyA = "TagKeyA";
+        final String tagValue1 = "TagValue1";
+        final String tagValue2 = "TagValue2";
+
+        final String tagKeyB = "TagKey3";
+        final String tagValue3 = "TagValue3";
+
+        final Map<String, String> tags = configuration.resourceDefinedTags(ResourceModel.builder().tags(Arrays.asList(
+                new Tag(tagKeyA, tagValue1),
+                new Tag(tagKeyA, tagValue2),
+                new Tag(tagKeyB, tagValue3))).build());
+
+        assertThat(tags).hasSize(2);
+        assertThat(tags).containsExactly(
+                Assertions.entry(tagKeyA, tagValue2),
+                Assertions.entry(tagKeyB, tagValue3));
+    }
+
+    @Test
+    public void noTags() {
+        final Configuration configuration = new Configuration();
+        final Map<String, String> tags = configuration.resourceDefinedTags(ResourceModel.builder().build());
+
+        assertThat(tags).isNull();
+    }
+}

--- a/aws-rds-eventsubscription/src/test/java/software/amazon/rds/eventsubscription/ReadHandlerTest.java
+++ b/aws-rds-eventsubscription/src/test/java/software/amazon/rds/eventsubscription/ReadHandlerTest.java
@@ -23,6 +23,7 @@ import software.amazon.awssdk.services.rds.model.DescribeEventSubscriptionsRespo
 import software.amazon.awssdk.services.rds.model.EventSubscription;
 import software.amazon.awssdk.services.rds.model.ListTagsForResourceRequest;
 import software.amazon.awssdk.services.rds.model.ListTagsForResourceResponse;
+import software.amazon.awssdk.services.rds.model.Tag;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.OperationStatus;
 import software.amazon.cloudformation.proxy.ProgressEvent;
@@ -71,7 +72,9 @@ public class ReadHandlerTest extends AbstractTestBase {
         when(proxyRdsClient.client().describeEventSubscriptions(any(
                 DescribeEventSubscriptionsRequest.class))).thenReturn(describeEventSubscriptionsResponse);
 
-        final ListTagsForResourceResponse listTagsForResourceResponse = ListTagsForResourceResponse.builder().build();
+        final ListTagsForResourceResponse listTagsForResourceResponse = ListTagsForResourceResponse.builder()
+                .tagList(Tag.builder().key("key").value("value").build())
+                .build();
         when(proxyRdsClient.client().listTagsForResource(any(
                 ListTagsForResourceRequest.class))).thenReturn(listTagsForResourceResponse);
 

--- a/aws-rds-eventsubscription/template.yml
+++ b/aws-rds-eventsubscription/template.yml
@@ -5,7 +5,7 @@ Description: AWS SAM template for the AWS::RDS::EventSubscription resource type
 Globals:
   Function:
     Timeout: 60  # docker start-up times can be long for SAM CLI
-    MemorySize: 256
+    MemorySize: 512
 
 
 Resources:


### PR DESCRIPTION
This PR include:
- Migrate DBParameterGroup to use ErrorRuleSet to handle exceptions while calling RDS client.
- Solve duplicate tags as input in DBSubnetGroup, DPParameterGroup and EventSubscription
- Use Tagging common instead of duplicate login in DBParameterGroup 
- Logging failed requests
- Reformatting code to Defult java style

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.