### PR TITLE
Add source SourceDBClusterIdentifier along with engine parameter as R…

### DIFF
--- a/aws-rds-dbcluster/aws-rds-dbcluster.json
+++ b/aws-rds-dbcluster/aws-rds-dbcluster.json
@@ -200,8 +200,17 @@
   },
   "allOf": [
     {
-      "required": [
-        "Engine"
+      "oneOf": [
+        {
+          "required": [
+            "Engine"
+          ]
+        },
+        {
+          "required": [
+            "SourceDBClusterIdentifier"
+          ]
+        }
       ]
     },
     {


### PR DESCRIPTION
Accept `SourceDBClusterIdentifier` parameter in DBCluster schema as only required as customer doesn't need to specify engine in case of `RestoreDBClusterToPointInTime`

ref: https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_RestoreDBClusterToPointInTime.html  
Example stack
```
AWSTemplateFormatVersion: "2010-09-09"
Description: RDS DBInstance test leave snapshot behind if there DBClusterIdentifier and no deletion policy specified

Parameters:
  username:
    Type: String
    AllowedPattern: '[a-zA-Z][a-zA-Z0-9]*'
    NoEcho: true
    Default: testusername
  password:
    Type: String
    NoEcho: true
    Default: testpassword

Resources:
  RDSCluster:
    DeletionPolicy: Delete
    Properties:
      Engine: aurora
      MasterUserPassword:
        Ref: password
      MasterUsername:
        Ref: username
    Type: "AWS::RDS::DBCluster"
  RDSDBInstance1:
    Properties:
      DBClusterIdentifier:
        Ref: RDSCluster
      DBInstanceClass: db.t3.small
      Engine: aurora
      PubliclyAccessible: "true"
    Type: "AWS::RDS::DBInstance"
  RDSClusterClone:
      Type: AWS::RDS::DBCluster
      DeletionPolicy: Delete
      Properties:
        SourceDBClusterIdentifier:
          Ref: RDSCluster 
        UseLatestRestorableTime: true
        RestoreType: copy-on-write

```