### PR TITLE
[Common] Commons handler treats IgnoreErrorStatus as success

### DIFF
--- a/aws-rds-cfn-common/src/main/java/software/amazon/rds/common/error/ErrorStatus.java
+++ b/aws-rds-cfn-common/src/main/java/software/amazon/rds/common/error/ErrorStatus.java
@@ -1,6 +1,7 @@
 package software.amazon.rds.common.error;
 
 import software.amazon.cloudformation.proxy.HandlerErrorCode;
+import software.amazon.cloudformation.proxy.OperationStatus;
 
 public interface ErrorStatus {
 
@@ -9,6 +10,10 @@ public interface ErrorStatus {
     }
 
     static ErrorStatus ignore() {
-        return new IgnoreErrorStatus();
+        return ignore(OperationStatus.SUCCESS);
+    }
+
+    static ErrorStatus ignore(final OperationStatus status) {
+        return new IgnoreErrorStatus(status);
     }
 }

--- a/aws-rds-cfn-common/src/main/java/software/amazon/rds/common/error/IgnoreErrorStatus.java
+++ b/aws-rds-cfn-common/src/main/java/software/amazon/rds/common/error/IgnoreErrorStatus.java
@@ -1,4 +1,13 @@
 package software.amazon.rds.common.error;
 
+import lombok.Getter;
+import software.amazon.cloudformation.proxy.OperationStatus;
+
 public class IgnoreErrorStatus implements ErrorStatus {
+    @Getter
+    private final OperationStatus status;
+
+    public IgnoreErrorStatus(final OperationStatus status) {
+        this.status = status;
+    }
 }

--- a/aws-rds-cfn-common/src/main/java/software/amazon/rds/common/handler/Commons.java
+++ b/aws-rds-cfn-common/src/main/java/software/amazon/rds/common/handler/Commons.java
@@ -4,6 +4,7 @@ import java.util.function.Function;
 
 import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.cloudformation.proxy.HandlerErrorCode;
+import software.amazon.cloudformation.proxy.OperationStatus;
 import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.rds.common.error.ErrorCode;
 import software.amazon.rds.common.error.ErrorRuleSet;
@@ -45,7 +46,12 @@ public final class Commons {
         final ErrorStatus errorStatus = errorRuleSet.handle(exception);
 
         if (errorStatus instanceof IgnoreErrorStatus) {
-            return ProgressEvent.progress(model, context);
+            switch (((IgnoreErrorStatus) errorStatus).getStatus()) {
+                case IN_PROGRESS:
+                    return ProgressEvent.progress(model, context);
+                default:
+                    return ProgressEvent.success(model, context);
+            }
         } else if (errorStatus instanceof HandlerErrorStatus) {
             final HandlerErrorStatus handlerErrorStatus = (HandlerErrorStatus) errorStatus;
             return ProgressEvent.failed(model, context, handlerErrorStatus.getHandlerErrorCode(), exception.getMessage());

--- a/aws-rds-cfn-common/src/test/java/software/amazon/rds/common/handler/CommonsTest.java
+++ b/aws-rds-cfn-common/src/test/java/software/amazon/rds/common/handler/CommonsTest.java
@@ -83,7 +83,7 @@ public class CommonsTest {
                 .build();
         final ProgressEvent<Void, Void> resultEvent = Commons.handleException(event, exception, ruleSet);
         assertThat(resultEvent).isNotNull();
-        assertThat(resultEvent.isInProgress()).isTrue();
+        assertThat(resultEvent.isSuccess()).isTrue();
     }
 
     @Test

--- a/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/UpdateHandlerTest.java
+++ b/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/UpdateHandlerTest.java
@@ -360,7 +360,7 @@ public class UpdateHandlerTest extends AbstractHandlerTest {
         );
 
         verify(rdsProxy.client()).removeRoleFromDBInstance(any(RemoveRoleFromDbInstanceRequest.class));
-        verify(rdsProxy.client()).addRoleToDBInstance(any(AddRoleToDbInstanceRequest.class));
+        verify(rdsProxy.client(), times(2)).addRoleToDBInstance(any(AddRoleToDbInstanceRequest.class));
     }
 
     @Test

--- a/aws-rds-optiongroup/src/main/java/software/amazon/rds/optiongroup/BaseHandlerStd.java
+++ b/aws-rds-optiongroup/src/main/java/software/amazon/rds/optiongroup/BaseHandlerStd.java
@@ -18,6 +18,7 @@ import software.amazon.awssdk.services.rds.model.OptionGroupQuotaExceededExcepti
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.HandlerErrorCode;
 import software.amazon.cloudformation.proxy.Logger;
+import software.amazon.cloudformation.proxy.OperationStatus;
 import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
@@ -49,7 +50,7 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
     protected static final ErrorRuleSet DEFAULT_OPTION_GROUP_ERROR_RULE_SET = ErrorRuleSet.builder()
             .withErrorCodes(ErrorStatus.failWith(HandlerErrorCode.ResourceConflict),
                     ErrorCode.InvalidOptionGroupStateFault)
-            .withErrorClasses(ErrorStatus.ignore(),
+            .withErrorClasses(ErrorStatus.ignore(OperationStatus.IN_PROGRESS),
                     OptionGroupAlreadyExistsException.class)
             .withErrorClasses(ErrorStatus.failWith(HandlerErrorCode.NotFound),
                     OptionGroupNotFoundException.class)


### PR DESCRIPTION
This PR changes the way `Commons` handler interprets `IgnoreErrorStatus` upon an exception handling. The current implementation always handles this code as an `in-progress` event. This cr makes it configurable and returns a success event by default instead.

The reason for this change is the fact that an in-progress event chain won't execute the upcoming `then` stage right away, but will spin up another event processing cycle. This creates an unwanted processing cycle in cases like DBInstance when associated roles are being added.

On the opposite side, a success-event could be a subject for an early return from the chain, even if the chain is intentionally terminated with `progress()` invoker. For this purpose `IgnoreErrorStatus` is made configurable so the end invoker can declare the desired event status.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Signed-off-by: Oleg Sidorov <sidorovo@amazon.com>