### PR TITLE
[DBInstance] Remove `Iops` validator

### DIFF
--- a/aws-rds-dbinstance/aws-rds-dbinstance.json
+++ b/aws-rds-dbinstance/aws-rds-dbinstance.json
@@ -211,8 +211,7 @@
     },
     "Iops": {
       "type": "integer",
-      "minimum": 1000,
-      "description": "The number of I/O operations per second (IOPS) that the database provisions. The value must be equal to or greater than 1000."
+      "description": "The number of I/O operations per second (IOPS) that the database provisions."
     },
     "KmsKeyId": {
       "type": "string",

--- a/aws-rds-dbinstance/docs/README.md
+++ b/aws-rds-dbinstance/docs/README.md
@@ -423,7 +423,7 @@ _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormati
 
 #### Iops
 
-The number of I/O operations per second (IOPS) that the database provisions. The value must be equal to or greater than 1000.
+The number of I/O operations per second (IOPS) that the database provisions.
 
 _Required_: No
 


### PR DESCRIPTION
This commit removes validation constraint for `Iops` attribute. The reason for this change is that some engine types do not support setting `iops` and customers set it to 0 to keep it consistent across all the templates in use. RDS API treats a 0-value as null, hence it is a valid parameter.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Signed-off-by: Oleg Sidorov <sidorovo@amazon.com>