### PR TITLE
[EventSubscription] Implement soft fail in create, update, and read

### DIFF
--- a/aws-rds-eventsubscription/src/main/java/software/amazon/rds/eventsubscription/BaseHandlerStd.java
+++ b/aws-rds-eventsubscription/src/main/java/software/amazon/rds/eventsubscription/BaseHandlerStd.java
@@ -1,6 +1,5 @@
 package software.amazon.rds.eventsubscription;
 
-import java.util.Map;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 
@@ -89,26 +88,59 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
                 .stabilize((resourceModel, response, proxyInvocation, model, callbackContext) -> isStabilized(resourceModel, proxyInvocation)).progress();
     }
 
-    protected ProgressEvent<ResourceModel, CallbackContext> tagResource(
+    protected ProgressEvent<ResourceModel, CallbackContext> updateTags(
             final AmazonWebServicesClientProxy proxy,
-            final ProxyClient<RdsClient> proxyClient,
+            final ProxyClient<RdsClient> rdsProxyClient,
             final ProgressEvent<ResourceModel, CallbackContext> progress,
-            final Map<String, String> previousTags,
-            final Map<String, String> desiredTags) {
-        return proxy.initiate("rds::tag-event-subscription", proxyClient, progress.getResourceModel(), progress.getCallbackContext())
-                .translateToServiceRequest(Translator::describeEventSubscriptionsRequest)
-                .makeServiceCall((describeEventSubscriptionsRequest, proxyInvocation) -> proxyInvocation.injectCredentialsAndInvokeV2(describeEventSubscriptionsRequest, proxyInvocation.client()::describeEventSubscriptions))
-                .done((describeEventSubscriptionsRequest, describeEventSubscriptionsResponse, proxyInvocation, resourceModel, context) -> {
-                    final String arn = describeEventSubscriptionsResponse.eventSubscriptionsList().stream().findFirst().get().eventSubscriptionArn();
-                    return Tagging.updateTags(
-                            proxyInvocation,
-                            ProgressEvent.progress(resourceModel, context),
-                            arn,
-                            previousTags,
-                            desiredTags,
-                            DEFAULT_EVENT_SUBSCRIPTION_ERROR_RULE_SET
-                    );
-                });
+            final Tagging.TagSet previousTags,
+            final Tagging.TagSet desiredTags) {
+        final Tagging.TagSet tagsToAdd = Tagging.exclude(desiredTags, previousTags);
+        final Tagging.TagSet tagsToRemove = Tagging.exclude(previousTags, desiredTags);
+
+        if (tagsToAdd.isEmpty() && tagsToRemove.isEmpty()) {
+            return progress;
+        }
+
+        String arn = progress.getCallbackContext().getEventSubscriptionArn();
+        if (arn == null) {
+            ProgressEvent<ResourceModel, CallbackContext> progressEvent = fetchEventSubscriptionArn(proxy, rdsProxyClient, progress);
+            if (progressEvent.isFailed()) {
+                return progressEvent;
+            }
+            arn = progressEvent.getCallbackContext().getEventSubscriptionArn();
+        }
+
+        try {
+            Tagging.removeTags(rdsProxyClient, arn, Tagging.translateTagsToSdk(tagsToRemove));
+            Tagging.addTags(rdsProxyClient, arn, Tagging.translateTagsToSdk(tagsToAdd));
+        } catch (Exception exception) {
+            return Commons.handleException(
+                    progress,
+                    exception,
+                    Tagging.bestEffortErrorRuleSet(tagsToAdd, tagsToRemove, Tagging.SOFT_FAIL_IN_PROGRESS_TAGGING_ERROR_RULE_SET, Tagging.HARD_FAIL_TAG_ERROR_RULE_SET)
+                            .orElse(DEFAULT_EVENT_SUBSCRIPTION_ERROR_RULE_SET)
+            );
+        }
+
+        return progress;
     }
 
+    protected ProgressEvent<ResourceModel, CallbackContext> fetchEventSubscriptionArn(final AmazonWebServicesClientProxy proxy,
+                                                                                      final ProxyClient<RdsClient> proxyClient,
+                                                                                      final ProgressEvent<ResourceModel, CallbackContext> progress) {
+        return proxy.initiate("rds::read-db-parameter-group-arn", proxyClient, progress.getResourceModel(), progress.getCallbackContext())
+                .translateToServiceRequest(Translator::describeEventSubscriptionsRequest)
+                .makeServiceCall((describeEventSubscriptionsRequest, proxyInvocation) -> proxyInvocation.injectCredentialsAndInvokeV2(describeEventSubscriptionsRequest, proxyInvocation.client()::describeEventSubscriptions))
+                .handleError((describeDbParameterGroupsRequest, exception, client, resourceModel, ctx) ->
+                        Commons.handleException(
+                                ProgressEvent.progress(resourceModel, ctx),
+                                exception,
+                                DEFAULT_EVENT_SUBSCRIPTION_ERROR_RULE_SET
+                        ))
+                .done((describeEventSubscriptionsRequest, describeEventSubscriptionsResponse, proxyInvocation, resourceModel, context) -> {
+                    final String arn = describeEventSubscriptionsResponse.eventSubscriptionsList().stream().findFirst().get().eventSubscriptionArn();
+                    context.setEventSubscriptionArn(arn);
+                    return ProgressEvent.progress(resourceModel, context);
+                });
+    }
 }

--- a/aws-rds-eventsubscription/src/main/java/software/amazon/rds/eventsubscription/CallbackContext.java
+++ b/aws-rds-eventsubscription/src/main/java/software/amazon/rds/eventsubscription/CallbackContext.java
@@ -7,4 +7,5 @@ import software.amazon.cloudformation.proxy.StdCallbackContext;
 @lombok.ToString
 @lombok.EqualsAndHashCode(callSuper = true)
 public class CallbackContext extends StdCallbackContext {
+    private String eventSubscriptionArn;
 }

--- a/aws-rds-eventsubscription/src/main/java/software/amazon/rds/eventsubscription/CreateHandler.java
+++ b/aws-rds-eventsubscription/src/main/java/software/amazon/rds/eventsubscription/CreateHandler.java
@@ -1,5 +1,6 @@
 package software.amazon.rds.eventsubscription;
 
+import java.util.HashSet;
 import java.util.Optional;
 
 import com.amazonaws.util.StringUtils;
@@ -25,6 +26,44 @@ public class CreateHandler extends BaseHandlerStd {
             final Logger logger) {
 
         final ResourceModel model = request.getDesiredResourceState();
+
+        final Tagging.TagSet systemTags = Tagging.TagSet.builder()
+                .systemTags(Tagging.translateTagsToSdk(request.getSystemTags()))
+                .build();
+
+        final Tagging.TagSet extraTags = Tagging.TagSet.builder()
+                .stackTags(Tagging.translateTagsToSdk(request.getDesiredResourceTags()))
+                .resourceTags(new HashSet<>(Translator.translateTagsToSdk(request.getDesiredResourceState().getTags())))
+                .build();
+
+        return ProgressEvent.progress(model, callbackContext)
+                .then(progress -> setEventSubscriptionNameIfEmpty(request, progress))
+                .then(progress -> createEventSubscription(proxy, proxyClient, progress, systemTags))
+                .then(progress -> updateTags(proxy, proxyClient, progress, Tagging.TagSet.emptySet(), extraTags))
+                .then(progress -> new ReadHandler().handleRequest(proxy, request, callbackContext, proxyClient, logger));
+    }
+
+    private ProgressEvent<ResourceModel, CallbackContext> createEventSubscription(final AmazonWebServicesClientProxy proxy,
+                                                                                  final ProxyClient<RdsClient> proxyClient,
+                                                                                  final ProgressEvent<ResourceModel, CallbackContext> progress,
+                                                                                  final Tagging.TagSet systemTags
+    ) {
+        return proxy.initiate("rds::create-event-subscription", proxyClient, progress.getResourceModel(), progress.getCallbackContext())
+                .translateToServiceRequest((resourceModel) -> Translator.createEventSubscriptionRequest(resourceModel, systemTags))
+                .makeServiceCall((createEventSubscriptionRequest, proxyInvocation) -> proxyInvocation.injectCredentialsAndInvokeV2(createEventSubscriptionRequest, proxyInvocation.client()::createEventSubscription))
+                .stabilize((createEventSubscriptionRequest, createEventSubscriptionResponse, proxyInvocation, resourceModel, context) ->
+                        isStabilized(resourceModel, proxyInvocation))
+                .handleError((createRequest, exception, client, resourceModel, ctx) -> Commons.handleException(
+                        ProgressEvent.progress(resourceModel, ctx),
+                        exception,
+                        DEFAULT_EVENT_SUBSCRIPTION_ERROR_RULE_SET))
+                .progress();
+    }
+
+    private ProgressEvent<ResourceModel, CallbackContext> setEventSubscriptionNameIfEmpty(final ResourceHandlerRequest<ResourceModel> request,
+                                                                                          final ProgressEvent<ResourceModel, CallbackContext> progress
+    ) {
+        ResourceModel model = progress.getResourceModel();
         if (StringUtils.isNullOrEmpty(model.getSubscriptionName())) {
             model.setSubscriptionName(IdentifierUtils.generateResourceIdentifier(
                     Optional.ofNullable(request.getStackId()).orElse("rds"),
@@ -33,19 +72,6 @@ public class CreateHandler extends BaseHandlerStd {
                     MAX_LENGTH_EVENT_SUBSCRIPTION
             ).toLowerCase());
         }
-
-        return proxy.initiate("rds::create-event-subscription", proxyClient, model, callbackContext)
-                .translateToServiceRequest((resourceModel) -> Translator.createEventSubscriptionRequest(
-                        resourceModel,
-                        Tagging.mergeTags(request.getSystemTags(), request.getDesiredResourceTags())))
-                .makeServiceCall((createEventSubscriptionRequest, proxyInvocation) -> proxyInvocation.injectCredentialsAndInvokeV2(createEventSubscriptionRequest, proxyInvocation.client()::createEventSubscription))
-                .stabilize((createEventSubscriptionRequest, createEventSubscriptionResponse, proxyInvocation, resourceModel, context) ->
-                        isStabilized(resourceModel, proxyInvocation))
-                .handleError((createRequest, exception, client, resourceModel, ctx) -> Commons.handleException(
-                        ProgressEvent.progress(resourceModel, ctx),
-                        exception,
-                        DEFAULT_EVENT_SUBSCRIPTION_ERROR_RULE_SET))
-                .progress()
-                .then(progress -> new ReadHandler().handleRequest(proxy, request, callbackContext, proxyClient, logger));
+        return progress;
     }
 }

--- a/aws-rds-eventsubscription/src/main/java/software/amazon/rds/eventsubscription/Translator.java
+++ b/aws-rds-eventsubscription/src/main/java/software/amazon/rds/eventsubscription/Translator.java
@@ -1,8 +1,11 @@
 package software.amazon.rds.eventsubscription;
 
+import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -19,7 +22,7 @@ import software.amazon.rds.common.handler.Tagging;
 public class Translator {
     static CreateEventSubscriptionRequest createEventSubscriptionRequest(
             final ResourceModel model,
-            final Map<String, String> tags
+            final Tagging.TagSet tags
     ) {
         return CreateEventSubscriptionRequest.builder()
                 .subscriptionName(model.getSubscriptionName())
@@ -80,19 +83,31 @@ public class Translator {
                 .build();
     }
 
-    static ResourceModel translateToModel(
-            final String subscriptionName,
-            final EventSubscription eventSubscription,
-            final Set<software.amazon.awssdk.services.rds.model.Tag> rdsTags
-    ) {
-        List<Tag> tags = CollectionUtils.isNullOrEmpty(rdsTags) ? null
+    public static List<software.amazon.awssdk.services.rds.model.Tag> translateTagsToSdk(final Collection<Tag> tags) {
+        return Optional.ofNullable(tags).orElse(Collections.emptyList())
+                .stream()
+                .map(tag -> software.amazon.awssdk.services.rds.model.Tag.builder()
+                        .key(tag.getKey())
+                        .value(tag.getValue())
+                        .build()
+                )
+                .collect(Collectors.toList());
+    }
+
+    static List<Tag> translateTags(final Collection<software.amazon.awssdk.services.rds.model.Tag> rdsTags) {
+        return CollectionUtils.isNullOrEmpty(rdsTags) ? null
                 : rdsTags.stream()
                 .map(tag -> Tag.builder()
                         .key(tag.key())
                         .value(tag.value())
                         .build())
                 .collect(Collectors.toList());
+    }
 
+    static ResourceModel translateToModel(
+            final String subscriptionName,
+            final EventSubscription eventSubscription
+    ) {
         return ResourceModel.builder()
                 .enabled(eventSubscription.enabled())
                 .eventCategories(eventSubscription.eventCategoriesList())
@@ -100,7 +115,6 @@ public class Translator {
                 .snsTopicArn(eventSubscription.snsTopicArn())
                 .sourceType(eventSubscription.sourceType())
                 .sourceIds(new HashSet<>(eventSubscription.sourceIdsList()))
-                .tags(tags)
                 .build();
     }
 }

--- a/aws-rds-eventsubscription/src/test/java/software/amazon/rds/eventsubscription/UpdateHandlerTest.java
+++ b/aws-rds-eventsubscription/src/test/java/software/amazon/rds/eventsubscription/UpdateHandlerTest.java
@@ -108,7 +108,7 @@ public class UpdateHandlerTest extends AbstractTestBase {
         assertThat(response.getErrorCode()).isNull();
 
         verify(proxyRdsClient.client()).modifyEventSubscription(any(ModifyEventSubscriptionRequest.class));
-        verify(proxyRdsClient.client(), times(4)).describeEventSubscriptions(any(DescribeEventSubscriptionsRequest.class));
+        verify(proxyRdsClient.client(), times(3)).describeEventSubscriptions(any(DescribeEventSubscriptionsRequest.class));
         verify(proxyRdsClient.client(), times(1)).listTagsForResource(any(ListTagsForResourceRequest.class));
     }
 


### PR DESCRIPTION
*Description of changes:*
Soft fails means ignoring permission denied exception and proceed with resource logic.This PR implements soft fail in EventSubscription:

   - Hard fail on add/remove resource tags
   - Soft fail on add/remove system tags
   - Soft fail on add/remove stack level tags
   - Soft fail on read tags


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
