### PR TITLE
[DBInstance] Increase MasterUsername maxlen constraint

### DIFF
--- a/aws-rds-dbinstance/aws-rds-dbinstance.json
+++ b/aws-rds-dbinstance/aws-rds-dbinstance.json
@@ -230,10 +230,10 @@
     },
     "MasterUsername": {
       "type": "string",
-      "pattern": "^[a-zA-Z][a-zA-Z0-9_]{0,15}$",
+      "pattern": "^[a-zA-Z][a-zA-Z0-9_]{0,127}$",
       "description": "The master user name for the DB instance.",
       "minLength": 1,
-      "maxLength": 16
+      "maxLength": 128
     },
     "MasterUserPassword": {
       "type": "string",

--- a/aws-rds-dbinstance/docs/README.md
+++ b/aws-rds-dbinstance/docs/README.md
@@ -463,9 +463,9 @@ _Type_: String
 
 _Minimum_: <code>1</code>
 
-_Maximum_: <code>16</code>
+_Maximum_: <code>128</code>
 
-_Pattern_: <code>^[a-zA-Z][a-zA-Z0-9_]{0,15}$</code>
+_Pattern_: <code>^[a-zA-Z][a-zA-Z0-9_]{0,127}$</code>
 
 _Update requires_: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
 


### PR DESCRIPTION
This commit alters the maxlen constraint for `MasterUsername` from 16 characters to 128 max. The reason for change is that initially DBInstance schema was aiming for the minimum length across all engines, but it causes validation failures on engines where longer usernames are allowed.

According to https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-rds-database-instance.html#cfn-rds-dbinstance-masterusername, the maxlen across all engines is 128 characters. If a csutomer provides
a username that is longer than the engine maxlen but below 128 characters, the value would be sent to RDS API and rejected by the backend on contrast to rejecting by the the CFN validator. We believe this is a reasonable tradeoff that would allow us to include all engine constraints.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Signed-off-by: Oleg Sidorov <sidorovo@amazon.com>