### PR TITLE
[DBCluster] Change schema validation

### DIFF
--- a/aws-rds-dbcluster/aws-rds-dbcluster.json
+++ b/aws-rds-dbcluster/aws-rds-dbcluster.json
@@ -209,9 +209,17 @@
     {
       "oneOf": [
         {
-          "required": [
-            "MasterUserPassword",
-            "MasterUsername"
+          "anyOf": [
+            {
+              "required": [
+                "MasterUserPassword"
+              ]
+            },
+            {
+              "required": [
+                "MasterUsername"
+              ]
+            }
           ]
         },
         {
@@ -223,43 +231,10 @@
           "required": [
             "SourceDBClusterIdentifier"
           ]
-        }
-      ]
-    },
-    {
-      "oneOf": [
-        {
-          "required": [
-            "MasterUsername"
-          ]
         },
         {
           "required": [
-            "SnapshotIdentifier"
-          ]
-        },
-        {
-          "required": [
-            "SourceDBClusterIdentifier"
-          ]
-        }
-      ]
-    },
-    {
-      "oneOf": [
-        {
-          "required": [
-            "MasterUserPassword"
-          ]
-        },
-        {
-          "required": [
-            "SnapshotIdentifier"
-          ]
-        },
-        {
-          "required": [
-            "SourceDBClusterIdentifier"
+            "GlobalClusterIdentifier"
           ]
         }
       ]


### PR DESCRIPTION
This commit alters the validator for conditionally required `MasterUsername` and `MasterUserPassword`: providing `GlobalClusterIdentifier` lets keeping these attributes empty.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Signed-off-by: Oleg Sidorov <sidorovo@amazon.com>