### PR TITLE
[DBParameterGroup] Fix DescribeDBParameters PermissionDenied Issue in Create Only Scenario

### DIFF
--- a/aws-rds-dbparametergroup/aws-rds-dbparametergroup.json
+++ b/aws-rds-dbparametergroup/aws-rds-dbparametergroup.json
@@ -76,9 +76,9 @@
   "handlers": {
     "create": {
       "permissions": [
+        "rds:AddTagsToResource",
         "rds:CreateDBParameterGroup",
         "rds:DescribeDBParameterGroups",
-        "rds:DescribeDBParameters",
         "rds:DescribeEngineDefaultParameters",
         "rds:ModifyDBParameterGroup",
         "rds:ListTagsForResource"

--- a/aws-rds-dbparametergroup/src/main/java/software/amazon/rds/dbparametergroup/Translator.java
+++ b/aws-rds-dbparametergroup/src/main/java/software/amazon/rds/dbparametergroup/Translator.java
@@ -69,7 +69,9 @@ public class Translator {
     ) {
         return ModifyDbParameterGroupRequest.builder()
                 .dbParameterGroupName(model.getDBParameterGroupName())
-                .parameters(parameters)
+                .parameters(parameters.stream()
+                        .map(p -> p.toBuilder().applyMethod(getParameterApplyMethod(p)).build())
+                        .collect(Collectors.toList()))
                 .build();
     }
 

--- a/aws-rds-dbparametergroup/src/main/java/software/amazon/rds/dbparametergroup/UpdateHandler.java
+++ b/aws-rds-dbparametergroup/src/main/java/software/amazon/rds/dbparametergroup/UpdateHandler.java
@@ -42,7 +42,7 @@ public class UpdateHandler extends BaseHandlerStd {
 
         return ProgressEvent.progress(request.getDesiredResourceState(), callbackContext)
                 .then(progress -> updateTags(proxy, proxyClient, progress, previousTags, desiredTags, requestLogger))
-                .then(progress -> applyParameters(proxy, proxyClient, progress, requestLogger))
+                .then(progress -> applyParametersWithReset(proxy, proxyClient, progress, requestLogger))
                 .then(progress -> new ReadHandler().handleRequest(proxy, request, callbackContext, proxyClient, requestLogger));
     }
 }


### PR DESCRIPTION
*Description of changes:*
In create only scenario, We do not need to calculate parameters to reset or describe current DB parameters as `DBParameterGroup` is recently created and all parameter will have same default values.

In this change:
- Rename old `applyParmeters` to more specific name `applyParameterWithReset`.
- Add new simple `applyParameter` method that
  - Describe `DefaultDBParameters`.
  - Validate input parameters against `DefaultDBParameters`.
  - Modify input parameters in stack.
- Update create handler permission in resource schema
- Add/Update related unit tests.   


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
