### PR TITLE
[DBCluster] Add mysql and postgres to DBCluster schema engines +2

### DIFF
--- a/aws-rds-dbcluster/aws-rds-dbcluster.json
+++ b/aws-rds-dbcluster/aws-rds-dbcluster.json
@@ -96,7 +96,9 @@
       "enum": [
         "aurora",
         "aurora-mysql",
-        "aurora-postgresql"
+        "aurora-postgresql",
+        "mysql",
+        "postgres"
       ]
     },
     "EngineMode": {

--- a/aws-rds-dbcluster/docs/README.md
+++ b/aws-rds-dbcluster/docs/README.md
@@ -266,7 +266,7 @@ _Required_: No
 
 _Type_: String
 
-_Allowed Values_: <code>aurora</code> | <code>aurora-mysql</code> | <code>aurora-postgres</code>
+_Allowed Values_: <code>aurora</code> | <code>aurora-mysql</code> | <code>aurora-postgresql</code> | <code>mysql</code> | <code>postgres</code>
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 

--- a/aws-rds-dbinstance/docs/README.md
+++ b/aws-rds-dbinstance/docs/README.md
@@ -319,7 +319,7 @@ _Required_: No
 
 _Type_: String
 
-_Pattern_: <code>^$|^[a-zA-Z]{1}(?:[-:]?[a-zA-Z0-9]){0,254}$</code>
+_Pattern_: <code>^$|^[a-zA-Z]{1}(?:[-:]?[a-zA-Z0-9_\.\s]){0,254}$</code>
 
 _Update requires_: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
 

--- a/aws-rds-dbsubnetgroup/aws-rds-dbsubnetgroup.json
+++ b/aws-rds-dbsubnetgroup/aws-rds-dbsubnetgroup.json
@@ -8,7 +8,7 @@
     },
     "DBSubnetGroupName": {
       "type": "string",
-      "pattern": "^(?!default$)[a-zA-Z]{1}[a-zA-Z0-9-_\\.\\s]{0,255}$"
+      "pattern": "^(?!default$)[a-zA-Z]{1}[a-zA-Z0-9-_\\.\\s]{0,254}$"
     },
     "SubnetIds": {
       "type": "array",

--- a/aws-rds-dbsubnetgroup/docs/README.md
+++ b/aws-rds-dbsubnetgroup/docs/README.md
@@ -49,7 +49,7 @@ _Required_: No
 
 _Type_: String
 
-_Pattern_: <code>^(?!default$)[a-zA-Z0-9-_\s]{1,255}$</code>
+_Pattern_: <code>^(?!default$)[a-zA-Z]{1}[a-zA-Z0-9-_\.\s]{0,254}$</code>
 
 _Update requires_: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
 


### PR DESCRIPTION
This commit incorporates 3 changes:
  - Adds mysql and postgres to DBCluster schema: the current implementation only declares aurora engine types
  - Changes DBSubnetGroup name length constraint from 256 to 255
  - Regenerated README files for all resources to reflect the most recent changes to the resource definition schemas

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Signed-off-by: Oleg Sidorov <sidorovo@amazon.com>