### PR TITLE
[DBInstance] Handle drifting update requests

### DIFF
--- a/aws-rds-cfn-common/src/main/java/software/amazon/rds/common/handler/Commons.java
+++ b/aws-rds-cfn-common/src/main/java/software/amazon/rds/common/handler/Commons.java
@@ -4,7 +4,6 @@ import java.util.function.Function;
 
 import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.cloudformation.proxy.HandlerErrorCode;
-import software.amazon.cloudformation.proxy.OperationStatus;
 import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.rds.common.error.ErrorCode;
 import software.amazon.rds.common.error.ErrorRuleSet;

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/Translator.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/Translator.java
@@ -24,6 +24,7 @@ import software.amazon.awssdk.services.rds.model.CreateDbInstanceRequest;
 import software.amazon.awssdk.services.rds.model.DBParameterGroupStatus;
 import software.amazon.awssdk.services.rds.model.DBSubnetGroup;
 import software.amazon.awssdk.services.rds.model.DeleteDbInstanceRequest;
+import software.amazon.awssdk.services.rds.model.DescribeDbClustersRequest;
 import software.amazon.awssdk.services.rds.model.DescribeDbEngineVersionsRequest;
 import software.amazon.awssdk.services.rds.model.DescribeDbInstancesRequest;
 import software.amazon.awssdk.services.rds.model.DescribeDbParameterGroupsRequest;
@@ -40,6 +41,12 @@ public class Translator {
     public static DescribeDbInstancesRequest describeDbInstancesRequest(final ResourceModel model) {
         return DescribeDbInstancesRequest.builder()
                 .dbInstanceIdentifier(model.getDBInstanceIdentifier())
+                .build();
+    }
+
+    public static DescribeDbClustersRequest describeDbClustersRequest(final ResourceModel model) {
+        return DescribeDbClustersRequest.builder()
+                .dbClusterIdentifier(model.getDBClusterIdentifier())
                 .build();
     }
 


### PR DESCRIPTION
This code change adds an alternative Update handler branch to facilitate a DBInstance resource drift resolution.

The change checks the request `Driftable` flag and performs a scatter-status check for the supporting objects. The check validates `in-sync` status for the following objects:
  - DBParameterGroup
  - OptionGroup
  - DBClusterParameterGroup (if applicable)

Upon a complete sync, the handler would check if the instance requires a restart and performs a `reboot-await`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Signed-off-by: Oleg Sidorov <sidorovo@amazon.com>