### PR TITLE
[DBParameterGroup] Calculating Parameters to Reset on Intersection Between Current Parameters and Default Parameters

### DIFF
--- a/aws-rds-dbparametergroup/src/main/java/software/amazon/rds/dbparametergroup/BaseHandlerStd.java
+++ b/aws-rds-dbparametergroup/src/main/java/software/amazon/rds/dbparametergroup/BaseHandlerStd.java
@@ -284,7 +284,9 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
     private Map<String, Parameter> getParametersToReset(final ResourceModel model,
                                                         final Map<String, Parameter> defaultEngineParameters,
                                                         final Map<String, Parameter> currentParameters) {
-        return defaultEngineParameters.entrySet()
+        Map<String, Parameter> defaultParametersToReset = Maps.newLinkedHashMap(defaultEngineParameters);
+        defaultParametersToReset.keySet().retainAll(currentParameters.keySet());
+        return defaultParametersToReset.entrySet()
                 .stream()
                 .filter(entry -> {
                     String parameterName = entry.getKey();

--- a/aws-rds-dbparametergroup/src/test/java/software/amazon/rds/dbparametergroup/CreateHandlerTest.java
+++ b/aws-rds-dbparametergroup/src/test/java/software/amazon/rds/dbparametergroup/CreateHandlerTest.java
@@ -263,12 +263,19 @@ public class CreateHandlerTest extends AbstractTestBase {
                 .isModifiable(isModifiable)
                 .applyType(secondParamApplyType)
                 .build();
+        //Adding parameter to default parameters and not adding it to current. Expected behaviour is to ignore it
+        Parameter param4 = Parameter.builder()
+                .parameterName("param4")
+                .parameterValue("system_value")
+                .isModifiable(isModifiable)
+                .applyType(secondParamApplyType)
+                .build();
 
 
         DescribeEngineDefaultParametersIterable describeEngineDefaultParametersResponses = mock(DescribeEngineDefaultParametersIterable.class);
         final DescribeEngineDefaultParametersResponse describeEngineDefaultParametersResponse = DescribeEngineDefaultParametersResponse.builder()
                 .engineDefaults(EngineDefaults.builder()
-                        .parameters(param1, param2)
+                        .parameters(param1, param2, param4)
                         .build()
                 ).build();
         when(describeEngineDefaultParametersResponses.stream())


### PR DESCRIPTION
*Description of changes:*

Some engines like `MariaDB` have 
- Extra current parameters that not found in default engine parameters.
- Extra default parameters that not found in current parameters.

Current cloudformation behavior is to ignore both of them. This change will meet this behavior by calculating parameters to reset from intersection between current and default only. That's mean any extra parameters in two of them will be ignored in resetting  

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
