### PR TITLE
[Common] Register Jackson JavaTimeModule explicitly

### DIFF
--- a/aws-rds-cfn-common/src/main/java/software/amazon/rds/common/printer/FilteredJsonPrinter.java
+++ b/aws-rds-cfn-common/src/main/java/software/amazon/rds/common/printer/FilteredJsonPrinter.java
@@ -16,6 +16,7 @@ import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.ser.FilterProvider;
 import com.fasterxml.jackson.databind.ser.impl.SimpleBeanPropertyFilter;
 import com.fasterxml.jackson.databind.ser.impl.SimpleFilterProvider;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 
 public class FilteredJsonPrinter implements JsonPrinter {
     final static String PWD = "pwd";
@@ -37,6 +38,7 @@ public class FilteredJsonPrinter implements JsonPrinter {
                 .setPropertyNamingStrategy(PropertyNamingStrategy.UPPER_CAMEL_CASE)
                 .enable(SerializationFeature.INDENT_OUTPUT)
                 .disable(SerializationFeature.FAIL_ON_EMPTY_BEANS);
+        mapper.registerModule(new JavaTimeModule());
         mapper.addMixIn(Object.class, PropertyFilterMixIn.class);
         mapper.setVisibility(PropertyAccessor.ALL, JsonAutoDetect.Visibility.NONE);
         mapper.setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY);


### PR DESCRIPTION
This PR changes introduces an explicit import of Jackson JavaTimeModule library and registers it in the FilteredJsonPrinter ObjectMapper.

The reason for having this import and registration is because the module autoscan does not work under some build systems, e.g. Groovy. Maven picks this up just fine, but it is a non-generic approach. This code change ensures the import is enforced.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Signed-off-by: Oleg Sidorov <sidorovo@amazon.com>