### PR TITLE
[DBCluster] Remove upper length constraint for `MasterUsername`

### DIFF
--- a/aws-rds-dbcluster/aws-rds-dbcluster.json
+++ b/aws-rds-dbcluster/aws-rds-dbcluster.json
@@ -123,9 +123,8 @@
     "MasterUsername": {
       "description": "The name of the master user for the DB cluster. You must specify MasterUsername, unless you specify SnapshotIdentifier. In that case, don't specify MasterUsername.",
       "type": "string",
-      "pattern": "^[a-zA-Z]{1}[a-zA-Z0-9_]{0,15}$",
-      "minLength": 1,
-      "maxLength": 16
+      "pattern": "^[a-zA-Z]{1}[a-zA-Z0-9_]*$",
+      "minLength": 1
     },
     "MasterUserPassword": {
       "description": "The master password for the DB instance.",

--- a/aws-rds-dbcluster/docs/README.md
+++ b/aws-rds-dbcluster/docs/README.md
@@ -312,9 +312,7 @@ _Type_: String
 
 _Minimum_: <code>1</code>
 
-_Maximum_: <code>16</code>
-
-_Pattern_: <code>^[a-zA-Z]{1}[a-zA-Z0-9_]{0,15}$</code>
+_Pattern_: <code>^[a-zA-Z]{1}[a-zA-Z0-9_]*$</code>
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 


### PR DESCRIPTION
This commit relaxes the validation constraint for `MasterUsername` attribute for the sake of simplifying engine-specific attribute checks.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Signed-off-by: Oleg Sidorov <sidorovo@amazon.com>