### PR TITLE
Fix missing copyTagsToSnapshot on DBInstance create

### DIFF
--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/Translator.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/Translator.java
@@ -136,6 +136,7 @@ public class Translator {
                 .availabilityZone(model.getAvailabilityZone())
                 .backupRetentionPeriod(model.getBackupRetentionPeriod())
                 .characterSetName(model.getCharacterSetName())
+                .copyTagsToSnapshot(model.getCopyTagsToSnapshot())
                 .dbClusterIdentifier(model.getDBClusterIdentifier())
                 .dbInstanceClass(model.getDBInstanceClass())
                 .dbInstanceIdentifier(model.getDBInstanceIdentifier())


### PR DESCRIPTION
This commit adds a missing attribute `copyTagsToSnapshot` to CreateDBInstance
request.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Signed-off-by: Oleg Sidorov <sidorovo@amazon.com>