### PR TITLE
Handle remove DBCluster from GlobalCluster case

### DIFF
--- a/aws-rds-dbcluster/aws-rds-dbcluster.json
+++ b/aws-rds-dbcluster/aws-rds-dbcluster.json
@@ -50,8 +50,8 @@
     "GlobalClusterIdentifier": {
       "description": "If you are configuring an Aurora global database cluster and want your Aurora DB cluster to be a secondary member in the global database cluster, specify the global cluster ID of the global database cluster. To define the primary database cluster of the global cluster, use the AWS::RDS::GlobalCluster resource.\n\nIf you aren't configuring a global database cluster, don't specify this property.",
       "type": "string",
-      "pattern": "^[a-zA-Z]{1}(?:-?[a-zA-Z0-9]){0,62}$",
-      "minLength": 1,
+      "pattern": "^$|^[a-zA-Z]{1}(?:-?[a-zA-Z0-9]){0,62}$",
+      "minLength": 0,
       "maxLength": 63
     },
     "DBClusterIdentifier": {

--- a/aws-rds-dbcluster/docs/README.md
+++ b/aws-rds-dbcluster/docs/README.md
@@ -176,11 +176,9 @@ _Required_: No
 
 _Type_: String
 
-_Minimum_: <code>1</code>
-
 _Maximum_: <code>63</code>
 
-_Pattern_: <code>^[a-zA-Z]{1}(?:-?[a-zA-Z0-9]){0,62}$</code>
+_Pattern_: <code>^$|^[a-zA-Z]{1}(?:-?[a-zA-Z0-9]){0,62}$</code>
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 

--- a/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/util/ImmutabilityHelper.java
+++ b/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/util/ImmutabilityHelper.java
@@ -14,7 +14,7 @@ public final class ImmutabilityHelper {
 
     static boolean isGlobalClusterMutable(final ResourceModel previous, final ResourceModel desired) {
         if (StringUtils.isNullOrEmpty(desired.getGlobalClusterIdentifier())) {
-            return Objects.equal(previous.getGlobalClusterIdentifier(), desired.getGlobalClusterIdentifier());
+            return true;
         }
         return desired.getGlobalClusterIdentifier().equals(previous.getGlobalClusterIdentifier());
     }

--- a/aws-rds-dbcluster/src/test/java/software/amazon/rds/dbcluster/util/ImmutabilityHelperTest.java
+++ b/aws-rds-dbcluster/src/test/java/software/amazon/rds/dbcluster/util/ImmutabilityHelperTest.java
@@ -36,7 +36,7 @@ class ImmutabilityHelperTest {
                 ResourceModelTestCase.builder()
                         .previous(ResourceModel.builder().globalClusterIdentifier("global-cluster-identifier").build())
                         .desired(ResourceModel.builder().globalClusterIdentifier(null).build())
-                        .expect(false)
+                        .expect(true)
                         .build(),
                 ResourceModelTestCase.builder()
                         .previous(ResourceModel.builder().globalClusterIdentifier("global-cluster-identifier").build())


### PR DESCRIPTION
Accept empty global cluster in schema which translated to removing DBCluster from GlobalCluster


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
