### PR TITLE
[DBCluster] Remove from global cluster on update

### DIFF
--- a/aws-rds-dbcluster/aws-rds-dbcluster.json
+++ b/aws-rds-dbcluster/aws-rds-dbcluster.json
@@ -50,8 +50,8 @@
     "GlobalClusterIdentifier": {
       "description": "If you are configuring an Aurora global database cluster and want your Aurora DB cluster to be a secondary member in the global database cluster, specify the global cluster ID of the global database cluster. To define the primary database cluster of the global cluster, use the AWS::RDS::GlobalCluster resource.\n\nIf you aren't configuring a global database cluster, don't specify this property.",
       "type": "string",
-      "pattern": "^[a-zA-Z]{1}(?:-?[a-zA-Z0-9]){0,62}$",
-      "minLength": 1,
+      "pattern": "^$|^[a-zA-Z]{1}(?:-?[a-zA-Z0-9]){0,62}$",
+      "minLength": 0,
       "maxLength": 63
     },
     "DBClusterIdentifier": {
@@ -395,13 +395,13 @@
     "create": {
       "permissions": [
         "iam:PassRole",
-        "rds:CreateDBCluster",
-        "rds:RestoreDBClusterFromSnapshot",
-        "rds:RestoreDBClusterToPointInTime",
-        "rds:ModifyDBCluster",
-        "rds:DescribeDBClusters",
         "rds:AddRoleToDBCluster",
-        "rds:AddTagsToResource"
+        "rds:AddTagsToResource",
+        "rds:CreateDBCluster",
+        "rds:DescribeDBClusters",
+        "rds:ModifyDBCluster",
+        "rds:RestoreDBClusterFromSnapshot",
+        "rds:RestoreDBClusterToPointInTime"
       ]
     },
     "read": {
@@ -412,18 +412,19 @@
     "update": {
       "permissions": [
         "iam:PassRole",
-        "rds:ModifyDBCluster",
-        "rds:DescribeDBClusters",
         "rds:AddRoleToDBCluster",
+        "rds:AddTagsFromResource",
+        "rds:DescribeDBClusters",
+        "rds:ModifyDBCluster",
+        "rds:RemoveFromGlobalCluster",
         "rds:RemoveRoleFromDBCluster",
-        "rds:RemoveTagsFromResource",
-        "rds:AddTagsFromResource"
+        "rds:RemoveTagsFromResource"
       ]
     },
     "delete": {
       "permissions": [
-        "rds:DescribeDBClusters",
         "rds:DeleteDBCluster",
+        "rds:DescribeDBClusters",
         "rds:RemoveFromGlobalCluster"
       ]
     },

--- a/aws-rds-dbcluster/docs/README.md
+++ b/aws-rds-dbcluster/docs/README.md
@@ -176,11 +176,9 @@ _Required_: No
 
 _Type_: String
 
-_Minimum_: <code>1</code>
-
 _Maximum_: <code>63</code>
 
-_Pattern_: <code>^[a-zA-Z]{1}(?:-?[a-zA-Z0-9]){0,62}$</code>
+_Pattern_: <code>^$|^[a-zA-Z]{1}(?:-?[a-zA-Z0-9]){0,62}$</code>
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 

--- a/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/Translator.java
+++ b/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/Translator.java
@@ -189,10 +189,10 @@ public class Translator {
         return builder.build();
     }
 
-    static RemoveFromGlobalClusterRequest removeFromGlobalClusterRequest(final ResourceModel model, final String clusterArn) {
+    static RemoveFromGlobalClusterRequest removeFromGlobalClusterRequest(final String globalClusterIdentifier, final String clusterArn) {
         return RemoveFromGlobalClusterRequest.builder()
                 .dbClusterIdentifier(clusterArn)
-                .globalClusterIdentifier(model.getGlobalClusterIdentifier())
+                .globalClusterIdentifier(globalClusterIdentifier)
                 .build();
     }
 

--- a/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/util/ImmutabilityHelper.java
+++ b/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/util/ImmutabilityHelper.java
@@ -13,10 +13,12 @@ public final class ImmutabilityHelper {
     }
 
     static boolean isGlobalClusterMutable(final ResourceModel previous, final ResourceModel desired) {
-        if (StringUtils.isNullOrEmpty(desired.getGlobalClusterIdentifier())) {
-            return Objects.equal(previous.getGlobalClusterIdentifier(), desired.getGlobalClusterIdentifier());
+        if (StringUtils.hasValue(previous.getGlobalClusterIdentifier()) &&
+            StringUtils.isNullOrEmpty(desired.getGlobalClusterIdentifier())) {
+            // This would be handled by calling remove-from-global-cluster explicitly
+            return true;
         }
-        return desired.getGlobalClusterIdentifier().equals(previous.getGlobalClusterIdentifier());
+        return Objects.equal(previous.getGlobalClusterIdentifier(), desired.getGlobalClusterIdentifier());
     }
 
     static boolean isEngineMutable(final ResourceModel previous, final ResourceModel desired) {

--- a/aws-rds-dbcluster/src/test/java/software/amazon/rds/dbcluster/util/ImmutabilityHelperTest.java
+++ b/aws-rds-dbcluster/src/test/java/software/amazon/rds/dbcluster/util/ImmutabilityHelperTest.java
@@ -36,7 +36,7 @@ class ImmutabilityHelperTest {
                 ResourceModelTestCase.builder()
                         .previous(ResourceModel.builder().globalClusterIdentifier("global-cluster-identifier").build())
                         .desired(ResourceModel.builder().globalClusterIdentifier(null).build())
-                        .expect(false)
+                        .expect(true)
                         .build(),
                 ResourceModelTestCase.builder()
                         .previous(ResourceModel.builder().globalClusterIdentifier("global-cluster-identifier").build())


### PR DESCRIPTION
This PR changes the behavior of `UpdateHandler`. In particular, a change from a non-empty global cluster identifier to an empty value engages the global cluster membership termination mechanism. The code would invoke `RemoveFromGlobalCluster` API and ensure the cluster has stabilized before the primary update operation begins.

A reverse operation is handled by RDS API, hence no need for a special treatment.

The schema validation constraint allows an empty global cluster identifier as well.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Signed-off-by: Oleg Sidorov <sidorovo@amazon.com>