### PR TITLE
[DBCluster] Add `KmsKeyId` to RestoreDBClusterToPointInTime

### DIFF
--- a/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/Translator.java
+++ b/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/Translator.java
@@ -83,6 +83,7 @@ public class Translator {
                 .dbClusterInstanceClass(model.getDBClusterInstanceClass())
                 .dbSubnetGroupName(model.getDBSubnetGroupName())
                 .iops(model.getIops())
+                .kmsKeyId(model.getKmsKeyId())
                 .publiclyAccessible(model.getPubliclyAccessible())
                 .restoreType(model.getRestoreType())
                 .sourceDBClusterIdentifier(model.getSourceDBClusterIdentifier())


### PR DESCRIPTION
This commit adds a missing `KmsKeyId` attribute to `RestoreDBClusterToPointInTime` call. The reason for this change is to
ensure the CFN backend behavior is consistent across `CreateDBCluster`, `RestoreDBClusterFromSnapshot` and the aforementioned one.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Signed-off-by: Oleg Sidorov <sidorovo@amazon.com>