### PR TITLE
Fix `RestoreDBInstanceFromDBSnapshot` permission in DBInstance

### DIFF
--- a/aws-rds-dbinstance/aws-rds-dbinstance.json
+++ b/aws-rds-dbinstance/aws-rds-dbinstance.json
@@ -457,7 +457,7 @@
         "rds:DescribeDBSnapshots",
         "rds:ModifyDBInstance",
         "rds:RebootDBInstance",
-        "rds:RestoreDBInstanceFromDbSnapshot"
+        "rds:RestoreDBInstanceFromDBSnapshot"
       ]
     },
     "read": {

--- a/aws-rds-dbinstance/resource-role.yaml
+++ b/aws-rds-dbinstance/resource-role.yaml
@@ -50,7 +50,7 @@ Resources:
                 - "rds:RebootDBInstance"
                 - "rds:RemoveRoleFromDBInstance"
                 - "rds:RemoveTagsFromResource"
-                - "rds:RestoreDBInstanceFromDbSnapshot"
+                - "rds:RestoreDBInstanceFromDBSnapshot"
                 Resource: "*"
 Outputs:
   ExecutionRoleArn:


### PR DESCRIPTION
*Description of changes:*
Fix `RestoreDBInstanceFromDBSnapshot` permission in DBInstance

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
