### PR TITLE
Unset DBInstance MaxAllocatedStorage

### DIFF
--- a/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/AbstractHandlerTest.java
+++ b/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/AbstractHandlerTest.java
@@ -110,7 +110,7 @@ public abstract class AbstractHandlerTest extends AbstractTestBase<DBInstance, R
     protected static final String LICENSE_MODEL_GENERAL_PUBLIC_LICENSE = "general-public-license";
     protected static final String MASTER_USERNAME = "master-username";
     protected static final String MASTER_USER_PASSWORD = "xxx";
-    protected static final Integer MAX_ALLOCATED_STORAGE_DEFAULT = 42;
+    protected static final Integer MAX_ALLOCATED_STORAGE_DEFAULT = 1000;
     protected static final Integer MONITORING_INTERVAL_DEFAULT = 0;
     protected static final String MONITORING_ROLE_ARN = "monitoring-role-arn";
     protected static final Boolean MULTI_AZ_YES = true;


### PR DESCRIPTION
This commit addresses unsetting `MaxAllocatedStorage` property upon a DBInstance update.

Given a CFN template (state A):
```yaml
Resources:
  DBInstance:
    Type: AWS::RDS::DBInstance
    Properties:
      AllocatedStorage: 100
      ...
```
Provided an update (state B):
```yaml
Resources:
  DBInstance:
    Type: AWS::RDS::DBInstance
    Properties:
      AllocatedStorage: 100
      MaxAllocatedStorage: 1000
      ...
```
Transition to state B will set `MaxAllocatedStorage` to 1000 and enable the autoscaling.

If `MaxAllowedStorage` is unset later in the template (transition back to state A or its equivalent), the current implementation will keep the property in place rather than unsetting it.

RDS API does not have an explicit request parameter to unset this property. The way to get around it is to set `MaxAllocatedStorage` to the current `AllocatedStorage`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Signed-off-by: Oleg Sidorov <sidorovo@amazon.com>