### PR TITLE
[DBCluster] Force final snapshot ID generation upon a deletion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+aws-rds-handlers.iml
+rpdk.log

--- a/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/BaseHandlerStd.java
+++ b/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/BaseHandlerStd.java
@@ -20,6 +20,7 @@ import software.amazon.awssdk.services.rds.model.DbClusterSnapshotNotFoundExcept
 import software.amazon.awssdk.services.rds.model.DbInstanceNotFoundException;
 import software.amazon.awssdk.services.rds.model.DbSubnetGroupDoesNotCoverEnoughAZsException;
 import software.amazon.awssdk.services.rds.model.DbSubnetGroupNotFoundException;
+import software.amazon.awssdk.services.rds.model.DescribeDbClustersRequest;
 import software.amazon.awssdk.services.rds.model.DescribeDbClustersResponse;
 import software.amazon.awssdk.services.rds.model.DomainNotFoundException;
 import software.amazon.awssdk.services.rds.model.GlobalClusterNotFoundException;
@@ -35,6 +36,7 @@ import software.amazon.awssdk.services.rds.model.StorageQuotaExceededException;
 import software.amazon.cloudformation.exceptions.CfnNotFoundException;
 import software.amazon.cloudformation.exceptions.CfnNotStabilizedException;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
+import software.amazon.cloudformation.proxy.CallChain;
 import software.amazon.cloudformation.proxy.HandlerErrorCode;
 import software.amazon.cloudformation.proxy.Logger;
 import software.amazon.cloudformation.proxy.ProgressEvent;

--- a/aws-rds-dbcluster/src/test/java/software/amazon/rds/dbcluster/DeleteHandlerTest.java
+++ b/aws-rds-dbcluster/src/test/java/software/amazon/rds/dbcluster/DeleteHandlerTest.java
@@ -131,38 +131,6 @@ public class DeleteHandlerTest extends AbstractHandlerTest {
     }
 
     @Test
-    public void handleRequest_finalSnapshotIdentifierIsSet() {
-        when(rdsProxy.client().deleteDBCluster(any(DeleteDbClusterRequest.class)))
-                .thenReturn(DeleteDbClusterResponse.builder().build());
-
-        final Queue<DBCluster> transitions = new ConcurrentLinkedQueue<>();
-        transitions.add(DBCLUSTER_ACTIVE);
-
-        final String snapshotIdentifier = "test-snapshot-identifier";
-
-        test_handleRequest_base(
-                new CallbackContext(),
-                ResourceHandlerRequest.<ResourceModel>builder()
-                        .snapshotRequested(true),
-                () -> {
-                    if (transitions.size() > 0) {
-                        return transitions.remove();
-                    }
-                    throw DbClusterNotFoundException.builder().message(MSG_NOT_FOUND).build();
-                },
-                () -> RESOURCE_MODEL,
-                () -> RESOURCE_MODEL.toBuilder()
-                        .snapshotIdentifier(snapshotIdentifier)
-                        .build(),
-                expectSuccess()
-        );
-
-        ArgumentCaptor<DeleteDbClusterRequest> argument = ArgumentCaptor.forClass(DeleteDbClusterRequest.class);
-        verify(rdsProxy.client(), times(1)).deleteDBCluster(argument.capture());
-        Assertions.assertEquals(argument.getValue().finalDBSnapshotIdentifier(), snapshotIdentifier);
-    }
-
-    @Test
     public void handleRequest_NoSnapshotRequested() {
         when(rdsProxy.client().deleteDBCluster(any(DeleteDbClusterRequest.class)))
                 .thenReturn(DeleteDbClusterResponse.builder().build());


### PR DESCRIPTION
This code change enforces a final snapshot ID generate if a snapshot is requested. In contrast with the current implementation, where the ID generation was conditional (`DBSnapshotIdentifier` was reused), the new behavior generates a unique ID when a resource is being deleted.

The motivation for this change is to eliminate a customer snapshot override. This strategy was added by default and is seen wrong now.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Signed-off-by: Oleg Sidorov <sidorovo@amazon.com>