### PR TITLE
[DBInstance] Remove `StorageType` enum-based validator

### DIFF
--- a/aws-rds-dbinstance/aws-rds-dbinstance.json
+++ b/aws-rds-dbinstance/aws-rds-dbinstance.json
@@ -324,11 +324,6 @@
     },
     "StorageType": {
       "type": "string",
-      "enum": [
-        "standard",
-        "gp2",
-        "io1"
-      ],
       "description": "Specifies the storage type to be associated with the DB instance."
     },
     "Tags": {

--- a/aws-rds-dbinstance/docs/README.md
+++ b/aws-rds-dbinstance/docs/README.md
@@ -651,8 +651,6 @@ _Required_: No
 
 _Type_: String
 
-_Allowed Values_: <code>standard</code> | <code>gp2</code> | <code>io1</code>
-
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 
 #### Tags


### PR DESCRIPTION
This commit removes the enum-based validator that was defined on `StorageType` attribute previously. The reason for the removal is because CFN performs a case-sensitive enum lookup, so the values in different case spelling would be rejected.

A case-insensitive enum would rather be an option on CFN side, hence this commit could be rejected once ignore-case check is supported by CFN.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Signed-off-by: Oleg Sidorov <sidorovo@amazon.com>