### PR TITLE
[DBInstance] Fix never-stabilizing delete requests

### DIFF
--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/BaseHandlerStd.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/BaseHandlerStd.java
@@ -186,7 +186,7 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
             .orElse(DEFAULT_DB_INSTANCE_ERROR_RULE_SET);
 
     protected static final ErrorRuleSet DELETE_DB_INSTANCE_ERROR_RULE_SET = ErrorRuleSet.builder()
-            .withErrorCodes(ErrorStatus.ignore(),
+            .withErrorCodes(ErrorStatus.failWith(HandlerErrorCode.InvalidRequest),
                     ErrorCode.InvalidParameterValue)
             .withErrorCodes(ErrorStatus.failWith(HandlerErrorCode.NotFound),
                     ErrorCode.DBInstanceNotFound)
@@ -239,11 +239,11 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
             final ProgressEvent<ResourceModel, CallbackContext> progress
     ) {
         return proxy.initiate(
-                "rds::stabilize-db-instance-" + getClass().getSimpleName(),
-                rdsProxyClient,
-                progress.getResourceModel(),
-                progress.getCallbackContext()
-        )
+                        "rds::stabilize-db-instance-" + getClass().getSimpleName(),
+                        rdsProxyClient,
+                        progress.getResourceModel(),
+                        progress.getCallbackContext()
+                )
                 .translateToServiceRequest(Function.identity())
                 .backoffDelay(config.getBackoff())
                 .makeServiceCall(NOOP_CALL)
@@ -493,11 +493,11 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
             final ProgressEvent<ResourceModel, CallbackContext> progress
     ) {
         return proxy.initiate(
-                "rds::reboot-db-instance",
-                rdsProxyClient,
-                progress.getResourceModel(),
-                progress.getCallbackContext()
-        ).translateToServiceRequest(Translator::rebootDbInstanceRequest)
+                        "rds::reboot-db-instance",
+                        rdsProxyClient,
+                        progress.getResourceModel(),
+                        progress.getCallbackContext()
+                ).translateToServiceRequest(Translator::rebootDbInstanceRequest)
                 .backoffDelay(config.getBackoff())
                 .makeServiceCall((rebootRequest, proxyInvocation) -> proxyInvocation.injectCredentialsAndInvokeV2(
                         rebootRequest,

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/DeleteHandler.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/DeleteHandler.java
@@ -4,7 +4,6 @@ import java.util.Optional;
 
 import org.apache.commons.lang3.BooleanUtils;
 
-import com.amazonaws.util.StringUtils;
 import software.amazon.awssdk.awscore.exception.AwsServiceException;
 import software.amazon.awssdk.services.ec2.Ec2Client;
 import software.amazon.awssdk.services.rds.RdsClient;
@@ -39,20 +38,16 @@ public class DeleteHandler extends BaseHandlerStd {
             final ProxyClient<Ec2Client> ec2ProxyClient,
             final Logger logger
     ) {
-        final ResourceModel resourceModel = request.getDesiredResourceState();
         String snapshotIdentifier = null;
         // https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html
         // For AWS::RDS::DBInstance resources that don't specify the DBClusterIdentifier property, the default policy is Snapshot.
         if (BooleanUtils.isNotFalse(request.getSnapshotRequested())) {
-            snapshotIdentifier = resourceModel.getDBSnapshotIdentifier();
-            if (StringUtils.isNullOrEmpty(snapshotIdentifier)) {
-                snapshotIdentifier = generateResourceIdentifier(
-                        Optional.ofNullable(request.getStackId()).orElse(STACK_NAME),
-                        SNAPSHOT_PREFIX + Optional.ofNullable(request.getLogicalResourceIdentifier()).orElse(RESOURCE_IDENTIFIER),
-                        request.getClientRequestToken(),
-                        SNAPSHOT_MAX_LENGTH
-                );
-            }
+            snapshotIdentifier = generateResourceIdentifier(
+                    Optional.ofNullable(request.getStackId()).orElse(STACK_NAME),
+                    SNAPSHOT_PREFIX + Optional.ofNullable(request.getLogicalResourceIdentifier()).orElse(RESOURCE_IDENTIFIER),
+                    request.getClientRequestToken(),
+                    SNAPSHOT_MAX_LENGTH
+            );
         }
         final String finalSnapshotIdentifier = snapshotIdentifier;
 

--- a/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/DeleteHandlerTest.java
+++ b/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/DeleteHandlerTest.java
@@ -214,10 +214,8 @@ public class DeleteHandlerTest extends AbstractHandlerTest {
                 new CallbackContext(),
                 null,
                 () -> RESOURCE_MODEL_BLDR().build(),
-                expectInProgress(0)
+                expectFailed(HandlerErrorCode.InvalidRequest)
         );
-
-        assertThat(response.getMessage()).isNull();
 
         verify(rdsProxy.client(), times(1)).deleteDBInstance(any(DeleteDbInstanceRequest.class));
     }


### PR DESCRIPTION
This PR addresses an issue with `DeleteHandler` where `DBSnapshotIdentifier` resource attribute is being copied to `FinalDBSnapshotIdentifier` `delete-db-instance` request attribute. The validation logic for these 2 attributes on RDS API side differs: whereas the former can be a fully-qualified ARN, the latter must be a plain identifier. The identifier copy part turned out to be inconsistent with the legacy implementation, hence this PR enforces a snapshot id re-generation upon a delete call.

This PR also changes the original behavior of `DeleteHandler` which used to ignore `InvalidParameterValue` error code. The fix changes this to throwing a terminal error so the customer can address the validation issue.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Signed-off-by: Oleg Sidorov <sidorovo@amazon.com>