### PR TITLE
Use cluster arn in removing cluster from global cluster

### DIFF
--- a/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/DeleteHandler.java
+++ b/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/DeleteHandler.java
@@ -116,8 +116,12 @@ public class DeleteHandler extends BaseHandlerStd {
             final ProxyClient<RdsClient> proxyClient,
             final ProgressEvent<ResourceModel, CallbackContext> progress
     ) {
-        return proxy.initiate("rds::remove-from-global-cluster", proxyClient, progress.getResourceModel(), progress.getCallbackContext())
-                .translateToServiceRequest(Translator::removeFromGlobalClusterRequest)
+        final ResourceModel resourceModel = progress.getResourceModel();
+        return proxy.initiate("rds::remove-from-global-cluster", proxyClient, resourceModel, progress.getCallbackContext())
+                .translateToServiceRequest(model -> {
+                    final String clusterArn = fetchDBCluster(proxyClient, resourceModel).dbClusterArn();
+                    return Translator.removeFromGlobalClusterRequest(model, clusterArn);
+                })
                 .backoffDelay(config.getBackoff())
                 .makeServiceCall((removeRequest, proxyInvocation) -> proxyInvocation.injectCredentialsAndInvokeV2(
                         removeRequest,

--- a/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/Translator.java
+++ b/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/Translator.java
@@ -189,9 +189,9 @@ public class Translator {
         return builder.build();
     }
 
-    static RemoveFromGlobalClusterRequest removeFromGlobalClusterRequest(final ResourceModel model) {
+    static RemoveFromGlobalClusterRequest removeFromGlobalClusterRequest(final ResourceModel model, final String clusterArn) {
         return RemoveFromGlobalClusterRequest.builder()
-                .dbClusterIdentifier(model.getDBClusterIdentifier())
+                .dbClusterIdentifier(clusterArn)
                 .globalClusterIdentifier(model.getGlobalClusterIdentifier())
                 .build();
     }

--- a/aws-rds-dbcluster/src/test/java/software/amazon/rds/dbcluster/DeleteHandlerTest.java
+++ b/aws-rds-dbcluster/src/test/java/software/amazon/rds/dbcluster/DeleteHandlerTest.java
@@ -195,6 +195,7 @@ public class DeleteHandlerTest extends AbstractHandlerTest {
                 .thenReturn(DeleteDbClusterResponse.builder().build());
         Queue<DBCluster> transitions = new ConcurrentLinkedQueue<>();
         transitions.add(DBCLUSTER_INPROGRESS);
+        transitions.add(DBCLUSTER_INPROGRESS);
         transitions.add(DBCLUSTER_ACTIVE);
 
         test_handleRequest_base(


### PR DESCRIPTION
RemoveFromGlobalGlobal cluster API only accept ClusterArn as DBClusterIdentifier. Otherwise it will throw malformed DBClusterIdentifier exception.

Ref: https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_RemoveFromGlobalCluster.html
Input Test stack:
```
{
  "Description": "Basic DBCluster Template",
  "Parameters": {
    "DBClusterId": {
      "Type": "String"
    },
    "GlobalClusterId": {
      "Type": "String"
    }
  },
  "Resources": {
    "BasicDBCluster": {
      "Type": "AWS::RDS::DBCluster",
      "DeletionPolicy" : "Delete",
      "Properties": {
        "Engine": "aurora",
        "MasterUsername": "guest",
        "MasterUserPassword": "******",
        "EngineVersion" : "5.6.mysql_aurora.1.22.2",
        "DBClusterIdentifier": { "Ref": "DBClusterId" },
        "GlobalClusterIdentifier": { "Ref": "GlobalClusterId" }
      }
    }
  }
}
```
