### PR TITLE
Add missing iam:PassRole to DBInstance create and update

### DIFF
--- a/aws-rds-dbinstance/aws-rds-dbinstance.json
+++ b/aws-rds-dbinstance/aws-rds-dbinstance.json
@@ -435,6 +435,7 @@
   "handlers": {
     "create": {
       "permissions": [
+        "iam:PassRole",
         "rds:AddRoleToDBInstance",
         "rds:CreateDBInstance",
         "rds:CreateDbInstanceReadReplica",
@@ -452,6 +453,7 @@
     },
     "update": {
       "permissions": [
+        "iam:PassRole",
         "rds:AddRoleToDBInstance",
         "rds:AddTagsToResource",
         "rds:DescribeDbEngineVersions",

--- a/aws-rds-dbinstance/resource-role.yaml
+++ b/aws-rds-dbinstance/resource-role.yaml
@@ -24,6 +24,7 @@ Resources:
               - Effect: Allow
                 Action:
                 - "ec2:DescribeSecurityGroups"
+                - "iam:PassRole"
                 - "rds:AddRoleToDBInstance"
                 - "rds:AddTagsToResource"
                 - "rds:CreateDBInstance"


### PR DESCRIPTION
This commit adds a missing IAM permission to AWS::RDS::DBInstance that
is required to add associated roles to the instances.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Signed-off-by: Oleg Sidorov <sidorovo@amazon.com>