### PR TITLE
Handle RDS InternalFailure

### DIFF
--- a/aws-rds-cfn-common/src/main/java/software/amazon/rds/common/error/ErrorCode.java
+++ b/aws-rds-cfn-common/src/main/java/software/amazon/rds/common/error/ErrorCode.java
@@ -14,6 +14,7 @@ public enum ErrorCode {
     DBSubnetGroupNotFoundFault("DBSubnetGroupNotFoundFault"),
     InstanceQuotaExceeded("InstanceQuotaExceeded"),
     InsufficientDBInstanceCapacity("InsufficientDBInstanceCapacity"),
+    InternalFailure("InternalFailure"),
     InvalidDBInstanceState("InvalidDBInstanceState"),
     InvalidDBSecurityGroupState("InvalidDBSecurityGroupState"),
     InvalidDBSnapshotState("InvalidDBSnapshotState"),

--- a/aws-rds-cfn-common/src/main/java/software/amazon/rds/common/handler/Commons.java
+++ b/aws-rds-cfn-common/src/main/java/software/amazon/rds/common/handler/Commons.java
@@ -16,7 +16,8 @@ public final class Commons {
 
     public static final ErrorRuleSet DEFAULT_ERROR_RULE_SET = ErrorRuleSet.builder()
             .withErrorCodes(ErrorStatus.failWith(HandlerErrorCode.ServiceInternalError),
-                    ErrorCode.ClientUnavailable)
+                    ErrorCode.ClientUnavailable,
+                    ErrorCode.InternalFailure)
             .withErrorCodes(ErrorStatus.failWith(HandlerErrorCode.AccessDenied),
                     ErrorCode.AccessDeniedException,
                     ErrorCode.NotAuthorized)


### PR DESCRIPTION
This commit adds a new ErrorCode called `InternalFailure`. It is returned by RDS API in a case of a service event.

An additional change to DBInstance and DBInstance role stabilization logic: errors are handled by `Commons.handleException/3` instead of the custom local try-catch block because it fails with a stack trace and an internal error status if RDS API returns a 5xx response code.

Signed-off-by: Oleg Sidorov <sidorovo@amazon.com>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
