### PR TITLE
[DBCluster] Set Engine and MasterUserPassword conditionally

### DIFF
--- a/aws-rds-cfn-common/src/main/java/software/amazon/rds/common/test/AbstractTestBase.java
+++ b/aws-rds-cfn-common/src/main/java/software/amazon/rds/common/test/AbstractTestBase.java
@@ -1,5 +1,6 @@
 package software.amazon.rds.common.test;
 
+import java.security.SecureRandom;
 import java.util.UUID;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
@@ -13,6 +14,10 @@ import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 
 public abstract class AbstractTestBase<ResourceT, ModelT, CallbackT> {
 
+    final private static SecureRandom random = new SecureRandom();
+    final public static String ALPHA = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+    final public static String ALPHANUM = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+
     protected abstract String getLogicalResourceIdentifier();
 
     protected abstract void expectResourceSupply(final Supplier<ResourceT> supplier);
@@ -25,6 +30,14 @@ public abstract class AbstractTestBase<ResourceT, ModelT, CallbackT> {
 
     protected String newStackId() {
         return UUID.randomUUID().toString();
+    }
+
+    protected String randomString(final int length, final String alphabet) {
+        StringBuilder builder = new StringBuilder(length);
+        for (int i = 0; i < length; i++) {
+            builder.append(alphabet.charAt(random.nextInt(alphabet.length())));
+        }
+        return builder.toString();
     }
 
     protected Consumer<ProgressEvent<ModelT, CallbackT>> expectInProgress(int pause) {

--- a/aws-rds-cfn-common/src/test/java/software/amazon/rds/common/test/AbstractTestBaseTest.java
+++ b/aws-rds-cfn-common/src/test/java/software/amazon/rds/common/test/AbstractTestBaseTest.java
@@ -159,4 +159,21 @@ class AbstractTestBaseTest {
 
         verify(builder, times(1)).desiredResourceState(any());
     }
+
+    @Test
+    public void test_randomString() {
+        final TestAbstractTestBase testBase = new TestAbstractTestBase();
+        final int length = 16;
+        final String alphabet = "abc";
+
+        final String randStr = testBase.randomString(length, alphabet);
+        assertThat(randStr.length()).isEqualTo(length);
+
+        final String resultAlphabet = randStr.chars()
+                .distinct()
+                .sorted()
+                .collect(StringBuilder::new, StringBuilder::appendCodePoint, StringBuilder::append)
+                .toString();
+        assertThat(alphabet.contains(resultAlphabet)).isTrue();
+    }
 }

--- a/aws-rds-dbcluster/aws-rds-dbcluster.json
+++ b/aws-rds-dbcluster/aws-rds-dbcluster.json
@@ -368,7 +368,6 @@
     "/properties/DatabaseName",
     "/properties/EngineMode",
     "/properties/KmsKeyId",
-    "/properties/MasterUsername",
     "/properties/RestoreType",
     "/properties/SnapshotIdentifier",
     "/properties/SourceDBClusterIdentifier",
@@ -378,7 +377,8 @@
   ],
   "conditionalCreateOnlyProperties": [
     "/properties/Engine",
-    "/properties/GlobalClusterIdentifier"
+    "/properties/GlobalClusterIdentifier",
+    "/properties/MasterUsername"
   ],
   "primaryIdentifier": [
     "/properties/DBClusterIdentifier"

--- a/aws-rds-dbcluster/docs/README.md
+++ b/aws-rds-dbcluster/docs/README.md
@@ -316,7 +316,7 @@ _Maximum_: <code>16</code>
 
 _Pattern_: <code>^[a-zA-Z]{1}[a-zA-Z0-9]{0,15}$</code>
 
-_Update requires_: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 
 #### MasterUserPassword
 

--- a/aws-rds-dbcluster/src/test/java/software/amazon/rds/dbcluster/UpdateHandlerTest.java
+++ b/aws-rds-dbcluster/src/test/java/software/amazon/rds/dbcluster/UpdateHandlerTest.java
@@ -13,9 +13,11 @@ import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -30,6 +32,7 @@ import software.amazon.awssdk.services.rds.model.DbClusterNotFoundException;
 import software.amazon.awssdk.services.rds.model.DbClusterRoleNotFoundException;
 import software.amazon.awssdk.services.rds.model.DescribeDbClustersRequest;
 import software.amazon.awssdk.services.rds.model.ModifyDbClusterRequest;
+import software.amazon.awssdk.services.rds.model.ModifyDbClusterResponse;
 import software.amazon.awssdk.services.rds.model.RemoveFromGlobalClusterRequest;
 import software.amazon.awssdk.services.rds.model.RemoveFromGlobalClusterResponse;
 import software.amazon.awssdk.services.rds.model.RemoveRoleFromDbClusterRequest;
@@ -199,5 +202,211 @@ public class UpdateHandlerTest extends AbstractHandlerTest {
         );
 
         verify(rdsProxy.client(), times(1)).modifyDBCluster(any(ModifyDbClusterRequest.class));
+    }
+
+    @Test
+    public void handleRequest_ImmutableUpdate_GlobalCluster() {
+        expectServiceInvocation = false;
+        test_handleRequest_base(
+                new CallbackContext(),
+                null,
+                () -> RESOURCE_MODEL.toBuilder().globalClusterIdentifier("globalClusterIdentifier_1").build(),
+                () -> RESOURCE_MODEL.toBuilder().globalClusterIdentifier("globalClusterIdentifier_2").build(),
+                expectFailed(HandlerErrorCode.NotUpdatable)
+        );
+    }
+
+    @Test
+    public void handleRequest_ImmutableUpdate_Engine() {
+        expectServiceInvocation = false;
+        test_handleRequest_base(
+                new CallbackContext(),
+                null,
+                () -> RESOURCE_MODEL.toBuilder().engine("engine_1").build(),
+                () -> RESOURCE_MODEL.toBuilder().engine("engine_2").build(),
+                expectFailed(HandlerErrorCode.NotUpdatable)
+        );
+    }
+
+    @Test
+    public void handleRequest_NoMasterUserUpdateIfMatch() {
+        final String masterUserPassword = randomString(16, ALPHANUM);
+
+        Queue<DBCluster> transitions = new ConcurrentLinkedQueue<>();
+        transitions.add(DBCLUSTER_ACTIVE);
+        transitions.add(DBCLUSTER_INPROGRESS);
+        transitions.add(DBCLUSTER_ACTIVE_NO_ROLE);
+
+        when(rdsProxy.client().modifyDBCluster(any(ModifyDbClusterRequest.class)))
+                .thenReturn(ModifyDbClusterResponse.builder().build());
+        when(rdsProxy.client().removeRoleFromDBCluster(any(RemoveRoleFromDbClusterRequest.class)))
+                .thenReturn(RemoveRoleFromDbClusterResponse.builder().build());
+        when(rdsProxy.client().addRoleToDBCluster(any(AddRoleToDbClusterRequest.class)))
+                .thenReturn(AddRoleToDbClusterResponse.builder().build());
+
+        test_handleRequest_base(
+                new CallbackContext(),
+                () -> {
+                    if (transitions.size() > 0) {
+                        return transitions.remove();
+                    }
+                    return DBCLUSTER_ACTIVE;
+                },
+                () -> RESOURCE_MODEL.toBuilder().masterUserPassword(masterUserPassword).build(),
+                () -> RESOURCE_MODEL.toBuilder().masterUserPassword(masterUserPassword).build(),
+                expectSuccess()
+        );
+
+        ArgumentCaptor<ModifyDbClusterRequest> argument = ArgumentCaptor.forClass(ModifyDbClusterRequest.class);
+        verify(rdsProxy.client(), times(1)).modifyDBCluster(argument.capture());
+        Assertions.assertNull(argument.getValue().masterUserPassword());
+    }
+
+    @Test
+    public void handleRequest_UpdateMasterUserPasswordIfMismatch() {
+        final String masterUserPassword1 = randomString(16, ALPHANUM);
+        final String masterUserPassword2 = randomString(16, ALPHANUM);
+
+        Assertions.assertNotEquals(masterUserPassword1, masterUserPassword2);
+
+        Queue<DBCluster> transitions = new ConcurrentLinkedQueue<>();
+        transitions.add(DBCLUSTER_ACTIVE);
+        transitions.add(DBCLUSTER_INPROGRESS);
+        transitions.add(DBCLUSTER_ACTIVE_NO_ROLE);
+
+        when(rdsProxy.client().modifyDBCluster(any(ModifyDbClusterRequest.class)))
+                .thenReturn(ModifyDbClusterResponse.builder().build());
+        when(rdsProxy.client().removeRoleFromDBCluster(any(RemoveRoleFromDbClusterRequest.class)))
+                .thenReturn(RemoveRoleFromDbClusterResponse.builder().build());
+        when(rdsProxy.client().addRoleToDBCluster(any(AddRoleToDbClusterRequest.class)))
+                .thenReturn(AddRoleToDbClusterResponse.builder().build());
+
+        test_handleRequest_base(
+                new CallbackContext(),
+                () -> {
+                    if (transitions.size() > 0) {
+                        return transitions.remove();
+                    }
+                    return DBCLUSTER_ACTIVE;
+                },
+                () -> RESOURCE_MODEL.toBuilder().masterUserPassword(masterUserPassword1).build(),
+                () -> RESOURCE_MODEL.toBuilder().masterUserPassword(masterUserPassword2).build(),
+                expectSuccess()
+        );
+
+        ArgumentCaptor<ModifyDbClusterRequest> argument = ArgumentCaptor.forClass(ModifyDbClusterRequest.class);
+        verify(rdsProxy.client(), times(1)).modifyDBCluster(argument.capture());
+        Assertions.assertEquals(argument.getValue().masterUserPassword(), masterUserPassword2);
+    }
+
+    @Test
+    public void handleRequest_NoEngineVersionUpdateIfMatch() {
+        final String engineVersion = randomString(16, ALPHANUM);
+
+        Queue<DBCluster> transitions = new ConcurrentLinkedQueue<>();
+        transitions.add(DBCLUSTER_ACTIVE);
+        transitions.add(DBCLUSTER_INPROGRESS);
+        transitions.add(DBCLUSTER_ACTIVE_NO_ROLE);
+
+        when(rdsProxy.client().modifyDBCluster(any(ModifyDbClusterRequest.class)))
+                .thenReturn(ModifyDbClusterResponse.builder().build());
+        when(rdsProxy.client().removeRoleFromDBCluster(any(RemoveRoleFromDbClusterRequest.class)))
+                .thenReturn(RemoveRoleFromDbClusterResponse.builder().build());
+        when(rdsProxy.client().addRoleToDBCluster(any(AddRoleToDbClusterRequest.class)))
+                .thenReturn(AddRoleToDbClusterResponse.builder().build());
+
+        test_handleRequest_base(
+                new CallbackContext(),
+                () -> {
+                    if (transitions.size() > 0) {
+                        return transitions.remove();
+                    }
+                    return DBCLUSTER_ACTIVE;
+                },
+                () -> RESOURCE_MODEL.toBuilder().engineVersion(engineVersion).build(),
+                () -> RESOURCE_MODEL.toBuilder().engineVersion(engineVersion).build(),
+                expectSuccess()
+        );
+
+        ArgumentCaptor<ModifyDbClusterRequest> argument = ArgumentCaptor.forClass(ModifyDbClusterRequest.class);
+        verify(rdsProxy.client(), times(1)).modifyDBCluster(argument.capture());
+        Assertions.assertNull(argument.getValue().engineVersion());
+    }
+
+    @Test
+    public void handleRequest_NoEngineVersionUpdateIfRollback() {
+        final String engineVersion1 = randomString(16, ALPHANUM);
+        final String engineVersion2 = randomString(16, ALPHANUM);
+
+        Assertions.assertNotEquals(engineVersion1, engineVersion2);
+
+        Queue<DBCluster> transitions = new ConcurrentLinkedQueue<>();
+        transitions.add(DBCLUSTER_ACTIVE);
+        transitions.add(DBCLUSTER_INPROGRESS);
+        transitions.add(DBCLUSTER_ACTIVE_NO_ROLE);
+
+        when(rdsProxy.client().modifyDBCluster(any(ModifyDbClusterRequest.class)))
+                .thenReturn(ModifyDbClusterResponse.builder().build());
+        when(rdsProxy.client().removeRoleFromDBCluster(any(RemoveRoleFromDbClusterRequest.class)))
+                .thenReturn(RemoveRoleFromDbClusterResponse.builder().build());
+        when(rdsProxy.client().addRoleToDBCluster(any(AddRoleToDbClusterRequest.class)))
+                .thenReturn(AddRoleToDbClusterResponse.builder().build());
+
+        test_handleRequest_base(
+                new CallbackContext(),
+                ResourceHandlerRequest.<ResourceModel>builder().rollback(true),
+                () -> {
+                    if (transitions.size() > 0) {
+                        return transitions.remove();
+                    }
+                    return DBCLUSTER_ACTIVE;
+                },
+                () -> RESOURCE_MODEL.toBuilder().engineVersion(engineVersion1).build(),
+                () -> RESOURCE_MODEL.toBuilder().engineVersion(engineVersion2).build(),
+                expectSuccess()
+        );
+
+        ArgumentCaptor<ModifyDbClusterRequest> argument = ArgumentCaptor.forClass(ModifyDbClusterRequest.class);
+        verify(rdsProxy.client(), times(1)).modifyDBCluster(argument.capture());
+        Assertions.assertNull(argument.getValue().engineVersion());
+    }
+
+    @Test
+    public void handleRequest_EngineVersionUpdateIfMismatch() {
+        final String engineVersion1 = randomString(16, ALPHANUM);
+        final String engineVersion2 = randomString(16, ALPHANUM);
+
+        Assertions.assertNotEquals(engineVersion1, engineVersion2);
+
+        Queue<DBCluster> transitions = new ConcurrentLinkedQueue<>();
+        transitions.add(DBCLUSTER_ACTIVE);
+        transitions.add(DBCLUSTER_INPROGRESS);
+        transitions.add(DBCLUSTER_ACTIVE_NO_ROLE);
+
+        when(rdsProxy.client().modifyDBCluster(any(ModifyDbClusterRequest.class)))
+                .thenReturn(ModifyDbClusterResponse.builder().build());
+        when(rdsProxy.client().removeRoleFromDBCluster(any(RemoveRoleFromDbClusterRequest.class)))
+                .thenReturn(RemoveRoleFromDbClusterResponse.builder().build());
+        when(rdsProxy.client().addRoleToDBCluster(any(AddRoleToDbClusterRequest.class)))
+                .thenReturn(AddRoleToDbClusterResponse.builder().build());
+
+        test_handleRequest_base(
+                new CallbackContext(),
+                () -> {
+                    if (transitions.size() > 0) {
+                        return transitions.remove();
+                    }
+                    return DBCLUSTER_ACTIVE;
+                },
+                () -> RESOURCE_MODEL.toBuilder().engineVersion(engineVersion1).build(),
+                () -> RESOURCE_MODEL.toBuilder().engineVersion(engineVersion2).build(),
+                expectSuccess()
+        );
+
+        ArgumentCaptor<ModifyDbClusterRequest> argument = ArgumentCaptor.forClass(ModifyDbClusterRequest.class);
+        verify(rdsProxy.client(), times(1)).modifyDBCluster(argument.capture());
+        Assertions.assertEquals(argument.getValue().engineVersion(), engineVersion2);
+        Assertions.assertTrue(argument.getValue().applyImmediately());
+        Assertions.assertTrue(argument.getValue().allowMajorVersionUpgrade());
     }
 }


### PR DESCRIPTION
This PR changes the way `ModifyDBCluster` request attributes are being set. In particular, `Engine` and `MasterUserPassword` are being set conditionally.

`Engine` should only be set if the previous and the desired values differ and the stack is not undergoing a rollback. Otherwise RDS API will return an error "Cannot modify engine version without a healthy primary instance in DB cluster".

`MasterUserPassword` should only be set if the values differ.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Signed-off-by: Oleg Sidorov <sidorovo@amazon.com>