### PR TITLE
[All]Rename Contract Tests Input Identifiers to Include `contract`

### DIFF
--- a/aws-rds-dbcluster/inputs/inputs_1_create.json
+++ b/aws-rds-dbcluster/inputs/inputs_1_create.json
@@ -2,5 +2,5 @@
   "Engine": "aurora",
   "MasterUsername": "guest",
   "MasterUserPassword": "guest123",
-  "DBClusterIdentifier": "testdbclusterdelete8"
+  "DBClusterIdentifier": "dbcluster-contract-test"
 }

--- a/aws-rds-dbcluster/inputs/inputs_1_invalid.json
+++ b/aws-rds-dbcluster/inputs/inputs_1_invalid.json
@@ -2,5 +2,5 @@
   "Engine": "aurora1",
   "MasterUsername": "guest",
   "MasterUserPassword": "guest123",
-  "DBClusterIdentifier": "testdbclusterinvalid"
+  "DBClusterIdentifier": "dbcluster-contract-test-invalid"
 }

--- a/aws-rds-dbcluster/inputs/inputs_1_update.json
+++ b/aws-rds-dbcluster/inputs/inputs_1_update.json
@@ -2,5 +2,5 @@
   "Engine": "aurora",
   "MasterUsername": "guest",
   "MasterUserPassword": "guest1234",
-  "DBClusterIdentifier": "testdbclusterdelete8"
+  "DBClusterIdentifier": "dbcluster-contract-test"
 }

--- a/aws-rds-dbclusterparametergroup/inputs/inputs_1_create.json
+++ b/aws-rds-dbclusterparametergroup/inputs/inputs_1_create.json
@@ -1,5 +1,5 @@
 {
-  "DBClusterParameterGroupName": "dbclusterparametergrouptest",
+  "DBClusterParameterGroupName": "dbclusterparametergroup-contract-test",
   "Parameters": {
     "character_set_database": "utf32",
     "binlog_checksum": "CRC32"

--- a/aws-rds-dbclusterparametergroup/inputs/inputs_1_invalid.json
+++ b/aws-rds-dbclusterparametergroup/inputs/inputs_1_invalid.json
@@ -1,5 +1,5 @@
 {
-  "DBClusterParameterGroupName": "dbclusterparametergrouptest",
+  "DBClusterParameterGroupName": "dbclusterparametergroup-contract-test",
   "Parameters": {
     "character_set_database": "utf321",
     "binlog_checksum": "CRC32"

--- a/aws-rds-dbclusterparametergroup/inputs/inputs_1_update.json
+++ b/aws-rds-dbclusterparametergroup/inputs/inputs_1_update.json
@@ -1,5 +1,5 @@
 {
-  "DBClusterParameterGroupName": "dbclusterparametergrouptest",
+  "DBClusterParameterGroupName": "dbclusterparametergroup-contract-test",
   "Parameters": {
     "character_set_database": "utf32",
     "binlog_checksum": "NONE"

--- a/aws-rds-dbinstance/inputs/inputs_1_create.json
+++ b/aws-rds-dbinstance/inputs/inputs_1_create.json
@@ -1,7 +1,7 @@
 {
   "AllocatedStorage": "5",
   "AutoMinorVersionUpgrade": false,
-  "DBInstanceIdentifier": "test-db-instance",
+  "DBInstanceIdentifier": "dbinstance-contract-test",
   "DBInstanceClass": "db.t3.micro",
   "DBName": "testdbname",
   "Engine": "postgres",

--- a/aws-rds-dbinstance/inputs/inputs_1_update.json
+++ b/aws-rds-dbinstance/inputs/inputs_1_update.json
@@ -1,7 +1,7 @@
 {
   "AllocatedStorage": "5",
   "AutoMinorVersionUpgrade": false,
-  "DBInstanceIdentifier": "test-db-instance",
+  "DBInstanceIdentifier": "dbinstance-contract-test",
   "DBInstanceClass": "db.t3.micro",
   "DBName": "testdbname",
   "EnablePerformanceInsights": true,

--- a/aws-rds-dbparametergroup/inputs/inputs_1_create.json
+++ b/aws-rds-dbparametergroup/inputs/inputs_1_create.json
@@ -1,5 +1,5 @@
 {
-  "DBParameterGroupName": "new",
+  "DBParameterGroupName": "dbparametergroup-contract-test",
   "Description": "cloudFormation",
   "Family": "mysql8.0",
   "Parameters": {}

--- a/aws-rds-dbparametergroup/inputs/inputs_1_update.json
+++ b/aws-rds-dbparametergroup/inputs/inputs_1_update.json
@@ -1,5 +1,5 @@
 {
-  "DBParameterGroupName": "new",
+  "DBParameterGroupName": "dbparametergroup-contract-test",
   "Description": "cloudFormation",
   "Family": "mysql8.0",
   "Parameters": {

--- a/aws-rds-dbsubnetgroup/inputs/inputs_1_create.json
+++ b/aws-rds-dbsubnetgroup/inputs/inputs_1_create.json
@@ -1,6 +1,6 @@
 {
   "DBSubnetGroupDescription": "test",
-  "DBSubnetGroupName": "testdbsubnetgroup",
+  "DBSubnetGroupName": "dbsubnetgroup-contract-test",
   "SubnetIds": [
     "{{SubnetID1}}",
     "{{SubnetID2}}"

--- a/aws-rds-dbsubnetgroup/inputs/inputs_1_invalid.json
+++ b/aws-rds-dbsubnetgroup/inputs/inputs_1_invalid.json
@@ -1,4 +1,4 @@
 {
   "DBSubnetGroupDescription": "test",
-  "DBSubnetGroupName": "testdbsubnetgroup"
+  "DBSubnetGroupName": "dbsubnetgroup-contract-test-invalid"
 }

--- a/aws-rds-dbsubnetgroup/inputs/inputs_1_update.json
+++ b/aws-rds-dbsubnetgroup/inputs/inputs_1_update.json
@@ -1,6 +1,6 @@
 {
   "DBSubnetGroupDescription": "test",
-  "DBSubnetGroupName": "testdbsubnetgroup",
+  "DBSubnetGroupName": "dbsubnetgroup-contract-test",
   "SubnetIds": [
     "{{SubnetID3}}",
     "{{SubnetID4}}"

--- a/aws-rds-optiongroup/inputs/inputs_1_create.json
+++ b/aws-rds-optiongroup/inputs/inputs_1_create.json
@@ -1,5 +1,5 @@
 {
-  "OptionGroupName": "test-option-group",
+  "OptionGroupName": "optiongroup-contract-test",
   "OptionGroupDescription": "A test option group",
   "EngineName": "mysql",
   "MajorEngineVersion": "5.6",

--- a/aws-rds-optiongroup/inputs/inputs_1_invalid.json
+++ b/aws-rds-optiongroup/inputs/inputs_1_invalid.json
@@ -1,5 +1,5 @@
 {
-  "OptionGroupName": "test-option-group",
+  "OptionGroupName": "optiongroup-contract-test",
   "EngineName": "mysql",
   "OptionGroupDescription": "A test option group",
   "OptionConfigurations": [

--- a/aws-rds-optiongroup/inputs/inputs_1_update.json
+++ b/aws-rds-optiongroup/inputs/inputs_1_update.json
@@ -1,5 +1,5 @@
 {
-  "OptionGroupName": "test-option-group",
+  "OptionGroupName": "optiongroup-contract-test",
   "EngineName": "mysql",
   "MajorEngineVersion": "5.6",
   "OptionGroupDescription": "A test option group",


### PR DESCRIPTION
*Description of changes:*
Renaming contract test identifiers input to include word `contract` so operator can relate created resource to contract test runs

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
