### PR TITLE
Fix DBInstance Infinite Stabilization and Timeout If Role Already Exist or Already Deleted

### DIFF
--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/BaseHandlerStd.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/BaseHandlerStd.java
@@ -449,7 +449,7 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
                             UPDATE_ASSOCIATED_ROLES_ERROR_RULE_SET
                     ))
                     .success();
-            if (!progressEvent.isSuccess()) {
+            if (progressEvent.isFailed()) {
                 return progressEvent;
             }
         }
@@ -480,7 +480,7 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
                             UPDATE_ASSOCIATED_ROLES_ERROR_RULE_SET
                     ))
                     .success();
-            if (!progressEvent.isSuccess()) {
+            if (progressEvent.isFailed()) {
                 return progressEvent;
             }
         }

--- a/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/UpdateHandlerTest.java
+++ b/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/UpdateHandlerTest.java
@@ -360,7 +360,7 @@ public class UpdateHandlerTest extends AbstractHandlerTest {
         );
 
         verify(rdsProxy.client()).removeRoleFromDBInstance(any(RemoveRoleFromDbInstanceRequest.class));
-        verify(rdsProxy.client()).addRoleToDBInstance(any(AddRoleToDbInstanceRequest.class));
+        verify(rdsProxy.client(), times(2)).addRoleToDBInstance(any(AddRoleToDbInstanceRequest.class));
     }
 
     @Test


### PR DESCRIPTION
Return in Failure only in adding roles or removing roles to DBInstance. Otherwise resource will return IN_PROGRESS status and never complete the loop. Cloud formation will keep calling it up to 250 time then throw stabilization timeout.

Steps to trigger the issue:

   - Create DBInstace manually. Add associated role A to it
   - Do stack import with same instance and Try to add associated role A, B to it
