### PR TITLE
[DBCluster] Remove default parameter group name set on cluster create

### DIFF
--- a/aws-rds-dbcluster/docs/README.md
+++ b/aws-rds-dbcluster/docs/README.md
@@ -314,7 +314,7 @@ _Minimum_: <code>1</code>
 
 _Maximum_: <code>16</code>
 
-_Pattern_: <code>^[a-zA-Z]{1}[a-zA-Z0-9]{0,15}$</code>
+_Pattern_: <code>^[a-zA-Z]{1}[a-zA-Z0-9_]{0,15}$</code>
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 

--- a/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/ModelAdapter.java
+++ b/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/ModelAdapter.java
@@ -5,19 +5,17 @@ import java.util.List;
 import com.google.common.collect.Lists;
 
 public class ModelAdapter {
-    protected static final int DEFAULT_PORT = 3306;
-    private static final int MIN_CAPACITY_DEFAULT = 2;
-    private static final int MAX_CAPACITY_DEFAULT = 16;
-    private static final int SECONDS_UNTIL_AUTO_PAUSE_DEFAULT = 300;
+    private static final boolean DEFAULT_PAUSE_DEFAULT = true;
     private static final int DEFAULT_BACKUP_RETENTION_PERIOD = 1;
+    private static final int DEFAULT_MAX_CAPACITY = 16;
+    private static final int DEFAULT_MIN_CAPACITY = 2;
+    private static final int DEFAULT_PORT = 3306;
+    private static final int DEFAULT_SECONDS_UNTIL_AUTO_PAUSE = 300;
     private static final String SERVERLESS_ENGINE_MODE = "serverless";
-    private static final String DEFAULT_DB_CLUSTER_PARAMETER_GROUP_NAME = "default.aurora5.6";
-    private static final boolean AUTO_PAUSE_DEFAULT = true;
 
     public static ResourceModel setDefaults(final ResourceModel resourceModel) {
 
         final Integer port = resourceModel.getPort();
-        final String dBClusterParameterGroupName = resourceModel.getDBClusterParameterGroupName();
         final Integer backupRetentionPeriod = resourceModel.getBackupRetentionPeriod();
         final List<DBClusterRole> associatedRoles = resourceModel.getAssociatedRoles();
         final ScalingConfiguration scalingConfiguration = resourceModel.getScalingConfiguration();
@@ -27,15 +25,14 @@ public class ModelAdapter {
 
         if (SERVERLESS_ENGINE_MODE.equalsIgnoreCase(resourceModel.getEngineMode())) {
             ScalingConfiguration defaultScalingConfiguration = ScalingConfiguration.builder()
-                    .secondsUntilAutoPause(SECONDS_UNTIL_AUTO_PAUSE_DEFAULT)
-                    .autoPause(AUTO_PAUSE_DEFAULT)
-                    .minCapacity(MIN_CAPACITY_DEFAULT)
-                    .maxCapacity(MAX_CAPACITY_DEFAULT)
+                    .secondsUntilAutoPause(DEFAULT_SECONDS_UNTIL_AUTO_PAUSE)
+                    .autoPause(DEFAULT_PAUSE_DEFAULT)
+                    .minCapacity(DEFAULT_MIN_CAPACITY)
+                    .maxCapacity(DEFAULT_MAX_CAPACITY)
                     .build();
             resourceModel.setScalingConfiguration(scalingConfiguration == null ? defaultScalingConfiguration : scalingConfiguration);
         } else {
             resourceModel.setPort(port == null ? DEFAULT_PORT : port);
-            resourceModel.setDBClusterParameterGroupName(dBClusterParameterGroupName == null ? DEFAULT_DB_CLUSTER_PARAMETER_GROUP_NAME : dBClusterParameterGroupName);
         }
 
         return resourceModel;


### PR DESCRIPTION
This commit removes the code that sets the default DBCluster parameter group name upon creation. The reason for change is that RDS API picks up the default parameter group name automatically depending on the engine version. The previous implementation hardcoded the group name to `default.aurora5.6`, which caused troubles on other engine versions.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Signed-off-by: Oleg Sidorov <sidorovo@amazon.com>