### PR TITLE
Fix regression in DBInstance introduced by immutability checks

### DIFF
--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/UpdateHandler.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/UpdateHandler.java
@@ -51,7 +51,7 @@ public class UpdateHandler extends BaseHandlerStd {
             final ProxyClient<Ec2Client> ec2ProxyClient,
             final Logger logger
     ) {
-        if (ImmutabilityHelper.isChangeImmutable(request.getPreviousResourceState(), request.getDesiredResourceState())) {
+        if (!ImmutabilityHelper.isChangeMutable(request.getPreviousResourceState(), request.getDesiredResourceState())) {
             return ProgressEvent.failed(
                     request.getDesiredResourceState(),
                     callbackContext,

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/util/ImmutabilityHelper.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/util/ImmutabilityHelper.java
@@ -3,8 +3,6 @@ package software.amazon.rds.dbinstance.util;
 import java.util.Arrays;
 import java.util.List;
 
-import org.apache.commons.lang3.builder.EqualsBuilder;
-
 import com.google.common.base.Objects;
 import software.amazon.rds.dbinstance.ResourceModel;
 
@@ -35,31 +33,18 @@ public final class ImmutabilityHelper {
                 desired.getEngine().equals(AURORA_MYSQL);
     }
 
-    static boolean isAZMutable(final ResourceModel previous, final ResourceModel desired) {
-        return Objects.equal(desired.getAvailabilityZone(), previous.getAvailabilityZone()) ||
-                desired.getAvailabilityZone() == null &&
-                        Boolean.TRUE.equals(desired.getMultiAZ());
-    }
-
-    static boolean isPerformanceInsightsMutable(final ResourceModel previous, final ResourceModel desired) {
-        return previous.getEnablePerformanceInsights() == null ||
-                !previous.getEnablePerformanceInsights() ||
-                !desired.getEnablePerformanceInsights() ||
-                Objects.equal(previous.getPerformanceInsightsKMSKeyId(), desired.getPerformanceInsightsKMSKeyId());
-    }
-
-    public static boolean isChangeImmutable(
-            final ResourceModel previous,
-            final ResourceModel desired
-    ) {
-        final boolean isEngineMutable = Objects.equal(previous.getEngine(), desired.getEngine()) ||
+    static boolean isEngineMutable(final ResourceModel previous, final ResourceModel desired) {
+        return Objects.equal(previous.getEngine(), desired.getEngine()) ||
                 isUpgradeToAuroraMySQL(previous, desired) ||
                 isUpgradeToOracleSE2(previous, desired);
-        final boolean isPerformanceInsightsKMSKeyIdMutable = isPerformanceInsightsMutable(previous, desired);
-        final boolean isAZMutable = isAZMutable(previous, desired);
+    }
 
-        final boolean isMutable = isAZMutable && isEngineMutable && isPerformanceInsightsKMSKeyIdMutable;
+    static boolean isPerformanceInsightsKMSKeyIdMutable(final ResourceModel previous, final ResourceModel desired) {
+        return Objects.equal(previous.getPerformanceInsightsKMSKeyId(), desired.getPerformanceInsightsKMSKeyId());
+    }
 
-        return !isMutable;
+    public static boolean isChangeMutable(final ResourceModel previous, final ResourceModel desired) {
+        return isEngineMutable(previous, desired) &&
+                isPerformanceInsightsKMSKeyIdMutable(previous, desired);
     }
 }

--- a/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/util/ImmutabilityHelperTest.java
+++ b/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/util/ImmutabilityHelperTest.java
@@ -69,7 +69,7 @@ class ImmutabilityHelperTest {
     }
 
     @Test
-    public void test_isAZMutable() {
+    public void test_isPerformanceInsightsKMSKeyIdMutable() {
         final List<ResourceModelTestCase> tests = Arrays.asList(
                 ResourceModelTestCase.builder()
                         .previous(ResourceModel.builder().build())
@@ -77,86 +77,52 @@ class ImmutabilityHelperTest {
                         .expect(true)
                         .build(),
                 ResourceModelTestCase.builder()
-                        .previous(ResourceModel.builder().availabilityZone("multi-az").build())
-                        .desired(ResourceModel.builder().availabilityZone("multi-az").build())
-                        .expect(true)
-                        .build(),
-                ResourceModelTestCase.builder()
-                        .previous(ResourceModel.builder().availabilityZone("foo").build())
-                        .desired(ResourceModel.builder().multiAZ(true).build())
-                        .expect(true)
-                        .build(),
-                ResourceModelTestCase.builder()
-                        .previous(ResourceModel.builder().availabilityZone("foo").build())
-                        .desired(ResourceModel.builder().multiAZ(false).build())
+                        .previous(ResourceModel.builder().performanceInsightsKMSKeyId("key-1").build())
+                        .desired(ResourceModel.builder().build())
                         .expect(false)
                         .build(),
                 ResourceModelTestCase.builder()
-                        .previous(ResourceModel.builder().build())
-                        .desired(ResourceModel.builder().multiAZ(true).availabilityZone("multi-az").build())
+                        .previous(ResourceModel.builder().performanceInsightsKMSKeyId("key-1").build())
+                        .desired(ResourceModel.builder().performanceInsightsKMSKeyId("key-2").build())
                         .expect(false)
-                        .build()
-        );
-        for (final ResourceModelTestCase test : tests) {
-            assertThat(ImmutabilityHelper.isAZMutable(test.previous, test.desired)).isEqualTo(test.expect);
-        }
-    }
-
-    @Test
-    public void test_isPerformanceInsightsMutable() {
-        final List<ResourceModelTestCase> tests = Arrays.asList(
-                ResourceModelTestCase.builder()
-                        .previous(ResourceModel.builder().build())
-                        .desired(ResourceModel.builder().build())
-                        .expect(true)
                         .build(),
                 ResourceModelTestCase.builder()
-                        .previous(ResourceModel.builder().enablePerformanceInsights(false).build())
-                        .desired(ResourceModel.builder().build())
-                        .expect(true)
-                        .build(),
-                ResourceModelTestCase.builder()
-                        .previous(ResourceModel.builder().enablePerformanceInsights(true).build())
-                        .desired(ResourceModel.builder().enablePerformanceInsights(false).build())
-                        .expect(true)
-                        .build(),
-                ResourceModelTestCase.builder()
-                        .previous(ResourceModel.builder().enablePerformanceInsights(true).build())
-                        .desired(ResourceModel.builder().enablePerformanceInsights(true).build())
+                        .previous(ResourceModel.builder().performanceInsightsKMSKeyId("key-1").build())
+                        .desired(ResourceModel.builder().performanceInsightsKMSKeyId("key-1").build())
                         .expect(true)
                         .build()
         );
         for (final ResourceModelTestCase test : tests) {
-            assertThat(ImmutabilityHelper.isPerformanceInsightsMutable(test.previous, test.desired)).isEqualTo(test.expect);
+            assertThat(ImmutabilityHelper.isPerformanceInsightsKMSKeyIdMutable(test.previous, test.desired)).isEqualTo(test.expect);
         }
     }
 
     @Test
-    public void test_isChangeImmutable() {
+    public void test_isEngineMutable() {
         final List<ResourceModelTestCase> tests = Arrays.asList(
                 ResourceModelTestCase.builder()
                         .previous(ResourceModel.builder().engine("mysql").build())
                         .desired(ResourceModel.builder().engine("mysql").build())
-                        .expect(false)
+                        .expect(true)
                         .build(),
                 ResourceModelTestCase.builder()
                         .previous(ResourceModel.builder().engine("aurora").build())
                         .desired(ResourceModel.builder().engine("aurora-mysql").build())
-                        .expect(false)
+                        .expect(true)
                         .build(),
                 ResourceModelTestCase.builder()
                         .previous(ResourceModel.builder().engine("aurora").build())
                         .desired(ResourceModel.builder().engine("aurora-postgres").build())
-                        .expect(true)
+                        .expect(false)
                         .build(),
                 ResourceModelTestCase.builder()
                         .previous(ResourceModel.builder().engine("oracle-se").build())
                         .desired(ResourceModel.builder().engine("oracle-se2").build())
-                        .expect(false)
+                        .expect(true)
                         .build()
         );
         for (final ResourceModelTestCase test : tests) {
-            assertThat(ImmutabilityHelper.isChangeImmutable(test.previous, test.desired)).isEqualTo(test.expect);
+            assertThat(ImmutabilityHelper.isChangeMutable(test.previous, test.desired)).isEqualTo(test.expect);
         }
     }
 }


### PR DESCRIPTION
This commit addresses a regression introduced by
https://github.com/aws-cloudformation/aws-cloudformation-resource-providers-rds/pull/83

The regression is impacting contract test suite, forcing an early
error-status exit on some test cases.

RDS API handles AZ modifications fine, given AvailabilityZone is a
create-only parameter and MultiAZ is defined as conditionally immutable.
From this perspective there is no need to handle it here.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Signed-off-by: Oleg Sidorov <sidorovo@amazon.com>