### PR TITLE
Set processorFeatures on modify-db-instance conditionally

### DIFF
--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/Translator.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/Translator.java
@@ -6,6 +6,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -205,13 +206,11 @@ public class Translator {
                 .performanceInsightsRetentionPeriod(desiredModel.getPerformanceInsightsRetentionPeriod())
                 .preferredBackupWindow(desiredModel.getPreferredBackupWindow())
                 .preferredMaintenanceWindow(desiredModel.getPreferredMaintenanceWindow())
-                .processorFeatures(translateProcessorFeaturesToSdk(desiredModel.getProcessorFeatures()))
                 .promotionTier(desiredModel.getPromotionTier())
                 .publiclyAccessible(desiredModel.getPubliclyAccessible())
                 .storageType(desiredModel.getStorageType())
                 .tdeCredentialArn(desiredModel.getTdeCredentialArn())
                 .tdeCredentialPassword(desiredModel.getTdeCredentialPassword())
-                .useDefaultProcessorFeatures(desiredModel.getUseDefaultProcessorFeatures())
                 .vpcSecurityGroupIds(desiredModel.getVPCSecurityGroups());
 
         // An attempt to "move" an instance to the same db subnet will cause a
@@ -239,6 +238,11 @@ public class Translator {
         } else {
             builder.allocatedStorage(getAllocatedStorage(desiredModel));
             builder.iops(desiredModel.getIops());
+        }
+
+        if (shouldSetProcessorFeatures(previousModel, desiredModel)) {
+            builder.processorFeatures(translateProcessorFeaturesToSdk(desiredModel.getProcessorFeatures()));
+            builder.useDefaultProcessorFeatures(desiredModel.getUseDefaultProcessorFeatures());
         }
 
         return builder.build();
@@ -583,5 +587,11 @@ public class Translator {
 
     private static boolean canUpdateIops(final Integer fromIops, final Integer toIops) {
         return fromIops == null || toIops == null || toIops >= fromIops;
+    }
+
+    private static boolean shouldSetProcessorFeatures(final ResourceModel previousModel, final ResourceModel desiredModel) {
+        return previousModel != null && desiredModel != null &&
+                (!Objects.deepEquals(previousModel.getProcessorFeatures(), desiredModel.getProcessorFeatures()) ||
+                        !Objects.equals(previousModel.getUseDefaultProcessorFeatures(), desiredModel.getUseDefaultProcessorFeatures()));
     }
 }

--- a/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/TranslatorTest.java
+++ b/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/TranslatorTest.java
@@ -2,6 +2,8 @@ package software.amazon.rds.dbinstance;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.Arrays;
+
 import org.junit.jupiter.api.Test;
 
 import software.amazon.awssdk.services.ec2.Ec2Client;
@@ -114,6 +116,32 @@ class TranslatorTest extends AbstractHandlerTest {
         final Boolean isRollback = true;
         final ModifyDbInstanceRequest request = Translator.modifyDbInstanceRequest(previousModel, desiredModel, isRollback);
         assertThat(request.iops()).isEqualTo(IOPS_DEFAULT);
+    }
+
+    @Test
+    public void test_modifyDbInstanceRequest_setUseDefaultProcessorFeatures() {
+        final ResourceModel previousModel = RESOURCE_MODEL_BLDR()
+                .useDefaultProcessorFeatures(false)
+                .build();
+        final ResourceModel desiredModel = RESOURCE_MODEL_BLDR()
+                .useDefaultProcessorFeatures(true)
+                .build();
+        final Boolean isRollback = false;
+        final ModifyDbInstanceRequest request = Translator.modifyDbInstanceRequest(previousModel, desiredModel, isRollback);
+        assertThat(request.useDefaultProcessorFeatures()).isTrue();
+    }
+
+    @Test
+    public void test_modifyDbInstanceRequest_setProcessorFeatures() {
+        final ResourceModel previousModel = RESOURCE_MODEL_BLDR()
+                .processorFeatures(Arrays.asList(PROCESSOR_FEATURE, ProcessorFeature.builder().build()))
+                .build();
+        final ResourceModel desiredModel = RESOURCE_MODEL_BLDR()
+                .processorFeatures(Arrays.asList(PROCESSOR_FEATURE))
+                .build();
+        final Boolean isRollback = false;
+        final ModifyDbInstanceRequest request = Translator.modifyDbInstanceRequest(previousModel, desiredModel, isRollback);
+        assertThat(request.processorFeatures()).hasSameElementsAs(Translator.translateProcessorFeaturesToSdk(Arrays.asList(PROCESSOR_FEATURE)));
     }
 
     // Stub methods to satisfy the interface. This is a 1-time thing.


### PR DESCRIPTION
This commit changes the way modify-db-instance request is built. By
default, `UseDefaultProcessorFeatures` and `ProcessorFeatures` should be
unset. Once either of these 2 differs upon a stack modification, we set
it explicitly in the request.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Signed-off-by: Oleg Sidorov <sidorovo@amazon.com>