### PR TITLE
Set default MultiAZ flag upon an AWS::RDS::DBInstance restore from snapshot

### DIFF
--- a/aws-rds-dbinstance/aws-rds-dbinstance.json
+++ b/aws-rds-dbinstance/aws-rds-dbinstance.json
@@ -439,6 +439,7 @@
         "rds:CreateDBInstance",
         "rds:CreateDbInstanceReadReplica",
         "rds:DescribeDBInstances",
+        "rds:DescribeDBSnapshots",
         "rds:ModifyDBInstance",
         "rds:RebootDBInstance",
         "rds:RestoreDbInstanceFromDbSnapshot"

--- a/aws-rds-dbinstance/resource-role.yaml
+++ b/aws-rds-dbinstance/resource-role.yaml
@@ -30,6 +30,7 @@ Resources:
                 - "rds:CreateDbInstanceReadReplica"
                 - "rds:DeleteDBInstance"
                 - "rds:DescribeDBInstances"
+                - "rds:DescribeDBSnapshots"
                 - "rds:DescribeDbEngineVersions"
                 - "rds:DescribeDbParameterGroups"
                 - "rds:ModifyDBInstance"

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/Translator.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/Translator.java
@@ -26,6 +26,7 @@ import software.amazon.awssdk.services.rds.model.DeleteDbInstanceRequest;
 import software.amazon.awssdk.services.rds.model.DescribeDbEngineVersionsRequest;
 import software.amazon.awssdk.services.rds.model.DescribeDbInstancesRequest;
 import software.amazon.awssdk.services.rds.model.DescribeDbParameterGroupsRequest;
+import software.amazon.awssdk.services.rds.model.DescribeDbSnapshotsRequest;
 import software.amazon.awssdk.services.rds.model.ModifyDbInstanceRequest;
 import software.amazon.awssdk.services.rds.model.RebootDbInstanceRequest;
 import software.amazon.awssdk.services.rds.model.RemoveRoleFromDbInstanceRequest;
@@ -44,6 +45,12 @@ public class Translator {
     public static DescribeDbInstancesRequest describeDbInstancesRequest(final String nextToken) {
         return DescribeDbInstancesRequest.builder()
                 .marker(nextToken)
+                .build();
+    }
+
+    public static DescribeDbSnapshotsRequest describeDbSnapshotsRequest(final ResourceModel model) {
+        return DescribeDbSnapshotsRequest.builder()
+                .dbSnapshotIdentifier(model.getDBSnapshotIdentifier())
                 .build();
     }
 


### PR DESCRIPTION
This commit changes the default `MultiAZ` flag behavior on restoring a db
instance from a snapshot. The previous behavior was consuming the flag from the
request object with no change.

In fact, the default value for `MultiAZ` flag is engine-dependent. Whereas for the
majority of the engines the default value would be set to false, SQLServer
engines supporting mirroring expect this value set to null upon a restore.

A new IAM policy `rds:DescribeDBSnapshots` has been added to Create handler
permissions.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Signed-off-by: Oleg Sidorov <sidorovo@amazon.com>