### PR TITLE
[DBParameterGroup]Soft fail for `DescribeDBParameterGroups` call

### DIFF
--- a/aws-rds-dbparametergroup/src/main/java/software/amazon/rds/dbparametergroup/ReadHandler.java
+++ b/aws-rds-dbparametergroup/src/main/java/software/amazon/rds/dbparametergroup/ReadHandler.java
@@ -38,7 +38,7 @@ public class ReadHandler extends BaseHandlerStd {
                         Commons.handleException(
                                 ProgressEvent.progress(resourceModel, ctx),
                                 exception,
-                                DEFAULT_DB_PARAMETER_GROUP_ERROR_RULE_SET
+                                SOFT_FAIL_NPROGRESS_TAGGING_ERROR_RULE_SET
                         ))
                 .done((describeDbParameterGroupsRequest, describeDbParameterGroupsResponse, proxyInvocation, model, context) -> {
                     try {

--- a/aws-rds-dbparametergroup/src/main/java/software/amazon/rds/dbparametergroup/Translator.java
+++ b/aws-rds-dbparametergroup/src/main/java/software/amazon/rds/dbparametergroup/Translator.java
@@ -7,6 +7,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+import com.amazonaws.arn.Arn;
 import com.amazonaws.util.CollectionUtils;
 import software.amazon.awssdk.services.rds.model.ApplyMethod;
 import software.amazon.awssdk.services.rds.model.CreateDbParameterGroupRequest;
@@ -18,9 +19,13 @@ import software.amazon.awssdk.services.rds.model.DescribeEngineDefaultParameters
 import software.amazon.awssdk.services.rds.model.ModifyDbParameterGroupRequest;
 import software.amazon.awssdk.services.rds.model.Parameter;
 import software.amazon.awssdk.services.rds.model.ResetDbParameterGroupRequest;
+import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 import software.amazon.rds.common.handler.Tagging;
 
 public class Translator {
+
+    public static final String RDS = "rds";
+    public static final String RESOURCE_PREFIX = "pg:";
 
     static CreateDbParameterGroupRequest createDbParameterGroupRequest(
             final ResourceModel model,
@@ -129,6 +134,17 @@ public class Translator {
                         .value(tag.value())
                         .build())
                 .collect(Collectors.toList());
+    }
+
+    static Arn buildParameterGroupArn(final ResourceHandlerRequest<ResourceModel> request) {
+        String resource = RESOURCE_PREFIX + request.getDesiredResourceState().getDBParameterGroupName();
+        return Arn.builder()
+                .withPartition(request.getAwsPartition())
+                .withRegion(request.getRegion())
+                .withService(RDS)
+                .withAccountId(request.getAwsAccountId())
+                .withResource(resource)
+                .build();
     }
 
     private static ApplyMethod getParameterApplyMethod(final Parameter parameter) {

--- a/aws-rds-dbparametergroup/src/main/java/software/amazon/rds/dbparametergroup/UpdateHandler.java
+++ b/aws-rds-dbparametergroup/src/main/java/software/amazon/rds/dbparametergroup/UpdateHandler.java
@@ -41,7 +41,6 @@ public class UpdateHandler extends BaseHandlerStd {
                 .build();
 
         return ProgressEvent.progress(request.getDesiredResourceState(), callbackContext)
-                .then(progress -> fetchDBParameterGroupArn(proxy, proxyClient, progress))
                 .then(progress -> updateTags(proxy, proxyClient, progress, previousTags, desiredTags, requestLogger))
                 .then(progress -> applyParameters(proxy, proxyClient, progress, requestLogger))
                 .then(progress -> new ReadHandler().handleRequest(proxy, request, callbackContext, proxyClient, requestLogger));

--- a/aws-rds-dbparametergroup/src/test/java/software/amazon/rds/dbparametergroup/UpdateHandlerTest.java
+++ b/aws-rds-dbparametergroup/src/test/java/software/amazon/rds/dbparametergroup/UpdateHandlerTest.java
@@ -109,7 +109,7 @@ public class UpdateHandlerTest extends AbstractTestBase {
         assertThat(response.getMessage()).isNull();
         assertThat(response.getErrorCode()).isNull();
 
-        verify(proxyRdsClient.client(), times(2)).describeDBParameterGroups(any(DescribeDbParameterGroupsRequest.class));
+        verify(proxyRdsClient.client(), times(1)).describeDBParameterGroups(any(DescribeDbParameterGroupsRequest.class));
         verify(proxyRdsClient.client(), times(1)).listTagsForResource(any(ListTagsForResourceRequest.class));
         verify(proxyRdsClient.client()).addTagsToResource(any(AddTagsToResourceRequest.class));
     }
@@ -139,7 +139,7 @@ public class UpdateHandlerTest extends AbstractTestBase {
         assertThat(response.getMessage()).isNull();
         assertThat(response.getErrorCode()).isNull();
 
-        verify(proxyRdsClient.client(), times(2)).describeDBParameterGroups(any(DescribeDbParameterGroupsRequest.class));
+        verify(proxyRdsClient.client(), times(1)).describeDBParameterGroups(any(DescribeDbParameterGroupsRequest.class));
         verify(proxyRdsClient.client(), times(1)).listTagsForResource(any(ListTagsForResourceRequest.class));
         verify(proxyRdsClient.client()).addTagsToResource(any(AddTagsToResourceRequest.class));
     }


### PR DESCRIPTION
*Description of changes:*
Implementing soft failing while doing `DescribeDBPrameterGroups` call to be backward compatible with current CloudFormation customer to prevent `AccessDenied` exception for existing stacks.
Changes:
- Compose `DBParameterGroupArn` from `Request` and `ResourceModel` instead of retrieving it from `DescribeDBPrameterGroups` call.
- Remove `fetchDBParameterGroupArn` as it triggers `DescribeDBPrameterGroups` call.
- Apply `setDBParameterGroupArn` in all handlers.
- Use in progress soft fail error rule set while executing `DescribeDBPrameterGroups` call in read handler.
- Update relative unit tests.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
