### PR TITLE
Extend AWS::RDS::DBInstance FAS policies with EC2:Describe*

### DIFF
--- a/aws-rds-dbinstance/aws-rds-dbinstance.json
+++ b/aws-rds-dbinstance/aws-rds-dbinstance.json
@@ -435,7 +435,19 @@
   "handlers": {
     "create": {
       "permissions": [
+        "ec2:DescribeAccountAttributes",
+        "ec2:DescribeAvailabilityZones",
+        "ec2:DescribeInternetGateways",
+        "ec2:DescribeSecurityGroups",
+        "ec2:DescribeSubnets",
+        "ec2:DescribeVpcAttribute",
+        "ec2:DescribeVpcs",
+        "iam:CreateServiceLinkedRole",
+        "iam:GetRole",
+        "iam:ListRoles",
         "iam:PassRole",
+        "kms:CreateGrant",
+        "kms:DescribeKey",
         "rds:AddRoleToDBInstance",
         "rds:CreateDBInstance",
         "rds:CreateDbInstanceReadReplica",
@@ -448,21 +460,39 @@
     },
     "read": {
       "permissions": [
+        "ec2:DescribeAccountAttributes",
+        "ec2:DescribeAvailabilityZones",
+        "ec2:DescribeInternetGateways",
+        "ec2:DescribeSecurityGroups",
+        "ec2:DescribeSubnets",
+        "ec2:DescribeVpcAttribute",
+        "ec2:DescribeVpcs",
         "rds:DescribeDBInstances"
       ]
     },
     "update": {
       "permissions": [
+        "ec2:DescribeAccountAttributes",
+        "ec2:DescribeAvailabilityZones",
+        "ec2:DescribeInternetGateways",
+        "ec2:DescribeSecurityGroups",
+        "ec2:DescribeSubnets",
+        "ec2:DescribeVpcAttribute",
+        "ec2:DescribeVpcs",
+        "iam:CreateServiceLinkedRole",
+        "iam:GetRole",
+        "iam:ListRoles",
         "iam:PassRole",
+        "kms:CreateGrant",
+        "kms:DescribeKey",
         "rds:AddRoleToDBInstance",
         "rds:AddTagsToResource",
-        "rds:DescribeDbEngineVersions",
         "rds:DescribeDBInstances",
+        "rds:DescribeDbEngineVersions",
         "rds:DescribeDbParameterGroups",
         "rds:ModifyDBInstance",
         "rds:RemoveRoleFromDBInstance",
-        "rds:RemoveTagsFromResource",
-        "ec2:DescribeSecurityGroups"
+        "rds:RemoveTagsFromResource"
       ]
     },
     "delete": {

--- a/aws-rds-dbinstance/resource-role.yaml
+++ b/aws-rds-dbinstance/resource-role.yaml
@@ -23,8 +23,19 @@ Resources:
             Statement:
               - Effect: Allow
                 Action:
+                - "ec2:DescribeAccountAttributes"
+                - "ec2:DescribeAvailabilityZones"
+                - "ec2:DescribeInternetGateways"
                 - "ec2:DescribeSecurityGroups"
+                - "ec2:DescribeSubnets"
+                - "ec2:DescribeVpcAttribute"
+                - "ec2:DescribeVpcs"
+                - "iam:CreateServiceLinkedRole"
+                - "iam:GetRole"
+                - "iam:ListRoles"
                 - "iam:PassRole"
+                - "kms:CreateGrant"
+                - "kms:DescribeKey"
                 - "rds:AddRoleToDBInstance"
                 - "rds:AddTagsToResource"
                 - "rds:CreateDBInstance"


### PR DESCRIPTION
This commit adds an additional set of FAS policies to DBInstance
requested permissions. In particular, the following policies are being
additionally requested:
  * ec2:DescribeVpcAttribute
  * ec2:DescribeSecurityGroups
  * ec2:DescribeInternetGateways
  * ec2:DescribeAvailabilityZones
  * ec2:DescribeVpcs
  * ec2:DescribeAccountAttributes
  * ec2:DescribeSubnets
  * iam:GetRole
  * iam:ListRoles

The motivation for this change is to align the minimal requested FAS
policy set to the one elaborated in AWS documentation:
  * https://aws.amazon.com/premiumsupport/knowledge-center/rds-iam-least-privileges/
  * https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazonrds.html#amazonrds-actions-as-permissions

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Signed-off-by: Oleg Sidorov <sidorovo@amazon.com>