### PR TITLE
[DBInstance] Fix errors in schema regex validators

### DIFF
--- a/aws-rds-dbinstance/aws-rds-dbinstance.json
+++ b/aws-rds-dbinstance/aws-rds-dbinstance.json
@@ -140,12 +140,12 @@
     },
     "DBName": {
       "type": "string",
-      "pattern": "^$|^[_a-zA-Z][a-zA-Z0-9]{0,63}$",
+      "pattern": "^$|^[_a-zA-Z][a-zA-Z0-9_]{0,63}$",
       "description": "The meaning of this parameter differs according to the database engine you use."
     },
     "DBParameterGroupName": {
       "type": "string",
-      "pattern": "^$|^[a-zA-Z]{1}(?:-?[a-zA-Z0-9\\.]){0,254}$",
+      "pattern": "^$|^[a-zA-Z]{1}(?:[:-]?[a-zA-Z0-9\\.]){0,254}$",
       "description": "The name of an existing DB parameter group or a reference to an AWS::RDS::DBParameterGroup resource created in the template."
     },
     "DBSecurityGroups": {
@@ -159,12 +159,12 @@
     "DBSnapshotIdentifier": {
       "type": "string",
       "description": "The name or Amazon Resource Name (ARN) of the DB snapshot that's used to restore the DB instance. If you're restoring from a shared manual DB snapshot, you must specify the ARN of the snapshot.",
-      "pattern": "^$|^[a-zA-Z]{1}(?:-?[a-zA-Z0-9]){0,254}$"
+      "pattern": "^$|^[a-zA-Z]{1}(?:[:-]?[a-zA-Z0-9]){0,254}$"
     },
     "DBSubnetGroupName": {
       "type": "string",
       "description": "A DB subnet group to associate with the DB instance. If you update this value, the new subnet group must be a subnet group in a new VPC.",
-      "pattern": "^$|^[a-zA-Z]{1}(?:-?[a-zA-Z0-9]){0,254}$"
+      "pattern": "^$|^[a-zA-Z]{1}(?:[-:]?[a-zA-Z0-9]){0,254}$"
     },
     "DeleteAutomatedBackups": {
       "type": "boolean",
@@ -230,7 +230,7 @@
     },
     "MasterUsername": {
       "type": "string",
-      "pattern": "^[a-zA-Z][a-zA-Z0-9]{0,15}$",
+      "pattern": "^[a-zA-Z][a-zA-Z0-9_]{0,15}$",
       "description": "The master user name for the DB instance."
     },
     "MasterUserPassword": {

--- a/aws-rds-dbinstance/docs/README.md
+++ b/aws-rds-dbinstance/docs/README.md
@@ -273,7 +273,7 @@ _Required_: No
 
 _Type_: String
 
-_Pattern_: <code>^$|^[_a-zA-Z][a-zA-Z0-9]{0,63}$</code>
+_Pattern_: <code>^$|^[_a-zA-Z][a-zA-Z0-9_]{0,63}$</code>
 
 _Update requires_: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
 
@@ -285,7 +285,7 @@ _Required_: No
 
 _Type_: String
 
-_Pattern_: <code>^$|^[a-zA-Z]{1}(?:-?[a-zA-Z0-9\.]){0,254}$</code>
+_Pattern_: <code>^$|^[a-zA-Z]{1}(?:[:-]?[a-zA-Z0-9\.]){0,254}$</code>
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 
@@ -307,7 +307,7 @@ _Required_: No
 
 _Type_: String
 
-_Pattern_: <code>^$|^[a-zA-Z]{1}(?:-?[a-zA-Z0-9]){0,254}$</code>
+_Pattern_: <code>^$|^[a-zA-Z]{1}(?:[:-]?[a-zA-Z0-9]){0,254}$</code>
 
 _Update requires_: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
 
@@ -319,7 +319,7 @@ _Required_: No
 
 _Type_: String
 
-_Pattern_: <code>^$|^[a-zA-Z]{1}(?:-?[a-zA-Z0-9]){0,254}$</code>
+_Pattern_: <code>^$|^[a-zA-Z]{1}(?:[-:]?[a-zA-Z0-9]){0,254}$</code>
 
 _Update requires_: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
 
@@ -461,7 +461,7 @@ _Required_: No
 
 _Type_: String
 
-_Pattern_: <code>^[a-zA-Z][a-zA-Z0-9]{0,15}$</code>
+_Pattern_: <code>^[a-zA-Z][a-zA-Z0-9_]{0,15}$</code>
 
 _Update requires_: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
 


### PR DESCRIPTION
This PR is addressing 3 major regressions introduced by the current implementation:
  * DBName validation fails if the attribute contains an underscore
  * DBSnapshotIdentifier validation fails if an ARN value is provided
  * MasterUsername validation fails if the attribute contains an
  undescore

The PR intoduces the corresponding changes to the schema.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Signed-off-by: Oleg Sidorov <sidorovo@amazon.com>