### PR TITLE
[DBInstance] Disable engine setting upon an update

### DIFF
--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/UpdateHandler.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/UpdateHandler.java
@@ -97,7 +97,6 @@ public class UpdateHandler extends BaseHandlerStd {
                     }
                     return progress;
                 })
-                .then(progress -> ensureEngineSet(rdsProxyClient, progress))
                 .then(progress -> Commons.execOnce(progress, () ->
                                 updateDbInstance(proxy, request, rdsProxyClient, progress),
                         CallbackContext::isUpdated, CallbackContext::setUpdated)


### PR DESCRIPTION
This commit removes an engine set enforcement from the UpdateHandler. The reason be: `ModifyDBInstance` never updates the engine name itself: it only checks if there is an engine name change and triggers a replacement cycle if this is the case.

Setting an engine in this part of the code caused a regression under which the handler invoked `ModifyDBInstance` request once and failed upon a stabilization right away as `ensureEngineSet` invocation updated the desired resource model by reference. A close review of this code indicates that setting the engine name here is a no-op, hence it is removed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Signed-off-by: Oleg Sidorov <sidorovo@amazon.com>