### PR TITLE
[DBClusterParameterGroup] Implement Soft Failing While Calling Descri…

### DIFF
--- a/aws-rds-dbclusterparametergroup/src/main/java/software/amazon/rds/dbclusterparametergroup/CreateHandler.java
+++ b/aws-rds-dbclusterparametergroup/src/main/java/software/amazon/rds/dbclusterparametergroup/CreateHandler.java
@@ -9,10 +9,20 @@ import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 import software.amazon.cloudformation.resource.IdentifierUtils;
 import software.amazon.rds.common.handler.Commons;
+import software.amazon.rds.common.handler.HandlerConfig;
 import software.amazon.rds.common.handler.Tagging;
 
 
 public class CreateHandler extends BaseHandlerStd {
+
+    public CreateHandler() {
+        this(HandlerConfig.builder().build());
+    }
+
+    public CreateHandler(final HandlerConfig config) {
+        super(config);
+    }
+
     @Override
     protected ProgressEvent<ResourceModel, CallbackContext> handleRequest(final AmazonWebServicesClientProxy proxy,
                                                                           final ResourceHandlerRequest<ResourceModel> request,

--- a/aws-rds-dbclusterparametergroup/src/main/java/software/amazon/rds/dbclusterparametergroup/DeleteHandler.java
+++ b/aws-rds-dbclusterparametergroup/src/main/java/software/amazon/rds/dbclusterparametergroup/DeleteHandler.java
@@ -7,8 +7,18 @@ import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 import software.amazon.rds.common.handler.Commons;
+import software.amazon.rds.common.handler.HandlerConfig;
 
 public class DeleteHandler extends BaseHandlerStd {
+
+    public DeleteHandler() {
+        this(HandlerConfig.builder().build());
+    }
+
+    public DeleteHandler(final HandlerConfig config) {
+        super(config);
+    }
+
     @Override
     protected ProgressEvent<ResourceModel, CallbackContext> handleRequest(final AmazonWebServicesClientProxy proxy,
                                                                           final ResourceHandlerRequest<ResourceModel> request,

--- a/aws-rds-dbclusterparametergroup/src/main/java/software/amazon/rds/dbclusterparametergroup/ListHandler.java
+++ b/aws-rds-dbclusterparametergroup/src/main/java/software/amazon/rds/dbclusterparametergroup/ListHandler.java
@@ -9,10 +9,19 @@ import software.amazon.cloudformation.proxy.OperationStatus;
 import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 import software.amazon.rds.common.handler.Commons;
+import software.amazon.rds.common.handler.HandlerConfig;
 
 import java.util.stream.Collectors;
 
 public class ListHandler extends BaseHandlerStd {
+
+    public ListHandler() {
+        this(HandlerConfig.builder().build());
+    }
+
+    public ListHandler(final HandlerConfig config) {
+        super(config);
+    }
 
     @Override
     public ProgressEvent<ResourceModel, CallbackContext> handleRequest(

--- a/aws-rds-dbclusterparametergroup/src/main/java/software/amazon/rds/dbclusterparametergroup/ReadHandler.java
+++ b/aws-rds-dbclusterparametergroup/src/main/java/software/amazon/rds/dbclusterparametergroup/ReadHandler.java
@@ -10,9 +10,19 @@ import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 import software.amazon.rds.common.handler.Commons;
+import software.amazon.rds.common.handler.HandlerConfig;
 import software.amazon.rds.common.handler.Tagging;
 
 public class ReadHandler extends BaseHandlerStd {
+
+    public ReadHandler() {
+        this(HandlerConfig.builder().build());
+    }
+
+    public ReadHandler(final HandlerConfig config) {
+        super(config);
+    }
+
     @Override
     protected ProgressEvent<ResourceModel, CallbackContext> handleRequest(final AmazonWebServicesClientProxy proxy,
                                                                           final ResourceHandlerRequest<ResourceModel> request,

--- a/aws-rds-dbclusterparametergroup/src/main/java/software/amazon/rds/dbclusterparametergroup/Translator.java
+++ b/aws-rds-dbclusterparametergroup/src/main/java/software/amazon/rds/dbclusterparametergroup/Translator.java
@@ -8,6 +8,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import com.amazonaws.arn.Arn;
 import software.amazon.awssdk.services.rds.model.ApplyMethod;
 import software.amazon.awssdk.services.rds.model.CreateDbClusterParameterGroupRequest;
 import software.amazon.awssdk.services.rds.model.DeleteDbClusterParameterGroupRequest;
@@ -17,9 +18,13 @@ import software.amazon.awssdk.services.rds.model.DescribeDbClustersRequest;
 import software.amazon.awssdk.services.rds.model.ModifyDbClusterParameterGroupRequest;
 import software.amazon.awssdk.services.rds.model.Parameter;
 import software.amazon.awssdk.services.rds.model.ResetDbClusterParameterGroupRequest;
+import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 import software.amazon.rds.common.handler.Tagging;
 
 public class Translator {
+
+    public static final String RDS = "rds";
+    public static final String RESOURCE_PREFIX = "cluster-pg:";
 
     static CreateDbClusterParameterGroupRequest createDbClusterParameterGroupRequest(final ResourceModel model,
                                                                                      final Tagging.TagSet tags) {
@@ -109,5 +114,16 @@ public class Translator {
         return Optional.ofNullable(collection)
                 .map(Collection::stream)
                 .orElseGet(Stream::empty);
+    }
+
+    public static Arn buildClusterParameterGroupArn(final ResourceHandlerRequest<ResourceModel> request) {
+        String resource = RESOURCE_PREFIX + request.getDesiredResourceState().getDBClusterParameterGroupName();
+        return Arn.builder()
+                .withPartition(request.getAwsPartition())
+                .withRegion(request.getRegion())
+                .withService(RDS)
+                .withAccountId(request.getAwsAccountId())
+                .withResource(resource)
+                .build();
     }
 }

--- a/aws-rds-dbclusterparametergroup/src/main/java/software/amazon/rds/dbclusterparametergroup/UpdateHandler.java
+++ b/aws-rds-dbclusterparametergroup/src/main/java/software/amazon/rds/dbclusterparametergroup/UpdateHandler.java
@@ -9,9 +9,18 @@ import software.amazon.cloudformation.proxy.Logger;
 import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
+import software.amazon.rds.common.handler.HandlerConfig;
 import software.amazon.rds.common.handler.Tagging;
 
 public class UpdateHandler extends BaseHandlerStd {
+
+    public UpdateHandler() {
+        this(HandlerConfig.builder().build());
+    }
+
+    public UpdateHandler(final HandlerConfig config) {
+        super(config);
+    }
 
     @Override
     protected ProgressEvent<ResourceModel, CallbackContext> handleRequest(final AmazonWebServicesClientProxy proxy,
@@ -38,23 +47,5 @@ public class UpdateHandler extends BaseHandlerStd {
                 .then(progress -> resetAllParameters(progress, proxy, proxyClient))
                 .then(progress -> applyParameters(proxy, proxyClient, progress.getResourceModel(), progress.getCallbackContext()))
                 .then(progress -> new ReadHandler().handleRequest(proxy, request, callbackContext, proxyClient, logger));
-    }
-
-    private ProgressEvent<ResourceModel, CallbackContext> tagResource(final AmazonWebServicesClientProxy proxy,
-                                                                      final ProxyClient<RdsClient> proxyClient,
-                                                                      final ProgressEvent<ResourceModel, CallbackContext> progress,
-                                                                      final Map<String, String> previousTags,
-                                                                      final Map<String, String> desiredTags) {
-        return describeDbClusterParameterGroup(proxy, proxyClient, progress.getResourceModel(), progress.getCallbackContext())
-                .done((describeDbClusterParameterGroupsRequest, describeDbClusterParameterGroupsResponse, invocation, resourceModel, context) -> {
-                    final String arn = describeDbClusterParameterGroupsResponse.dbClusterParameterGroups().stream().findFirst().get().dbClusterParameterGroupArn();
-                    return Tagging.updateTags(
-                            invocation,
-                            ProgressEvent.progress(resourceModel, context),
-                            arn,
-                            previousTags,
-                            desiredTags,
-                            DEFAULT_DB_CLUSTER_PARAMETER_GROUP_ERROR_RULE_SET);
-                });
     }
 }

--- a/aws-rds-dbclusterparametergroup/src/test/java/software/amazon/rds/dbclusterparametergroup/CreateHandlerTest.java
+++ b/aws-rds-dbclusterparametergroup/src/test/java/software/amazon/rds/dbclusterparametergroup/CreateHandlerTest.java
@@ -199,13 +199,6 @@ public class CreateHandlerTest extends AbstractTestBase {
         final CreateHandler handler = new CreateHandler();
         final CreateDbClusterParameterGroupResponse createDbClusterParameterGroupResponse = CreateDbClusterParameterGroupResponse.builder().build();
         when(rds.createDBClusterParameterGroup(any(CreateDbClusterParameterGroupRequest.class))).thenReturn(createDbClusterParameterGroupResponse);
-        final DescribeDbClusterParameterGroupsResponse describeDbClusterParameterGroupsResponse = DescribeDbClusterParameterGroupsResponse.builder()
-                .dbClusterParameterGroups(DBClusterParameterGroup.builder()
-                        .dbClusterParameterGroupArn("arn")
-                        .dbClusterParameterGroupName(RESOURCE_MODEL.getDBClusterParameterGroupName())
-                        .dbParameterGroupFamily(RESOURCE_MODEL.getFamily())
-                        .description(RESOURCE_MODEL.getDescription()).build()).build();
-        when(rds.describeDBClusterParameterGroups(any(DescribeDbClusterParameterGroupsRequest.class))).thenReturn(describeDbClusterParameterGroupsResponse);
         mockDescribeDbClusterParametersResponse("static", "dynamic", false);
         final AddTagsToResourceResponse addTagsToResourceResponse = AddTagsToResourceResponse.builder().build();
         when(rds.addTagsToResource(any(AddTagsToResourceRequest.class))).thenReturn(addTagsToResourceResponse);
@@ -224,7 +217,6 @@ public class CreateHandlerTest extends AbstractTestBase {
 
         verify(proxyRdsClient.client()).createDBClusterParameterGroup(any(CreateDbClusterParameterGroupRequest.class));
         verify(proxyRdsClient.client()).describeDBClusterParametersPaginator(any(DescribeDbClusterParametersRequest.class));
-        verify(proxyRdsClient.client()).describeDBClusterParameterGroups(any(DescribeDbClusterParameterGroupsRequest.class));
     }
 
     @Test
@@ -232,13 +224,6 @@ public class CreateHandlerTest extends AbstractTestBase {
         final CreateHandler handler = new CreateHandler();
         final CreateDbClusterParameterGroupResponse createDbClusterParameterGroupResponse = CreateDbClusterParameterGroupResponse.builder().build();
         when(rds.createDBClusterParameterGroup(any(CreateDbClusterParameterGroupRequest.class))).thenReturn(createDbClusterParameterGroupResponse);
-        final DescribeDbClusterParameterGroupsResponse describeDbClusterParameterGroupsResponse = DescribeDbClusterParameterGroupsResponse.builder()
-                .dbClusterParameterGroups(DBClusterParameterGroup.builder()
-                        .dbClusterParameterGroupArn("arn")
-                        .dbClusterParameterGroupName(RESOURCE_MODEL.getDBClusterParameterGroupName())
-                        .dbParameterGroupFamily(RESOURCE_MODEL.getFamily())
-                        .description(RESOURCE_MODEL.getDescription()).build()).build();
-        when(rds.describeDBClusterParameterGroups(any(DescribeDbClusterParameterGroupsRequest.class))).thenReturn(describeDbClusterParameterGroupsResponse);
         final AddTagsToResourceResponse addTagsToResourceResponse = AddTagsToResourceResponse.builder().build();
         when(rds.addTagsToResource(any(AddTagsToResourceRequest.class))).thenReturn(addTagsToResourceResponse);
         mockDescribeDbClusterParametersResponse("static", "dynamic", true);


### PR DESCRIPTION
*Description of changes:*
Implementing soft failing while doing DescribeDBPrameterGroups call to be backward compatible with current CloudFormation customer to prevent AccessDenied exception for existing stacks.
Changes:

   - Compose `DBClusterParameterGroupArn` from Request and ResourceModel instead of retrieving it from `DescribeDBPrameterGroups` call.
    - Remove `fetchDBClusterParameterGroupArn` as it triggers `DescribeDBClusterPrameterGroups` call.
    - Apply `setDBClusterParameterGroupArn` in all handlers.
    - Use in progress soft fail error rule set while executing `DescribeClusterDBPrameterGroups` call in read handler.
    - Add config handlers.
    - Update relative unit tests.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
