### PR TITLE
[DBInstance] Rework DeleteHandler to use EventChain

### DIFF
--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/DeleteHandler.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/DeleteHandler.java
@@ -4,10 +4,8 @@ import java.util.Optional;
 
 import org.apache.commons.lang3.BooleanUtils;
 
-import software.amazon.awssdk.awscore.exception.AwsServiceException;
 import software.amazon.awssdk.services.ec2.Ec2Client;
 import software.amazon.awssdk.services.rds.RdsClient;
-import software.amazon.awssdk.services.rds.model.DeleteDbInstanceResponse;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.Logger;
 import software.amazon.cloudformation.proxy.ProgressEvent;
@@ -20,7 +18,6 @@ public class DeleteHandler extends BaseHandlerStd {
 
     private static final String SNAPSHOT_PREFIX = "Snapshot-";
     private static final int SNAPSHOT_MAX_LENGTH = 255;
-    private static final String DB_INSTANCE_IS_BEING_DELETED_ERR = "is already being deleted";
 
     public DeleteHandler() {
         this(HandlerConfig.builder().probingEnabled(true).build());
@@ -54,24 +51,10 @@ public class DeleteHandler extends BaseHandlerStd {
         return proxy.initiate("rds::delete-db-instance", rdsProxyClient, request.getDesiredResourceState(), callbackContext)
                 .translateToServiceRequest(model -> Translator.deleteDbInstanceRequest(model, finalSnapshotIdentifier))
                 .backoffDelay(config.getBackoff())
-                .makeServiceCall((deleteRequest, proxyInvocation) -> {
-                    if (callbackContext.isDeleted()) {
-                        return callbackContext.response("rds::delete-db-instance");
-                    }
-                    DeleteDbInstanceResponse response = null;
-                    try {
-                        response = proxyInvocation.injectCredentialsAndInvokeV2(
-                                deleteRequest,
-                                proxyInvocation.client()::deleteDBInstance
-                        );
-                    } catch (Exception exception) {
-                        if (!isDbInstanceDeletingException(exception)) {
-                            throw exception;
-                        }
-                    }
-                    callbackContext.setDeleted(true);
-                    return response;
-                })
+                .makeServiceCall((deleteRequest, proxyInvocation) -> proxyInvocation.injectCredentialsAndInvokeV2(
+                        deleteRequest,
+                        proxyInvocation.client()::deleteDBInstance
+                ))
                 .stabilize((deleteRequest, deleteResponse, proxyInvocation, model, context) -> isDbInstanceDeleted(proxyInvocation, model))
                 .handleError((deleteRequest, exception, client, model, context) -> Commons.handleException(
                         ProgressEvent.progress(model, context),
@@ -79,12 +62,5 @@ public class DeleteHandler extends BaseHandlerStd {
                         DELETE_DB_INSTANCE_ERROR_RULE_SET
                 ))
                 .done((deleteRequest, deleteResponse, proxyInvocation, model, context) -> ProgressEvent.defaultSuccessHandler(null));
-    }
-
-    private boolean isDbInstanceDeletingException(final Exception exception) {
-        if (exception instanceof AwsServiceException) {
-            return Optional.ofNullable(exception.getMessage()).orElse("").contains(DB_INSTANCE_IS_BEING_DELETED_ERR);
-        }
-        return false;
     }
 }

--- a/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/DeleteHandlerTest.java
+++ b/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/DeleteHandlerTest.java
@@ -27,7 +27,6 @@ import software.amazon.awssdk.services.rds.model.DbInstanceNotFoundException;
 import software.amazon.awssdk.services.rds.model.DeleteDbInstanceRequest;
 import software.amazon.awssdk.services.rds.model.DeleteDbInstanceResponse;
 import software.amazon.awssdk.services.rds.model.DescribeDbInstancesRequest;
-import software.amazon.awssdk.services.rds.model.InvalidDbInstanceStateException;
 import software.amazon.awssdk.services.rds.model.RdsException;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.HandlerErrorCode;
@@ -108,25 +107,6 @@ public class DeleteHandlerTest extends AbstractHandlerTest {
     }
 
     @Test
-    public void handleRequest_IsGone() {
-        final CallbackContext context = new CallbackContext();
-        context.setDeleted(true);
-
-        final ProgressEvent<ResourceModel, CallbackContext> response = test_handleRequest_base(
-                context,
-                () -> {
-                    throw DbInstanceNotFoundException.builder().message(MSG_NOT_FOUND_ERR).build();
-                },
-                () -> RESOURCE_MODEL_BLDR().build(),
-                expectSuccess()
-        );
-
-        assertThat(response.getMessage()).isNull();
-
-        verify(rdsProxy.client(), times(1)).describeDBInstances(any(DescribeDbInstancesRequest.class));
-    }
-
-    @Test
     public void handleRequest_DbInstanceNotFound() {
         final DbInstanceNotFoundException exception = DbInstanceNotFoundException.builder().message(MSG_NOT_FOUND_ERR).build();
         when(rdsProxy.client().deleteDBInstance(any(DeleteDbInstanceRequest.class))).thenThrow(exception);
@@ -155,47 +135,6 @@ public class DeleteHandlerTest extends AbstractHandlerTest {
                 null,
                 () -> RESOURCE_MODEL_BLDR().build(),
                 expectFailed(HandlerErrorCode.ResourceConflict)
-        );
-
-        verify(rdsProxy.client(), times(1)).deleteDBInstance(any(DeleteDbInstanceRequest.class));
-    }
-
-    @Test
-    public void handleRequest_AwsServiceExceptionIsDeleting() {
-        when(rdsProxy.client().deleteDBInstance(any(DeleteDbInstanceRequest.class))).thenThrow(
-                RdsException.builder()
-                        .awsErrorDetails(AwsErrorDetails.builder()
-                                .errorCode(ErrorCode.InvalidDBInstanceState.toString())
-                                .errorMessage("Instance " + DB_INSTANCE_IDENTIFIER_NON_EMPTY + " is already being deleted.")
-                                .build()
-                        ).build());
-
-        test_handleRequest_base(
-                new CallbackContext(),
-                () -> {
-                    throw DbInstanceNotFoundException.builder().message(MSG_NOT_FOUND_ERR).build();
-                },
-                () -> RESOURCE_MODEL_BLDR().build(),
-                expectSuccess()
-        );
-
-        verify(rdsProxy.client(), times(1)).deleteDBInstance(any(DeleteDbInstanceRequest.class));
-    }
-
-    @Test
-    public void handleRequest_InvalidDbInstanceStateFaultIsDeleting() {
-        when(rdsProxy.client().deleteDBInstance(any(DeleteDbInstanceRequest.class))).thenThrow(
-                InvalidDbInstanceStateException.builder()
-                        .message("Instance " + DB_INSTANCE_IDENTIFIER_NON_EMPTY + " is already being deleted.")
-                        .build());
-
-        test_handleRequest_base(
-                new CallbackContext(),
-                () -> {
-                    throw DbInstanceNotFoundException.builder().message(MSG_NOT_FOUND_ERR).build();
-                },
-                () -> RESOURCE_MODEL_BLDR().build(),
-                expectSuccess()
         );
 
         verify(rdsProxy.client(), times(1)).deleteDBInstance(any(DeleteDbInstanceRequest.class));


### PR DESCRIPTION
This PR provides an alternative implementation for DBInstance
DeleteHandler. In particular, it removes a manual DeleteDBInstance
invocation, delegating it to a proxyInvocation.

We are removing an explicit handling of `DbInstanceDeletingException` as
it is being handled by `DELETE_DB_INSTANCE_ERROR_RULE_SET` already.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Signed-off-by: Oleg Sidorov <sidorovo@amazon.com>