### PR TITLE
[DBInstance] Soft fail stack-level tag updates

### DIFF
--- a/aws-rds-cfn-common/src/main/java/software/amazon/rds/common/error/ErrorCode.java
+++ b/aws-rds-cfn-common/src/main/java/software/amazon/rds/common/error/ErrorCode.java
@@ -1,5 +1,7 @@
 package software.amazon.rds.common.error;
 
+import software.amazon.awssdk.awscore.exception.AwsErrorDetails;
+import software.amazon.awssdk.awscore.exception.AwsServiceException;
 import software.amazon.awssdk.utils.StringUtils;
 
 public enum ErrorCode {
@@ -46,6 +48,14 @@ public enum ErrorCode {
                     return errorCode;
                 }
             }
+        }
+        return null;
+    }
+
+    public static ErrorCode fromException(final AwsServiceException exception) {
+        final AwsErrorDetails errorDetails = exception.awsErrorDetails();
+        if (errorDetails != null) {
+            return ErrorCode.fromString(errorDetails.errorCode());
         }
         return null;
     }

--- a/aws-rds-cfn-common/src/main/java/software/amazon/rds/common/handler/Tagging.java
+++ b/aws-rds-cfn-common/src/main/java/software/amazon/rds/common/handler/Tagging.java
@@ -11,17 +11,74 @@ import java.util.stream.Collectors;
 
 import com.amazonaws.util.CollectionUtils;
 import com.google.common.collect.Sets;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
 import software.amazon.awssdk.services.rds.RdsClient;
 import software.amazon.awssdk.services.rds.model.AddTagsToResourceRequest;
 import software.amazon.awssdk.services.rds.model.ListTagsForResourceRequest;
 import software.amazon.awssdk.services.rds.model.ListTagsForResourceResponse;
 import software.amazon.awssdk.services.rds.model.RemoveTagsFromResourceRequest;
 import software.amazon.awssdk.services.rds.model.Tag;
+import software.amazon.cloudformation.proxy.HandlerErrorCode;
 import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ProxyClient;
+import software.amazon.rds.common.error.ErrorCode;
 import software.amazon.rds.common.error.ErrorRuleSet;
+import software.amazon.rds.common.error.ErrorStatus;
 
 public final class Tagging {
+
+    public static final ErrorRuleSet SOFT_FAIL_TAG_ERROR_RULE_SET = ErrorRuleSet.builder()
+            .withErrorCodes(ErrorStatus.ignore(),
+                    ErrorCode.AccessDenied,
+                    ErrorCode.AccessDeniedException
+            ).build();
+
+    public static final ErrorRuleSet HARD_FAIL_TAG_ERROR_RULE_SET = ErrorRuleSet.builder()
+            .withErrorCodes(ErrorStatus.failWith(HandlerErrorCode.AccessDenied),
+                    ErrorCode.AccessDenied,
+                    ErrorCode.AccessDeniedException
+            ).build();
+
+    @Builder(toBuilder = true)
+    @AllArgsConstructor
+    @Data
+    public static class TagSet {
+        @Builder.Default
+        private Set<Tag> systemTags = new HashSet<>();
+        @Builder.Default
+        private Set<Tag> stackTags = new HashSet<>();
+        @Builder.Default
+        private Set<Tag> resourceTags = new HashSet<>();
+
+        public boolean isEmpty() {
+            return systemTags.isEmpty() &&
+                    stackTags.isEmpty() &&
+                    resourceTags.isEmpty();
+        }
+
+        public static TagSet emptySet() {
+            return TagSet.builder().build();
+        }
+    }
+
+    public static TagSet exclude(final TagSet from, final TagSet what) {
+        final Set<Tag> systemTags = new HashSet<>(from.getSystemTags());
+        systemTags.removeAll(what.getSystemTags());
+
+        final Set<Tag> stackTags = new HashSet<>(from.getStackTags());
+        stackTags.removeAll(what.getStackTags());
+
+        final Set<Tag> resourceTags = new HashSet<>(from.getResourceTags());
+        resourceTags.removeAll(what.getResourceTags());
+
+        return TagSet.builder()
+                .systemTags(systemTags)
+                .stackTags(stackTags)
+                .resourceTags(resourceTags)
+                .build();
+    }
 
     public static <K, V> Map<K, V> mergeTags(Map<K, V> tagsMap1, Map<K, V> tagsMap2) {
         final Map<K, V> result = new HashMap<>();
@@ -30,8 +87,16 @@ public final class Tagging {
         return result;
     }
 
-    public static Set<Tag> translateTagsToSdk(Map<String, String> tags) {
-        return tags.entrySet()
+    public static Set<Tag> translateTagsToSdk(final TagSet tagSet) {
+        final Set<Tag> allTags = new HashSet<>();
+        allTags.addAll(tagSet.getSystemTags());
+        allTags.addAll(tagSet.getStackTags());
+        allTags.addAll(tagSet.getResourceTags());
+        return allTags;
+    }
+
+    public static Set<Tag> translateTagsToSdk(final Map<String, String> tags) {
+        return Optional.ofNullable(tags).orElse(Collections.emptyMap()).entrySet()
                 .stream()
                 .map(entry -> Tag.builder()
                         .key(entry.getKey())
@@ -42,16 +107,15 @@ public final class Tagging {
 
     public static Set<Tag> listTagsForResource(
             final ProxyClient<RdsClient> rdsProxyClient,
-            final String arn) {
-
-        ListTagsForResourceResponse listTagsForResourceResponse = rdsProxyClient.injectCredentialsAndInvokeV2(
+            final String arn
+    ) {
+        final ListTagsForResourceResponse listTagsForResourceResponse = rdsProxyClient.injectCredentialsAndInvokeV2(
                 listTagsForResourceRequest(arn),
                 rdsProxyClient.client()::listTagsForResource
         );
 
         return listTagsForResourceResponse.hasTagList() ?
                 Sets.newHashSet(listTagsForResourceResponse.tagList()) : Sets.newHashSet();
-
     }
 
     public static <M, C> ProgressEvent<M, C> updateTags(
@@ -77,13 +141,14 @@ public final class Tagging {
         }
     }
 
-    private static void addTags(
+    public static void addTags(
             final ProxyClient<RdsClient> rdsProxyClient,
             final String arn,
             final Collection<Tag> tagsToAdd
     ) {
-        if (CollectionUtils.isNullOrEmpty(tagsToAdd))
+        if (CollectionUtils.isNullOrEmpty(tagsToAdd)) {
             return;
+        }
 
         rdsProxyClient.injectCredentialsAndInvokeV2(
                 addTagsToResourceRequest(arn, tagsToAdd),
@@ -91,13 +156,14 @@ public final class Tagging {
         );
     }
 
-    private static void removeTags(
+    public static void removeTags(
             final ProxyClient<RdsClient> rdsProxyClient,
             final String arn,
             final Collection<Tag> tagsToRemove
     ) {
-        if (CollectionUtils.isNullOrEmpty(tagsToRemove))
+        if (CollectionUtils.isNullOrEmpty(tagsToRemove)) {
             return;
+        }
 
         rdsProxyClient.injectCredentialsAndInvokeV2(
                 removeTagsFromResourceRequest(arn, tagsToRemove),
@@ -128,4 +194,14 @@ public final class Tagging {
                 .build();
     }
 
+    public static ErrorRuleSet bestEffortErrorRuleSet(
+            final TagSet tagsToAdd,
+            final TagSet tagsToRemove
+    ) {
+        // Only soft fail if the customer provided no resource-level tags
+        if (tagsToAdd.getResourceTags().isEmpty() && tagsToRemove.getResourceTags().isEmpty()) {
+            return SOFT_FAIL_TAG_ERROR_RULE_SET;
+        }
+        return HARD_FAIL_TAG_ERROR_RULE_SET;
+    }
 }

--- a/aws-rds-cfn-common/src/test/java/software/amazon/rds/common/handler/TaggingTest.java
+++ b/aws-rds-cfn-common/src/test/java/software/amazon/rds/common/handler/TaggingTest.java
@@ -7,13 +7,19 @@ import static org.mockito.Mockito.when;
 
 import java.time.Duration;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 
 import com.google.common.collect.ImmutableMap;
+import software.amazon.awssdk.awscore.exception.AwsErrorDetails;
+import software.amazon.awssdk.awscore.exception.AwsServiceException;
 import software.amazon.awssdk.services.rds.RdsClient;
 import software.amazon.awssdk.services.rds.model.AddTagsToResourceRequest;
 import software.amazon.awssdk.services.rds.model.AddTagsToResourceResponse;
@@ -26,6 +32,10 @@ import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
+import software.amazon.rds.common.error.ErrorRuleSet;
+import software.amazon.rds.common.error.ErrorStatus;
+import software.amazon.rds.common.error.IgnoreErrorStatus;
+import software.amazon.rds.common.error.UnexpectedErrorStatus;
 import software.amazon.rds.common.logging.LoggingProxyClient;
 import software.amazon.rds.common.logging.RequestLogger;
 import software.amazon.rds.common.printer.FilteredJsonPrinter;
@@ -83,5 +93,188 @@ public class TaggingTest extends ProxyClientTestBase {
                         .build());
         Collection<Tag> result = Tagging.listTagsForResource(proxyRdsClient, "arn");
         assertThat(result).isNotEmpty();
+    }
+
+    @Test
+    void test_TagSet_isEmpty() {
+        final Tagging.TagSet tagSet = Tagging.TagSet.builder().build();
+        assertThat(tagSet.isEmpty()).isTrue();
+    }
+
+    @Test
+    void test_TagSet_isNotEmpty() {
+        final Tagging.TagSet tagSet = Tagging.TagSet.builder()
+                .stackTags(Collections.singleton(Tag.builder().build()))
+                .build();
+        assertThat(tagSet.isEmpty()).isFalse();
+    }
+
+    @Test
+    void test_TagSet_emptySet() {
+        final Tagging.TagSet tagSet = Tagging.TagSet.emptySet();
+        assertThat(tagSet.isEmpty()).isTrue();
+    }
+
+    @Test
+    void test_SoftFailErrorRuleSet_AwsServiceException_AccessDenied() {
+        final Exception exception = AwsServiceException.builder()
+                .awsErrorDetails(AwsErrorDetails.builder()
+                        .errorCode("AccessDenied")
+                        .build())
+                .build();
+        final ErrorRuleSet ruleSet = Tagging.SOFT_FAIL_TAG_ERROR_RULE_SET;
+        final ErrorStatus status = ruleSet.handle(exception);
+        assertThat(status).isInstanceOf(IgnoreErrorStatus.class);
+    }
+
+    @Test
+    void test_SoftFailErrorRuleSet_AwsServiceException_OtherCode() {
+        final Exception exception = AwsServiceException.builder()
+                .awsErrorDetails(AwsErrorDetails.builder()
+                        .errorCode("InternalFailure")
+                        .build())
+                .build();
+        final ErrorRuleSet ruleSet = Tagging.SOFT_FAIL_TAG_ERROR_RULE_SET;
+        final ErrorStatus status = ruleSet.handle(exception);
+        assertThat(status).isInstanceOf(UnexpectedErrorStatus.class);
+    }
+
+    @Test
+    void test_SoftFailErrorRuleSet_OtherException() {
+        final Exception exception = new RuntimeException("test exception");
+        final ErrorRuleSet ruleSet = Tagging.SOFT_FAIL_TAG_ERROR_RULE_SET;
+        final ErrorStatus status = ruleSet.handle(exception);
+        assertThat(status).isInstanceOf(UnexpectedErrorStatus.class);
+    }
+
+    @Test
+    void test_translateTagsToSdk() {
+        final Set<Tag> systemTags = Stream.of(
+                Tag.builder().key("system-tag-key-1").value("system-tag-value-1").build(),
+                Tag.builder().key("system-tag-key-2").value("system-tag-value-2").build()
+        ).collect(Collectors.toSet());
+        final Set<Tag> stackTags = Stream.of(
+                Tag.builder().key("stack-tag-key-1").value("stack-tag-value-1").build(),
+                Tag.builder().key("stack-tag-key-2").value("stack-tag-value-2").build()
+        ).collect(Collectors.toSet());
+        final Set<Tag> resourceTags = Stream.of(
+                Tag.builder().key("resource-tag-key-1").value("resource-tag-value-1").build(),
+                Tag.builder().key("resource-tag-key-2").value("resource-tag-value-2").build()
+        ).collect(Collectors.toSet());
+
+        final Tagging.TagSet tagSet = Tagging.TagSet.builder()
+                .systemTags(systemTags)
+                .stackTags(stackTags)
+                .resourceTags(resourceTags)
+                .build();
+
+        final Set<Tag> allTags = Tagging.translateTagsToSdk(tagSet);
+
+        assertThat(allTags.containsAll(systemTags)).isTrue();
+        assertThat(allTags.containsAll(stackTags)).isTrue();
+        assertThat(allTags.containsAll(resourceTags)).isTrue();
+    }
+
+    @Test
+    void test_exclude() {
+        final Tagging.TagSet minuend = Tagging.TagSet.builder()
+                .systemTags(Stream.of(
+                        Tag.builder().key("system-tag-key-1").value("system-tag-value-1").build(),
+                        Tag.builder().key("system-tag-key-2").value("system-tag-value-2").build()
+                ).collect(Collectors.toSet()))
+                .stackTags(Stream.of(
+                        Tag.builder().key("stack-tag-key-1").value("stack-tag-value-1").build(),
+                        Tag.builder().key("stack-tag-key-2").value("stack-tag-value-2").build()
+                ).collect(Collectors.toSet()))
+                .resourceTags(Stream.of(
+                        Tag.builder().key("resource-tag-key-1").value("resource-tag-value-1").build(),
+                        Tag.builder().key("resource-tag-key-2").value("resource-tag-value-2").build()
+                ).collect(Collectors.toSet()))
+                .build();
+
+        final Tagging.TagSet subtrahend = Tagging.TagSet.builder()
+                .systemTags(Stream.of(
+                        Tag.builder().key("system-tag-key-1").value("system-tag-value-1").build()
+                ).collect(Collectors.toSet()))
+                .stackTags(Stream.of(
+                        Tag.builder().key("stack-tag-key-1").value("stack-tag-value-1").build()
+                ).collect(Collectors.toSet()))
+                .resourceTags(Stream.of(
+                        Tag.builder().key("resource-tag-key-1").value("resource-tag-value-1").build()
+                ).collect(Collectors.toSet()))
+                .build();
+
+        final Tagging.TagSet expect = Tagging.TagSet.builder()
+                .systemTags(Stream.of(
+                        Tag.builder().key("system-tag-key-2").value("system-tag-value-2").build()
+                ).collect(Collectors.toSet()))
+                .stackTags(Stream.of(
+                        Tag.builder().key("stack-tag-key-2").value("stack-tag-value-2").build()
+                ).collect(Collectors.toSet()))
+                .resourceTags(Stream.of(
+                        Tag.builder().key("resource-tag-key-2").value("resource-tag-value-2").build()
+                ).collect(Collectors.toSet()))
+                .build();
+
+        final Tagging.TagSet difference = Tagging.exclude(minuend, subtrahend);
+        assertThat(difference).isEqualTo(expect);
+    }
+
+    @Test
+    void test_bestEffortErrorRuleSet_emptyResourceTags() {
+        final ErrorRuleSet errorRuleSet = Tagging.bestEffortErrorRuleSet(
+                Tagging.TagSet.builder()
+                        .stackTags(Collections.singleton(Tag.builder().build()))
+                        .stackTags(Collections.singleton(Tag.builder().build()))
+                        .build(),
+                Tagging.TagSet.builder()
+                        .stackTags(Collections.singleton(Tag.builder().build()))
+                        .stackTags(Collections.singleton(Tag.builder().build()))
+                        .build()
+        );
+
+        assertThat(errorRuleSet).isEqualTo(Tagging.SOFT_FAIL_TAG_ERROR_RULE_SET);
+    }
+
+    @Test
+    void test_bestEffortErrorRuleSet_nonEmptyResourceTags() {
+        assertThat(Tagging.bestEffortErrorRuleSet(
+                Tagging.TagSet.builder()
+                        .stackTags(Collections.singleton(Tag.builder().build()))
+                        .stackTags(Collections.singleton(Tag.builder().build()))
+                        .resourceTags(Collections.singleton(Tag.builder().build()))
+                        .build(),
+                Tagging.TagSet.builder()
+                        .stackTags(Collections.singleton(Tag.builder().build()))
+                        .stackTags(Collections.singleton(Tag.builder().build()))
+                        .resourceTags(Collections.singleton(Tag.builder().build()))
+                        .build()
+        )).isEqualTo(Tagging.HARD_FAIL_TAG_ERROR_RULE_SET);
+
+        assertThat(Tagging.bestEffortErrorRuleSet(
+                Tagging.TagSet.builder()
+                        .stackTags(Collections.singleton(Tag.builder().build()))
+                        .stackTags(Collections.singleton(Tag.builder().build()))
+                        .resourceTags(Collections.emptySet())
+                        .build(),
+                Tagging.TagSet.builder()
+                        .stackTags(Collections.singleton(Tag.builder().build()))
+                        .stackTags(Collections.singleton(Tag.builder().build()))
+                        .resourceTags(Collections.singleton(Tag.builder().build()))
+                        .build()
+        )).isEqualTo(Tagging.HARD_FAIL_TAG_ERROR_RULE_SET);
+
+        assertThat(Tagging.bestEffortErrorRuleSet(
+                Tagging.TagSet.builder()
+                        .stackTags(Collections.singleton(Tag.builder().build()))
+                        .stackTags(Collections.singleton(Tag.builder().build()))
+                        .resourceTags(Collections.singleton(Tag.builder().build()))
+                        .build(),
+                Tagging.TagSet.builder()
+                        .stackTags(Collections.singleton(Tag.builder().build()))
+                        .stackTags(Collections.singleton(Tag.builder().build()))
+                        .resourceTags(Collections.emptySet())
+                        .build()
+        )).isEqualTo(Tagging.HARD_FAIL_TAG_ERROR_RULE_SET);
     }
 }

--- a/aws-rds-dbinstance/aws-rds-dbinstance.json
+++ b/aws-rds-dbinstance/aws-rds-dbinstance.json
@@ -449,6 +449,7 @@
         "kms:CreateGrant",
         "kms:DescribeKey",
         "rds:AddRoleToDBInstance",
+        "rds:AddTagsToResource",
         "rds:CreateDBInstance",
         "rds:CreateDBInstanceReadReplica",
         "rds:DescribeDBInstances",

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/BaseHandlerStd.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/BaseHandlerStd.java
@@ -3,10 +3,8 @@ package software.amazon.rds.dbinstance;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.BiFunction;
@@ -64,6 +62,7 @@ import software.amazon.rds.common.error.ErrorRuleSet;
 import software.amazon.rds.common.error.ErrorStatus;
 import software.amazon.rds.common.handler.Commons;
 import software.amazon.rds.common.handler.HandlerConfig;
+import software.amazon.rds.common.handler.Tagging;
 import software.amazon.rds.common.logging.LoggingProxyClient;
 import software.amazon.rds.common.logging.RequestLogger;
 import software.amazon.rds.common.printer.FilteredJsonPrinter;
@@ -257,11 +256,11 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
             final ProgressEvent<ResourceModel, CallbackContext> progress
     ) {
         return proxy.initiate(
-                "rds::stabilize-db-instance-" + getClass().getSimpleName(),
-                rdsProxyClient,
-                progress.getResourceModel(),
-                progress.getCallbackContext()
-        )
+                        "rds::stabilize-db-instance-" + getClass().getSimpleName(),
+                        rdsProxyClient,
+                        progress.getResourceModel(),
+                        progress.getCallbackContext()
+                )
                 .translateToServiceRequest(Function.identity())
                 .backoffDelay(config.getBackoff())
                 .makeServiceCall(NOOP_CALL)
@@ -455,34 +454,6 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
         );
     }
 
-    protected void addNewTags(
-            final ProxyClient<RdsClient> rdsProxyClient,
-            final String arn,
-            final Collection<Tag> tagsToAdd
-    ) {
-        if (CollectionUtils.isNullOrEmpty(tagsToAdd)) {
-            return;
-        }
-        rdsProxyClient.injectCredentialsAndInvokeV2(
-                Translator.addTagsToResourceRequest(arn, tagsToAdd),
-                rdsProxyClient.client()::addTagsToResource
-        );
-    }
-
-    protected void removeOldTags(
-            final ProxyClient<RdsClient> rdsProxyClient,
-            final String arn,
-            final Collection<Tag> tagsToRemove
-    ) {
-        if (CollectionUtils.isNullOrEmpty(tagsToRemove)) {
-            return;
-        }
-        rdsProxyClient.injectCredentialsAndInvokeV2(
-                Translator.removeTagsFromResourceRequest(arn, tagsToRemove),
-                rdsProxyClient.client()::removeTagsFromResource
-        );
-    }
-
     protected ProgressEvent<ResourceModel, CallbackContext> updateAssociatedRoles(
             final AmazonWebServicesClientProxy proxy,
             final ProxyClient<RdsClient> rdsProxyClient,
@@ -611,17 +582,44 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
         return progress;
     }
 
-    protected <K, V> Map<K, V> mergeMaps(Collection<Map<K, V>> maps) {
-        final Map<K, V> result = new HashMap<>();
-        for (Map<K, V> map : maps) {
-            if (map != null) {
-                result.putAll(map);
-            }
+    protected ProgressEvent<ResourceModel, CallbackContext> updateTags(
+            final AmazonWebServicesClientProxy proxy,
+            final ProxyClient<RdsClient> rdsProxyClient,
+            final ProgressEvent<ResourceModel, CallbackContext> progress,
+            final Tagging.TagSet previousTags,
+            final Tagging.TagSet desiredTags
+    ) {
+        final Tagging.TagSet tagsToAdd = Tagging.exclude(desiredTags, previousTags);
+        final Tagging.TagSet tagsToRemove = Tagging.exclude(previousTags, desiredTags);
+
+        if (tagsToAdd.isEmpty() && tagsToRemove.isEmpty()) {
+            return progress;
         }
-        return result;
+
+        DBInstance dbInstance;
+        try {
+            dbInstance = fetchDBInstance(rdsProxyClient, progress.getResourceModel());
+        } catch (Exception exception) {
+            return Commons.handleException(progress, exception, DEFAULT_DB_INSTANCE_ERROR_RULE_SET);
+        }
+
+        final String arn = dbInstance.dbInstanceArn();
+
+        try {
+            Tagging.removeTags(rdsProxyClient, arn, Tagging.translateTagsToSdk(tagsToRemove));
+            Tagging.addTags(rdsProxyClient, arn, Tagging.translateTagsToSdk(tagsToAdd));
+        } catch (Exception exception) {
+            return Commons.handleException(
+                    progress,
+                    exception,
+                    Tagging.bestEffortErrorRuleSet(tagsToAdd, tagsToRemove).orElse(DEFAULT_DB_INSTANCE_ERROR_RULE_SET)
+            );
+        }
+
+        return progress;
     }
 
-    public String generateResourceIdentifier(
+    protected String generateResourceIdentifier(
             final String stackId,
             final String logicalResourceId,
             final String clientRequestToken,

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/Configuration.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/Configuration.java
@@ -1,12 +1,7 @@
 package software.amazon.rds.dbinstance;
 
-import java.util.Map;
-import java.util.stream.Collectors;
-
 import org.json.JSONObject;
 import org.json.JSONTokener;
-
-import com.amazonaws.util.CollectionUtils;
 
 class Configuration extends BaseConfiguration {
 
@@ -15,17 +10,6 @@ class Configuration extends BaseConfiguration {
     }
 
     public JSONObject resourceSchemaJsonObject() {
-        return new JSONObject(
-                new JSONTokener(this.getClass().getClassLoader().getResourceAsStream(schemaFilename)));
-    }
-
-    public Map<String, String> resourceDefinedTags(final ResourceModel model) {
-        if (CollectionUtils.isNullOrEmpty(model.getTags())) {
-            return null;
-        }
-
-        return model.getTags()
-                .stream()
-                .collect(Collectors.toMap(Tag::getKey, Tag::getValue, (v1, v2) -> v2));
+        return new JSONObject(new JSONTokener(this.getClass().getClassLoader().getResourceAsStream(schemaFilename)));
     }
 }

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/Translator.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/Translator.java
@@ -17,7 +17,6 @@ import org.apache.commons.lang3.BooleanUtils;
 import software.amazon.awssdk.services.ec2.model.DescribeSecurityGroupsRequest;
 import software.amazon.awssdk.services.ec2.model.Filter;
 import software.amazon.awssdk.services.rds.model.AddRoleToDbInstanceRequest;
-import software.amazon.awssdk.services.rds.model.AddTagsToResourceRequest;
 import software.amazon.awssdk.services.rds.model.CloudwatchLogsExportConfiguration;
 import software.amazon.awssdk.services.rds.model.CreateDbInstanceReadReplicaRequest;
 import software.amazon.awssdk.services.rds.model.CreateDbInstanceRequest;
@@ -32,9 +31,9 @@ import software.amazon.awssdk.services.rds.model.DescribeDbSnapshotsRequest;
 import software.amazon.awssdk.services.rds.model.ModifyDbInstanceRequest;
 import software.amazon.awssdk.services.rds.model.RebootDbInstanceRequest;
 import software.amazon.awssdk.services.rds.model.RemoveRoleFromDbInstanceRequest;
-import software.amazon.awssdk.services.rds.model.RemoveTagsFromResourceRequest;
 import software.amazon.awssdk.services.rds.model.RestoreDbInstanceFromDbSnapshotRequest;
 import software.amazon.awssdk.utils.StringUtils;
+import software.amazon.rds.common.handler.Tagging;
 
 public class Translator {
 
@@ -62,7 +61,10 @@ public class Translator {
                 .build();
     }
 
-    public static CreateDbInstanceReadReplicaRequest createDbInstanceReadReplicaRequest(final ResourceModel model) {
+    public static CreateDbInstanceReadReplicaRequest createDbInstanceReadReplicaRequest(
+            final ResourceModel model,
+            final Tagging.TagSet tagSet
+    ) {
         return CreateDbInstanceReadReplicaRequest.builder()
                 .autoMinorVersionUpgrade(model.getAutoMinorVersionUpgrade())
                 .availabilityZone(model.getAvailabilityZone())
@@ -90,13 +92,16 @@ public class Translator {
                 .sourceDBInstanceIdentifier(model.getSourceDBInstanceIdentifier())
                 .sourceRegion(model.getSourceRegion())
                 .storageType(model.getStorageType())
-                .tags(translateTagsToSdk(model.getTags()))
+                .tags(Tagging.translateTagsToSdk(tagSet))
                 .useDefaultProcessorFeatures(model.getUseDefaultProcessorFeatures())
                 .vpcSecurityGroupIds(model.getVPCSecurityGroups())
                 .build();
     }
 
-    public static RestoreDbInstanceFromDbSnapshotRequest restoreDbInstanceFromSnapshotRequest(final ResourceModel model) {
+    public static RestoreDbInstanceFromDbSnapshotRequest restoreDbInstanceFromSnapshotRequest(
+            final ResourceModel model,
+            final Tagging.TagSet tagSet
+    ) {
         return RestoreDbInstanceFromDbSnapshotRequest.builder()
                 .autoMinorVersionUpgrade(model.getAutoMinorVersionUpgrade())
                 .availabilityZone(model.getAvailabilityZone())
@@ -120,7 +125,7 @@ public class Translator {
                 .processorFeatures(translateProcessorFeaturesToSdk(model.getProcessorFeatures()))
                 .publiclyAccessible(model.getPubliclyAccessible())
                 .storageType(model.getStorageType())
-                .tags(translateTagsToSdk(model.getTags()))
+                .tags(Tagging.translateTagsToSdk(tagSet))
                 .tdeCredentialArn(model.getTdeCredentialArn())
                 .tdeCredentialPassword(model.getTdeCredentialPassword())
                 .useDefaultProcessorFeatures(model.getUseDefaultProcessorFeatures())
@@ -136,7 +141,10 @@ public class Translator {
         return allocatedStorage;
     }
 
-    public static CreateDbInstanceRequest createDbInstanceRequest(final ResourceModel model) {
+    public static CreateDbInstanceRequest createDbInstanceRequest(
+            final ResourceModel model,
+            final Tagging.TagSet tagSet
+    ) {
         return CreateDbInstanceRequest.builder()
                 .allocatedStorage(getAllocatedStorage(model))
                 .autoMinorVersionUpgrade(model.getAutoMinorVersionUpgrade())
@@ -179,7 +187,7 @@ public class Translator {
                 .publiclyAccessible(model.getPubliclyAccessible())
                 .storageEncrypted(model.getStorageEncrypted())
                 .storageType(model.getStorageType())
-                .tags(translateTagsToSdk(model.getTags()))
+                .tags(Tagging.translateTagsToSdk(tagSet))
                 .tdeCredentialArn(model.getTdeCredentialArn())
                 .tdeCredentialPassword(model.getTdeCredentialPassword())
                 .timezone(model.getTimezone())
@@ -281,26 +289,6 @@ public class Translator {
                 .dbInstanceIdentifier(model.getDBInstanceIdentifier())
                 .roleArn(role.getRoleArn())
                 .featureName(role.getFeatureName())
-                .build();
-    }
-
-    public static AddTagsToResourceRequest addTagsToResourceRequest(
-            final String arn,
-            final Collection<Tag> tags
-    ) {
-        return AddTagsToResourceRequest.builder()
-                .resourceName(arn)
-                .tags(translateTagsToSdk(tags))
-                .build();
-    }
-
-    public static RemoveTagsFromResourceRequest removeTagsFromResourceRequest(
-            final String arn,
-            final Collection<Tag> tags
-    ) {
-        return RemoveTagsFromResourceRequest.builder()
-                .resourceName(arn)
-                .tagKeys(tags.stream().map(Tag::getKey).collect(Collectors.toSet()))
                 .build();
     }
 
@@ -489,17 +477,6 @@ public class Translator {
                         .value(tag.value())
                         .build()
                 )
-                .collect(Collectors.toList());
-    }
-
-    public static List<Tag> translateTagsFromRequest(final Map<String, String> tags) {
-        return Optional.ofNullable(tags).orElse(Collections.emptyMap())
-                .entrySet()
-                .stream()
-                .map(entry -> Tag.builder()
-                        .key(entry.getKey())
-                        .value(entry.getValue())
-                        .build())
                 .collect(Collectors.toList());
     }
 

--- a/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/CreateHandlerTest.java
+++ b/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/CreateHandlerTest.java
@@ -28,6 +28,8 @@ import software.amazon.awssdk.services.ec2.Ec2Client;
 import software.amazon.awssdk.services.rds.RdsClient;
 import software.amazon.awssdk.services.rds.model.AddRoleToDbInstanceRequest;
 import software.amazon.awssdk.services.rds.model.AddRoleToDbInstanceResponse;
+import software.amazon.awssdk.services.rds.model.AddTagsToResourceRequest;
+import software.amazon.awssdk.services.rds.model.AddTagsToResourceResponse;
 import software.amazon.awssdk.services.rds.model.CreateDbInstanceReadReplicaRequest;
 import software.amazon.awssdk.services.rds.model.CreateDbInstanceReadReplicaResponse;
 import software.amazon.awssdk.services.rds.model.CreateDbInstanceRequest;
@@ -108,6 +110,8 @@ public class CreateHandlerTest extends AbstractHandlerTest {
         final RestoreDbInstanceFromDbSnapshotResponse restoreResponse = RestoreDbInstanceFromDbSnapshotResponse.builder().build();
         when(rdsProxy.client().restoreDBInstanceFromDBSnapshot(any(RestoreDbInstanceFromDbSnapshotRequest.class)))
                 .thenReturn(restoreResponse);
+        when(rdsProxy.client().addTagsToResource(any(AddTagsToResourceRequest.class)))
+                .thenReturn(AddTagsToResourceResponse.builder().build());
 
         final CallbackContext context = new CallbackContext();
         context.setCreated(false);
@@ -123,7 +127,8 @@ public class CreateHandlerTest extends AbstractHandlerTest {
         );
 
         verify(rdsProxy.client(), times(1)).restoreDBInstanceFromDBSnapshot(any(RestoreDbInstanceFromDbSnapshotRequest.class));
-        verify(rdsProxy.client(), times(2)).describeDBInstances(any(DescribeDbInstancesRequest.class));
+        verify(rdsProxy.client(), times(3)).describeDBInstances(any(DescribeDbInstancesRequest.class));
+        verify(rdsProxy.client(), times(1)).addTagsToResource(any(AddTagsToResourceRequest.class));
     }
 
     @Test
@@ -133,10 +138,10 @@ public class CreateHandlerTest extends AbstractHandlerTest {
                 .build();
         when(rdsProxy.client().describeDBSnapshots(any(DescribeDbSnapshotsRequest.class)))
                 .thenReturn(describeDbSnapshotsResponse);
-
-        final RestoreDbInstanceFromDbSnapshotResponse restoreResponse = RestoreDbInstanceFromDbSnapshotResponse.builder().build();
         when(rdsProxy.client().restoreDBInstanceFromDBSnapshot(any(RestoreDbInstanceFromDbSnapshotRequest.class)))
-                .thenReturn(restoreResponse);
+                .thenReturn(RestoreDbInstanceFromDbSnapshotResponse.builder().build());
+        when(rdsProxy.client().addTagsToResource(any(AddTagsToResourceRequest.class)))
+                .thenReturn(AddTagsToResourceResponse.builder().build());
 
         final CallbackContext context = new CallbackContext();
         context.setCreated(false);
@@ -152,7 +157,8 @@ public class CreateHandlerTest extends AbstractHandlerTest {
         );
 
         verify(rdsProxy.client(), times(1)).describeDBSnapshots(any(DescribeDbSnapshotsRequest.class));
-        verify(rdsProxy.client(), times(2)).describeDBInstances(any(DescribeDbInstancesRequest.class));
+        verify(rdsProxy.client(), times(3)).describeDBInstances(any(DescribeDbInstancesRequest.class));
+        verify(rdsProxy.client(), times(1)).addTagsToResource(any(AddTagsToResourceRequest.class));
 
         ArgumentCaptor<RestoreDbInstanceFromDbSnapshotRequest> argument = ArgumentCaptor.forClass(RestoreDbInstanceFromDbSnapshotRequest.class);
         verify(rdsProxy.client(), times(1)).restoreDBInstanceFromDBSnapshot(argument.capture());
@@ -166,10 +172,10 @@ public class CreateHandlerTest extends AbstractHandlerTest {
                 .build();
         when(rdsProxy.client().describeDBSnapshots(any(DescribeDbSnapshotsRequest.class)))
                 .thenReturn(describeDbSnapshotsResponse);
-
-        final RestoreDbInstanceFromDbSnapshotResponse restoreResponse = RestoreDbInstanceFromDbSnapshotResponse.builder().build();
         when(rdsProxy.client().restoreDBInstanceFromDBSnapshot(any(RestoreDbInstanceFromDbSnapshotRequest.class)))
-                .thenReturn(restoreResponse);
+                .thenReturn(RestoreDbInstanceFromDbSnapshotResponse.builder().build());
+        when(rdsProxy.client().addTagsToResource(any(AddTagsToResourceRequest.class)))
+                .thenReturn(AddTagsToResourceResponse.builder().build());
 
         final CallbackContext context = new CallbackContext();
         context.setCreated(false);
@@ -185,7 +191,8 @@ public class CreateHandlerTest extends AbstractHandlerTest {
         );
 
         verify(rdsProxy.client(), times(1)).describeDBSnapshots(any(DescribeDbSnapshotsRequest.class));
-        verify(rdsProxy.client(), times(2)).describeDBInstances(any(DescribeDbInstancesRequest.class));
+        verify(rdsProxy.client(), times(3)).describeDBInstances(any(DescribeDbInstancesRequest.class));
+        verify(rdsProxy.client(), times(1)).addTagsToResource(any(AddTagsToResourceRequest.class));
 
         ArgumentCaptor<RestoreDbInstanceFromDbSnapshotRequest> argument = ArgumentCaptor.forClass(RestoreDbInstanceFromDbSnapshotRequest.class);
         verify(rdsProxy.client(), times(1)).restoreDBInstanceFromDBSnapshot(argument.capture());
@@ -273,9 +280,11 @@ public class CreateHandlerTest extends AbstractHandlerTest {
     }
 
     @Test
-    public void handleRequest_CreateReadReplica_Create_InProgress() {
-        final CreateDbInstanceReadReplicaResponse createResponse = CreateDbInstanceReadReplicaResponse.builder().build();
-        when(rdsProxy.client().createDBInstanceReadReplica(any(CreateDbInstanceReadReplicaRequest.class))).thenReturn(createResponse);
+    public void handleRequest_CreateReadReplica_Create_Success() {
+        when(rdsProxy.client().createDBInstanceReadReplica(any(CreateDbInstanceReadReplicaRequest.class)))
+                .thenReturn(CreateDbInstanceReadReplicaResponse.builder().build());
+        when(rdsProxy.client().addTagsToResource(any(AddTagsToResourceRequest.class)))
+                .thenReturn(AddTagsToResourceResponse.builder().build());
 
         final CallbackContext context = new CallbackContext();
         context.setCreated(false);
@@ -291,13 +300,16 @@ public class CreateHandlerTest extends AbstractHandlerTest {
         );
 
         verify(rdsProxy.client(), times(1)).createDBInstanceReadReplica(any(CreateDbInstanceReadReplicaRequest.class));
-        verify(rdsProxy.client(), times(2)).describeDBInstances(any(DescribeDbInstancesRequest.class));
+        verify(rdsProxy.client(), times(3)).describeDBInstances(any(DescribeDbInstancesRequest.class));
+        verify(rdsProxy.client(), times(1)).addTagsToResource(any(AddTagsToResourceRequest.class));
     }
 
     @Test
-    public void handleRequest_CreateReadReplica_Update_InProgress() {
-        final ModifyDbInstanceResponse modifyDbInstanceResponse = ModifyDbInstanceResponse.builder().build();
-        when(rdsProxy.client().modifyDBInstance(any(ModifyDbInstanceRequest.class))).thenReturn(modifyDbInstanceResponse);
+    public void handleRequest_CreateReadReplica_Update_Success() {
+        when(rdsProxy.client().modifyDBInstance(any(ModifyDbInstanceRequest.class)))
+                .thenReturn(ModifyDbInstanceResponse.builder().build());
+        when(rdsProxy.client().addTagsToResource(any(AddTagsToResourceRequest.class)))
+                .thenReturn(AddTagsToResourceResponse.builder().build());
 
         final CallbackContext context = new CallbackContext();
         context.setCreated(true);
@@ -313,13 +325,16 @@ public class CreateHandlerTest extends AbstractHandlerTest {
         );
 
         verify(rdsProxy.client(), times(1)).modifyDBInstance(any(ModifyDbInstanceRequest.class));
-        verify(rdsProxy.client(), times(2)).describeDBInstances(any(DescribeDbInstancesRequest.class));
+        verify(rdsProxy.client(), times(3)).describeDBInstances(any(DescribeDbInstancesRequest.class));
+        verify(rdsProxy.client(), times(1)).addTagsToResource(any(AddTagsToResourceRequest.class));
     }
 
     @Test
     public void handleRequest_CreateReadReplica_Reboot_Success() {
-        final RebootDbInstanceResponse rebootDbInstanceResponse = RebootDbInstanceResponse.builder().build();
-        when(rdsProxy.client().rebootDBInstance(any(RebootDbInstanceRequest.class))).thenReturn(rebootDbInstanceResponse);
+        when(rdsProxy.client().rebootDBInstance(any(RebootDbInstanceRequest.class)))
+                .thenReturn(RebootDbInstanceResponse.builder().build());
+        when(rdsProxy.client().addTagsToResource(any(AddTagsToResourceRequest.class)))
+                .thenReturn(AddTagsToResourceResponse.builder().build());
 
         final CallbackContext context = new CallbackContext();
         context.setCreated(true);
@@ -335,13 +350,16 @@ public class CreateHandlerTest extends AbstractHandlerTest {
         );
 
         verify(rdsProxy.client(), times(1)).rebootDBInstance(any(RebootDbInstanceRequest.class));
-        verify(rdsProxy.client(), times(2)).describeDBInstances(any(DescribeDbInstancesRequest.class));
+        verify(rdsProxy.client(), times(3)).describeDBInstances(any(DescribeDbInstancesRequest.class));
+        verify(rdsProxy.client(), times(1)).addTagsToResource(any(AddTagsToResourceRequest.class));
     }
 
     @Test
     public void handleRequest_CreateReadReplica_Success() {
-        final CreateDbInstanceReadReplicaResponse createDbInstanceReadReplicaResponse = CreateDbInstanceReadReplicaResponse.builder().build();
-        when(rdsProxy.client().createDBInstanceReadReplica(any(CreateDbInstanceReadReplicaRequest.class))).thenReturn(createDbInstanceReadReplicaResponse);
+        when(rdsProxy.client().createDBInstanceReadReplica(any(CreateDbInstanceReadReplicaRequest.class)))
+                .thenReturn(CreateDbInstanceReadReplicaResponse.builder().build());
+        when(rdsProxy.client().addTagsToResource(any(AddTagsToResourceRequest.class)))
+                .thenReturn(AddTagsToResourceResponse.builder().build());
 
         final CallbackContext context = new CallbackContext();
         context.setCreated(false);
@@ -357,7 +375,8 @@ public class CreateHandlerTest extends AbstractHandlerTest {
         );
 
         verify(rdsProxy.client(), times(1)).createDBInstanceReadReplica(any(CreateDbInstanceReadReplicaRequest.class));
-        verify(rdsProxy.client(), times(2)).describeDBInstances(any(DescribeDbInstancesRequest.class));
+        verify(rdsProxy.client(), times(3)).describeDBInstances(any(DescribeDbInstancesRequest.class));
+        verify(rdsProxy.client(), times(1)).addTagsToResource(any(AddTagsToResourceRequest.class));
     }
 
     @Test
@@ -500,6 +519,9 @@ public class CreateHandlerTest extends AbstractHandlerTest {
 
     @Test
     public void handleRequest_CreateNewInstance_Success() {
+        when(rdsProxy.client().addTagsToResource(any(AddTagsToResourceRequest.class)))
+                .thenReturn(AddTagsToResourceResponse.builder().build());
+
         final CallbackContext context = new CallbackContext();
         context.setCreated(true);
         context.setUpdated(true);
@@ -513,13 +535,16 @@ public class CreateHandlerTest extends AbstractHandlerTest {
                 expectSuccess()
         );
 
-        verify(rdsProxy.client(), times(1)).describeDBInstances(any(DescribeDbInstancesRequest.class));
+        verify(rdsProxy.client(), times(2)).describeDBInstances(any(DescribeDbInstancesRequest.class));
+        verify(rdsProxy.client(), times(1)).addTagsToResource(any(AddTagsToResourceRequest.class));
     }
 
     @Test
     public void handleRequest_CreateNewInstance_UpdateRoles_Success() {
-        final AddRoleToDbInstanceResponse addRoleToDbInstanceResponse = AddRoleToDbInstanceResponse.builder().build();
-        when(rdsProxy.client().addRoleToDBInstance(any(AddRoleToDbInstanceRequest.class))).thenReturn(addRoleToDbInstanceResponse);
+        when(rdsProxy.client().addRoleToDBInstance(any(AddRoleToDbInstanceRequest.class)))
+                .thenReturn(AddRoleToDbInstanceResponse.builder().build());
+        when(rdsProxy.client().addTagsToResource(any(AddTagsToResourceRequest.class)))
+                .thenReturn(AddTagsToResourceResponse.builder().build());
 
         final Queue<DBInstance> transitions = new ConcurrentLinkedQueue<>(
                 computeAssociatedRoleTransitions(DB_INSTANCE_ACTIVE, Collections.emptyList(), ASSOCIATED_ROLES)
@@ -543,12 +568,13 @@ public class CreateHandlerTest extends AbstractHandlerTest {
 
         verify(rdsProxy.client(), times(3)).describeDBInstances(any(DescribeDbInstancesRequest.class));
         verify(rdsProxy.client(), times(1)).addRoleToDBInstance(any(AddRoleToDbInstanceRequest.class));
+        verify(rdsProxy.client(), times(1)).addTagsToResource(any(AddTagsToResourceRequest.class));
     }
 
     @Test
-    public void handleRequest_CreateNewInstance_NoIdentifier_InProgress() {
-        final CreateDbInstanceResponse createResponse = CreateDbInstanceResponse.builder().build();
-        when(rdsProxy.client().createDBInstance(any(CreateDbInstanceRequest.class))).thenReturn(createResponse);
+    public void handleRequest_CreateNewInstance_NoIdentifier_Success() {
+        when(rdsProxy.client().createDBInstance(any(CreateDbInstanceRequest.class)))
+                .thenReturn(CreateDbInstanceResponse.builder().build());
 
         final CallbackContext context = new CallbackContext();
         context.setCreated(false);
@@ -589,6 +615,9 @@ public class CreateHandlerTest extends AbstractHandlerTest {
 
     @Test
     public void handleRequest_CreateNewInstance_ShouldNotReboot_Success() {
+        when(rdsProxy.client().addTagsToResource(any(AddTagsToResourceRequest.class)))
+                .thenReturn(AddTagsToResourceResponse.builder().build());
+
         final CallbackContext context = new CallbackContext();
         context.setCreated(true);
         context.setUpdated(true);
@@ -602,11 +631,14 @@ public class CreateHandlerTest extends AbstractHandlerTest {
                 expectSuccess()
         );
 
-        verify(rdsProxy.client(), times(1)).describeDBInstances(any(DescribeDbInstancesRequest.class));
+        verify(rdsProxy.client(), times(2)).describeDBInstances(any(DescribeDbInstancesRequest.class));
     }
 
     @Test
     public void handleRequest_CreateNewInstance_ShouldNotUpdate_Success() {
+        when(rdsProxy.client().addTagsToResource(any(AddTagsToResourceRequest.class)))
+                .thenReturn(AddTagsToResourceResponse.builder().build());
+
         final CallbackContext context = new CallbackContext();
         context.setCreated(true);
         context.setUpdated(false);
@@ -620,13 +652,14 @@ public class CreateHandlerTest extends AbstractHandlerTest {
                 expectSuccess()
         );
 
-        verify(rdsProxy.client(), times(1)).describeDBInstances(any(DescribeDbInstancesRequest.class));
+        verify(rdsProxy.client(), times(2)).describeDBInstances(any(DescribeDbInstancesRequest.class));
+        verify(rdsProxy.client(), times(1)).addTagsToResource(any(AddTagsToResourceRequest.class));
     }
 
     @Test
     public void handleRequest_CreateReadReplica_DbSecurityGroups_ShouldUpdate_Success() {
-        final ModifyDbInstanceResponse modifyDbInstanceResponse = ModifyDbInstanceResponse.builder().build();
-        when(rdsProxy.client().modifyDBInstance(any(ModifyDbInstanceRequest.class))).thenReturn(modifyDbInstanceResponse);
+        when(rdsProxy.client().modifyDBInstance(any(ModifyDbInstanceRequest.class)))
+                .thenReturn(ModifyDbInstanceResponse.builder().build());
 
         final CallbackContext context = new CallbackContext();
         context.setCreated(true);
@@ -650,8 +683,8 @@ public class CreateHandlerTest extends AbstractHandlerTest {
 
     @Test
     public void handleRequest_CreateReadReplica_AllocatedStorage_ShouldUpdate_Success() {
-        final ModifyDbInstanceResponse modifyDbInstanceResponse = ModifyDbInstanceResponse.builder().build();
-        when(rdsProxy.client().modifyDBInstance(any(ModifyDbInstanceRequest.class))).thenReturn(modifyDbInstanceResponse);
+        when(rdsProxy.client().modifyDBInstance(any(ModifyDbInstanceRequest.class)))
+                .thenReturn(ModifyDbInstanceResponse.builder().build());
 
         final CallbackContext context = new CallbackContext();
         context.setCreated(true);
@@ -675,8 +708,8 @@ public class CreateHandlerTest extends AbstractHandlerTest {
 
     @Test
     public void handleRequest_CreateReadReplica_CACertificateIdentifier_ShouldUpdate_Success() {
-        final ModifyDbInstanceResponse modifyDbInstanceResponse = ModifyDbInstanceResponse.builder().build();
-        when(rdsProxy.client().modifyDBInstance(any(ModifyDbInstanceRequest.class))).thenReturn(modifyDbInstanceResponse);
+        when(rdsProxy.client().modifyDBInstance(any(ModifyDbInstanceRequest.class)))
+                .thenReturn(ModifyDbInstanceResponse.builder().build());
 
         final CallbackContext context = new CallbackContext();
         context.setCreated(true);
@@ -700,8 +733,8 @@ public class CreateHandlerTest extends AbstractHandlerTest {
 
     @Test
     public void handleRequest_CreateReadReplica_DBParameterGroup_ShouldUpdate_Success() {
-        final ModifyDbInstanceResponse modifyDbInstanceResponse = ModifyDbInstanceResponse.builder().build();
-        when(rdsProxy.client().modifyDBInstance(any(ModifyDbInstanceRequest.class))).thenReturn(modifyDbInstanceResponse);
+        when(rdsProxy.client().modifyDBInstance(any(ModifyDbInstanceRequest.class)))
+                .thenReturn(ModifyDbInstanceResponse.builder().build());
 
         final CallbackContext context = new CallbackContext();
         context.setCreated(true);
@@ -725,8 +758,8 @@ public class CreateHandlerTest extends AbstractHandlerTest {
 
     @Test
     public void handleRequest_CreateReadReplica_EngineVersion_ShouldUpdate_Success() {
-        final ModifyDbInstanceResponse modifyDbInstanceResponse = ModifyDbInstanceResponse.builder().build();
-        when(rdsProxy.client().modifyDBInstance(any(ModifyDbInstanceRequest.class))).thenReturn(modifyDbInstanceResponse);
+        when(rdsProxy.client().modifyDBInstance(any(ModifyDbInstanceRequest.class)))
+                .thenReturn(ModifyDbInstanceResponse.builder().build());
 
         final CallbackContext context = new CallbackContext();
         context.setCreated(true);
@@ -750,8 +783,8 @@ public class CreateHandlerTest extends AbstractHandlerTest {
 
     @Test
     public void handleRequest_CreateReadReplica_MasterUserPassword_ShouldUpdate_Success() {
-        final ModifyDbInstanceResponse modifyDbInstanceResponse = ModifyDbInstanceResponse.builder().build();
-        when(rdsProxy.client().modifyDBInstance(any(ModifyDbInstanceRequest.class))).thenReturn(modifyDbInstanceResponse);
+        when(rdsProxy.client().modifyDBInstance(any(ModifyDbInstanceRequest.class)))
+                .thenReturn(ModifyDbInstanceResponse.builder().build());
 
         final CallbackContext context = new CallbackContext();
         context.setCreated(true);
@@ -775,8 +808,8 @@ public class CreateHandlerTest extends AbstractHandlerTest {
 
     @Test
     public void handleRequest_CreateReadReplica_PreferredBackupWindow_ShouldUpdate_Success() {
-        final ModifyDbInstanceResponse modifyDbInstanceResponse = ModifyDbInstanceResponse.builder().build();
-        when(rdsProxy.client().modifyDBInstance(any(ModifyDbInstanceRequest.class))).thenReturn(modifyDbInstanceResponse);
+        when(rdsProxy.client().modifyDBInstance(any(ModifyDbInstanceRequest.class)))
+                .thenReturn(ModifyDbInstanceResponse.builder().build());
 
         final CallbackContext context = new CallbackContext();
         context.setCreated(true);
@@ -800,8 +833,8 @@ public class CreateHandlerTest extends AbstractHandlerTest {
 
     @Test
     public void handleRequest_CreateReadReplica_PreferredMaintenanceWindow_ShouldUpdate_Success() {
-        final ModifyDbInstanceResponse modifyDbInstanceResponse = ModifyDbInstanceResponse.builder().build();
-        when(rdsProxy.client().modifyDBInstance(any(ModifyDbInstanceRequest.class))).thenReturn(modifyDbInstanceResponse);
+        when(rdsProxy.client().modifyDBInstance(any(ModifyDbInstanceRequest.class)))
+                .thenReturn(ModifyDbInstanceResponse.builder().build());
 
         final CallbackContext context = new CallbackContext();
         context.setCreated(true);
@@ -825,8 +858,8 @@ public class CreateHandlerTest extends AbstractHandlerTest {
 
     @Test
     public void handleRequest_CreateReadReplica_BackupRetentionPeriod_ShouldUpdate_Success() {
-        final ModifyDbInstanceResponse modifyDbInstanceResponse = ModifyDbInstanceResponse.builder().build();
-        when(rdsProxy.client().modifyDBInstance(any(ModifyDbInstanceRequest.class))).thenReturn(modifyDbInstanceResponse);
+        when(rdsProxy.client().modifyDBInstance(any(ModifyDbInstanceRequest.class)))
+                .thenReturn(ModifyDbInstanceResponse.builder().build());
 
         final CallbackContext context = new CallbackContext();
         context.setCreated(true);
@@ -850,8 +883,8 @@ public class CreateHandlerTest extends AbstractHandlerTest {
 
     @Test
     public void handleRequest_CreateReadReplica_Iops_ShouldUpdate_Success() {
-        final ModifyDbInstanceResponse modifyDbInstanceResponse = ModifyDbInstanceResponse.builder().build();
-        when(rdsProxy.client().modifyDBInstance(any(ModifyDbInstanceRequest.class))).thenReturn(modifyDbInstanceResponse);
+        when(rdsProxy.client().modifyDBInstance(any(ModifyDbInstanceRequest.class)))
+                .thenReturn(ModifyDbInstanceResponse.builder().build());
 
         final CallbackContext context = new CallbackContext();
         context.setCreated(true);
@@ -875,8 +908,8 @@ public class CreateHandlerTest extends AbstractHandlerTest {
 
     @Test
     public void handleRequest_CreateReadReplica_MaxAllocatedStorage_ShouldUpdate_Success() {
-        final ModifyDbInstanceResponse modifyDbInstanceResponse = ModifyDbInstanceResponse.builder().build();
-        when(rdsProxy.client().modifyDBInstance(any(ModifyDbInstanceRequest.class))).thenReturn(modifyDbInstanceResponse);
+        when(rdsProxy.client().modifyDBInstance(any(ModifyDbInstanceRequest.class)))
+                .thenReturn(ModifyDbInstanceResponse.builder().build());
 
         final CallbackContext context = new CallbackContext();
         context.setCreated(true);

--- a/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/UpdateHandlerTest.java
+++ b/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/UpdateHandlerTest.java
@@ -123,6 +123,10 @@ public class UpdateHandlerTest extends AbstractHandlerTest {
                 .dbInstance(DB_INSTANCE_ACTIVE)
                 .build();
         when(rdsProxy.client().modifyDBInstance(any(ModifyDbInstanceRequest.class))).thenReturn(modifyDbInstanceResponse);
+        when(rdsProxy.client().addTagsToResource(any(AddTagsToResourceRequest.class)))
+                .thenReturn(AddTagsToResourceResponse.builder().build());
+        when(rdsProxy.client().removeTagsFromResource(any(RemoveTagsFromResourceRequest.class)))
+                .thenReturn(RemoveTagsFromResourceResponse.builder().build());
 
         final CallbackContext context = new CallbackContext();
         context.setUpdated(false);
@@ -137,8 +141,10 @@ public class UpdateHandlerTest extends AbstractHandlerTest {
                 expectSuccess()
         );
 
-        verify(rdsProxy.client(), times(2)).describeDBInstances(any(DescribeDbInstancesRequest.class));
+        verify(rdsProxy.client(), times(3)).describeDBInstances(any(DescribeDbInstancesRequest.class));
         verify(rdsProxy.client()).modifyDBInstance(any(ModifyDbInstanceRequest.class));
+        verify(rdsProxy.client()).addTagsToResource(any(AddTagsToResourceRequest.class));
+        verify(rdsProxy.client()).removeTagsFromResource(any(RemoveTagsFromResourceRequest.class));
     }
 
     @Test
@@ -317,6 +323,11 @@ public class UpdateHandlerTest extends AbstractHandlerTest {
         final AddRoleToDbInstanceResponse addRoleToDBInstanceResponse = AddRoleToDbInstanceResponse.builder().build();
         when(rdsProxy.client().addRoleToDBInstance(any(AddRoleToDbInstanceRequest.class))).thenReturn(addRoleToDBInstanceResponse);
 
+        when(rdsProxy.client().addTagsToResource(any(AddTagsToResourceRequest.class)))
+                .thenReturn(AddTagsToResourceResponse.builder().build());
+        when(rdsProxy.client().removeTagsFromResource(any(RemoveTagsFromResourceRequest.class)))
+                .thenReturn(RemoveTagsFromResourceResponse.builder().build());
+
         final CallbackContext context = new CallbackContext();
         context.setUpdated(true);
         context.setRebooted(true);
@@ -349,8 +360,12 @@ public class UpdateHandlerTest extends AbstractHandlerTest {
 
         final RemoveRoleFromDbInstanceResponse removeRoleFromDBInstanceResponse = RemoveRoleFromDbInstanceResponse.builder().build();
         when(rdsProxy.client().removeRoleFromDBInstance(any(RemoveRoleFromDbInstanceRequest.class))).thenReturn(removeRoleFromDBInstanceResponse);
-
-        when(rdsProxy.client().addRoleToDBInstance(any(AddRoleToDbInstanceRequest.class))).thenThrow(DbInstanceRoleAlreadyExistsException.class);
+        when(rdsProxy.client().addRoleToDBInstance(any(AddRoleToDbInstanceRequest.class)))
+                .thenThrow(DbInstanceRoleAlreadyExistsException.class);
+        when(rdsProxy.client().addTagsToResource(any(AddTagsToResourceRequest.class)))
+                .thenReturn(AddTagsToResourceResponse.builder().build());
+        when(rdsProxy.client().removeTagsFromResource(any(RemoveTagsFromResourceRequest.class)))
+                .thenReturn(RemoveTagsFromResourceResponse.builder().build());
 
         final CallbackContext context = new CallbackContext();
         context.setUpdated(true);


### PR DESCRIPTION
This code change introduces a soft failing mechanism for stack-level tags upon a `DBInstance` update/create handler invocation.

The motivation for this change is to keep a complete backwards compatibility with the existing implementation. The point of interest is whether a customer has the corresponding IAM permissions:
  - `rds:AddTagsToResource`
  - `rds:RemoveTagsFromResource`

The current logic is:
  - System tags are created and managed by CloudFormation. RDS API recognizes these tags and requires no extra IAM permissions to create these tags.
  - Resource-level tags can only be provided by the customer, hence require both permissions mentioned above.
  - Stack-level tags are declared by the customer but replicated to the resources by CloudFormation. In the light of the fact that distinct resources handle stack tags `AccessDenied` error in a different way, RDS tends to act the "soft way" and ignores these errors.

This change introduces a 2-stage tag create: the initial create/restore operation only creates system-level tags. The next stage is the resource- and stack-level tag update, which is packed in a single request. If the request contains no resource-level tags (stack-level only), an `AccessDenied` error would be soft-handled. In case there are customer-provided resource tags, the request would hard fail.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Signed-off-by: Oleg Sidorov <sidorovo@amazon.com>