### PR TITLE
Re-implement AWS::RDS::DBCluster

### DIFF
--- a/aws-rds-cfn-common/src/main/java/software/amazon/rds/common/error/ErrorCode.java
+++ b/aws-rds-cfn-common/src/main/java/software/amazon/rds/common/error/ErrorCode.java
@@ -5,6 +5,7 @@ import software.amazon.awssdk.utils.StringUtils;
 public enum ErrorCode {
     AccessDeniedException("AccessDeniedException"),
     ClientUnavailable("ClientUnavailable"),
+    DBClusterAlreadyExistsFault("DBClusterAlreadyExistsFault"),
     DBInstanceAlreadyExists("DBInstanceAlreadyExists"),
     DBInstanceNotFound("DBInstanceNotFound"),
     DBParameterGroupNotFound("DBParameterGroupNotFound"),

--- a/aws-rds-cfn-common/src/main/java/software/amazon/rds/common/error/PlainErrorRuleSet.java
+++ b/aws-rds-cfn-common/src/main/java/software/amazon/rds/common/error/PlainErrorRuleSet.java
@@ -3,6 +3,7 @@ package software.amazon.rds.common.error;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
+import software.amazon.awssdk.awscore.exception.AwsErrorDetails;
 import software.amazon.awssdk.awscore.exception.AwsServiceException;
 
 public class PlainErrorRuleSet implements ErrorRuleSet {
@@ -20,10 +21,13 @@ public class PlainErrorRuleSet implements ErrorRuleSet {
         }
         if (exception instanceof AwsServiceException) {
             final AwsServiceException awsServiceException = (AwsServiceException) exception;
-            final String errorStr = awsServiceException.awsErrorDetails().errorCode();
-            final ErrorCode errorCode = ErrorCode.fromString(errorStr);
-            if (errorCode != null && errorCodeMap.containsKey(errorCode)) {
-                return errorCodeMap.get(errorCode);
+            final AwsErrorDetails errorDetails = awsServiceException.awsErrorDetails();
+            if (errorDetails != null) {
+                final String errorStr = errorDetails.errorCode();
+                final ErrorCode errorCode = ErrorCode.fromString(errorStr);
+                if (errorCode != null && errorCodeMap.containsKey(errorCode)) {
+                    return errorCodeMap.get(errorCode);
+                }
             }
         }
         return new UnexpectedErrorStatus(exception);

--- a/aws-rds-cfn-common/src/main/java/software/amazon/rds/common/handler/ProgressEventLambda.java
+++ b/aws-rds-cfn-common/src/main/java/software/amazon/rds/common/handler/ProgressEventLambda.java
@@ -1,0 +1,7 @@
+package software.amazon.rds.common.handler;
+
+import software.amazon.cloudformation.proxy.ProgressEvent;
+
+public interface ProgressEventLambda<M, C> {
+    ProgressEvent<M, C> enact();
+}

--- a/aws-rds-cfn-common/src/main/java/software/amazon/rds/common/handler/VoidBiFunction.java
+++ b/aws-rds-cfn-common/src/main/java/software/amazon/rds/common/handler/VoidBiFunction.java
@@ -1,4 +1,4 @@
-package software.amazon.rds.dbinstance.util;
+package software.amazon.rds.common.handler;
 
 @FunctionalInterface
 public interface VoidBiFunction<T, U> {

--- a/aws-rds-dbcluster/aws-rds-dbcluster.json
+++ b/aws-rds-dbcluster/aws-rds-dbcluster.json
@@ -39,14 +39,27 @@
       "minimum": 1,
       "type": "integer"
     },
+    "CopyTagsToSnapshot": {
+      "description": "A value that indicates whether to copy all tags from the DB cluster to snapshots of the DB cluster. The default is not to copy them.",
+      "type": "boolean"
+    },
     "DatabaseName": {
       "description": "The name of your database. If you don't provide a name, then Amazon RDS won't create a database in this DB cluster. For naming constraints, see Naming Constraints in the Amazon RDS User Guide.",
       "type": "string"
     },
+    "GlobalClusterIdentifier": {
+      "description": "If you are configuring an Aurora global database cluster and want your Aurora DB cluster to be a secondary member in the global database cluster, specify the global cluster ID of the global database cluster. To define the primary database cluster of the global cluster, use the AWS::RDS::GlobalCluster resource.\n\nIf you aren't configuring a global database cluster, don't specify this property.",
+      "type": "string",
+      "pattern": "^[a-zA-Z]{1}(?:-?[a-zA-Z0-9]){0,62}$",
+      "minLength": 1,
+      "maxLength": 63
+    },
     "DBClusterIdentifier": {
       "description": "The DB cluster identifier. This parameter is stored as a lowercase string.",
       "type": "string",
-      "pattern": "^[a-zA-Z]{1}(?:-?[a-zA-Z0-9]){0,62}$"
+      "pattern": "^[a-zA-Z]{1}(?:-?[a-zA-Z0-9]){0,62}$",
+      "minLength": 1,
+      "maxLength": 63
     },
     "DBClusterParameterGroupName": {
       "description": "The name of the DB cluster parameter group to associate with this DB cluster.",
@@ -108,7 +121,9 @@
     "MasterUsername": {
       "description": "The name of the master user for the DB cluster. You must specify MasterUsername, unless you specify SnapshotIdentifier. In that case, don't specify MasterUsername.",
       "type": "string",
-      "pattern": "^[a-zA-Z]{1}[a-zA-Z0-9]{0,15}$"
+      "pattern": "^[a-zA-Z]{1}[a-zA-Z0-9]{0,15}$",
+      "minLength": 1,
+      "maxLength": 16
     },
     "MasterUserPassword": {
       "description": "The master password for the DB instance.",
@@ -185,58 +200,66 @@
   },
   "allOf": [
     {
-      "allOf": [
+      "required": [
+        "Engine"
+      ]
+    },
+    {
+      "oneOf": [
         {
-          "oneOf": [
-            {
-              "required": [
-                "MasterUsername"
-              ]
-            },
-            {
-              "required": [
-                "SnapshotIdentifier"
-              ]
-            }
+          "required": [
+            "MasterUserPassword",
+            "MasterUsername"
           ]
         },
         {
-          "anyOf": [
-            {
-              "oneOf": [
-                {
-                  "anyOf": [
-                    {
-                      "required": [
-                        "SourceDBClusterIdentifier"
-                      ]
-                    },
-                    {
-                      "required": [
-                        "SnapshotIdentifier"
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "required": [
-                    "MasterUserPassword"
-                  ]
-                }
-              ]
-            },
-            {
-              "required": [
-                "MasterUsername"
-              ]
-            }
+          "required": [
+            "SnapshotIdentifier"
+          ]
+        },
+        {
+          "required": [
+            "SourceDBClusterIdentifier"
           ]
         }
       ]
     },
     {
-      "required": [
-        "Engine"
+      "oneOf": [
+        {
+          "required": [
+            "MasterUsername"
+          ]
+        },
+        {
+          "required": [
+            "SnapshotIdentifier"
+          ]
+        },
+        {
+          "required": [
+            "SourceDBClusterIdentifier"
+          ]
+        }
+      ]
+    },
+    {
+      "oneOf": [
+        {
+          "required": [
+            "MasterUserPassword"
+          ]
+        },
+        {
+          "required": [
+            "SnapshotIdentifier"
+          ]
+        },
+        {
+          "required": [
+            "SourceDBClusterIdentifier"
+          ]
+        }
       ]
     }
   ],
@@ -333,16 +356,17 @@
   "additionalProperties": false,
   "readOnlyProperties": [
     "/properties/Endpoint",
-    "/properties/ReadEndpoint"
+    "/properties/Endpoint/Address",
+    "/properties/Endpoint/Port",
+    "/properties/ReadEndpoint/Port",
+    "/properties/ReadEndpoint/Address"
   ],
   "createOnlyProperties": [
     "/properties/AvailabilityZones",
-    "/properties/DatabaseName",
     "/properties/DBClusterIdentifier",
     "/properties/DBSubnetGroupName",
-    "/properties/Engine",
+    "/properties/DatabaseName",
     "/properties/EngineMode",
-    "/properties/EngineVersion",
     "/properties/KmsKeyId",
     "/properties/MasterUsername",
     "/properties/RestoreType",
@@ -351,6 +375,10 @@
     "/properties/SourceRegion",
     "/properties/StorageEncrypted",
     "/properties/UseLatestRestorableTime"
+  ],
+  "conditionalCreateOnlyProperties": [
+    "/properties/Engine",
+    "/properties/GlobalClusterIdentifier"
   ],
   "primaryIdentifier": [
     "/properties/DBClusterIdentifier"
@@ -366,28 +394,28 @@
   "handlers": {
     "create": {
       "permissions": [
+        "iam:PassRole",
         "rds:CreateDBCluster",
         "rds:RestoreDBClusterFromSnapshot",
         "rds:RestoreDBClusterToPointInTime",
         "rds:ModifyDBCluster",
         "rds:DescribeDBClusters",
         "rds:AddRoleToDBCluster",
-        "rds:ListTagsForResource"
+        "rds:AddTagsToResource"
       ]
     },
     "read": {
       "permissions": [
-        "rds:DescribeDBClusters",
-        "rds:ListTagsForResource"
+        "rds:DescribeDBClusters"
       ]
     },
     "update": {
       "permissions": [
+        "iam:PassRole",
         "rds:ModifyDBCluster",
         "rds:DescribeDBClusters",
         "rds:AddRoleToDBCluster",
         "rds:RemoveRoleFromDBCluster",
-        "rds:ListTagsForResource",
         "rds:RemoveTagsFromResource",
         "rds:AddTagsFromResource"
       ]
@@ -395,7 +423,8 @@
     "delete": {
       "permissions": [
         "rds:DescribeDBClusters",
-        "rds:DeleteDBCluster"
+        "rds:DeleteDBCluster",
+        "rds:RemoveFromGlobalCluster"
       ]
     },
     "list": {

--- a/aws-rds-dbcluster/docs/README.md
+++ b/aws-rds-dbcluster/docs/README.md
@@ -12,11 +12,14 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 {
     "Type" : "AWS::RDS::DBCluster",
     "Properties" : {
+        "<a href="#readendpoint" title="ReadEndpoint">ReadEndpoint</a>" : <i><a href="readendpoint.md">ReadEndpoint</a></i>,
         "<a href="#associatedroles" title="AssociatedRoles">AssociatedRoles</a>" : <i>[ <a href="dbclusterrole.md">DBClusterRole</a>, ... ]</i>,
         "<a href="#availabilityzones" title="AvailabilityZones">AvailabilityZones</a>" : <i>[ String, ... ]</i>,
         "<a href="#backtrackwindow" title="BacktrackWindow">BacktrackWindow</a>" : <i>Integer</i>,
         "<a href="#backupretentionperiod" title="BackupRetentionPeriod">BackupRetentionPeriod</a>" : <i>Integer</i>,
+        "<a href="#copytagstosnapshot" title="CopyTagsToSnapshot">CopyTagsToSnapshot</a>" : <i>Boolean</i>,
         "<a href="#databasename" title="DatabaseName">DatabaseName</a>" : <i>String</i>,
+        "<a href="#globalclusteridentifier" title="GlobalClusterIdentifier">GlobalClusterIdentifier</a>" : <i>String</i>,
         "<a href="#dbclusteridentifier" title="DBClusterIdentifier">DBClusterIdentifier</a>" : <i>String</i>,
         "<a href="#dbclusterparametergroupname" title="DBClusterParameterGroupName">DBClusterParameterGroupName</a>" : <i>String</i>,
         "<a href="#dbsubnetgroupname" title="DBSubnetGroupName">DBSubnetGroupName</a>" : <i>String</i>,
@@ -52,13 +55,16 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 <pre>
 Type: AWS::RDS::DBCluster
 Properties:
+    <a href="#readendpoint" title="ReadEndpoint">ReadEndpoint</a>: <i><a href="readendpoint.md">ReadEndpoint</a></i>
     <a href="#associatedroles" title="AssociatedRoles">AssociatedRoles</a>: <i>
       - <a href="dbclusterrole.md">DBClusterRole</a></i>
     <a href="#availabilityzones" title="AvailabilityZones">AvailabilityZones</a>: <i>
       - String</i>
     <a href="#backtrackwindow" title="BacktrackWindow">BacktrackWindow</a>: <i>Integer</i>
     <a href="#backupretentionperiod" title="BackupRetentionPeriod">BackupRetentionPeriod</a>: <i>Integer</i>
+    <a href="#copytagstosnapshot" title="CopyTagsToSnapshot">CopyTagsToSnapshot</a>: <i>Boolean</i>
     <a href="#databasename" title="DatabaseName">DatabaseName</a>: <i>String</i>
+    <a href="#globalclusteridentifier" title="GlobalClusterIdentifier">GlobalClusterIdentifier</a>: <i>String</i>
     <a href="#dbclusteridentifier" title="DBClusterIdentifier">DBClusterIdentifier</a>: <i>String</i>
     <a href="#dbclusterparametergroupname" title="DBClusterParameterGroupName">DBClusterParameterGroupName</a>: <i>String</i>
     <a href="#dbsubnetgroupname" title="DBSubnetGroupName">DBSubnetGroupName</a>: <i>String</i>
@@ -91,6 +97,14 @@ Properties:
 </pre>
 
 ## Properties
+
+#### ReadEndpoint
+
+_Required_: No
+
+_Type_: <a href="readendpoint.md">ReadEndpoint</a>
+
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 
 #### AssociatedRoles
 
@@ -132,6 +146,16 @@ _Type_: Integer
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 
+#### CopyTagsToSnapshot
+
+A value that indicates whether to copy all tags from the DB cluster to snapshots of the DB cluster. The default is not to copy them.
+
+_Required_: No
+
+_Type_: Boolean
+
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+
 #### DatabaseName
 
 The name of your database. If you don't provide a name, then Amazon RDS won't create a database in this DB cluster. For naming constraints, see Naming Constraints in the Amazon RDS User Guide.
@@ -142,6 +166,24 @@ _Type_: String
 
 _Update requires_: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
 
+#### GlobalClusterIdentifier
+
+If you are configuring an Aurora global database cluster and want your Aurora DB cluster to be a secondary member in the global database cluster, specify the global cluster ID of the global database cluster. To define the primary database cluster of the global cluster, use the AWS::RDS::GlobalCluster resource.
+
+If you aren't configuring a global database cluster, don't specify this property.
+
+_Required_: No
+
+_Type_: String
+
+_Minimum_: <code>1</code>
+
+_Maximum_: <code>63</code>
+
+_Pattern_: <code>^[a-zA-Z]{1}(?:-?[a-zA-Z0-9]){0,62}$</code>
+
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+
 #### DBClusterIdentifier
 
 The DB cluster identifier. This parameter is stored as a lowercase string.
@@ -149,6 +191,10 @@ The DB cluster identifier. This parameter is stored as a lowercase string.
 _Required_: No
 
 _Type_: String
+
+_Minimum_: <code>1</code>
+
+_Maximum_: <code>63</code>
 
 _Pattern_: <code>^[a-zA-Z]{1}(?:-?[a-zA-Z0-9]){0,62}$</code>
 
@@ -224,7 +270,7 @@ _Type_: String
 
 _Allowed Values_: <code>aurora</code> | <code>aurora-mysql</code> | <code>aurora-postgres</code>
 
-_Update requires_: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 
 #### EngineMode
 
@@ -246,7 +292,7 @@ _Required_: No
 
 _Type_: String
 
-_Update requires_: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 
 #### KmsKeyId
 
@@ -265,6 +311,10 @@ The name of the master user for the DB cluster. You must specify MasterUsername,
 _Required_: No
 
 _Type_: String
+
+_Minimum_: <code>1</code>
+
+_Maximum_: <code>16</code>
 
 _Pattern_: <code>^[a-zA-Z]{1}[a-zA-Z0-9]{0,15}$</code>
 
@@ -433,6 +483,18 @@ For more information about using the `Fn::GetAtt` intrinsic function, see [Fn::G
 
 Returns the <code>Endpoint</code> value.
 
-#### ReadEndpoint
+#### Address
 
-Returns the <code>ReadEndpoint</code> value.
+Returns the <code>Address</code> value.
+
+#### Port
+
+Returns the <code>Port</code> value.
+
+#### Port
+
+Returns the <code>Port</code> value.
+
+#### Address
+
+Returns the <code>Address</code> value.

--- a/aws-rds-dbcluster/docs/endpoint.md
+++ b/aws-rds-dbcluster/docs/endpoint.md
@@ -8,36 +8,12 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 
 <pre>
 {
-    "<a href="#address" title="Address">Address</a>" : <i>String</i>,
-    "<a href="#port" title="Port">Port</a>" : <i>String</i>
 }
 </pre>
 
 ### YAML
 
 <pre>
-<a href="#address" title="Address">Address</a>: <i>String</i>
-<a href="#port" title="Port">Port</a>: <i>String</i>
 </pre>
 
 ## Properties
-
-#### Address
-
-The connection endpoint for the DB cluster.
-
-_Required_: No
-
-_Type_: String
-
-_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
-
-#### Port
-
-The port number that will accept connections on this DB cluster.
-
-_Required_: No
-
-_Type_: String
-
-_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)

--- a/aws-rds-dbcluster/docs/readendpoint.md
+++ b/aws-rds-dbcluster/docs/readendpoint.md
@@ -8,24 +8,12 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 
 <pre>
 {
-    "<a href="#address" title="Address">Address</a>" : <i>String</i>
 }
 </pre>
 
 ### YAML
 
 <pre>
-<a href="#address" title="Address">Address</a>: <i>String</i>
 </pre>
 
 ## Properties
-
-#### Address
-
-The reader endpoint for the DB cluster.
-
-_Required_: No
-
-_Type_: String
-
-_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)

--- a/aws-rds-dbcluster/inputs/inputs_1_create.json
+++ b/aws-rds-dbcluster/inputs/inputs_1_create.json
@@ -1,0 +1,6 @@
+{
+  "Engine": "aurora",
+  "MasterUsername": "guest",
+  "MasterUserPassword": "guest123",
+  "DBClusterIdentifier": "testdbclusterdelete8"
+}

--- a/aws-rds-dbcluster/inputs/inputs_1_invalid.json
+++ b/aws-rds-dbcluster/inputs/inputs_1_invalid.json
@@ -1,0 +1,6 @@
+{
+  "Engine": "aurora1",
+  "MasterUsername": "guest",
+  "MasterUserPassword": "guest123",
+  "DBClusterIdentifier": "testdbclusterinvalid"
+}

--- a/aws-rds-dbcluster/inputs/inputs_1_update.json
+++ b/aws-rds-dbcluster/inputs/inputs_1_update.json
@@ -1,0 +1,6 @@
+{
+  "Engine": "aurora",
+  "MasterUsername": "guest",
+  "MasterUserPassword": "guest1234",
+  "DBClusterIdentifier": "testdbclusterdelete8"
+}

--- a/aws-rds-dbcluster/pom.xml
+++ b/aws-rds-dbcluster/pom.xml
@@ -29,7 +29,7 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>rds</artifactId>
-            <version>2.13.17</version>
+            <version>2.15.74</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/software.amazon.cloudformation/aws-cloudformation-rpdk-java-plugin -->
         <dependency>
@@ -72,6 +72,12 @@
             <artifactId>mockito-junit-jupiter</artifactId>
             <version>2.26.0</version>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.rds.common</groupId>
+            <artifactId>aws-rds-cfn-common</artifactId>
+            <version>1.0</version>
+            <scope>compile</scope>
         </dependency>
     </dependencies>
 
@@ -190,12 +196,12 @@
                                         <limit>
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.82</minimum>
+                                            <minimum>0.8</minimum>
                                         </limit>
                                         <limit>
                                             <counter>INSTRUCTION</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.96</minimum>
+                                            <minimum>0.8</minimum>
                                         </limit>
                                     </limits>
                                 </rule>

--- a/aws-rds-dbcluster/resource-role.yaml
+++ b/aws-rds-dbcluster/resource-role.yaml
@@ -23,13 +23,15 @@ Resources:
             Statement:
               - Effect: Allow
                 Action:
+                - "iam:PassRole"
                 - "rds:AddRoleToDBCluster"
                 - "rds:AddTagsFromResource"
+                - "rds:AddTagsToResource"
                 - "rds:CreateDBCluster"
                 - "rds:DeleteDBCluster"
                 - "rds:DescribeDBClusters"
-                - "rds:ListTagsForResource"
                 - "rds:ModifyDBCluster"
+                - "rds:RemoveFromGlobalCluster"
                 - "rds:RemoveRoleFromDBCluster"
                 - "rds:RemoveTagsFromResource"
                 - "rds:RestoreDBClusterFromSnapshot"

--- a/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/CallbackContext.java
+++ b/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/CallbackContext.java
@@ -8,4 +8,5 @@ import software.amazon.cloudformation.proxy.StdCallbackContext;
 @lombok.EqualsAndHashCode(callSuper = true)
 public class CallbackContext extends StdCallbackContext {
     private boolean modified;
+    private boolean deleting;
 }

--- a/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/Configuration.java
+++ b/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/Configuration.java
@@ -1,8 +1,30 @@
 package software.amazon.rds.dbcluster;
 
-class Configuration extends BaseConfiguration {
+import java.util.Map;
+import java.util.stream.Collectors;
 
+import org.json.JSONObject;
+import org.json.JSONTokener;
+
+import com.amazonaws.util.CollectionUtils;
+
+class Configuration extends BaseConfiguration {
     public Configuration() {
         super("aws-rds-dbcluster.json");
+    }
+
+    public JSONObject resourceSchemaJsonObject() {
+        return new JSONObject(
+                new JSONTokener(this.getClass().getClassLoader().getResourceAsStream(schemaFilename)));
+    }
+
+    public Map<String, String> resourceDefinedTags(final ResourceModel model) {
+        if (CollectionUtils.isNullOrEmpty(model.getTags())) {
+            return null;
+        }
+
+        return model.getTags()
+                .stream()
+                .collect(Collectors.toMap(Tag::getKey, Tag::getValue, (v1, v2) -> v2));
     }
 }

--- a/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/DBClusterStatus.java
+++ b/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/DBClusterStatus.java
@@ -3,8 +3,7 @@ package software.amazon.rds.dbcluster;
 public enum DBClusterStatus {
     Available("available"),
     Creating("creating"),
-    Deleted("deleted"),
-    Failed("failed");
+    Deleted("deleted");
 
     private String value;
 

--- a/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/DeleteHandler.java
+++ b/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/DeleteHandler.java
@@ -1,26 +1,150 @@
 package software.amazon.rds.dbcluster;
 
+import java.util.Optional;
+
+import org.apache.commons.lang3.BooleanUtils;
+
+import com.amazonaws.util.StringUtils;
 import software.amazon.awssdk.services.rds.RdsClient;
+import software.amazon.awssdk.services.rds.model.DBCluster;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
-import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
-import software.amazon.cloudformation.proxy.ProxyClient;
-import software.amazon.cloudformation.proxy.ProgressEvent;
+import software.amazon.cloudformation.proxy.HandlerErrorCode;
 import software.amazon.cloudformation.proxy.Logger;
+import software.amazon.cloudformation.proxy.ProgressEvent;
+import software.amazon.cloudformation.proxy.ProxyClient;
+import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
+import software.amazon.cloudformation.resource.IdentifierUtils;
+import software.amazon.rds.common.handler.Commons;
+import software.amazon.rds.common.handler.HandlerConfig;
 
 public class DeleteHandler extends BaseHandlerStd {
 
-    protected ProgressEvent<ResourceModel, CallbackContext> handleRequest(final AmazonWebServicesClientProxy proxy,
-                                                                          final ResourceHandlerRequest<ResourceModel> request,
-                                                                          final CallbackContext callbackContext,
-                                                                          final ProxyClient<RdsClient> proxyClient,
-                                                                          final Logger logger) {
-        return proxy.initiate("rds::delete-dbcluster", proxyClient, request.getDesiredResourceState(), callbackContext)
-                // request to delete db cluster
-                .translateToServiceRequest(Translator::deleteDbClusterRequest)
-                .backoffDelay(BACKOFF_STRATEGY)
-                .makeServiceCall((deleteDbClusterRequest, proxyInvocation) -> proxyInvocation.injectCredentialsAndInvokeV2(deleteDbClusterRequest, proxyInvocation.client()::deleteDBCluster))
-                // wait until deleted
-                .stabilize((deleteDbClusterRequest, deleteDbClusterResponse, proxyInvocation, model, context) -> isDBClusterStabilized(proxyInvocation, model, DBClusterStatus.Deleted))
-                .success();
+    private static final String SNAPSHOT_PREFIX = "Snapshot-";
+    private static final int SNAPSHOT_MAX_LENGTH = 255;
+    private static final String DELETION_PROTECTION_ENABLED_ERROR = "Cannot delete protected Cluster %s, please disable deletion protection and try again";
+
+    public DeleteHandler() {
+        this(HandlerConfig.builder().build());
+    }
+
+    public DeleteHandler(final HandlerConfig config) {
+        super(config);
+    }
+
+    protected ProgressEvent<ResourceModel, CallbackContext> handleRequest(
+            final AmazonWebServicesClientProxy proxy,
+            final ResourceHandlerRequest<ResourceModel> request,
+            final CallbackContext callbackContext,
+            final ProxyClient<RdsClient> proxyClient,
+            final Logger logger
+    ) {
+        final ResourceModel model = request.getDesiredResourceState();
+
+        if (!callbackContext.isDeleting()) {
+            boolean deletionProtectionEnabled;
+            try {
+                deletionProtectionEnabled = isDeletionProtectionEnabled(proxyClient, model);
+            } catch (Exception exception) {
+                return Commons.handleException(
+                        ProgressEvent.progress(model, callbackContext),
+                        exception,
+                        DEFAULT_DB_CLUSTER_ERROR_RULE_SET
+                );
+            }
+            if (deletionProtectionEnabled) {
+                return ProgressEvent.failed(
+                        model,
+                        callbackContext,
+                        HandlerErrorCode.NotUpdatable,
+                        String.format(DELETION_PROTECTION_ENABLED_ERROR, model.getDBClusterIdentifier())
+                );
+            }
+        }
+
+        return ProgressEvent.progress(model, callbackContext)
+                .then(progress -> {
+                    if (isGlobalClusterMember(model)) {
+                        return removeFromGlobalCluster(proxy, proxyClient, progress);
+                    }
+                    return progress;
+                })
+                .then(progress -> deleteDbCluster(proxy, request, proxyClient, progress));
+    }
+
+    private ProgressEvent<ResourceModel, CallbackContext> deleteDbCluster(
+            final AmazonWebServicesClientProxy proxy,
+            final ResourceHandlerRequest<ResourceModel> request,
+            final ProxyClient<RdsClient> proxyClient,
+            final ProgressEvent<ResourceModel, CallbackContext> progress
+    ) {
+        final ResourceModel resourceModel = request.getDesiredResourceState();
+
+        String snapshotIdentifier = null;
+        if (BooleanUtils.isNotFalse(request.getSnapshotRequested())) {
+            snapshotIdentifier = resourceModel.getSnapshotIdentifier();
+            if (StringUtils.isNullOrEmpty(snapshotIdentifier)) {
+                snapshotIdentifier = IdentifierUtils.generateResourceIdentifier(
+                        Optional.ofNullable(request.getStackId()).orElse(STACK_NAME),
+                        SNAPSHOT_PREFIX + Optional.ofNullable(request.getLogicalResourceIdentifier()).orElse(RESOURCE_IDENTIFIER),
+                        request.getClientRequestToken(),
+                        SNAPSHOT_MAX_LENGTH
+                );
+            }
+        }
+        final String finalSnapshotIdentifier = snapshotIdentifier;
+
+        progress.getCallbackContext().setDeleting(true);
+
+        return proxy.initiate("rds::delete-dbcluster", proxyClient, progress.getResourceModel(), progress.getCallbackContext())
+                .translateToServiceRequest(model -> Translator.deleteDbClusterRequest(model, finalSnapshotIdentifier))
+                .backoffDelay(config.getBackoff())
+                .makeServiceCall((deleteRequest, proxyInvocation) -> proxyInvocation.injectCredentialsAndInvokeV2(
+                        deleteRequest,
+                        proxyInvocation.client()::deleteDBCluster
+                ))
+                .stabilize((deleteRequest, deleteResponse, proxyInvocation, model, context) -> isDBClusterDeleted(proxyInvocation, model))
+                .handleError((deleteRequest, exception, client, model, context) -> Commons.handleException(
+                        ProgressEvent.progress(model, context),
+                        exception,
+                        DEFAULT_DB_CLUSTER_ERROR_RULE_SET
+                ))
+                .done((deleteRequest, deleteResponse, proxyInvocation, model, context) -> ProgressEvent.defaultSuccessHandler(null));
+    }
+
+    private ProgressEvent<ResourceModel, CallbackContext> removeFromGlobalCluster(
+            final AmazonWebServicesClientProxy proxy,
+            final ProxyClient<RdsClient> proxyClient,
+            final ProgressEvent<ResourceModel, CallbackContext> progress
+    ) {
+        return proxy.initiate("rds::remove-from-global-cluster", proxyClient, progress.getResourceModel(), progress.getCallbackContext())
+                .translateToServiceRequest(Translator::removeFromGlobalClusterRequest)
+                .backoffDelay(config.getBackoff())
+                .makeServiceCall((removeRequest, proxyInvocation) -> proxyInvocation.injectCredentialsAndInvokeV2(
+                        removeRequest,
+                        proxyInvocation.client()::removeFromGlobalCluster
+                ))
+                .stabilize((removeRequest, removeResponse, proxyInvocation, model, context) -> isDBClusterStabilized(
+                        proxyInvocation,
+                        model,
+                        DBClusterStatus.Available
+                ))
+                .handleError((removeRequest, exception, client, model, context) -> Commons.handleException(
+                        ProgressEvent.progress(model, context),
+                        exception,
+                        DEFAULT_DB_CLUSTER_ERROR_RULE_SET
+                ))
+                .progress();
+    }
+
+    protected boolean isDeletionProtectionEnabled(
+            final ProxyClient<RdsClient> proxyClient,
+            final ResourceModel model
+    ) {
+        final DBCluster dbCluster = fetchDBCluster(proxyClient, model);
+        return dbCluster.deletionProtection();
+    }
+
+    private boolean isGlobalClusterMember(final ResourceModel model) {
+        return StringUtils.hasValue(model.getGlobalClusterIdentifier());
     }
 }

--- a/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/ListHandler.java
+++ b/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/ListHandler.java
@@ -1,33 +1,44 @@
 package software.amazon.rds.dbcluster;
 
+import java.util.stream.Collectors;
+
 import software.amazon.awssdk.services.rds.RdsClient;
 import software.amazon.awssdk.services.rds.model.DescribeDbClustersResponse;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.Logger;
-import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.OperationStatus;
+import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
-
-import java.util.stream.Collectors;
+import software.amazon.rds.common.handler.HandlerConfig;
 
 public class ListHandler extends BaseHandlerStd {
 
+    public ListHandler() {
+        this(HandlerConfig.builder().build());
+    }
+
+    public ListHandler(final HandlerConfig config) {
+        super(config);
+    }
+
     @Override
     public ProgressEvent<ResourceModel, CallbackContext> handleRequest(
-        final AmazonWebServicesClientProxy proxy,
-        final ResourceHandlerRequest<ResourceModel> request,
-        final CallbackContext callbackContext,
-        final ProxyClient<RdsClient> proxyClient,
-        final Logger logger) {
-
-        final DescribeDbClustersResponse describeDbClustersResponse = proxy.injectCredentialsAndInvokeV2(Translator.describeDbClustersRequest(request.getNextToken()), proxyClient.client()::describeDBClusters);
+            final AmazonWebServicesClientProxy proxy,
+            final ResourceHandlerRequest<ResourceModel> request,
+            final CallbackContext callbackContext,
+            final ProxyClient<RdsClient> proxyClient,
+            final Logger logger
+    ) {
+        final DescribeDbClustersResponse describeDbClustersResponse = proxy.injectCredentialsAndInvokeV2(
+                Translator.describeDbClustersRequest(request.getNextToken()),
+                proxyClient.client()::describeDBClusters
+        );
 
         return ProgressEvent.<ResourceModel, CallbackContext>builder()
                 .resourceModels(describeDbClustersResponse.dbClusters()
                         .stream()
-                        .map(dbCluster -> ResourceModel.builder()
-                                .dBClusterIdentifier(dbCluster.dbClusterIdentifier()).build())
+                        .map(Translator::translateDbClusterFromSdk)
                         .collect(Collectors.toList()))
                 .nextToken(describeDbClustersResponse.marker())
                 .status(OperationStatus.SUCCESS)

--- a/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/ModelAdapter.java
+++ b/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/ModelAdapter.java
@@ -1,13 +1,15 @@
 package software.amazon.rds.dbcluster;
 
-import com.google.common.collect.Lists;
 import java.util.List;
 
+import com.google.common.collect.Lists;
+
 public class ModelAdapter {
-    protected static final int DEFAULT_PORT= 3306;
+    protected static final int DEFAULT_PORT = 3306;
     private static final int DEFAULT_BACKUP_RETENTION_PERIOD = 1;
     private static final String SERVERLESS_ENGINE_MODE = "serverless";
     private static final String DEFAULT_DB_CLUSTER_PARAMETER_GROUP_NAME = "default.aurora5.6";
+
     public static ResourceModel setDefaults(final ResourceModel resourceModel) {
 
         final Integer port = resourceModel.getPort();
@@ -16,15 +18,14 @@ public class ModelAdapter {
         final List<DBClusterRole> associatedRoles = resourceModel.getAssociatedRoles();
         final ScalingConfiguration scalingConfiguration = resourceModel.getScalingConfiguration();
 
-        resourceModel.setBackupRetentionPeriod(backupRetentionPeriod==null ? DEFAULT_BACKUP_RETENTION_PERIOD : backupRetentionPeriod);
+        resourceModel.setBackupRetentionPeriod(backupRetentionPeriod == null ? DEFAULT_BACKUP_RETENTION_PERIOD : backupRetentionPeriod);
         resourceModel.setAssociatedRoles(associatedRoles == null ? Lists.newArrayList() : associatedRoles);
 
-        if (resourceModel.getEngineMode() == null || !resourceModel.getEngineMode().equalsIgnoreCase(SERVERLESS_ENGINE_MODE)) { // not serverless
-            resourceModel.setPort(port == null ? DEFAULT_PORT : port);
-            resourceModel.setDBClusterParameterGroupName(dBClusterParameterGroupName==null ? DEFAULT_DB_CLUSTER_PARAMETER_GROUP_NAME : dBClusterParameterGroupName);
-
-        } else { // serverless
+        if (SERVERLESS_ENGINE_MODE.equalsIgnoreCase(resourceModel.getEngineMode())) {
             resourceModel.setScalingConfiguration(scalingConfiguration == null ? ScalingConfiguration.builder().build() : scalingConfiguration);
+        } else {
+            resourceModel.setPort(port == null ? DEFAULT_PORT : port);
+            resourceModel.setDBClusterParameterGroupName(dBClusterParameterGroupName == null ? DEFAULT_DB_CLUSTER_PARAMETER_GROUP_NAME : dBClusterParameterGroupName);
         }
 
         return resourceModel;

--- a/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/ReadHandler.java
+++ b/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/ReadHandler.java
@@ -2,70 +2,46 @@ package software.amazon.rds.dbcluster;
 
 import software.amazon.awssdk.services.rds.RdsClient;
 import software.amazon.awssdk.services.rds.model.DBCluster;
-import software.amazon.awssdk.services.rds.model.DBClusterRole;
-import software.amazon.awssdk.services.rds.model.ListTagsForResourceResponse;
-import software.amazon.awssdk.services.rds.model.VpcSecurityGroupMembership;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
-import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
-import software.amazon.cloudformation.proxy.ProxyClient;
-import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.Logger;
-
-import java.util.function.Function;
-import java.util.stream.Collectors;
-
-import static software.amazon.rds.dbcluster.Translator.listTagsForResourceRequest;
+import software.amazon.cloudformation.proxy.ProgressEvent;
+import software.amazon.cloudformation.proxy.ProxyClient;
+import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
+import software.amazon.rds.common.handler.Commons;
+import software.amazon.rds.common.handler.HandlerConfig;
 
 public class ReadHandler extends BaseHandlerStd {
 
-    protected ProgressEvent<ResourceModel, CallbackContext> handleRequest(final AmazonWebServicesClientProxy proxy,
-                                                                          final ResourceHandlerRequest<ResourceModel> request,
-                                                                          final CallbackContext callbackContext,
-                                                                          final ProxyClient<RdsClient> proxyClient,
-                                                                          final Logger logger) {
+    public ReadHandler() {
+        this(HandlerConfig.builder().build());
+    }
+
+    public ReadHandler(final HandlerConfig config) {
+        super(config);
+    }
+
+    @Override
+    protected ProgressEvent<ResourceModel, CallbackContext> handleRequest(
+            final AmazonWebServicesClientProxy proxy,
+            final ResourceHandlerRequest<ResourceModel> request,
+            final CallbackContext callbackContext,
+            final ProxyClient<RdsClient> proxyClient,
+            final Logger logger
+    ) {
         return proxy.initiate("rds::describe-db-cluster", proxyClient, request.getDesiredResourceState(), callbackContext)
                 .translateToServiceRequest(Translator::describeDbClustersRequest)
-                .makeServiceCall((describeDbClustersRequest, proxyInvocation) -> proxyInvocation.injectCredentialsAndInvokeV2(describeDbClustersRequest, proxyInvocation.client()::describeDBClusters))
-                .done((describeDbClustersRequest, describeDbClustersResponse, proxyInvocation, model, context) -> {
-
-                    final Function<DBClusterRole, software.amazon.rds.dbcluster.DBClusterRole> roleTransform = (DBClusterRole dbClusterRole) -> new software.amazon.rds.dbcluster.DBClusterRole(dbClusterRole.roleArn(), dbClusterRole.featureName());
-                    final DBCluster targetDBCluster = describeDbClustersResponse.dbClusters().stream().findFirst().get();
-                    final ListTagsForResourceResponse listTagsForResourceResponse = proxyInvocation.injectCredentialsAndInvokeV2(listTagsForResourceRequest(targetDBCluster.dbClusterArn()), proxyInvocation.client()::listTagsForResource);
-
-                    return ProgressEvent.defaultSuccessHandler(ResourceModel.builder()
-                            // read only properties GetAtt
-                            .endpoint(Endpoint.builder()
-                                    .address(targetDBCluster.endpoint())
-                                    .port(targetDBCluster.port().toString()).build())
-                            .readEndpoint(ReadEndpoint.builder()
-                                    .address(targetDBCluster.readerEndpoint()).build())
-
-                            .associatedRoles(targetDBCluster.associatedRoles().stream().map(roleTransform).collect(Collectors.toList()))
-                            .availabilityZones(targetDBCluster.availabilityZones())
-                            .backtrackWindow(Translator.castToInt(targetDBCluster.backtrackWindow()))
-                            .backupRetentionPeriod(targetDBCluster.backupRetentionPeriod())
-                            .databaseName(targetDBCluster.databaseName())
-                            .dBClusterIdentifier(targetDBCluster.dbClusterIdentifier())
-                            .dBClusterParameterGroupName(targetDBCluster.dbClusterParameterGroup())
-                            .dBSubnetGroupName(targetDBCluster.dbSubnetGroup())
-                            .deletionProtection(targetDBCluster.deletionProtection())
-                            .enableCloudwatchLogsExports(targetDBCluster.enabledCloudwatchLogsExports())
-                            .enableHttpEndpoint(targetDBCluster.httpEndpointEnabled())
-                            .enableIAMDatabaseAuthentication(targetDBCluster.iamDatabaseAuthenticationEnabled())
-                            .engine(targetDBCluster.engine())
-                            .engineMode(targetDBCluster.engineMode())
-                            .engineVersion(targetDBCluster.engineVersion())
-                            .kmsKeyId(targetDBCluster.kmsKeyId())
-                            .masterUsername(targetDBCluster.masterUsername())
-                            .port(targetDBCluster.port())
-                            .preferredBackupWindow(targetDBCluster.preferredBackupWindow())
-                            .preferredMaintenanceWindow(targetDBCluster.preferredMaintenanceWindow())
-                            .replicationSourceIdentifier(targetDBCluster.replicationSourceIdentifier())
-                            .scalingConfiguration(Translator.translateScalingConfigurationFromSdk(targetDBCluster.scalingConfigurationInfo()))
-                            .storageEncrypted(targetDBCluster.storageEncrypted())
-                            .tags(Translator.translateTagsFromSdk(listTagsForResourceResponse.tagList()))
-                            .vpcSecurityGroupIds(targetDBCluster.vpcSecurityGroups().stream().map(VpcSecurityGroupMembership::vpcSecurityGroupId).collect(Collectors.toList()))
-                            .build());
+                .makeServiceCall((describeRequest, proxyInvocation) -> proxyInvocation.injectCredentialsAndInvokeV2(
+                        describeRequest,
+                        proxyInvocation.client()::describeDBClusters
+                ))
+                .handleError((describeRequest, exception, client, model, context) -> Commons.handleException(
+                        ProgressEvent.progress(model, context),
+                        exception,
+                        DEFAULT_DB_CLUSTER_ERROR_RULE_SET
+                ))
+                .done((describeRequest, describeResponse, proxyInvocation, model, context) -> {
+                    final DBCluster dbCluster = describeResponse.dbClusters().stream().findFirst().get();
+                    return ProgressEvent.success(Translator.translateDbClusterFromSdk(dbCluster), context);
                 });
     }
 }

--- a/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/Translator.java
+++ b/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/Translator.java
@@ -1,105 +1,114 @@
 package software.amazon.rds.dbcluster;
 
-import com.google.common.collect.Sets;
-import software.amazon.awssdk.services.rds.model.CloudwatchLogsExportConfiguration;
-import software.amazon.awssdk.services.rds.model.CreateDbClusterRequest;
-import software.amazon.awssdk.services.rds.model.RestoreDbClusterToPointInTimeRequest;
-import software.amazon.awssdk.services.rds.model.RestoreDbClusterFromSnapshotRequest;
-import software.amazon.awssdk.services.rds.model.AddRoleToDbClusterRequest;
-import software.amazon.awssdk.services.rds.model.RemoveRoleFromDbClusterRequest;
-import software.amazon.awssdk.services.rds.model.ModifyDbClusterRequest;
-import software.amazon.awssdk.services.rds.model.DeleteDbClusterRequest;
-import software.amazon.awssdk.services.rds.model.DescribeDbClustersRequest;
-import software.amazon.awssdk.services.rds.model.ListTagsForResourceRequest;
-import software.amazon.awssdk.services.rds.model.AddTagsToResourceRequest;
-import software.amazon.awssdk.services.rds.model.RemoveTagsFromResourceRequest;
-import software.amazon.awssdk.services.rds.model.ScalingConfigurationInfo;
-import software.amazon.awssdk.services.rds.model.ScalingConfiguration;
-import software.amazon.awssdk.services.rds.model.Tag;
-import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
-
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
+
+import com.amazonaws.util.StringUtils;
+import com.google.common.collect.Sets;
+import software.amazon.awssdk.services.rds.model.AddRoleToDbClusterRequest;
+import software.amazon.awssdk.services.rds.model.AddTagsToResourceRequest;
+import software.amazon.awssdk.services.rds.model.CloudwatchLogsExportConfiguration;
+import software.amazon.awssdk.services.rds.model.CreateDbClusterRequest;
+import software.amazon.awssdk.services.rds.model.CreateDbClusterSnapshotRequest;
+import software.amazon.awssdk.services.rds.model.DeleteDbClusterRequest;
+import software.amazon.awssdk.services.rds.model.DescribeDbClusterSnapshotsRequest;
+import software.amazon.awssdk.services.rds.model.DescribeDbClustersRequest;
+import software.amazon.awssdk.services.rds.model.ModifyDbClusterRequest;
+import software.amazon.awssdk.services.rds.model.RemoveFromGlobalClusterRequest;
+import software.amazon.awssdk.services.rds.model.RemoveRoleFromDbClusterRequest;
+import software.amazon.awssdk.services.rds.model.RemoveTagsFromResourceRequest;
+import software.amazon.awssdk.services.rds.model.RestoreDbClusterFromSnapshotRequest;
+import software.amazon.awssdk.services.rds.model.RestoreDbClusterToPointInTimeRequest;
+import software.amazon.awssdk.services.rds.model.VpcSecurityGroupMembership;
+import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 
 public class Translator {
     static CreateDbClusterRequest createDbClusterRequest(final ResourceModel model) {
         return CreateDbClusterRequest.builder()
                 .availabilityZones(model.getAvailabilityZones())
+                .backtrackWindow(castToLong(model.getBacktrackWindow()))
                 .backupRetentionPeriod(model.getBackupRetentionPeriod())
+                .copyTagsToSnapshot(model.getCopyTagsToSnapshot())
                 .databaseName(model.getDatabaseName())
                 .dbClusterIdentifier(model.getDBClusterIdentifier())
                 .dbClusterParameterGroupName(model.getDBClusterParameterGroupName())
                 .dbSubnetGroupName(model.getDBSubnetGroupName())
+                .deletionProtection(model.getDeletionProtection())
+                .enableCloudwatchLogsExports(model.getEnableCloudwatchLogsExports())
+                .enableHttpEndpoint(model.getEnableHttpEndpoint())
+                .enableIAMDatabaseAuthentication(model.getEnableIAMDatabaseAuthentication())
                 .engine(model.getEngine())
+                .engineMode(model.getEngineMode())
                 .engineVersion(model.getEngineVersion())
+                .globalClusterIdentifier(model.getGlobalClusterIdentifier())
                 .kmsKeyId(model.getKmsKeyId())
-                .masterUsername(model.getMasterUsername())
                 .masterUserPassword(model.getMasterUserPassword())
+                .masterUsername(model.getMasterUsername())
                 .port(model.getPort())
                 .preferredBackupWindow(model.getPreferredBackupWindow())
                 .preferredMaintenanceWindow(model.getPreferredMaintenanceWindow())
                 .replicationSourceIdentifier(model.getReplicationSourceIdentifier())
-                .storageEncrypted(model.getStorageEncrypted())
-                .vpcSecurityGroupIds(model.getVpcSecurityGroupIds())
-                .tags(translateTagsToSdk(model.getTags()))
-                .engineMode(model.getEngineMode())
                 .scalingConfiguration(translateScalingConfigurationToSdk(model.getScalingConfiguration()))
-                .backtrackWindow(castToLong(model.getBacktrackWindow()))
-                .enableCloudwatchLogsExports(model.getEnableCloudwatchLogsExports())
-                .enableIAMDatabaseAuthentication(model.getEnableIAMDatabaseAuthentication())
-                .deletionProtection(model.getDeletionProtection())
-                .enableHttpEndpoint(model.getEnableHttpEndpoint())
                 .sourceRegion(model.getSourceRegion())
+                .storageEncrypted(model.getStorageEncrypted())
+                .tags(translateTagsToSdk(model.getTags()))
+                .vpcSecurityGroupIds(model.getVpcSecurityGroupIds())
                 .build();
     }
 
     static RestoreDbClusterToPointInTimeRequest restoreDbClusterToPointInTimeRequest(final ResourceModel model) {
         return RestoreDbClusterToPointInTimeRequest.builder()
+                .copyTagsToSnapshot(model.getCopyTagsToSnapshot())
                 .dbClusterIdentifier(model.getDBClusterIdentifier())
                 .dbSubnetGroupName(model.getDBSubnetGroupName())
+                .restoreType(model.getRestoreType())
                 .sourceDBClusterIdentifier(model.getSourceDBClusterIdentifier())
                 .useLatestRestorableTime(model.getUseLatestRestorableTime())
-                .restoreType(model.getRestoreType())
                 .build();
     }
 
     static RestoreDbClusterFromSnapshotRequest restoreDbClusterFromSnapshotRequest(final ResourceModel model) {
         return RestoreDbClusterFromSnapshotRequest.builder()
-                .dbClusterIdentifier(model.getDBClusterIdentifier())
-                .snapshotIdentifier(model.getSnapshotIdentifier())
-                .engine(model.getEngine())
-                .engineVersion(model.getEngineVersion())
                 .availabilityZones(model.getAvailabilityZones())
-                .port(model.getPort())
-                .dbSubnetGroupName(model.getDBSubnetGroupName())
-                .databaseName(model.getDatabaseName())
-                .kmsKeyId(model.getKmsKeyId())
-                .vpcSecurityGroupIds(model.getVpcSecurityGroupIds())
-                .tags(translateTagsToSdk(model.getTags()))
                 .backtrackWindow(castToLong(model.getBacktrackWindow()))
+                .copyTagsToSnapshot(model.getCopyTagsToSnapshot())
+                .databaseName(model.getDatabaseName())
+                .dbClusterIdentifier(model.getDBClusterIdentifier())
+                .dbSubnetGroupName(model.getDBSubnetGroupName())
+                .deletionProtection(model.getDeletionProtection())
                 .enableCloudwatchLogsExports(model.getEnableCloudwatchLogsExports())
                 .enableIAMDatabaseAuthentication(model.getEnableIAMDatabaseAuthentication())
-                .deletionProtection(model.getDeletionProtection())
+                .engine(model.getEngine())
                 .engineMode(model.getEngineMode())
+                .engineVersion(model.getEngineVersion())
+                .kmsKeyId(model.getKmsKeyId())
+                .port(model.getPort())
                 .scalingConfiguration(translateScalingConfigurationToSdk(model.getScalingConfiguration()))
+                .snapshotIdentifier(model.getSnapshotIdentifier())
+                .tags(translateTagsToSdk(model.getTags()))
+                .vpcSecurityGroupIds(model.getVpcSecurityGroupIds())
                 .build();
     }
 
     static Long castToLong(Object object) {
         return object == null ? null : Long.parseLong(String.valueOf(object));
     }
+
     static Integer castToInt(Object object) {
         return object == null ? null : Integer.parseInt(String.valueOf(object));
     }
 
-    static AddRoleToDbClusterRequest addRoleToDbClusterRequest(final String dbClusterIdentifier,
-                                                               final String roleArn,
-                                                               final String featureName) {
+    static AddRoleToDbClusterRequest addRoleToDbClusterRequest(
+            final String dbClusterIdentifier,
+            final String roleArn,
+            final String featureName
+    ) {
         return AddRoleToDbClusterRequest.builder()
                 .dbClusterIdentifier(dbClusterIdentifier)
                 .roleArn(roleArn)
@@ -107,9 +116,11 @@ public class Translator {
                 .build();
     }
 
-    static RemoveRoleFromDbClusterRequest removeRoleFromDbClusterRequest(final String dbClusterIdentifier,
-                                                                         final String roleArn,
-                                                                         final String featureName) {
+    static RemoveRoleFromDbClusterRequest removeRoleFromDbClusterRequest(
+            final String dbClusterIdentifier,
+            final String roleArn,
+            final String featureName
+    ) {
         return RemoveRoleFromDbClusterRequest.builder()
                 .dbClusterIdentifier(dbClusterIdentifier)
                 .roleArn(roleArn)
@@ -117,28 +128,37 @@ public class Translator {
                 .build();
     }
 
-    static ModifyDbClusterRequest modifyDbClusterRequest(final ResourceModel model,
-                                                         final CloudwatchLogsExportConfiguration config) {
+    static ModifyDbClusterRequest modifyDbClusterRequest(final ResourceModel model) {
+        return modifyDbClusterRequest(model, CloudwatchLogsExportConfiguration.builder().build());
+    }
+
+    static ModifyDbClusterRequest modifyDbClusterRequest(
+            final ResourceModel model,
+            final CloudwatchLogsExportConfiguration config
+    ) {
         return ModifyDbClusterRequest.builder()
                 .backtrackWindow(castToLong(model.getBacktrackWindow()))
-                .cloudwatchLogsExportConfiguration(config)
-                .dbClusterIdentifier(model.getDBClusterIdentifier())
                 .backupRetentionPeriod(model.getBackupRetentionPeriod())
+                .cloudwatchLogsExportConfiguration(config)
+                .copyTagsToSnapshot(model.getCopyTagsToSnapshot())
+                .dbClusterIdentifier(model.getDBClusterIdentifier())
                 .dbClusterParameterGroupName(model.getDBClusterParameterGroupName())
                 .deletionProtection(model.getDeletionProtection())
-                .enableIAMDatabaseAuthentication(model.getEnableIAMDatabaseAuthentication())
                 .enableHttpEndpoint(model.getEnableHttpEndpoint())
+                .enableIAMDatabaseAuthentication(model.getEnableIAMDatabaseAuthentication())
+                .engineVersion(model.getEngineVersion())
                 .masterUserPassword(model.getMasterUserPassword())
                 .port(model.getPort())
                 .preferredBackupWindow(model.getPreferredBackupWindow())
                 .preferredMaintenanceWindow(model.getPreferredMaintenanceWindow())
                 .scalingConfiguration(translateScalingConfigurationToSdk(model.getScalingConfiguration()))
                 .vpcSecurityGroupIds(model.getVpcSecurityGroupIds())
-                .engineVersion(model.getEngineVersion())
                 .build();
     }
 
-    static CloudwatchLogsExportConfiguration cloudwatchLogsExportConfiguration(final ResourceHandlerRequest<ResourceModel> request) {
+    static CloudwatchLogsExportConfiguration cloudwatchLogsExportConfiguration(
+            final ResourceHandlerRequest<ResourceModel> request
+    ) {
         CloudwatchLogsExportConfiguration.Builder config = CloudwatchLogsExportConfiguration.builder();
 
         final List<String> currentLogsExports = request.getDesiredResourceState().getEnableCloudwatchLogsExports();
@@ -154,79 +174,214 @@ public class Translator {
         return config.enableLogTypes(logTypesToEnable).disableLogTypes(logTypesToDisable).build();
     }
 
-    static DeleteDbClusterRequest deleteDbClusterRequest(final ResourceModel model) {
-        return DeleteDbClusterRequest.builder()
+    static DeleteDbClusterRequest deleteDbClusterRequest(
+            final ResourceModel model,
+            final String finalDBSnapshotIdentifier
+    ) {
+        final DeleteDbClusterRequest.Builder builder = DeleteDbClusterRequest.builder()
+                .dbClusterIdentifier(model.getDBClusterIdentifier());
+        if (StringUtils.isNullOrEmpty(finalDBSnapshotIdentifier)) {
+            builder.skipFinalSnapshot(true);
+        } else {
+            builder.skipFinalSnapshot(false)
+                    .finalDBSnapshotIdentifier(finalDBSnapshotIdentifier);
+        }
+        return builder.build();
+    }
+
+    static RemoveFromGlobalClusterRequest removeFromGlobalClusterRequest(final ResourceModel model) {
+        return RemoveFromGlobalClusterRequest.builder()
                 .dbClusterIdentifier(model.getDBClusterIdentifier())
-                .skipFinalSnapshot(true)
+                .globalClusterIdentifier(model.getGlobalClusterIdentifier())
                 .build();
     }
 
-    static DescribeDbClustersRequest describeDbClustersRequest(final ResourceModel model) {
+    static CreateDbClusterSnapshotRequest createDbClusterSnapshotRequest(
+            final ResourceModel model,
+            final String finalDBSnapshotIdentifier
+    ) {
+        return CreateDbClusterSnapshotRequest.builder()
+                .dbClusterIdentifier(model.getDBClusterIdentifier())
+                .dbClusterSnapshotIdentifier(finalDBSnapshotIdentifier)
+                .build();
+    }
+
+    static DescribeDbClusterSnapshotsRequest describeDbClusterSnapshotsRequest(
+            final String dbSnapshotIdentifier
+    ) {
+        return DescribeDbClusterSnapshotsRequest.builder()
+                .dbClusterSnapshotIdentifier(dbSnapshotIdentifier)
+                .build();
+    }
+
+    static DescribeDbClustersRequest describeDbClustersRequest(
+            final ResourceModel model
+    ) {
         return DescribeDbClustersRequest.builder()
                 .dbClusterIdentifier(model.getDBClusterIdentifier())
                 .build();
     }
 
-    static DescribeDbClustersRequest describeDbClustersRequest(final String nextToken) {
+    static DescribeDbClustersRequest describeDbClustersRequest(
+            final String nextToken
+    ) {
         return DescribeDbClustersRequest.builder()
                 .marker(nextToken)
                 .build();
     }
 
-    static ListTagsForResourceRequest listTagsForResourceRequest(final String dbClusterArn) {
-        return ListTagsForResourceRequest.builder()
-                .resourceName(dbClusterArn)
-                .build();
-    }
-
-    static AddTagsToResourceRequest addTagsToResourceRequest(final String dbClusterParameterGroupArn,
-                                                             final Set<software.amazon.rds.dbcluster.Tag> tags) {
+    static AddTagsToResourceRequest addTagsToResourceRequest(
+            final String dbClusterParameterGroupArn,
+            final Set<Tag> tags
+    ) {
         return AddTagsToResourceRequest.builder()
                 .resourceName(dbClusterParameterGroupArn)
                 .tags(translateTagsToSdk(tags))
                 .build();
     }
 
-    static RemoveTagsFromResourceRequest removeTagsFromResourceRequest(final String dbClusterParameterGroupArn,
-                                                                       final Set<software.amazon.rds.dbcluster.Tag> tags) {
+    static RemoveTagsFromResourceRequest removeTagsFromResourceRequest(
+            final String dbClusterParameterGroupArn,
+            final Set<Tag> tags
+    ) {
         return RemoveTagsFromResourceRequest.builder()
                 .resourceName(dbClusterParameterGroupArn)
                 .tagKeys(tags
                         .stream()
-                        .map(software.amazon.rds.dbcluster.Tag::getKey)
+                        .map(Tag::getKey)
                         .collect(Collectors.toSet()))
                 .build();
     }
 
-    static Set<Tag> translateTagsToSdk(final Collection<software.amazon.rds.dbcluster.Tag> tags) {
+    static Set<software.amazon.awssdk.services.rds.model.Tag> translateTagsToSdk(
+            final Collection<Tag> tags
+    ) {
         return Optional.ofNullable(tags).orElse(Collections.emptySet())
                 .stream()
-                .map(tag -> Tag.builder().key(tag.getKey()).value(tag.getValue()).build())
+                .map(tag -> software.amazon.awssdk.services.rds.model.Tag.builder()
+                        .key(tag.getKey())
+                        .value(tag.getValue())
+                        .build())
                 .collect(Collectors.toSet());
     }
 
-    static Set<software.amazon.rds.dbcluster.Tag> translateTagsFromSdk(final Collection<Tag> tags) {
+    static Set<Tag> translateTagsFromSdk(
+            final Collection<software.amazon.awssdk.services.rds.model.Tag> tags
+    ) {
         return Optional.ofNullable(tags).orElse(Collections.emptySet())
                 .stream()
-                .map(tag -> software.amazon.rds.dbcluster.Tag.builder().key(tag.key()).value(tag.value()).build())
+                .map(tag -> software.amazon.rds.dbcluster.Tag.builder()
+                        .key(tag.key())
+                        .value(tag.value())
+                        .build())
                 .collect(Collectors.toSet());
     }
 
-    static ScalingConfiguration translateScalingConfigurationToSdk(final software.amazon.rds.dbcluster.ScalingConfiguration scalingConfiguration) {
-        if (scalingConfiguration == null) return null;
-        return ScalingConfiguration.builder()
+    static software.amazon.awssdk.services.rds.model.ScalingConfiguration translateScalingConfigurationToSdk(
+            final ScalingConfiguration scalingConfiguration
+    ) {
+        if (scalingConfiguration == null) {
+            return null;
+        }
+        return software.amazon.awssdk.services.rds.model.ScalingConfiguration.builder()
                 .autoPause(scalingConfiguration.getAutoPause())
                 .maxCapacity(scalingConfiguration.getMaxCapacity())
                 .minCapacity(scalingConfiguration.getMinCapacity())
                 .secondsUntilAutoPause(scalingConfiguration.getSecondsUntilAutoPause()).build();
     }
 
-    static software.amazon.rds.dbcluster.ScalingConfiguration translateScalingConfigurationFromSdk(final ScalingConfigurationInfo scalingConfiguration) {
-        if (scalingConfiguration == null) return null;
-        return software.amazon.rds.dbcluster.ScalingConfiguration.builder()
+    static ScalingConfiguration translateScalingConfigurationFromSdk(
+            final software.amazon.awssdk.services.rds.model.ScalingConfigurationInfo scalingConfiguration
+    ) {
+        if (scalingConfiguration == null) {
+            return null;
+        }
+        return ScalingConfiguration.builder()
                 .autoPause(scalingConfiguration.autoPause())
                 .maxCapacity(scalingConfiguration.maxCapacity())
                 .minCapacity(scalingConfiguration.minCapacity())
                 .secondsUntilAutoPause(scalingConfiguration.secondsUntilAutoPause()).build();
+    }
+
+    public static DBClusterRole transformDBCusterRoleFromSdk(
+            final software.amazon.awssdk.services.rds.model.DBClusterRole dbClusterRole
+    ) {
+        return DBClusterRole.builder()
+                .featureName(dbClusterRole.featureName())
+                .roleArn(dbClusterRole.roleArn())
+                .build();
+    }
+
+    public static Map<String, String> translateTagsToRequest(final Collection<Tag> tags) {
+        return Optional.ofNullable(tags).orElse(Collections.emptyList())
+                .stream()
+                .collect(Collectors.toMap(Tag::getKey, Tag::getValue));
+    }
+
+    public static Set<Tag> translateTagsFromRequest(final Map<String, String> tags) {
+        return Optional.ofNullable(tags).orElse(Collections.emptyMap())
+                .entrySet()
+                .stream()
+                .map(entry -> Tag.builder()
+                        .key(entry.getKey())
+                        .value(entry.getValue())
+                        .build())
+                .collect(Collectors.toSet());
+    }
+
+    public static ResourceModel translateDbClusterFromSdk(
+            final software.amazon.awssdk.services.rds.model.DBCluster dbCluster
+    ) {
+        return ResourceModel.builder()
+                .associatedRoles(
+                        Optional.ofNullable(dbCluster.associatedRoles())
+                                .orElse(Collections.emptyList())
+                                .stream()
+                                .map(Translator::transformDBCusterRoleFromSdk)
+                                .collect(Collectors.toList())
+                )
+                .availabilityZones(dbCluster.availabilityZones())
+                .backtrackWindow(Translator.castToInt(dbCluster.backtrackWindow()))
+                .backupRetentionPeriod(dbCluster.backupRetentionPeriod())
+                .copyTagsToSnapshot(dbCluster.copyTagsToSnapshot())
+                .databaseName(dbCluster.databaseName())
+                .dBClusterIdentifier(dbCluster.dbClusterIdentifier())
+                .dBClusterParameterGroupName(dbCluster.dbClusterParameterGroup())
+                .dBSubnetGroupName(dbCluster.dbSubnetGroup())
+                .deletionProtection(dbCluster.deletionProtection())
+                .enableCloudwatchLogsExports(dbCluster.enabledCloudwatchLogsExports())
+                .enableHttpEndpoint(dbCluster.httpEndpointEnabled())
+                .enableIAMDatabaseAuthentication(dbCluster.iamDatabaseAuthenticationEnabled())
+                .endpoint(
+                        Endpoint.builder()
+                                .address(dbCluster.endpoint())
+                                .port(Optional.ofNullable(dbCluster.port()).map(Object::toString).orElse(""))
+                                .build()
+                )
+                .engine(dbCluster.engine())
+                .engineMode(dbCluster.engineMode())
+                .engineVersion(dbCluster.engineVersion())
+                .kmsKeyId(dbCluster.kmsKeyId())
+                .masterUsername(dbCluster.masterUsername())
+                .port(dbCluster.port())
+                .preferredBackupWindow(dbCluster.preferredBackupWindow())
+                .preferredMaintenanceWindow(dbCluster.preferredMaintenanceWindow())
+                .readEndpoint(
+                        ReadEndpoint.builder()
+                                .address(dbCluster.readerEndpoint())
+                                .build()
+                )
+                .replicationSourceIdentifier(dbCluster.replicationSourceIdentifier())
+                .scalingConfiguration(Translator.translateScalingConfigurationFromSdk(dbCluster.scalingConfigurationInfo()))
+                .storageEncrypted(dbCluster.storageEncrypted())
+                .tags(Translator.translateTagsFromSdk(dbCluster.tagList()))
+                .vpcSecurityGroupIds(
+                        Optional.ofNullable(dbCluster.vpcSecurityGroups())
+                                .orElse(Collections.emptyList())
+                                .stream()
+                                .map(VpcSecurityGroupMembership::vpcSecurityGroupId)
+                                .collect(Collectors.toList())
+                )
+                .build();
     }
 }

--- a/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/util/ImmutabilityHelper.java
+++ b/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/util/ImmutabilityHelper.java
@@ -1,0 +1,30 @@
+package software.amazon.rds.dbcluster.util;
+
+import com.amazonaws.util.StringUtils;
+import com.google.common.base.Objects;
+import software.amazon.rds.dbcluster.ResourceModel;
+
+public final class ImmutabilityHelper {
+
+    private static final String AURORA = "aurora";
+    private static final String AURORA_MYSQL = "aurora-mysql";
+
+    private ImmutabilityHelper() {
+    }
+
+    static boolean isGlobalClusterMutable(final ResourceModel previous, final ResourceModel desired) {
+        if (StringUtils.isNullOrEmpty(desired.getGlobalClusterIdentifier())) {
+            return Objects.equal(previous.getGlobalClusterIdentifier(), desired.getGlobalClusterIdentifier());
+        }
+        return desired.getGlobalClusterIdentifier().equals(previous.getGlobalClusterIdentifier());
+    }
+
+    static boolean isEngineMutable(final ResourceModel previous, final ResourceModel desired) {
+        return (AURORA.equals(previous.getEngine()) && AURORA_MYSQL.equals(desired.getEngine())) ||
+                Objects.equal(previous.getEngine(), desired.getEngine());
+    }
+
+    public static boolean isChangeMutable(final ResourceModel previous, final ResourceModel desired) {
+        return isGlobalClusterMutable(previous, desired) && isEngineMutable(previous, desired);
+    }
+}

--- a/aws-rds-dbcluster/src/test/java/software/amazon/rds/dbcluster/DeleteHandlerTest.java
+++ b/aws-rds-dbcluster/src/test/java/software/amazon/rds/dbcluster/DeleteHandlerTest.java
@@ -1,90 +1,217 @@
 package software.amazon.rds.dbcluster;
 
-import org.junit.jupiter.api.AfterEach;
-import software.amazon.awssdk.services.rds.RdsClient;
-import software.amazon.awssdk.services.rds.model.DeleteDbClusterRequest;
-import software.amazon.awssdk.services.rds.model.DeleteDbClusterResponse;
-import software.amazon.awssdk.services.rds.model.DescribeDbClustersRequest;
-import software.amazon.awssdk.services.rds.model.DescribeDbClustersResponse;
-import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
-import software.amazon.cloudformation.proxy.ProxyClient;
-import software.amazon.cloudformation.proxy.ProgressEvent;
-import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
-import software.amazon.cloudformation.proxy.OperationStatus;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
-
-import java.time.Duration;
-import java.util.concurrent.atomic.AtomicInteger;
-
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
-@ExtendWith(MockitoExtension.class)
-public class DeleteHandlerTest extends AbstractTestBase {
+import java.time.Duration;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
 
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import lombok.Getter;
+import software.amazon.awssdk.services.rds.RdsClient;
+import software.amazon.awssdk.services.rds.model.DBCluster;
+import software.amazon.awssdk.services.rds.model.DbClusterNotFoundException;
+import software.amazon.awssdk.services.rds.model.DeleteDbClusterRequest;
+import software.amazon.awssdk.services.rds.model.DeleteDbClusterResponse;
+import software.amazon.awssdk.services.rds.model.RemoveFromGlobalClusterRequest;
+import software.amazon.awssdk.services.rds.model.RemoveFromGlobalClusterResponse;
+import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
+import software.amazon.cloudformation.proxy.HandlerErrorCode;
+import software.amazon.cloudformation.proxy.ProxyClient;
+import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
+import software.amazon.cloudformation.proxy.delay.Constant;
+import software.amazon.rds.common.handler.HandlerConfig;
+
+@ExtendWith(MockitoExtension.class)
+public class DeleteHandlerTest extends AbstractHandlerTest {
+
+    private static final String MSG_NOT_FOUND = "not found";
 
     @Mock
+    @Getter
     private AmazonWebServicesClientProxy proxy;
 
     @Mock
-    private ProxyClient<RdsClient> proxyRdsClient;
+    @Getter
+    private ProxyClient<RdsClient> rdsProxy;
 
     @Mock
-    RdsClient rds;
+    @Getter
+    RdsClient rdsClient;
 
+    @Getter
     private DeleteHandler handler;
 
-    @AfterEach
-    public void post_execute() {
-        verify(rds, atLeastOnce()).serviceName();
-        verifyNoMoreInteractions(rds);
-    }
+    private boolean expectServiceInvocation;
 
     @BeforeEach
     public void setup() {
-        handler = new DeleteHandler();
-        rds = mock(RdsClient.class);
+        handler = new DeleteHandler(
+                HandlerConfig.builder()
+                        .probingEnabled(false)
+                        .backoff(Constant.of()
+                                .delay(Duration.ofSeconds(1))
+                                .timeout(Duration.ofSeconds(120))
+                                .build())
+                        .build()
+        );
+        rdsClient = mock(RdsClient.class);
         proxy = new AmazonWebServicesClientProxy(logger, MOCK_CREDENTIALS, () -> Duration.ofSeconds(600).toMillis());
-        proxyRdsClient = MOCK_PROXY(proxy, rds);
+        rdsProxy = MOCK_PROXY(proxy, rdsClient);
+        expectServiceInvocation = true;
+    }
+
+    @AfterEach
+    public void tear_down() {
+        if (expectServiceInvocation) {
+            verify(rdsClient, atLeastOnce()).serviceName();
+        }
+        verifyNoMoreInteractions(rdsClient);
     }
 
     @Test
     public void handleRequest_SimpleSuccess() {
-        final DeleteDbClusterResponse deleteDbClusterRequest = DeleteDbClusterResponse.builder().build();
-        when(proxyRdsClient.client().deleteDBCluster(any(DeleteDbClusterRequest.class))).thenReturn(deleteDbClusterRequest);
-        final DescribeDbClustersResponse describeInProgressDbClustersResponse = DescribeDbClustersResponse.builder().dbClusters(DBCLUSTER_ACTIVE).build();
-        final DescribeDbClustersResponse describeDeletedDbClustersResponse = DescribeDbClustersResponse.builder().dbClusters(DBCLUSTER_DELETED).build();
-        AtomicInteger attempt = new AtomicInteger(2);
-        when(proxyRdsClient.client().describeDBClusters(any(DescribeDbClustersRequest.class))).then((m) -> {
-            switch (attempt.getAndDecrement()) {
-                case 2:
-                    return describeInProgressDbClustersResponse;
-                default:
-                    return describeDeletedDbClustersResponse;
-            }
-        });
-        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder().desiredResourceState(RESOURCE_MODEL).logicalResourceIdentifier("dbcluster").clientRequestToken("request").build();
-        final ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyRdsClient, logger);
+        when(rdsProxy.client().deleteDBCluster(any(DeleteDbClusterRequest.class)))
+                .thenReturn(DeleteDbClusterResponse.builder().build());
 
-        assertThat(response).isNotNull();
-        assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
-        assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
-        assertThat(response.getResourceModel()).isEqualTo(request.getDesiredResourceState());
-        assertThat(response.getResourceModels()).isNull();
-        assertThat(response.getMessage()).isNull();
-        assertThat(response.getErrorCode()).isNull();
+        final Queue<DBCluster> transitions = new ConcurrentLinkedQueue<>();
+        transitions.add(DBCLUSTER_ACTIVE);
 
-        verify(proxyRdsClient.client()).deleteDBCluster(any(DeleteDbClusterRequest.class));
-        verify(proxyRdsClient.client(), times(2)).describeDBClusters(any(DescribeDbClustersRequest.class));
+        test_handleRequest_base(
+                new CallbackContext(),
+                () -> {
+                    if (transitions.size() > 0) {
+                        return transitions.remove();
+                    }
+                    throw DbClusterNotFoundException.builder().message(MSG_NOT_FOUND).build();
+                },
+                () -> RESOURCE_MODEL,
+                expectSuccess()
+        );
+
+        verify(rdsProxy.client(), times(1)).deleteDBCluster(any(DeleteDbClusterRequest.class));
+    }
+
+    @Test
+    public void handleRequest_isDeletionProtectionEnabled() {
+        expectServiceInvocation = false;
+        test_handleRequest_base(
+                new CallbackContext(),
+                () -> DBCLUSTER_ACTIVE_DELETION_ENABLED,
+                () -> RESOURCE_MODEL,
+                expectFailed(HandlerErrorCode.NotUpdatable)
+        );
+    }
+
+    @Test
+    public void handleRequest_isDeletionProtectionEnabled_failure() {
+        expectServiceInvocation = false;
+        test_handleRequest_base(
+                new CallbackContext(),
+                () -> {
+                    throw DbClusterNotFoundException.builder().message(MSG_NOT_FOUND).build();
+                },
+                () -> RESOURCE_MODEL,
+                expectFailed(HandlerErrorCode.NotFound)
+        );
+    }
+
+    @Test
+    public void handleRequest_finalSnapshotIdentifierIsSet() {
+        when(rdsProxy.client().deleteDBCluster(any(DeleteDbClusterRequest.class)))
+                .thenReturn(DeleteDbClusterResponse.builder().build());
+
+        final Queue<DBCluster> transitions = new ConcurrentLinkedQueue<>();
+        transitions.add(DBCLUSTER_ACTIVE);
+
+        final String snapshotIdentifier = "test-snapshot-identifier";
+
+        test_handleRequest_base(
+                new CallbackContext(),
+                () -> {
+                    if (transitions.size() > 0) {
+                        return transitions.remove();
+                    }
+                    throw DbClusterNotFoundException.builder().message(MSG_NOT_FOUND).build();
+                },
+                () -> RESOURCE_MODEL.toBuilder()
+                        .snapshotIdentifier(snapshotIdentifier)
+                        .build(),
+                expectSuccess()
+        );
+
+        ArgumentCaptor<DeleteDbClusterRequest> argument = ArgumentCaptor.forClass(DeleteDbClusterRequest.class);
+        verify(rdsProxy.client(), times(1)).deleteDBCluster(argument.capture());
+        Assertions.assertEquals(argument.getValue().finalDBSnapshotIdentifier(), snapshotIdentifier);
+    }
+
+    @Test
+    public void handleRequest_NoSnapshotRequested() {
+        when(rdsProxy.client().deleteDBCluster(any(DeleteDbClusterRequest.class)))
+                .thenReturn(DeleteDbClusterResponse.builder().build());
+
+        final Queue<DBCluster> transitions = new ConcurrentLinkedQueue<>();
+        transitions.add(DBCLUSTER_ACTIVE);
+
+        test_handleRequest_base(
+                new CallbackContext(),
+                ResourceHandlerRequest.<ResourceModel>builder()
+                        .snapshotRequested(false),
+                () -> {
+                    if (transitions.size() > 0) {
+                        return transitions.remove();
+                    }
+                    throw DbClusterNotFoundException.builder().message(MSG_NOT_FOUND).build();
+                },
+                () -> RESOURCE_MODEL,
+                () -> RESOURCE_MODEL,
+                expectSuccess()
+        );
+
+        ArgumentCaptor<DeleteDbClusterRequest> argument = ArgumentCaptor.forClass(DeleteDbClusterRequest.class);
+        verify(rdsProxy.client(), times(1)).deleteDBCluster(argument.capture());
+        Assertions.assertNull(argument.getValue().finalDBSnapshotIdentifier());
+    }
+
+    @Test
+    public void handleRequest_globalClusterIdentifier_beforeDelete() {
+        when(rdsProxy.client().removeFromGlobalCluster(any(RemoveFromGlobalClusterRequest.class)))
+                .thenReturn(RemoveFromGlobalClusterResponse.builder().globalCluster(GLOBAL_CLUSTER).build());
+        when(rdsProxy.client().deleteDBCluster(any(DeleteDbClusterRequest.class)))
+                .thenReturn(DeleteDbClusterResponse.builder().build());
+        Queue<DBCluster> transitions = new ConcurrentLinkedQueue<>();
+        transitions.add(DBCLUSTER_INPROGRESS);
+        transitions.add(DBCLUSTER_ACTIVE);
+
+        test_handleRequest_base(
+                new CallbackContext(),
+                ResourceHandlerRequest.<ResourceModel>builder().snapshotRequested(true),
+                () -> {
+                    if (transitions.size() > 0) {
+                        return transitions.remove();
+                    }
+                    throw DbClusterNotFoundException.builder().message(MSG_NOT_FOUND).build();
+                },
+                () -> RESOURCE_MODEL_WITH_GLOBAL_CLUSTER,
+                () -> RESOURCE_MODEL_WITH_GLOBAL_CLUSTER,
+                expectSuccess()
+        );
+
+        verify(rdsProxy.client(), times(1)).removeFromGlobalCluster(any(RemoveFromGlobalClusterRequest.class));
+        verify(rdsProxy.client(), times(1)).deleteDBCluster(any(DeleteDbClusterRequest.class));
     }
 }

--- a/aws-rds-dbcluster/src/test/java/software/amazon/rds/dbcluster/ListHandlerTest.java
+++ b/aws-rds-dbcluster/src/test/java/software/amazon/rds/dbcluster/ListHandlerTest.java
@@ -1,88 +1,89 @@
 package software.amazon.rds.dbcluster;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
 import java.time.Duration;
-import java.util.Collections;
+
 import org.junit.jupiter.api.AfterEach;
-import software.amazon.awssdk.services.rds.RdsClient;
-import software.amazon.awssdk.services.rds.model.DBCluster;
-import software.amazon.awssdk.services.rds.model.DescribeDbClustersRequest;
-import software.amazon.awssdk.services.rds.model.DescribeDbClustersResponse;
-import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
-import software.amazon.cloudformation.proxy.OperationStatus;
-import software.amazon.cloudformation.proxy.ProgressEvent;
-import software.amazon.cloudformation.proxy.ProxyClient;
-import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.when;
+import lombok.Getter;
+import software.amazon.awssdk.services.rds.RdsClient;
+import software.amazon.awssdk.services.rds.model.DescribeDbClustersRequest;
+import software.amazon.awssdk.services.rds.model.DescribeDbClustersResponse;
+import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
+import software.amazon.cloudformation.proxy.ProgressEvent;
+import software.amazon.cloudformation.proxy.ProxyClient;
 
 @ExtendWith(MockitoExtension.class)
-public class ListHandlerTest extends AbstractTestBase{
+public class ListHandlerTest extends AbstractHandlerTest {
 
     @Mock
+    @Getter
     private AmazonWebServicesClientProxy proxy;
 
     @Mock
-    private ProxyClient<RdsClient> proxyRdsClient;
+    @Getter
+    private ProxyClient<RdsClient> rdsProxy;
 
     @Mock
-    RdsClient rds;
+    RdsClient rdsClient;
 
+    @Getter
     private ListHandler handler;
 
-    @AfterEach
-    public void post_execute() {
-        verifyNoMoreInteractions(rds);
-    }
+    private boolean expectServiceInvocation;
 
     @BeforeEach
     public void setup() {
         handler = new ListHandler();
-        rds = mock(RdsClient.class);
+        rdsClient = mock(RdsClient.class);
         proxy = new AmazonWebServicesClientProxy(logger, MOCK_CREDENTIALS, () -> Duration.ofSeconds(600).toMillis());
-        proxyRdsClient = MOCK_PROXY(proxy, rds);
+        rdsProxy = MOCK_PROXY(proxy, rdsClient);
+        expectServiceInvocation = true;
+    }
+
+    @AfterEach
+    public void tear_down() {
+        if (expectServiceInvocation) {
+            verify(rdsClient, atLeastOnce()).serviceName();
+        }
+        verifyNoMoreInteractions(rdsClient);
     }
 
     @Test
     public void handleRequest_SimpleSuccess() {
-        final DescribeDbClustersResponse describeDbClustersResponse = DescribeDbClustersResponse.builder()
-            .dbClusters(Collections.singletonList(DBCluster.builder().dbClusterIdentifier("sampleId").build()))
-            .marker("marker2")
-            .build();
+        when(rdsProxy.client().describeDBClusters(any(DescribeDbClustersRequest.class)))
+                .thenReturn(DescribeDbClustersResponse.builder()
+                        .dbClusters(DBCLUSTER_ACTIVE)
+                        .marker("marker2")
+                        .build());
 
-        when(proxyRdsClient.client().describeDBClusters(any(DescribeDbClustersRequest.class))).thenReturn(describeDbClustersResponse);
+        expectServiceInvocation = false;
 
-        final ResourceModel model = ResourceModel.builder().build();
+        final ProgressEvent<ResourceModel, CallbackContext> response = test_handleRequest_base(
+                new CallbackContext(),
+                null,
+                () -> RESOURCE_MODEL,
+                expectSuccess()
+        );
 
-        final ResourceModel expectedModel = ResourceModel.builder().dBClusterIdentifier("sampleId").build();
-
-        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
-            .desiredResourceState(model)
-            .build();
-
-        final ProgressEvent<ResourceModel, CallbackContext> response =
-            handler.handleRequest(proxy, request, new CallbackContext(), proxyRdsClient, logger);
-
-        assertThat(response).isNotNull();
-        assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
-        assertThat(response.getCallbackContext()).isNull();
-        assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
         assertThat(response.getResourceModel()).isNull();
         assertThat(response.getResourceModels()).isNotNull();
-        assertThat(response.getResourceModels()).containsExactly(expectedModel);
-        assertThat(response.getMessage()).isNull();
-        assertThat(response.getErrorCode()).isNull();
+        assertThat(response.getResourceModels()).containsExactly(Translator.translateDbClusterFromSdk(DBCLUSTER_ACTIVE));
         assertThat(response.getNextToken()).isEqualTo("marker2");
 
-        verify(proxyRdsClient.client()).describeDBClusters(any(DescribeDbClustersRequest.class));
+        verify(rdsProxy.client(), times(1)).describeDBClusters(any(DescribeDbClustersRequest.class));
     }
 }

--- a/aws-rds-dbcluster/src/test/java/software/amazon/rds/dbcluster/ReadHandlerTest.java
+++ b/aws-rds-dbcluster/src/test/java/software/amazon/rds/dbcluster/ReadHandlerTest.java
@@ -1,80 +1,67 @@
 package software.amazon.rds.dbcluster;
 
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import java.time.Duration;
+
 import org.junit.jupiter.api.AfterEach;
-import software.amazon.awssdk.services.rds.RdsClient;
-import software.amazon.awssdk.services.rds.model.DescribeDbClustersRequest;
-import software.amazon.awssdk.services.rds.model.DescribeDbClustersResponse;
-import software.amazon.awssdk.services.rds.model.ListTagsForResourceRequest;
-import software.amazon.awssdk.services.rds.model.ListTagsForResourceResponse;
-import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
-import software.amazon.cloudformation.proxy.ProxyClient;
-import software.amazon.cloudformation.proxy.ProgressEvent;
-import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
-import software.amazon.cloudformation.proxy.OperationStatus;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.time.Duration;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.atLeastOnce;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import lombok.Getter;
+import software.amazon.awssdk.services.rds.RdsClient;
+import software.amazon.awssdk.services.rds.model.DescribeDbClustersRequest;
+import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
+import software.amazon.cloudformation.proxy.ProxyClient;
 
 @ExtendWith(MockitoExtension.class)
-public class ReadHandlerTest extends AbstractTestBase {
+public class ReadHandlerTest extends AbstractHandlerTest {
 
     @Mock
+    @Getter
     private AmazonWebServicesClientProxy proxy;
 
     @Mock
-    private ProxyClient<RdsClient> proxyRdsClient;
+    @Getter
+    private ProxyClient<RdsClient> rdsProxy;
 
     @Mock
-    RdsClient rds;
+    RdsClient rdsClient;
 
+    @Getter
     private ReadHandler handler;
-
-    @AfterEach
-    public void post_execute() {
-        verify(rds, atLeastOnce()).serviceName();
-        verifyNoMoreInteractions(rds);
-    }
 
     @BeforeEach
     public void setup() {
         handler = new ReadHandler();
-        rds = mock(RdsClient.class);
+        rdsClient = mock(RdsClient.class);
         proxy = new AmazonWebServicesClientProxy(logger, MOCK_CREDENTIALS, () -> Duration.ofSeconds(600).toMillis());
-        proxyRdsClient = MOCK_PROXY(proxy, rds);
+        rdsProxy = MOCK_PROXY(proxy, rdsClient);
+    }
+
+    @AfterEach
+    public void tear_down() {
+        verify(rdsClient, atLeastOnce()).serviceName();
+        verifyNoMoreInteractions(rdsClient);
     }
 
     @Test
-    public void handleRequest_SimpleSuccess() {
+    public void handleRequest_ReadSuccess() {
+        test_handleRequest_base(
+                new CallbackContext(),
+                () -> DBCLUSTER_ACTIVE,
+                () -> RESOURCE_MODEL,
+                expectSuccess()
+        );
 
-        final DescribeDbClustersResponse describeActiveDbClustersResponse = DescribeDbClustersResponse.builder().dbClusters(DBCLUSTER_ACTIVE).build();
-        when(proxyRdsClient.client().describeDBClusters(any(DescribeDbClustersRequest.class))).thenReturn(describeActiveDbClustersResponse);
-        final ListTagsForResourceResponse listTagsForResourceResponse = ListTagsForResourceResponse.builder().build();
-        when(proxyRdsClient.client().listTagsForResource(any(ListTagsForResourceRequest.class))).thenReturn(listTagsForResourceResponse);
-
-        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder().desiredResourceState(RESOURCE_MODEL).build();
-        final ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyRdsClient, logger);
-
-        assertThat(response).isNotNull();
-        assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
-        assertThat(response.getCallbackContext()).isNull();
-        assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
-        assertThat(response.getResourceModels()).isNull();
-        assertThat(response.getMessage()).isNull();
-        assertThat(response.getErrorCode()).isNull();
-
-        verify(rds).describeDBClusters(any(DescribeDbClustersRequest.class));
-        verify(rds).listTagsForResource(any(ListTagsForResourceRequest.class));
+        verify(rdsProxy.client(), times(1)).describeDBClusters(any(DescribeDbClustersRequest.class));
     }
 }

--- a/aws-rds-dbcluster/src/test/java/software/amazon/rds/dbcluster/util/ImmutabilityHelperTest.java
+++ b/aws-rds-dbcluster/src/test/java/software/amazon/rds/dbcluster/util/ImmutabilityHelperTest.java
@@ -1,0 +1,93 @@
+package software.amazon.rds.dbcluster.util;
+
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import lombok.Builder;
+import software.amazon.rds.dbcluster.ResourceModel;
+
+class ImmutabilityHelperTest {
+
+    @Builder
+    private static class ResourceModelTestCase {
+        public ResourceModel previous;
+        public ResourceModel desired;
+        public boolean expect;
+    }
+
+    @Test
+    public void test_isGlobalClusterMutable() {
+        final List<ResourceModelTestCase> tests = Arrays.asList(
+                ResourceModelTestCase.builder()
+                        .previous(ResourceModel.builder().globalClusterIdentifier(null).build())
+                        .desired(ResourceModel.builder().globalClusterIdentifier(null).build())
+                        .expect(true)
+                        .build(),
+                ResourceModelTestCase.builder()
+                        .previous(ResourceModel.builder().globalClusterIdentifier(null).build())
+                        .desired(ResourceModel.builder().globalClusterIdentifier("global-cluster-identifier").build())
+                        .expect(false)
+                        .build(),
+                ResourceModelTestCase.builder()
+                        .previous(ResourceModel.builder().globalClusterIdentifier("global-cluster-identifier").build())
+                        .desired(ResourceModel.builder().globalClusterIdentifier(null).build())
+                        .expect(false)
+                        .build(),
+                ResourceModelTestCase.builder()
+                        .previous(ResourceModel.builder().globalClusterIdentifier("global-cluster-identifier").build())
+                        .desired(ResourceModel.builder().globalClusterIdentifier("global-cluster-identifier").build())
+                        .expect(true)
+                        .build()
+        );
+
+        for (final ResourceModelTestCase test : tests) {
+            assertThat(ImmutabilityHelper.isGlobalClusterMutable(test.previous, test.desired)).isEqualTo(test.expect);
+        }
+    }
+
+    @Test
+    public void test_isEngineMutable() {
+        final List<ResourceModelTestCase> tests = Arrays.asList(
+                ResourceModelTestCase.builder()
+                        .previous(ResourceModel.builder().engine(null).build())
+                        .desired(ResourceModel.builder().engine(null).build())
+                        .expect(true)
+                        .build(),
+                ResourceModelTestCase.builder()
+                        .previous(ResourceModel.builder().engine("mysql").build())
+                        .desired(ResourceModel.builder().engine("mysql").build())
+                        .expect(true)
+                        .build(),
+                ResourceModelTestCase.builder()
+                        .previous(ResourceModel.builder().engine("mysql").build())
+                        .desired(ResourceModel.builder().engine("postgres").build())
+                        .expect(false)
+                        .build(),
+                ResourceModelTestCase.builder()
+                        .previous(ResourceModel.builder().engine("aurora").build())
+                        .desired(ResourceModel.builder().engine("aurora-mysql").build())
+                        .expect(true)
+                        .build(),
+                ResourceModelTestCase.builder()
+                        .previous(ResourceModel.builder().engine("aurora").build())
+                        .desired(ResourceModel.builder().engine("aurora").build())
+                        .expect(true)
+                        .build(),
+                ResourceModelTestCase.builder()
+                        .previous(ResourceModel.builder().engine("aurora").build())
+                        .desired(ResourceModel.builder().engine("postgres").build())
+                        .expect(false)
+                        .build()
+        );
+
+        for (final ResourceModelTestCase test : tests) {
+            assertThat(ImmutabilityHelper.isEngineMutable(test.previous, test.desired)).isEqualTo(test.expect);
+        }
+    }
+
+}

--- a/aws-rds-dbcluster/template.yml
+++ b/aws-rds-dbcluster/template.yml
@@ -5,6 +5,7 @@ Description: AWS SAM template for the AWS::RDS::DBCluster resource type
 Globals:
   Function:
     Timeout: 60  # docker start-up times can be long for SAM CLI
+    MemorySize: 1024
 
 Resources:
   TypeFunction:

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/BaseHandlerStd.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/BaseHandlerStd.java
@@ -59,8 +59,6 @@ import software.amazon.rds.common.error.ErrorRuleSet;
 import software.amazon.rds.common.error.ErrorStatus;
 import software.amazon.rds.common.handler.Commons;
 import software.amazon.rds.common.handler.HandlerConfig;
-import software.amazon.rds.dbinstance.util.ProgressEventLambda;
-import software.amazon.rds.dbinstance.util.VoidBiFunction;
 
 public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
 
@@ -547,21 +545,6 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
             }
         }
         return result;
-    }
-
-    protected ProgressEvent<ResourceModel, CallbackContext> execOnce(
-            final ProgressEvent<ResourceModel, CallbackContext> progress,
-            final ProgressEventLambda func,
-            final Function<CallbackContext, Boolean> conditionGetter,
-            final VoidBiFunction<CallbackContext, Boolean> conditionSetter
-    ) {
-        if (!conditionGetter.apply(progress.getCallbackContext())) {
-            return func.enact().then(p -> {
-                conditionSetter.apply(p.getCallbackContext(), true);
-                return p;
-            });
-        }
-        return progress;
     }
 
     public String generateResourceIdentifier(

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/CreateHandler.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/CreateHandler.java
@@ -64,7 +64,7 @@ public class CreateHandler extends BaseHandlerStd {
         model.setTags(Translator.translateTagsFromRequest(tags));
 
         return ProgressEvent.progress(model, callbackContext)
-                .then(progress -> execOnce(progress, () -> {
+                .then(progress -> Commons.execOnce(progress, () -> {
                     if (isReadReplica(progress.getResourceModel())) {
                         return createDbInstanceReadReplica(proxy, rdsProxyClient, progress);
                     } else if (isRestoreFromSnapshot(progress.getResourceModel())) {
@@ -75,10 +75,10 @@ public class CreateHandler extends BaseHandlerStd {
                 .then(progress -> ensureEngineSet(rdsProxyClient, progress))
                 .then(progress -> {
                     if (shouldUpdateAfterCreate(progress.getResourceModel())) {
-                        return execOnce(progress, () ->
+                        return Commons.execOnce(progress, () ->
                                         updateDbInstanceAfterCreate(proxy, rdsProxyClient, progress, request.getDesiredResourceState()),
                                 CallbackContext::isUpdated, CallbackContext::setUpdated)
-                                .then(p -> execOnce(p, () -> {
+                                .then(p -> Commons.execOnce(p, () -> {
                                     if (shouldReboot(p.getResourceModel())) {
                                         return rebootAwait(proxy, rdsProxyClient, p);
                                     }
@@ -87,7 +87,7 @@ public class CreateHandler extends BaseHandlerStd {
                     }
                     return progress;
                 })
-                .then(progress -> execOnce(progress, () ->
+                .then(progress -> Commons.execOnce(progress, () ->
                                 updateAssociatedRoles(proxy, rdsProxyClient, progress, Collections.emptyList(), desiredRoles),
                         CallbackContext::isUpdatedRoles, CallbackContext::setUpdatedRoles))
                 .then(progress -> new ReadHandler().handleRequest(proxy, request, progress.getCallbackContext(), rdsProxyClient, ec2ProxyClient, logger));

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/util/ProgressEventLambda.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/util/ProgressEventLambda.java
@@ -1,9 +1,0 @@
-package software.amazon.rds.dbinstance.util;
-
-import software.amazon.cloudformation.proxy.ProgressEvent;
-import software.amazon.rds.dbinstance.CallbackContext;
-import software.amazon.rds.dbinstance.ResourceModel;
-
-public interface ProgressEventLambda {
-    ProgressEvent<ResourceModel, CallbackContext> enact();
-}


### PR DESCRIPTION
This commit contains a deep refactoring of AWS::RDS::DBCluster handler
resource.

The changes are progressively building on top of
https://github.com/aws-cloudformation/aws-cloudformation-resource-providers-rds/pull/81

The refactoring is touching all action handlers and unit tests. The
package imports aws-rds-cfn-common and uses it broadly in the test suite
and error handling.

ListTagsForResource was dropped from both: permission list and factual
use in the handlers. This implementation relies on
DescribeDBClustersResult containing the tag list.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Signed-off-by: Oleg Sidorov <sidorovo@amazon.com>