### PR TITLE
[DBParameterGroup]  Matching Current CloudFormation Behaviour in Calculating Parameters to Reset

### DIFF
--- a/aws-rds-dbparametergroup/src/main/java/software/amazon/rds/dbparametergroup/BaseHandlerStd.java
+++ b/aws-rds-dbparametergroup/src/main/java/software/amazon/rds/dbparametergroup/BaseHandlerStd.java
@@ -284,12 +284,12 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
     private Map<String, Parameter> getParametersToReset(final ResourceModel model,
                                                         final Map<String, Parameter> defaultEngineParameters,
                                                         final Map<String, Parameter> currentParameters) {
-        return currentParameters.entrySet()
+        return defaultEngineParameters.entrySet()
                 .stream()
                 .filter(entry -> {
                     String parameterName = entry.getKey();
-                    String currentParameterValue = entry.getValue().parameterValue();
-                    String defaultParameterValue = defaultEngineParameters.get(parameterName).parameterValue();
+                    String defaultParameterValue = entry.getValue().parameterValue();
+                    String currentParameterValue = currentParameters.get(parameterName).parameterValue();
                     Map<String, Object> parametersToModify = model.getParameters();
                     return parametersToModify != null && currentParameterValue != null
                             && !currentParameterValue.equals(defaultParameterValue)

--- a/aws-rds-dbparametergroup/src/test/java/software/amazon/rds/dbparametergroup/CreateHandlerTest.java
+++ b/aws-rds-dbparametergroup/src/test/java/software/amazon/rds/dbparametergroup/CreateHandlerTest.java
@@ -256,6 +256,14 @@ public class CreateHandlerTest extends AbstractTestBase {
                 .isModifiable(isModifiable)
                 .applyType(secondParamApplyType)
                 .build();
+        //Adding parameter to current parameters and not adding it to default. Expected behaviour is to ignore it
+        Parameter param3 = Parameter.builder()
+                .parameterName("param3")
+                .parameterValue("system_value")
+                .isModifiable(isModifiable)
+                .applyType(secondParamApplyType)
+                .build();
+
 
         DescribeEngineDefaultParametersIterable describeEngineDefaultParametersResponses = mock(DescribeEngineDefaultParametersIterable.class);
         final DescribeEngineDefaultParametersResponse describeEngineDefaultParametersResponse = DescribeEngineDefaultParametersResponse.builder()
@@ -274,7 +282,7 @@ public class CreateHandlerTest extends AbstractTestBase {
             return;
 
         final DescribeDbParametersResponse describeDbParametersResponse = DescribeDbParametersResponse.builder().marker(null)
-                .parameters(param1, param2).build();
+                .parameters(param1, param2, param3).build();
 
         final DescribeDBParametersIterable describeDbParametersIterable = mock(DescribeDBParametersIterable.class);
         when(describeDbParametersIterable.stream())


### PR DESCRIPTION
*Description of changes:*
We noticed there are extra parameters appeared in DBParameterGroup and not in DefaultEngineParameters. Current behavior in CloudFormation is ignoring these parameters.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
