### PR TITLE
Fix DBCluster Infinite Stabilization and Timeout If Role Already Exist or Already Deleted

### DIFF
--- a/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/BaseHandlerStd.java
+++ b/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/BaseHandlerStd.java
@@ -198,7 +198,7 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
                             ADD_ASSOC_ROLES_ERROR_RULE_SET
                     ))
                     .success();
-            if (!progressEvent.isSuccess()) {
+            if (progressEvent.isFailed()) {
                 return progressEvent;
             }
         }
@@ -234,7 +234,7 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
                             REMOVE_ASSOC_ROLES_ERROR_RULE_SET
                     ))
                     .success();
-            if (!progressEvent.isSuccess()) return progressEvent;
+            if (progressEvent.isFailed()) return progressEvent;
         }
         return ProgressEvent.progress(model, callbackContext);
     }


### PR DESCRIPTION
Return in Failure only in adding roles or removing  roles to DBCluster. Otherwise resource will return IN_PROGRESS status and never complete the loop. Cloudformation will keep calling it up to 250 time then throw stabilization tiomeout.

Steps to trigger the issue:

1. Create DBCluster manually. Add associated role A to it
2. Do stack import with same cluster and Try to add associated role A, B to it 