### PR TITLE
[DBInstance] Fix Endpoint.Port datatype from Integer to String

### DIFF
--- a/aws-rds-dbinstance/aws-rds-dbinstance.json
+++ b/aws-rds-dbinstance/aws-rds-dbinstance.json
@@ -12,7 +12,7 @@
           "description": "Specifies the DNS address of the DB instance."
         },
         "Port": {
-          "type": "integer",
+          "type": "string",
           "description": "Specifies the port that the database engine is listening on."
         },
         "HostedZoneId": {

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/Translator.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/Translator.java
@@ -434,7 +434,7 @@ public class Translator {
     private static Endpoint translateEndpointFromSdk(software.amazon.awssdk.services.rds.model.Endpoint endpoint) {
         return Endpoint.builder()
                 .address(endpoint.address())
-                .port(endpoint.port())
+                .port(endpoint.port() == null ? null : endpoint.port().toString())
                 .hostedZoneId(endpoint.hostedZoneId())
                 .build();
     }


### PR DESCRIPTION
This commit changes the data type definition for `Endpoint.Port`. The new implementation happened to copy the type definition from AWS RDS SDK, which declares this attribute as an Integer.

Having this fix in place will unblock customers using `Endpoint.Port` attribute in string functions.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Signed-off-by: Oleg Sidorov <sidorovo@amazon.com>