### PR TITLE
Check resource immutability on AWS::RDS::DBInstance update

### DIFF
--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/Translator.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/Translator.java
@@ -214,7 +214,6 @@ public class Translator {
                 .preferredBackupWindow(desiredModel.getPreferredBackupWindow())
                 .preferredMaintenanceWindow(desiredModel.getPreferredMaintenanceWindow())
                 .promotionTier(desiredModel.getPromotionTier())
-                .publiclyAccessible(desiredModel.getPubliclyAccessible())
                 .storageType(desiredModel.getStorageType())
                 .tdeCredentialArn(desiredModel.getTdeCredentialArn())
                 .tdeCredentialPassword(desiredModel.getTdeCredentialPassword())

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/UpdateHandler.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/UpdateHandler.java
@@ -22,12 +22,14 @@ import software.amazon.awssdk.services.rds.model.DbInstanceNotFoundException;
 import software.amazon.awssdk.services.rds.model.DescribeDbEngineVersionsResponse;
 import software.amazon.awssdk.services.rds.model.DescribeDbParameterGroupsResponse;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
+import software.amazon.cloudformation.proxy.HandlerErrorCode;
 import software.amazon.cloudformation.proxy.Logger;
 import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 import software.amazon.rds.common.handler.Commons;
 import software.amazon.rds.common.handler.HandlerConfig;
+import software.amazon.rds.dbinstance.util.ImmutabilityHelper;
 
 public class UpdateHandler extends BaseHandlerStd {
 
@@ -49,6 +51,15 @@ public class UpdateHandler extends BaseHandlerStd {
             final ProxyClient<Ec2Client> ec2ProxyClient,
             final Logger logger
     ) {
+        if (ImmutabilityHelper.isChangeImmutable(request.getPreviousResourceState(), request.getDesiredResourceState())) {
+            return ProgressEvent.failed(
+                    request.getDesiredResourceState(),
+                    callbackContext,
+                    HandlerErrorCode.NotUpdatable,
+                    "Resource is immutable"
+            );
+        }
+
         final Collection<Tag> previousTags = Translator.translateTagsFromRequest(
                 mergeMaps(Arrays.asList(
                         request.getPreviousSystemTags(),

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/util/ImmutabilityHelper.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/util/ImmutabilityHelper.java
@@ -1,0 +1,65 @@
+package software.amazon.rds.dbinstance.util;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.apache.commons.lang3.builder.EqualsBuilder;
+
+import com.google.common.base.Objects;
+import software.amazon.rds.dbinstance.ResourceModel;
+
+public final class ImmutabilityHelper {
+
+    private static final String ORACLE_SE = "oracle-se";
+    private static final String ORACLE_SE1 = "oracle-se1";
+    private static final String ORACLE_SE2 = "oracle-se2";
+
+    private static final String AURORA = "aurora";
+    private static final String AURORA_MYSQL = "aurora-mysql";
+
+    protected static final List<String> DEPRECATED_ORACLE_ENGINES = Arrays.asList(ORACLE_SE, ORACLE_SE1);
+
+    private ImmutabilityHelper() {
+    }
+
+    static boolean isUpgradeToOracleSE2(final ResourceModel previous, final ResourceModel desired) {
+        return previous.getEngine() != null &&
+                DEPRECATED_ORACLE_ENGINES.contains(previous.getEngine().toLowerCase()) &&
+                ORACLE_SE2.equalsIgnoreCase(desired.getEngine());
+    }
+
+    static boolean isUpgradeToAuroraMySQL(final ResourceModel previous, final ResourceModel desired) {
+        return previous.getEngine() != null &&
+                desired.getEngine() != null &&
+                previous.getEngine().equals(AURORA) &&
+                desired.getEngine().equals(AURORA_MYSQL);
+    }
+
+    static boolean isAZMutable(final ResourceModel previous, final ResourceModel desired) {
+        return Objects.equal(desired.getAvailabilityZone(), previous.getAvailabilityZone()) ||
+                desired.getAvailabilityZone() == null &&
+                        Boolean.TRUE.equals(desired.getMultiAZ());
+    }
+
+    static boolean isPerformanceInsightsMutable(final ResourceModel previous, final ResourceModel desired) {
+        return previous.getEnablePerformanceInsights() == null ||
+                !previous.getEnablePerformanceInsights() ||
+                !desired.getEnablePerformanceInsights() ||
+                Objects.equal(previous.getPerformanceInsightsKMSKeyId(), desired.getPerformanceInsightsKMSKeyId());
+    }
+
+    public static boolean isChangeImmutable(
+            final ResourceModel previous,
+            final ResourceModel desired
+    ) {
+        final boolean isEngineMutable = Objects.equal(previous.getEngine(), desired.getEngine()) ||
+                isUpgradeToAuroraMySQL(previous, desired) ||
+                isUpgradeToOracleSE2(previous, desired);
+        final boolean isPerformanceInsightsKMSKeyIdMutable = isPerformanceInsightsMutable(previous, desired);
+        final boolean isAZMutable = isAZMutable(previous, desired);
+
+        final boolean isMutable = isAZMutable && isEngineMutable && isPerformanceInsightsKMSKeyIdMutable;
+
+        return !isMutable;
+    }
+}

--- a/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/util/ImmutabilityHelperTest.java
+++ b/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/util/ImmutabilityHelperTest.java
@@ -1,0 +1,162 @@
+package software.amazon.rds.dbinstance.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import lombok.Builder;
+import software.amazon.rds.dbinstance.ResourceModel;
+
+class ImmutabilityHelperTest {
+
+    @Builder
+    private static class EngineTestCase {
+        public String previous;
+        public String desired;
+        public boolean expect;
+    }
+
+    @Builder
+    private static class ResourceModelTestCase {
+        public ResourceModel previous;
+        public ResourceModel desired;
+        public boolean expect;
+    }
+
+    @Test
+    public void test_isUpgradeToOracleSE2() {
+        final List<EngineTestCase> tests = Arrays.asList(
+                EngineTestCase.builder().previous("oracle-se").desired("oracle-se2").expect(true).build(),
+                EngineTestCase.builder().previous("oracle-se1").desired("oracle-se2").expect(true).build(),
+                EngineTestCase.builder().previous(null).desired("oracle-se2").expect(false).build(),
+                EngineTestCase.builder().previous(null).desired(null).expect(false).build(),
+                EngineTestCase.builder().previous("oracle-se").desired(null).expect(false).build(),
+                EngineTestCase.builder().previous("foo").desired("bar").expect(false).build()
+        );
+        for (final EngineTestCase test : tests) {
+            final ResourceModel previous = ResourceModel.builder()
+                    .engine(test.previous)
+                    .build();
+            final ResourceModel desired = ResourceModel.builder()
+                    .engine(test.desired)
+                    .build();
+            assertThat(ImmutabilityHelper.isUpgradeToOracleSE2(previous, desired)).isEqualTo(test.expect);
+        }
+    }
+
+    @Test
+    public void test_isUpgradeToAuroraMySQL() {
+        final List<EngineTestCase> tests = Arrays.asList(
+                EngineTestCase.builder().previous("aurora").desired("aurora-mysql").expect(true).build(),
+                EngineTestCase.builder().previous(null).desired("aurora-mysql").expect(false).build(),
+                EngineTestCase.builder().previous("aurora").desired(null).expect(false).build(),
+                EngineTestCase.builder().previous("aurora").desired("aurora-postgres").expect(false).build(),
+                EngineTestCase.builder().previous(null).desired(null).expect(false).build(),
+                EngineTestCase.builder().previous("foo").desired("bar").expect(false).build()
+        );
+        for (final EngineTestCase test : tests) {
+            final ResourceModel previous = ResourceModel.builder()
+                    .engine(test.previous)
+                    .build();
+            final ResourceModel desired = ResourceModel.builder()
+                    .engine(test.desired)
+                    .build();
+            assertThat(ImmutabilityHelper.isUpgradeToAuroraMySQL(previous, desired)).isEqualTo(test.expect);
+        }
+    }
+
+    @Test
+    public void test_isAZMutable() {
+        final List<ResourceModelTestCase> tests = Arrays.asList(
+                ResourceModelTestCase.builder()
+                        .previous(ResourceModel.builder().build())
+                        .desired(ResourceModel.builder().build())
+                        .expect(true)
+                        .build(),
+                ResourceModelTestCase.builder()
+                        .previous(ResourceModel.builder().availabilityZone("multi-az").build())
+                        .desired(ResourceModel.builder().availabilityZone("multi-az").build())
+                        .expect(true)
+                        .build(),
+                ResourceModelTestCase.builder()
+                        .previous(ResourceModel.builder().availabilityZone("foo").build())
+                        .desired(ResourceModel.builder().multiAZ(true).build())
+                        .expect(true)
+                        .build(),
+                ResourceModelTestCase.builder()
+                        .previous(ResourceModel.builder().availabilityZone("foo").build())
+                        .desired(ResourceModel.builder().multiAZ(false).build())
+                        .expect(false)
+                        .build(),
+                ResourceModelTestCase.builder()
+                        .previous(ResourceModel.builder().build())
+                        .desired(ResourceModel.builder().multiAZ(true).availabilityZone("multi-az").build())
+                        .expect(false)
+                        .build()
+        );
+        for (final ResourceModelTestCase test : tests) {
+            assertThat(ImmutabilityHelper.isAZMutable(test.previous, test.desired)).isEqualTo(test.expect);
+        }
+    }
+
+    @Test
+    public void test_isPerformanceInsightsMutable() {
+        final List<ResourceModelTestCase> tests = Arrays.asList(
+                ResourceModelTestCase.builder()
+                        .previous(ResourceModel.builder().build())
+                        .desired(ResourceModel.builder().build())
+                        .expect(true)
+                        .build(),
+                ResourceModelTestCase.builder()
+                        .previous(ResourceModel.builder().enablePerformanceInsights(false).build())
+                        .desired(ResourceModel.builder().build())
+                        .expect(true)
+                        .build(),
+                ResourceModelTestCase.builder()
+                        .previous(ResourceModel.builder().enablePerformanceInsights(true).build())
+                        .desired(ResourceModel.builder().enablePerformanceInsights(false).build())
+                        .expect(true)
+                        .build(),
+                ResourceModelTestCase.builder()
+                        .previous(ResourceModel.builder().enablePerformanceInsights(true).build())
+                        .desired(ResourceModel.builder().enablePerformanceInsights(true).build())
+                        .expect(true)
+                        .build()
+        );
+        for (final ResourceModelTestCase test : tests) {
+            assertThat(ImmutabilityHelper.isPerformanceInsightsMutable(test.previous, test.desired)).isEqualTo(test.expect);
+        }
+    }
+
+    @Test
+    public void test_isChangeImmutable() {
+        final List<ResourceModelTestCase> tests = Arrays.asList(
+                ResourceModelTestCase.builder()
+                        .previous(ResourceModel.builder().engine("mysql").build())
+                        .desired(ResourceModel.builder().engine("mysql").build())
+                        .expect(false)
+                        .build(),
+                ResourceModelTestCase.builder()
+                        .previous(ResourceModel.builder().engine("aurora").build())
+                        .desired(ResourceModel.builder().engine("aurora-mysql").build())
+                        .expect(false)
+                        .build(),
+                ResourceModelTestCase.builder()
+                        .previous(ResourceModel.builder().engine("aurora").build())
+                        .desired(ResourceModel.builder().engine("aurora-postgres").build())
+                        .expect(true)
+                        .build(),
+                ResourceModelTestCase.builder()
+                        .previous(ResourceModel.builder().engine("oracle-se").build())
+                        .desired(ResourceModel.builder().engine("oracle-se2").build())
+                        .expect(false)
+                        .build()
+        );
+        for (final ResourceModelTestCase test : tests) {
+            assertThat(ImmutabilityHelper.isChangeImmutable(test.previous, test.desired)).isEqualTo(test.expect);
+        }
+    }
+}


### PR DESCRIPTION
This commit adds an explicit DBInstance resource immutability check upon an
update.

The motivation for this change is to ensure the update can be updated to the
desired state. Otherwise a complete replacement is required.

The check logic is consolidated in a new utility class called
`ImmutabilityHelper`. The check is performed on a set of attributes:
  * Common attributes (db instance identifier, database name etc)
  * Engine
  * MultiAZ
  * PerformanceInsights

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Signed-off-by: Oleg Sidorov <sidorovo@amazon.com>