### PR TITLE
[DBClusterParameterGroup] Fix Missing Arn In Update Scenario

### DIFF
--- a/aws-rds-dbclusterparametergroup/src/main/java/software/amazon/rds/dbclusterparametergroup/BaseHandlerStd.java
+++ b/aws-rds-dbclusterparametergroup/src/main/java/software/amazon/rds/dbclusterparametergroup/BaseHandlerStd.java
@@ -98,7 +98,7 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
                 PARAMETERS_FILTER,
                 requestLogger -> handleRequest(proxy,
                         request,
-                        callbackContext != null ? callbackContext : new CallbackContext(),
+                        context,
                         new LoggingProxyClient<>(requestLogger, proxy.newProxy(ClientBuilder::getClient)),
                         logger));
     }

--- a/aws-rds-dbclusterparametergroup/src/main/java/software/amazon/rds/dbclusterparametergroup/CreateHandler.java
+++ b/aws-rds-dbclusterparametergroup/src/main/java/software/amazon/rds/dbclusterparametergroup/CreateHandler.java
@@ -61,7 +61,10 @@ public class CreateHandler extends BaseHandlerStd {
                                 ProgressEvent.progress(resourceModel, ctx),
                                 exception,
                                 DEFAULT_DB_CLUSTER_PARAMETER_GROUP_ERROR_RULE_SET))
-                .progress();
+                .done((paramGroupRequest, paramGroupResponse, proxyInvocation, resourceModel, context) -> {
+                    context.setDbClusterParameterGroupArn(paramGroupResponse.dbClusterParameterGroup().dbClusterParameterGroupArn());
+                    return ProgressEvent.progress(resourceModel, context);
+                });
     }
 
     private ProgressEvent<ResourceModel, CallbackContext> setDbClusterParameterGroupNameIfMissing(final ResourceHandlerRequest<ResourceModel> request,

--- a/aws-rds-dbclusterparametergroup/src/test/java/software/amazon/rds/dbclusterparametergroup/AbstractTestBase.java
+++ b/aws-rds-dbclusterparametergroup/src/test/java/software/amazon/rds/dbclusterparametergroup/AbstractTestBase.java
@@ -93,7 +93,7 @@ public class AbstractTestBase {
         UPDATED_DESCRIPTION = "updated description";
         FAMILY = "default.aurora.5";
         TAG_SET = Lists.newArrayList(Tag.builder().key("key").value("value").build());
-        
+
         DB_CLUSTER_PARAMETER_GROUP = DBClusterParameterGroup.builder()
                 .dbClusterParameterGroupArn("arn")
                 .dbClusterParameterGroupName("name")

--- a/aws-rds-dbclusterparametergroup/src/test/java/software/amazon/rds/dbclusterparametergroup/AbstractTestBase.java
+++ b/aws-rds-dbclusterparametergroup/src/test/java/software/amazon/rds/dbclusterparametergroup/AbstractTestBase.java
@@ -43,6 +43,7 @@ public class AbstractTestBase {
     protected static final String FAMILY;
     protected static final List<Tag> TAG_SET;
     protected static final Parameter PARAM_1, PARAM_2;
+    protected static final DBClusterParameterGroup DB_CLUSTER_PARAMETER_GROUP;
 
 
     static {
@@ -92,6 +93,11 @@ public class AbstractTestBase {
         UPDATED_DESCRIPTION = "updated description";
         FAMILY = "default.aurora.5";
         TAG_SET = Lists.newArrayList(Tag.builder().key("key").value("value").build());
+        
+        DB_CLUSTER_PARAMETER_GROUP = DBClusterParameterGroup.builder()
+                .dbClusterParameterGroupArn("arn")
+                .dbClusterParameterGroupName("name")
+                .build();
     }
 
     static Map<String, String> translateTagsToMap(final Collection<Tag> tags) {

--- a/aws-rds-dbclusterparametergroup/src/test/java/software/amazon/rds/dbclusterparametergroup/CreateHandlerTest.java
+++ b/aws-rds-dbclusterparametergroup/src/test/java/software/amazon/rds/dbclusterparametergroup/CreateHandlerTest.java
@@ -105,7 +105,8 @@ public class CreateHandlerTest extends AbstractTestBase {
     @Test
     public void handleRequest_SimpleSuccess() {
 
-        final CreateDbClusterParameterGroupResponse createDbClusterParameterGroupResponse = CreateDbClusterParameterGroupResponse.builder().build();
+        final CreateDbClusterParameterGroupResponse createDbClusterParameterGroupResponse = CreateDbClusterParameterGroupResponse
+                .builder().dbClusterParameterGroup(DB_CLUSTER_PARAMETER_GROUP).build();
         when(proxyRdsClient.client().createDBClusterParameterGroup(any(CreateDbClusterParameterGroupRequest.class))).thenReturn(createDbClusterParameterGroupResponse);
 
         final DescribeDbClusterParameterGroupsResponse describeDbClusterParameterGroupsResponse = DescribeDbClusterParameterGroupsResponse.builder()
@@ -147,7 +148,8 @@ public class CreateHandlerTest extends AbstractTestBase {
     @Test
     public void handleRequest_SimpleSuccessWithParameters() {
         final CreateHandler handler = new CreateHandler();
-        final CreateDbClusterParameterGroupResponse createDbClusterParameterGroupResponse = CreateDbClusterParameterGroupResponse.builder().build();
+        final CreateDbClusterParameterGroupResponse createDbClusterParameterGroupResponse = CreateDbClusterParameterGroupResponse
+                .builder().dbClusterParameterGroup(DB_CLUSTER_PARAMETER_GROUP).build();
         when(rds.createDBClusterParameterGroup(any(CreateDbClusterParameterGroupRequest.class))).thenReturn(createDbClusterParameterGroupResponse);
         final ModifyDbClusterParameterGroupResponse modifyDbClusterParameterGroupResponse = ModifyDbClusterParameterGroupResponse.builder().build();
         when(rds.modifyDBClusterParameterGroup(any(ModifyDbClusterParameterGroupRequest.class))).thenReturn(modifyDbClusterParameterGroupResponse);
@@ -197,7 +199,8 @@ public class CreateHandlerTest extends AbstractTestBase {
     @Test
     public void handleRequest_SimpleInProgressFailedUnmodifiableParams() {
         final CreateHandler handler = new CreateHandler();
-        final CreateDbClusterParameterGroupResponse createDbClusterParameterGroupResponse = CreateDbClusterParameterGroupResponse.builder().build();
+        final CreateDbClusterParameterGroupResponse createDbClusterParameterGroupResponse = CreateDbClusterParameterGroupResponse
+                .builder().dbClusterParameterGroup(DB_CLUSTER_PARAMETER_GROUP).build();
         when(rds.createDBClusterParameterGroup(any(CreateDbClusterParameterGroupRequest.class))).thenReturn(createDbClusterParameterGroupResponse);
         mockDescribeDbClusterParametersResponse("static", "dynamic", false);
         final AddTagsToResourceResponse addTagsToResourceResponse = AddTagsToResourceResponse.builder().build();
@@ -222,7 +225,8 @@ public class CreateHandlerTest extends AbstractTestBase {
     @Test
     public void handleRequest_SimpleInProgressFailedUnsupportedParams() {
         final CreateHandler handler = new CreateHandler();
-        final CreateDbClusterParameterGroupResponse createDbClusterParameterGroupResponse = CreateDbClusterParameterGroupResponse.builder().build();
+        final CreateDbClusterParameterGroupResponse createDbClusterParameterGroupResponse = CreateDbClusterParameterGroupResponse
+                .builder().dbClusterParameterGroup(DB_CLUSTER_PARAMETER_GROUP).build();
         when(rds.createDBClusterParameterGroup(any(CreateDbClusterParameterGroupRequest.class))).thenReturn(createDbClusterParameterGroupResponse);
         final AddTagsToResourceResponse addTagsToResourceResponse = AddTagsToResourceResponse.builder().build();
         when(rds.addTagsToResource(any(AddTagsToResourceRequest.class))).thenReturn(addTagsToResourceResponse);


### PR DESCRIPTION
*Description of changes:*
In this PR:
- Setting Arn at done in CreateHandler.
- Sending already created context in BaseHandler handle request method.  
- Update related unit test.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
