### PR TITLE
[DBInstance] Fix Port data type from integer to string

### DIFF
--- a/aws-rds-dbinstance/aws-rds-dbinstance.json
+++ b/aws-rds-dbinstance/aws-rds-dbinstance.json
@@ -280,10 +280,9 @@
       "description": "The amount of time, in days, to retain Performance Insights data. Valid values are 7 or 731 (2 years)."
     },
     "Port": {
-      "type": "integer",
+      "type": "string",
       "description": "The port number on which the database accepts connections.",
-      "minimum": 1150,
-      "maximum": 65535
+      "pattern": "^\\d*$"
     },
     "PreferredBackupWindow": {
       "type": "string",

--- a/aws-rds-dbinstance/docs/README.md
+++ b/aws-rds-dbinstance/docs/README.md
@@ -51,7 +51,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
         "<a href="#optiongroupname" title="OptionGroupName">OptionGroupName</a>" : <i>String</i>,
         "<a href="#performanceinsightskmskeyid" title="PerformanceInsightsKMSKeyId">PerformanceInsightsKMSKeyId</a>" : <i>String</i>,
         "<a href="#performanceinsightsretentionperiod" title="PerformanceInsightsRetentionPeriod">PerformanceInsightsRetentionPeriod</a>" : <i>Integer</i>,
-        "<a href="#port" title="Port">Port</a>" : <i>Integer</i>,
+        "<a href="#port" title="Port">Port</a>" : <i>String</i>,
         "<a href="#preferredbackupwindow" title="PreferredBackupWindow">PreferredBackupWindow</a>" : <i>String</i>,
         "<a href="#preferredmaintenancewindow" title="PreferredMaintenanceWindow">PreferredMaintenanceWindow</a>" : <i>String</i>,
         "<a href="#processorfeatures" title="ProcessorFeatures">ProcessorFeatures</a>" : <i>[ <a href="processorfeature.md">ProcessorFeature</a>, ... ]</i>,
@@ -118,7 +118,7 @@ Properties:
     <a href="#optiongroupname" title="OptionGroupName">OptionGroupName</a>: <i>String</i>
     <a href="#performanceinsightskmskeyid" title="PerformanceInsightsKMSKeyId">PerformanceInsightsKMSKeyId</a>: <i>String</i>
     <a href="#performanceinsightsretentionperiod" title="PerformanceInsightsRetentionPeriod">PerformanceInsightsRetentionPeriod</a>: <i>Integer</i>
-    <a href="#port" title="Port">Port</a>: <i>Integer</i>
+    <a href="#port" title="Port">Port</a>: <i>String</i>
     <a href="#preferredbackupwindow" title="PreferredBackupWindow">PreferredBackupWindow</a>: <i>String</i>
     <a href="#preferredmaintenancewindow" title="PreferredMaintenanceWindow">PreferredMaintenanceWindow</a>: <i>String</i>
     <a href="#processorfeatures" title="ProcessorFeatures">ProcessorFeatures</a>: <i>
@@ -557,7 +557,9 @@ The port number on which the database accepts connections.
 
 _Required_: No
 
-_Type_: Integer
+_Type_: String
+
+_Pattern_: <code>^\d*$</code>
 
 _Update requires_: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
 

--- a/aws-rds-dbinstance/docs/tag.md
+++ b/aws-rds-dbinstance/docs/tag.md
@@ -26,7 +26,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 
 #### Key
 
-The key name of the tag. You can specify a value that is 1 to 127 Unicode characters in length and cannot be prefixed with aws:. You can use any of the following characters: the set of Unicode letters, digits, whitespace, _, ., /, =, +, and -.
+The key name of the tag. You can specify a value that is 1 to 128 Unicode characters in length and cannot be prefixed with aws:. You can use any of the following characters: the set of Unicode letters, digits, whitespace, _, ., /, =, +, and -.
 
 _Required_: Yes
 
@@ -40,13 +40,11 @@ _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormati
 
 #### Value
 
-The value for the tag. You can specify a value that is 1 to 255 Unicode characters in length and cannot be prefixed with aws:. You can use any of the following characters: the set of Unicode letters, digits, whitespace, _, ., /, =, +, and -.
+The value for the tag. You can specify a value that is 0 to 256 Unicode characters in length and cannot be prefixed with aws:. You can use any of the following characters: the set of Unicode letters, digits, whitespace, _, ., /, =, +, and -.
 
 _Required_: Yes
 
 _Type_: String
-
-_Minimum_: <code>1</code>
 
 _Maximum_: <code>256</code>
 

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/Translator.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/Translator.java
@@ -62,6 +62,7 @@ public class Translator {
                 .build();
     }
 
+
     public static CreateDbInstanceReadReplicaRequest createDbInstanceReadReplicaRequest(
             final ResourceModel model,
             final Tagging.TagSet tagSet
@@ -87,7 +88,7 @@ public class Translator {
                 .optionGroupName(model.getOptionGroupName())
                 .performanceInsightsKMSKeyId(model.getPerformanceInsightsKMSKeyId())
                 .performanceInsightsRetentionPeriod(model.getPerformanceInsightsRetentionPeriod())
-                .port(model.getPort())
+                .port(translatePortToSdk(model.getPort()))
                 .processorFeatures(translateProcessorFeaturesToSdk(model.getProcessorFeatures()))
                 .publiclyAccessible(model.getPubliclyAccessible())
                 .sourceDBInstanceIdentifier(model.getSourceDBInstanceIdentifier())
@@ -122,7 +123,7 @@ public class Translator {
                 .licenseModel(model.getLicenseModel())
                 .multiAZ(model.getMultiAZ())
                 .optionGroupName(model.getOptionGroupName())
-                .port(model.getPort())
+                .port(translatePortToSdk(model.getPort()))
                 .processorFeatures(translateProcessorFeaturesToSdk(model.getProcessorFeatures()))
                 .publiclyAccessible(model.getPubliclyAccessible())
                 .storageType(model.getStorageType())
@@ -180,7 +181,7 @@ public class Translator {
                 .optionGroupName(model.getOptionGroupName())
                 .performanceInsightsKMSKeyId(model.getPerformanceInsightsKMSKeyId())
                 .performanceInsightsRetentionPeriod(model.getPerformanceInsightsRetentionPeriod())
-                .port(model.getPort())
+                .port(translatePortToSdk(model.getPort()))
                 .preferredBackupWindow(model.getPreferredBackupWindow())
                 .preferredMaintenanceWindow(model.getPreferredMaintenanceWindow())
                 .promotionTier(model.getPromotionTier())
@@ -211,7 +212,7 @@ public class Translator {
                 .dbInstanceClass(desiredModel.getDBInstanceClass())
                 .dbInstanceIdentifier(desiredModel.getDBInstanceIdentifier())
                 .dbParameterGroupName(desiredModel.getDBParameterGroupName())
-                .dbPortNumber(desiredModel.getPort())
+                .dbPortNumber(translatePortToSdk(desiredModel.getPort()))
                 .deletionProtection(desiredModel.getDeletionProtection())
                 .domain(desiredModel.getDomain())
                 .domainIAMRoleName(desiredModel.getDomainIAMRoleName())
@@ -416,7 +417,7 @@ public class Translator {
                 .multiAZ(dbInstance.multiAZ())
                 .performanceInsightsKMSKeyId(dbInstance.performanceInsightsKMSKeyId())
                 .performanceInsightsRetentionPeriod(dbInstance.performanceInsightsRetentionPeriod())
-                .port(port)
+                .port(port == null ? null : port.toString())
                 .preferredBackupWindow(dbInstance.preferredBackupWindow())
                 .preferredMaintenanceWindow(dbInstance.preferredMaintenanceWindow())
                 .processorFeatures(translateProcessorFeaturesFromSdk(dbInstance.processorFeatures()))
@@ -546,6 +547,21 @@ public class Translator {
                         .roleArn(role.getRoleArn())
                         .build())
                 .collect(Collectors.toList());
+    }
+
+    public static Integer translatePortToSdk(final String portStr) {
+        if (StringUtils.isEmpty(portStr)) {
+            return null;
+        }
+        //NumberFormatException
+        return Integer.parseInt(portStr, 10);
+    }
+
+    public static String translatePortFromSdk(final Integer port) {
+        if (port == null) {
+            return null;
+        }
+        return port.toString();
     }
 
     private static <T> Stream<T> streamOfOrEmpty(final Collection<T> collection) {

--- a/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/AbstractHandlerTest.java
+++ b/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/AbstractHandlerTest.java
@@ -118,7 +118,8 @@ public abstract class AbstractHandlerTest extends AbstractTestBase<DBInstance, R
     protected static final String OPTION_GROUP_NAME_MYSQL_DEFAULT = "default:mysql-5-6";
     protected static final String PERFORMANCE_INSIGHTS_KMS_ID_EMPTY = null;
     protected static final Integer PERFORMANCE_INSIGHTS_RETENTION_PERIOD_DEFAULT = 7;
-    protected static final Integer PORT_DEFAULT = 3306;
+    protected static final Integer PORT_DEFAULT_INT = 3306;
+    protected static final String PORT_DEFAULT_STR = PORT_DEFAULT_INT.toString();
     protected static final String PREFERRED_BACKUP_WINDOW_EMPTY = null;
     protected static final String PREFERRED_BACKUP_WINDOW_NON_EMPTY = "03:00–11:00";
     protected static final String PREFERRED_MAINTENANCE_WINDOW_NON_EMPTY = "03:00–11:00";
@@ -243,7 +244,7 @@ public abstract class AbstractHandlerTest extends AbstractTestBase<DBInstance, R
                 .iops(IOPS_DEFAULT)
                 .masterUsername(MASTER_USERNAME)
                 .masterUserPassword(MASTER_USER_PASSWORD)
-                .port(PORT_DEFAULT)
+                .port(PORT_DEFAULT_STR)
                 .build();
 
         RESOURCE_MODEL_ALTER = ResourceModel.builder()
@@ -282,7 +283,7 @@ public abstract class AbstractHandlerTest extends AbstractTestBase<DBInstance, R
                 .optionGroupName(OPTION_GROUP_NAME_MYSQL_DEFAULT)
                 .performanceInsightsKMSKeyId(PERFORMANCE_INSIGHTS_KMS_ID_EMPTY)
                 .performanceInsightsRetentionPeriod(PERFORMANCE_INSIGHTS_RETENTION_PERIOD_DEFAULT)
-                .port(PORT_DEFAULT)
+                .port(PORT_DEFAULT_STR)
                 .preferredBackupWindow(PREFERRED_BACKUP_WINDOW_EMPTY)
                 .preferredMaintenanceWindow(PREFERRED_MAINTENANCE_WINDOW_EMPTY)
                 .processorFeatures(PROCESSOR_FEATURES)
@@ -334,7 +335,7 @@ public abstract class AbstractHandlerTest extends AbstractTestBase<DBInstance, R
                 .optionGroupName(OPTION_GROUP_NAME_MYSQL_DEFAULT)
                 .performanceInsightsKMSKeyId(PERFORMANCE_INSIGHTS_KMS_ID_EMPTY)
                 .performanceInsightsRetentionPeriod(PERFORMANCE_INSIGHTS_RETENTION_PERIOD_DEFAULT)
-                .port(PORT_DEFAULT)
+                .port(PORT_DEFAULT_STR)
                 .preferredBackupWindow(PREFERRED_BACKUP_WINDOW_EMPTY)
                 .preferredMaintenanceWindow(PREFERRED_MAINTENANCE_WINDOW_EMPTY)
                 .processorFeatures(PROCESSOR_FEATURES)
@@ -386,7 +387,7 @@ public abstract class AbstractHandlerTest extends AbstractTestBase<DBInstance, R
                 .optionGroupName(OPTION_GROUP_NAME_MYSQL_DEFAULT)
                 .performanceInsightsKMSKeyId(PERFORMANCE_INSIGHTS_KMS_ID_EMPTY)
                 .performanceInsightsRetentionPeriod(PERFORMANCE_INSIGHTS_RETENTION_PERIOD_DEFAULT)
-                .port(PORT_DEFAULT)
+                .port(PORT_DEFAULT_STR)
                 .preferredBackupWindow(PREFERRED_BACKUP_WINDOW_EMPTY)
                 .preferredMaintenanceWindow(PREFERRED_MAINTENANCE_WINDOW_EMPTY)
                 .processorFeatures(PROCESSOR_FEATURES)
@@ -407,7 +408,7 @@ public abstract class AbstractHandlerTest extends AbstractTestBase<DBInstance, R
                 .dbName(DB_NAME)
                 .dbInstanceArn(DB_INSTANCE_ARN_NON_EMPTY)
                 .engine(ENGINE_MYSQL)
-                .dbInstancePort(PORT_DEFAULT)
+                .dbInstancePort(PORT_DEFAULT_INT)
                 .dbInstanceStatus(DB_INSTANCE_STATUS_AVAILABLE)
                 .build();
 
@@ -422,7 +423,7 @@ public abstract class AbstractHandlerTest extends AbstractTestBase<DBInstance, R
                 .dbInstanceIdentifier(DB_INSTANCE_IDENTIFIER_NON_EMPTY)
                 .dbClusterIdentifier(DB_CLUSTER_IDENTIFIER_EMPTY)
                 .dbInstanceArn(DB_INSTANCE_ARN_NON_EMPTY)
-                .dbInstancePort(PORT_DEFAULT)
+                .dbInstancePort(PORT_DEFAULT_INT)
                 .dbName(DB_NAME)
                 .dbInstanceClass(DB_INSTANCE_CLASS_DEFAULT)
                 .dbInstanceStatus(DB_INSTANCE_STATUS_AVAILABLE)
@@ -451,7 +452,7 @@ public abstract class AbstractHandlerTest extends AbstractTestBase<DBInstance, R
                 .dbInstancePort(null)
                 .endpoint(
                         Endpoint.builder()
-                                .port(PORT_DEFAULT)
+                                .port(PORT_DEFAULT_INT)
                                 .build()
                 )
                 .build();
@@ -499,7 +500,7 @@ public abstract class AbstractHandlerTest extends AbstractTestBase<DBInstance, R
                 .optionGroupName(OPTION_GROUP_NAME_MYSQL_DEFAULT)
                 .performanceInsightsKMSKeyId(PERFORMANCE_INSIGHTS_KMS_ID_EMPTY)
                 .performanceInsightsRetentionPeriod(PERFORMANCE_INSIGHTS_RETENTION_PERIOD_DEFAULT)
-                .port(PORT_DEFAULT)
+                .port(PORT_DEFAULT_STR)
                 .preferredBackupWindow(PREFERRED_BACKUP_WINDOW_EMPTY)
                 .preferredMaintenanceWindow(PREFERRED_MAINTENANCE_WINDOW_EMPTY)
                 .processorFeatures(PROCESSOR_FEATURES)

--- a/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/CreateHandlerTest.java
+++ b/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/CreateHandlerTest.java
@@ -945,4 +945,26 @@ public class CreateHandlerTest extends AbstractHandlerTest {
                 expectFailed(HandlerErrorCode.InvalidRequest)
         );
     }
+
+    @Test
+    public void handleRequest_CreateDBInstance_EmptyPortString() {
+        final CallbackContext context = new CallbackContext();
+        context.setCreated(false);
+        context.setUpdated(true);
+        context.setRebooted(true);
+        context.setUpdatedRoles(true);
+
+        test_handleRequest_base(
+                context,
+                () -> DB_INSTANCE_ACTIVE,
+                () -> RESOURCE_MODEL_BAREBONE_BLDR()
+                        .port("")
+                        .build(),
+                expectSuccess()
+        );
+
+        ArgumentCaptor<CreateDbInstanceRequest> argument = ArgumentCaptor.forClass(CreateDbInstanceRequest.class);
+        verify(rdsProxy.client(), times(1)).createDBInstance(argument.capture());
+        Assertions.assertThat(argument.getValue().port()).isNull();
+    }
 }


### PR DESCRIPTION
This PR changes `port` attribute data type from integer to string. It seems the old implementation was using a string attribute, and the new implementation translated it into an integer. The fix is required as customers who were using string functions (e.g. `Fn::Join`) experienced a regression due to an argument of an invalid data type provided.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Signed-off-by: Oleg Sidorov <sidorovo@amazon.com>