### PR TITLE
[DBSubnetGroup] Implement Soft Failing While Tagging Resource

### DIFF
--- a/aws-rds-dbsubnetgroup/src/main/java/software/amazon/rds/dbsubnetgroup/CallbackContext.java
+++ b/aws-rds-dbsubnetgroup/src/main/java/software/amazon/rds/dbsubnetgroup/CallbackContext.java
@@ -7,4 +7,5 @@ import software.amazon.cloudformation.proxy.StdCallbackContext;
 @lombok.ToString
 @lombok.EqualsAndHashCode(callSuper = true)
 public class CallbackContext extends StdCallbackContext {
+    private String dbSubnetGroupArn;
 }

--- a/aws-rds-dbsubnetgroup/src/main/java/software/amazon/rds/dbsubnetgroup/CreateHandler.java
+++ b/aws-rds-dbsubnetgroup/src/main/java/software/amazon/rds/dbsubnetgroup/CreateHandler.java
@@ -1,5 +1,7 @@
 package software.amazon.rds.dbsubnetgroup;
 
+import java.util.LinkedHashSet;
+
 import com.amazonaws.util.StringUtils;
 import software.amazon.awssdk.services.rds.RdsClient;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
@@ -9,9 +11,18 @@ import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 import software.amazon.cloudformation.resource.IdentifierUtils;
 import software.amazon.rds.common.handler.Commons;
+import software.amazon.rds.common.handler.HandlerConfig;
 import software.amazon.rds.common.handler.Tagging;
 
 public class CreateHandler extends BaseHandlerStd {
+
+    public CreateHandler() {
+        this(HandlerConfig.builder().build());
+    }
+
+    public CreateHandler(final HandlerConfig config) {
+        super(config);
+    }
     protected ProgressEvent<ResourceModel, CallbackContext> handleRequest(
             final AmazonWebServicesClientProxy proxy,
             final ResourceHandlerRequest<ResourceModel> request,
@@ -19,25 +30,51 @@ public class CreateHandler extends BaseHandlerStd {
             final ProxyClient<RdsClient> proxyClient,
             final Logger logger) {
 
+        final ResourceModel desiredModel = request.getDesiredResourceState();
+
+        final Tagging.TagSet systemTags = Tagging.TagSet.builder()
+                .systemTags(Tagging.translateTagsToSdk(request.getSystemTags()))
+                .build();
+
+        final Tagging.TagSet extraTags = Tagging.TagSet.builder()
+                .stackTags(Tagging.translateTagsToSdk(request.getDesiredResourceTags()))
+                .resourceTags(new LinkedHashSet<>(Translator.translateTagsToSdk(desiredModel.getTags())))
+                .build();
+
         return ProgressEvent.progress(request.getDesiredResourceState(), callbackContext)
-                .then(progress -> {
-                    final ResourceModel model = progress.getResourceModel();
-                    if (StringUtils.isNullOrEmpty(model.getDBSubnetGroupName()))
-                        model.setDBSubnetGroupName(IdentifierUtils.generateResourceIdentifier(request.getLogicalResourceIdentifier(), request.getClientRequestToken(), DB_SUBNET_GROUP_NAME_LENGTH).toLowerCase());
-                    return ProgressEvent.progress(model, progress.getCallbackContext());
-                })
-                .then(progress -> proxy.initiate("rds::create-dbsubnet-group", proxyClient, progress.getResourceModel(), progress.getCallbackContext())
-                        .translateToServiceRequest((resourceModel) -> Translator.createDbSubnetGroupRequest(
-                                resourceModel,
-                                Tagging.mergeTags(request.getSystemTags(), request.getDesiredResourceTags())))
-                        .backoffDelay(CONSTANT)
-                        .makeServiceCall((createDbSubnetGroupRequest, proxyInvocation) -> proxyInvocation.injectCredentialsAndInvokeV2(createDbSubnetGroupRequest, proxyInvocation.client()::createDBSubnetGroup))
-                        .stabilize(((createDbSubnetGroupRequest, createDbSubnetGroupResponse, proxyInvocation, resourceModel, context) -> isStabilized(resourceModel, proxyInvocation)))
-                        .handleError((awsRequest, exception, client, resourceModel, context) -> Commons.handleException(
-                                ProgressEvent.progress(resourceModel, context),
-                                exception,
-                                DEFAULT_DB_SUBNET_GROUP_ERROR_RULE_SET))
-                        .progress())
+                .then(progress -> setDbSubnetGroupNameIfEmpty(request, progress))
+                .then(progress -> createDbSubnetGroup(proxy, proxyClient, progress, systemTags))
+                .then(progress -> updateTags(proxyClient, progress, Tagging.TagSet.emptySet(), extraTags))
                 .then(progress -> new ReadHandler().handleRequest(proxy, request, callbackContext, proxyClient, logger));
+    }
+
+    private ProgressEvent<ResourceModel, CallbackContext> createDbSubnetGroup(final AmazonWebServicesClientProxy proxy,
+                                                                              final ProxyClient<RdsClient> proxyClient,
+                                                                              final ProgressEvent<ResourceModel, CallbackContext> progress,
+                                                                              final Tagging.TagSet systemTags) {
+        return proxy.initiate("rds::create-dbsubnet-group", proxyClient, progress.getResourceModel(), progress.getCallbackContext())
+                .translateToServiceRequest((resourceModel) -> Translator.createDbSubnetGroupRequest(resourceModel, systemTags))
+                .backoffDelay(config.getBackoff())
+                .makeServiceCall((createDbSubnetGroupRequest, proxyInvocation) -> proxyInvocation.injectCredentialsAndInvokeV2(createDbSubnetGroupRequest, proxyInvocation.client()::createDBSubnetGroup))
+                .stabilize(((createDbSubnetGroupRequest, createDbSubnetGroupResponse, proxyInvocation, resourceModel, context) -> isStabilized(resourceModel, proxyInvocation)))
+                .handleError((awsRequest, exception, client, resourceModel, context) -> Commons.handleException(
+                        ProgressEvent.progress(resourceModel, context),
+                        exception,
+                        DEFAULT_DB_SUBNET_GROUP_ERROR_RULE_SET))
+                .done((subnetGroupRequest, subnetGroupResponse, proxyInvocation, resourceModel, context) -> {
+                    context.setDbSubnetGroupArn(subnetGroupResponse.dbSubnetGroup().dbSubnetGroupArn());
+                    return ProgressEvent.progress(resourceModel, context);
+                });
+    }
+
+    private ProgressEvent<ResourceModel, CallbackContext> setDbSubnetGroupNameIfEmpty(final ResourceHandlerRequest<ResourceModel> request,
+                                                                                      final ProgressEvent<ResourceModel, CallbackContext> progress) {
+        final ResourceModel model = progress.getResourceModel();
+        if (StringUtils.isNullOrEmpty(model.getDBSubnetGroupName())){
+            model.setDBSubnetGroupName(IdentifierUtils
+                    .generateResourceIdentifier(request.getLogicalResourceIdentifier(), request.getClientRequestToken(), DB_SUBNET_GROUP_NAME_LENGTH)
+                    .toLowerCase());
+        }
+        return ProgressEvent.progress(model, progress.getCallbackContext());
     }
 }

--- a/aws-rds-dbsubnetgroup/src/main/java/software/amazon/rds/dbsubnetgroup/DeleteHandler.java
+++ b/aws-rds-dbsubnetgroup/src/main/java/software/amazon/rds/dbsubnetgroup/DeleteHandler.java
@@ -7,8 +7,18 @@ import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 import software.amazon.rds.common.handler.Commons;
+import software.amazon.rds.common.handler.HandlerConfig;
 
 public class DeleteHandler extends BaseHandlerStd {
+
+    public DeleteHandler() {
+        this(HandlerConfig.builder().build());
+    }
+
+    public DeleteHandler(final HandlerConfig config) {
+        super(config);
+    }
+
     protected ProgressEvent<ResourceModel, CallbackContext> handleRequest(
             final AmazonWebServicesClientProxy proxy,
             final ResourceHandlerRequest<ResourceModel> request,
@@ -17,7 +27,7 @@ public class DeleteHandler extends BaseHandlerStd {
             final Logger logger) {
         return proxy.initiate("rds::delete-dbsubnet-group", proxyClient, request.getDesiredResourceState(), callbackContext)
                 .translateToServiceRequest(Translator::deleteDbSubnetGroupRequest)
-                .backoffDelay(CONSTANT)
+                .backoffDelay(config.getBackoff())
                 .makeServiceCall((deleteDbSubnetGroupRequest, proxyInvocation) -> proxyInvocation.injectCredentialsAndInvokeV2(deleteDbSubnetGroupRequest, proxyInvocation.client()::deleteDBSubnetGroup))
                 .stabilize((deleteDbSubnetGroupRequest, deleteDbSubnetGroupResponse, proxyInvocation, resourceModel, context) -> isDeleted(resourceModel, proxyInvocation))
                 .handleError((deleteDbSubnetGroupRequest, exception, client, resourceModel, cxt) -> Commons.handleException(

--- a/aws-rds-dbsubnetgroup/src/main/java/software/amazon/rds/dbsubnetgroup/ListHandler.java
+++ b/aws-rds-dbsubnetgroup/src/main/java/software/amazon/rds/dbsubnetgroup/ListHandler.java
@@ -11,8 +11,17 @@ import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 import software.amazon.rds.common.handler.Commons;
+import software.amazon.rds.common.handler.HandlerConfig;
 
 public class ListHandler extends BaseHandlerStd {
+
+    public ListHandler() {
+        this(HandlerConfig.builder().build());
+    }
+
+    public ListHandler(final HandlerConfig config) {
+        super(config);
+    }
 
     @Override
     public ProgressEvent<ResourceModel, CallbackContext> handleRequest(

--- a/aws-rds-dbsubnetgroup/src/main/java/software/amazon/rds/dbsubnetgroup/ReadHandler.java
+++ b/aws-rds-dbsubnetgroup/src/main/java/software/amazon/rds/dbsubnetgroup/ReadHandler.java
@@ -1,19 +1,28 @@
 package software.amazon.rds.dbsubnetgroup;
 
-import java.util.Set;
+import java.util.List;
 
 import software.amazon.awssdk.services.rds.RdsClient;
 import software.amazon.awssdk.services.rds.model.DBSubnetGroup;
-import software.amazon.awssdk.services.rds.model.Tag;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.Logger;
 import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 import software.amazon.rds.common.handler.Commons;
+import software.amazon.rds.common.handler.HandlerConfig;
 import software.amazon.rds.common.handler.Tagging;
 
 public class ReadHandler extends BaseHandlerStd {
+
+    public ReadHandler() {
+        this(HandlerConfig.builder().build());
+    }
+
+    public ReadHandler(final HandlerConfig config) {
+        super(config);
+    }
+
     protected ProgressEvent<ResourceModel, CallbackContext> handleRequest(
             final AmazonWebServicesClientProxy proxy,
             final ResourceHandlerRequest<ResourceModel> request,
@@ -21,25 +30,49 @@ public class ReadHandler extends BaseHandlerStd {
             final ProxyClient<RdsClient> proxyClient,
             final Logger logger
     ) {
+        return ProgressEvent.progress(request.getDesiredResourceState(), callbackContext)
+                .then(progress -> describeDbSubnetGroup(proxy, request, callbackContext, proxyClient))
+                .then(progress -> readTags(proxyClient, progress));
+    }
+
+    private ProgressEvent<ResourceModel, CallbackContext> describeDbSubnetGroup(final AmazonWebServicesClientProxy proxy,
+                                                                                final ResourceHandlerRequest<ResourceModel> request,
+                                                                                final CallbackContext callbackContext,
+                                                                                final ProxyClient<RdsClient> proxyClient
+    ) {
         return proxy.initiate("rds::read-dbsubnet-group", proxyClient, request.getDesiredResourceState(), callbackContext)
                 .translateToServiceRequest(Translator::describeDbSubnetGroupsRequest)
-                .backoffDelay(CONSTANT)
+                .backoffDelay(config.getBackoff())
                 .makeServiceCall((describeDbSubnetGroupRequest, proxyInvocation) -> proxyInvocation.injectCredentialsAndInvokeV2(describeDbSubnetGroupRequest, proxyInvocation.client()::describeDBSubnetGroups))
                 .handleError((awsRequest, exception, client, resourceModel, context) -> Commons.handleException(
                         ProgressEvent.progress(resourceModel, context),
                         exception,
                         DEFAULT_DB_SUBNET_GROUP_ERROR_RULE_SET))
                 .done((describeDbSubnetGroupsRequest, describeDbSubnetGroupsResponse, proxyInvocation, model, context) -> {
-                    try {
-                        final DBSubnetGroup dbSubnetGroup = describeDbSubnetGroupsResponse.dbSubnetGroups().stream().findFirst().get();
-                        Set<Tag> rdsTags = Tagging.listTagsForResource(proxyInvocation, dbSubnetGroup.dbSubnetGroupArn());
-                        return Translator.translateToModel(dbSubnetGroup, rdsTags);
-                    } catch (Exception exception) {
-                        return Commons.handleException(
-                                ProgressEvent.progress(model, context),
-                                exception,
-                                DEFAULT_DB_SUBNET_GROUP_ERROR_RULE_SET);
-                    }
+                    final DBSubnetGroup dbSubnetGroup = describeDbSubnetGroupsResponse.dbSubnetGroups().stream().findFirst().get();
+                    context.setDbSubnetGroupArn(dbSubnetGroup.dbSubnetGroupArn());
+                    return ProgressEvent.progress(Translator.translateToModel(dbSubnetGroup), context);
                 });
+    }
+
+    protected ProgressEvent<ResourceModel, CallbackContext> readTags(
+            final ProxyClient<RdsClient> proxyClient,
+            final ProgressEvent<ResourceModel, CallbackContext> progress
+    ) {
+        ResourceModel model = progress.getResourceModel();
+        CallbackContext context = progress.getCallbackContext();
+        try {
+            String arn = progress.getCallbackContext().getDbSubnetGroupArn();
+            List<software.amazon.rds.dbsubnetgroup.Tag> resourceTags = Translator
+                    .translateTags(Tagging.listTagsForResource(proxyClient, arn));
+            model.setTags(resourceTags);
+        } catch (Exception exception) {
+            return Commons.handleException(
+                    ProgressEvent.progress(model, context),
+                    exception,
+                    Tagging.SOFT_FAIL_TAG_ERROR_RULE_SET.orElse(DEFAULT_DB_SUBNET_GROUP_ERROR_RULE_SET)
+            );
+        }
+        return ProgressEvent.success(model, context);
     }
 }

--- a/aws-rds-dbsubnetgroup/src/main/java/software/amazon/rds/dbsubnetgroup/UpdateHandler.java
+++ b/aws-rds-dbsubnetgroup/src/main/java/software/amazon/rds/dbsubnetgroup/UpdateHandler.java
@@ -1,5 +1,7 @@
 package software.amazon.rds.dbsubnetgroup;
 
+import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Map;
 
 import software.amazon.awssdk.services.rds.RdsClient;
@@ -9,39 +11,60 @@ import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 import software.amazon.rds.common.handler.Commons;
+import software.amazon.rds.common.handler.HandlerConfig;
 import software.amazon.rds.common.handler.Tagging;
 
 public class UpdateHandler extends BaseHandlerStd {
+
+    public UpdateHandler() {
+        this(HandlerConfig.builder().build());
+    }
+
+    public UpdateHandler(final HandlerConfig config) {
+        super(config);
+    }
 
     protected ProgressEvent<ResourceModel, CallbackContext> handleRequest(
             final AmazonWebServicesClientProxy proxy,
             final ResourceHandlerRequest<ResourceModel> request,
             final CallbackContext callbackContext,
             final ProxyClient<RdsClient> proxyClient,
-            final Logger logger) {
+            final Logger logger
+    ) {
+        final Tagging.TagSet previousTags = Tagging.TagSet.builder()
+                .systemTags(Tagging.translateTagsToSdk(request.getPreviousSystemTags()))
+                .stackTags(Tagging.translateTagsToSdk(request.getPreviousResourceTags()))
+                .resourceTags(new LinkedHashSet<>(Translator.translateTagsToSdk(request.getPreviousResourceState().getTags())))
+                .build();
 
-        final Map<String, String> previousTags = Tagging.mergeTags(
-                request.getPreviousSystemTags(),
-                request.getPreviousResourceTags()
-        );
-        final Map<String, String> desiredTags = Tagging.mergeTags(
-                request.getSystemTags(),
-                request.getDesiredResourceTags()
-        );
+        final Tagging.TagSet desiredTags = Tagging.TagSet.builder()
+                .systemTags(Tagging.translateTagsToSdk(request.getSystemTags()))
+                .stackTags(Tagging.translateTagsToSdk(request.getDesiredResourceTags()))
+                .resourceTags(new LinkedHashSet<>(Translator.translateTagsToSdk(request.getDesiredResourceState().getTags())))
+                .build();
 
         return ProgressEvent.progress(request.getDesiredResourceState(), callbackContext)
-                .then(progress -> proxy.initiate("rds::update-dbsubnet-group", proxyClient, progress.getResourceModel(), progress.getCallbackContext())
-                        .translateToServiceRequest(Translator::modifyDbSubnetGroupRequest)
-                        .backoffDelay(CONSTANT)
-                        .makeServiceCall((modifyDbSubnetGroupRequest, proxyInvocation) -> proxyInvocation.injectCredentialsAndInvokeV2(modifyDbSubnetGroupRequest, proxyInvocation.client()::modifyDBSubnetGroup))
-                        .stabilize((modifyDbSubnetGroupRequest, modifyDbSubnetGroupResponse, proxyInvocation, resourceModel, context) -> isStabilized(resourceModel, proxyInvocation))
-                        .handleError((awsRequest, exception, client, resourceModel, context) -> Commons.handleException(
-                                ProgressEvent.progress(resourceModel, context),
-                                exception,
-                                DEFAULT_DB_SUBNET_GROUP_ERROR_RULE_SET))
-                        .progress()
-                )
-                .then(progress -> tagResource(proxy, proxyClient, progress, previousTags, desiredTags))
+                .then(progress -> modifyDBSubnetGroup(proxy, proxyClient, progress))
+                .then(progress -> updateTags(proxyClient, progress, previousTags, desiredTags))
                 .then(progress -> new ReadHandler().handleRequest(proxy, request, callbackContext, proxyClient, logger));
+    }
+
+    private ProgressEvent<ResourceModel, CallbackContext> modifyDBSubnetGroup(final AmazonWebServicesClientProxy proxy,
+                                                                              final ProxyClient<RdsClient> proxyClient,
+                                                                              final ProgressEvent<ResourceModel, CallbackContext> progress
+    ) {
+        return proxy.initiate("rds::update-dbsubnet-group", proxyClient, progress.getResourceModel(), progress.getCallbackContext())
+                .translateToServiceRequest(Translator::modifyDbSubnetGroupRequest)
+                .backoffDelay(config.getBackoff())
+                .makeServiceCall((modifyDbSubnetGroupRequest, proxyInvocation) -> proxyInvocation.injectCredentialsAndInvokeV2(modifyDbSubnetGroupRequest, proxyInvocation.client()::modifyDBSubnetGroup))
+                .stabilize((modifyDbSubnetGroupRequest, modifyDbSubnetGroupResponse, proxyInvocation, resourceModel, context) -> isStabilized(resourceModel, proxyInvocation))
+                .handleError((awsRequest, exception, client, resourceModel, context) -> Commons.handleException(
+                        ProgressEvent.progress(resourceModel, context),
+                        exception,
+                        DEFAULT_DB_SUBNET_GROUP_ERROR_RULE_SET))
+                .done((subnetGroupRequest, subnetGroupResponse, proxyInvocation, resourceModel, context) -> {
+                    context.setDbSubnetGroupArn(subnetGroupResponse.dbSubnetGroup().dbSubnetGroupArn());
+                    return ProgressEvent.progress(resourceModel, context);
+                });
     }
 }

--- a/aws-rds-dbsubnetgroup/src/test/java/software/amazon/rds/dbsubnetgroup/CreateHandlerTest.java
+++ b/aws-rds-dbsubnetgroup/src/test/java/software/amazon/rds/dbsubnetgroup/CreateHandlerTest.java
@@ -21,8 +21,11 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import software.amazon.awssdk.services.rds.RdsClient;
+import software.amazon.awssdk.services.rds.model.AddTagsToResourceRequest;
+import software.amazon.awssdk.services.rds.model.AddTagsToResourceResponse;
 import software.amazon.awssdk.services.rds.model.CreateDbSubnetGroupRequest;
 import software.amazon.awssdk.services.rds.model.CreateDbSubnetGroupResponse;
+import software.amazon.awssdk.services.rds.model.DBSubnetGroup;
 import software.amazon.awssdk.services.rds.model.DbSubnetGroupAlreadyExistsException;
 import software.amazon.awssdk.services.rds.model.DescribeDbSubnetGroupsRequest;
 import software.amazon.awssdk.services.rds.model.DescribeDbSubnetGroupsResponse;
@@ -65,12 +68,12 @@ public class CreateHandlerTest extends AbstractTestBase {
 
     @Test
     public void handleRequest_SimpleSuccess() {
-
-        final CreateDbSubnetGroupResponse createDbSubnetGroupResponse = CreateDbSubnetGroupResponse.builder().build();
-        when(proxyRdsClient.client().createDBSubnetGroup(any(CreateDbSubnetGroupRequest.class))).thenReturn(createDbSubnetGroupResponse);
-
+        mockCreateCall();
         final DescribeDbSubnetGroupsResponse describeCreatingDbSubnetGroupsResponse = DescribeDbSubnetGroupsResponse.builder().dbSubnetGroups(DB_SUBNET_GROUP_CREATING).build();
         final DescribeDbSubnetGroupsResponse describeActiveDbSubnetGroupsResponse = DescribeDbSubnetGroupsResponse.builder().dbSubnetGroups(DB_SUBNET_GROUP_ACTIVE).build();
+
+        final AddTagsToResourceResponse addTagsToResourceResponse = AddTagsToResourceResponse.builder().build();
+        when(rds.addTagsToResource(any(AddTagsToResourceRequest.class))).thenReturn(addTagsToResourceResponse);
 
         AtomicInteger attempt = new AtomicInteger(2);
         when(proxyRdsClient.client().describeDBSubnetGroups(any(DescribeDbSubnetGroupsRequest.class))).then((m) -> {
@@ -95,7 +98,6 @@ public class CreateHandlerTest extends AbstractTestBase {
 
         assertThat(response).isNotNull();
         assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
-        assertThat(response.getCallbackContext()).isNull();
         assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
         assertThat(response.getResourceModels()).isNull();
         assertThat(response.getMessage()).isNull();
@@ -109,12 +111,12 @@ public class CreateHandlerTest extends AbstractTestBase {
 
     @Test
     public void handleRequest_SimpleSuccessAlternative() {
-
-        final CreateDbSubnetGroupResponse createDbSubnetGroupResponse = CreateDbSubnetGroupResponse.builder().build();
-        when(proxyRdsClient.client().createDBSubnetGroup(any(CreateDbSubnetGroupRequest.class))).thenReturn(createDbSubnetGroupResponse);
-
+        mockCreateCall();
         final DescribeDbSubnetGroupsResponse describeCreatingDbSubnetGroupsResponse = DescribeDbSubnetGroupsResponse.builder().dbSubnetGroups(DB_SUBNET_GROUP_CREATING).build();
         final DescribeDbSubnetGroupsResponse describeActiveDbSubnetGroupsResponse = DescribeDbSubnetGroupsResponse.builder().dbSubnetGroups(DB_SUBNET_GROUP_ACTIVE).build();
+
+        final AddTagsToResourceResponse addTagsToResourceResponse = AddTagsToResourceResponse.builder().build();
+        when(rds.addTagsToResource(any(AddTagsToResourceRequest.class))).thenReturn(addTagsToResourceResponse);
 
         AtomicInteger attempt = new AtomicInteger(2);
         when(proxyRdsClient.client().describeDBSubnetGroups(any(DescribeDbSubnetGroupsRequest.class))).then((m) -> {
@@ -139,7 +141,6 @@ public class CreateHandlerTest extends AbstractTestBase {
 
         assertThat(response).isNotNull();
         assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
-        assertThat(response.getCallbackContext()).isNull();
         assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
         assertThat(response.getResourceModels()).isNull();
         assertThat(response.getMessage()).isNull();
@@ -199,5 +200,10 @@ public class CreateHandlerTest extends AbstractTestBase {
         assertThat(response.getErrorCode()).isEqualTo(HandlerErrorCode.InternalFailure);
 
         verify(proxyRdsClient.client()).createDBSubnetGroup(any(CreateDbSubnetGroupRequest.class));
+    }
+
+    private void mockCreateCall() {
+        final CreateDbSubnetGroupResponse createDbSubnetGroupResponse = CreateDbSubnetGroupResponse.builder().dbSubnetGroup(DBSubnetGroup.builder().dbSubnetGroupArn("arn").build()).build();
+        when(proxyRdsClient.client().createDBSubnetGroup(any(CreateDbSubnetGroupRequest.class))).thenReturn(createDbSubnetGroupResponse);
     }
 }

--- a/aws-rds-dbsubnetgroup/src/test/java/software/amazon/rds/dbsubnetgroup/ReadHandlerTest.java
+++ b/aws-rds-dbsubnetgroup/src/test/java/software/amazon/rds/dbsubnetgroup/ReadHandlerTest.java
@@ -78,7 +78,6 @@ public class ReadHandlerTest extends AbstractTestBase {
 
         assertThat(response).isNotNull();
         assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
-        assertThat(response.getCallbackContext()).isNull();
         assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
         assertThat(response.getResourceModels()).isNull();
         assertThat(response.getMessage()).isNull();


### PR DESCRIPTION
*Description of changes:*
Soft fails means ignoring permission denied exception and proceed with resource logic. This PR implements soft fail in `DbSubnetGroup` resource:

- Hard fail on add/remove resource tags
- Soft fail on add/remove system tags
- Soft fail on add/remove stack level tags
- Soft fail on read tags


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
