### PR TITLE
Handle Error: Invalid Client Token Id

### DIFF
--- a/aws-rds-cfn-common/src/main/java/software/amazon/rds/common/error/ErrorCode.java
+++ b/aws-rds-cfn-common/src/main/java/software/amazon/rds/common/error/ErrorCode.java
@@ -24,6 +24,7 @@ public enum ErrorCode {
     InvalidParameterCombination("InvalidParameterCombination"),
     InvalidParameterValue("InvalidParameterValue"),
     InvalidRestoreFault("InvalidRestoreFault"),
+    InvalidClientTokenId("InvalidClientTokenId"),
     InvalidVPCNetworkStateFault("InvalidVPCNetworkStateFault"),
     KMSKeyNotAccessibleFault("KMSKeyNotAccessibleFault"),
     MissingParameter("MissingParameter"),

--- a/aws-rds-cfn-common/src/main/java/software/amazon/rds/common/handler/Commons.java
+++ b/aws-rds-cfn-common/src/main/java/software/amazon/rds/common/handler/Commons.java
@@ -19,7 +19,8 @@ public final class Commons {
     public static final ErrorRuleSet DEFAULT_ERROR_RULE_SET = ErrorRuleSet.builder()
             .withErrorCodes(ErrorStatus.failWith(HandlerErrorCode.ServiceInternalError),
                     ErrorCode.ClientUnavailable,
-                    ErrorCode.InternalFailure)
+                    ErrorCode.InternalFailure,
+                    ErrorCode.InvalidClientTokenId)
             .withErrorCodes(ErrorStatus.failWith(HandlerErrorCode.AccessDenied),
                     ErrorCode.AccessDenied,
                     ErrorCode.AccessDeniedException,

--- a/aws-rds-cfn-common/src/test/java/software/amazon/rds/common/handler/CommonsTest.java
+++ b/aws-rds-cfn-common/src/test/java/software/amazon/rds/common/handler/CommonsTest.java
@@ -26,6 +26,13 @@ public class CommonsTest {
     }
 
     @Test
+    public void handle_InvalidClientTokenId() {
+        final ErrorStatus status = Commons.DEFAULT_ERROR_RULE_SET.handle(newAwsServiceException(ErrorCode.InvalidClientTokenId));
+        assertThat(status).isInstanceOf(HandlerErrorStatus.class);
+        assertThat(((HandlerErrorStatus) status).getHandlerErrorCode()).isEqualTo(HandlerErrorCode.ServiceInternalError);
+    }
+
+    @Test
     public void handle_AccessDeniedException() {
         final ErrorStatus status = Commons.DEFAULT_ERROR_RULE_SET.handle(newAwsServiceException(ErrorCode.AccessDeniedException));
         assertThat(status).isInstanceOf(HandlerErrorStatus.class);


### PR DESCRIPTION
This PR adds an explicit error handler for `InvalidClientTokenId` error code.

AWS RDS Service might eventually return this error code if the credential token is stale. There is no better way to handle this rather than re-try in a bit: the error seems to be transient.

This PR treats `InvalidClientTokenId` as an internal service error.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Signed-off-by: Oleg Sidorov <sidorovo@amazon.com>