### PR TITLE
[DBInstance] Increase default handler request chain timeout

### DIFF
--- a/aws-rds-cfn-common/src/main/java/software/amazon/rds/common/handler/HandlerConfig.java
+++ b/aws-rds-cfn-common/src/main/java/software/amazon/rds/common/handler/HandlerConfig.java
@@ -17,6 +17,6 @@ public class HandlerConfig {
     @Builder.Default
     final private Constant backoff = Constant.of()
             .delay(Duration.ofSeconds(30))
-            .timeout(Duration.ofMinutes(60))
+            .timeout(Duration.ofMinutes(90))
             .build();
 }


### PR DESCRIPTION
This commit updates the default request chain timeout from `60` to `90` minutes. It seems some db instances time out to stabilize within 1hr if it observes a stabilization interruption. The stabilization for DBInstance is n-probed: the handler expects to observe 3 `available` statuses before it declares a stable state. If the counter is reset due to an interrupting instance reboot or upgrade, the handler will reset the probe counter and start it over. We are extending this default timeout in order to cover slow-provisioning cases.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Signed-off-by: Oleg Sidorov <sidorovo@amazon.com>