### PR TITLE
[Common] Introduce `IdentifierFactory`

### DIFF
--- a/aws-rds-cfn-common/src/main/java/software/amazon/rds/common/util/IdentifierFactory.java
+++ b/aws-rds-cfn-common/src/main/java/software/amazon/rds/common/util/IdentifierFactory.java
@@ -1,0 +1,67 @@
+package software.amazon.rds.common.util;
+
+import lombok.NonNull;
+import software.amazon.awssdk.utils.StringUtils;
+import software.amazon.cloudformation.resource.IdentifierUtils;
+
+public class IdentifierFactory {
+
+    private final String defaultStackId;
+    private final String defaultResourceId;
+    private final int maxLength;
+
+    public IdentifierFactory(
+            @NonNull final String defaultStackId,
+            @NonNull final String defaultResourceId,
+            final int maxLength
+    ) {
+        this.defaultStackId = defaultStackId;
+        this.defaultResourceId = defaultResourceId;
+        this.maxLength = maxLength;
+    }
+
+    public Identifier newIdentifier() {
+        return new Identifier(this);
+    }
+
+    public static class Identifier {
+
+        private final IdentifierFactory identifierFactory;
+        private String stackId;
+        private String resourceId;
+        private String requestToken;
+
+        private Identifier(IdentifierFactory identifierFactory) {
+            this.identifierFactory = identifierFactory;
+        }
+
+        public Identifier withStackId(final String stackId) {
+            this.stackId = stackId;
+            return this;
+        }
+
+        public Identifier withResourceId(final String resourceId) {
+            this.resourceId = resourceId;
+            return this;
+        }
+
+        public Identifier withRequestToken(final String requestToken) {
+            this.requestToken = requestToken;
+            return this;
+        }
+
+        public String toString() {
+            final String identifier = IdentifierUtils.generateResourceIdentifier(
+                    StringUtils.isEmpty(stackId) ? identifierFactory.defaultStackId : stackId,
+                    StringUtils.isEmpty(resourceId) ? identifierFactory.defaultResourceId : resourceId,
+                    StringUtils.isEmpty(requestToken) ? "" : requestToken,
+                    identifierFactory.maxLength
+            );
+            return identifier
+                    .replaceFirst("^-+", "")
+                    .replaceAll("-{2,}", "-")
+                    .replaceAll("-+$", "")
+                    .toLowerCase();
+        }
+    }
+}

--- a/aws-rds-cfn-common/src/test/java/software/amazon/rds/common/util/IdentifierFactoryTest.java
+++ b/aws-rds-cfn-common/src/test/java/software/amazon/rds/common/util/IdentifierFactoryTest.java
@@ -1,0 +1,39 @@
+package software.amazon.rds.common.util;
+
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class IdentifierFactoryTest {
+
+    private final static String DEFAULT_STACK_ID = "defaultStackId";
+    private final static String DEFAULT_RESOURCE_ID = "defaultResourceId";
+    private final static int DEFAULT_MAXLEN = 16;
+
+    @Test
+    public void test_defaultValues() {
+        final IdentifierFactory factory = new IdentifierFactory(DEFAULT_STACK_ID, DEFAULT_RESOURCE_ID, DEFAULT_MAXLEN);
+        final String identifier = factory.newIdentifier().toString();
+        assertValidIdentifier(identifier, DEFAULT_MAXLEN);
+    }
+
+    @Test
+    public void test_setValues() {
+        final IdentifierFactory factory = new IdentifierFactory(DEFAULT_STACK_ID, DEFAULT_RESOURCE_ID, DEFAULT_MAXLEN);
+        final String identifier = factory.newIdentifier()
+                .withStackId("stack-id")
+                .withResourceId("resource-id")
+                .withRequestToken("request-token")
+                .toString();
+        assertValidIdentifier(identifier, DEFAULT_MAXLEN);
+    }
+
+    private void assertValidIdentifier(final String identifier, final int maxlen) {
+        Assertions.assertThat(identifier).isNotBlank();
+        Assertions.assertThat(identifier).doesNotContain("--");
+        Assertions.assertThat(identifier).doesNotStartWith("-");
+        Assertions.assertThat(identifier).doesNotEndWith("-");
+        Assertions.assertThat(identifier).isLowerCase();
+        Assertions.assertThat(identifier.length()).isLessThanOrEqualTo(maxlen);
+    }
+}

--- a/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/CreateHandler.java
+++ b/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/CreateHandler.java
@@ -2,7 +2,6 @@ package software.amazon.rds.dbcluster;
 
 import java.time.Duration;
 import java.util.HashSet;
-import java.util.Optional;
 
 import com.amazonaws.util.StringUtils;
 import software.amazon.awssdk.services.rds.RdsClient;
@@ -12,12 +11,18 @@ import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 import software.amazon.cloudformation.proxy.delay.Constant;
-import software.amazon.cloudformation.resource.IdentifierUtils;
 import software.amazon.rds.common.handler.Commons;
 import software.amazon.rds.common.handler.HandlerConfig;
 import software.amazon.rds.common.handler.Tagging;
+import software.amazon.rds.common.util.IdentifierFactory;
 
 public class CreateHandler extends BaseHandlerStd {
+
+    private final static IdentifierFactory dbClusterIdentifierFactory = new IdentifierFactory(
+            STACK_NAME,
+            RESOURCE_IDENTIFIER,
+            RESOURCE_ID_MAX_LENGTH
+    );
 
     public CreateHandler() {
         this(HandlerConfig.builder()
@@ -39,14 +44,11 @@ public class CreateHandler extends BaseHandlerStd {
     ) {
         ResourceModel model = ModelAdapter.setDefaults(request.getDesiredResourceState());
         if (StringUtils.isNullOrEmpty(model.getDBClusterIdentifier())) {
-            model.setDBClusterIdentifier(
-                    IdentifierUtils.generateResourceIdentifier(
-                            Optional.ofNullable(request.getStackId()).orElse(STACK_NAME),
-                            Optional.ofNullable(request.getLogicalResourceIdentifier()).orElse(RESOURCE_IDENTIFIER),
-                            request.getClientRequestToken(),
-                            RESOURCE_ID_MAX_LENGTH
-                    ).toLowerCase()
-            );
+            model.setDBClusterIdentifier(dbClusterIdentifierFactory.newIdentifier()
+                    .withStackId(request.getStackId())
+                    .withResourceId(request.getLogicalResourceIdentifier())
+                    .withRequestToken(request.getClientRequestToken())
+                    .toString());
         }
 
         final Tagging.TagSet systemTags = Tagging.TagSet.builder()

--- a/aws-rds-dbclusterparametergroup/src/main/java/software/amazon/rds/dbclusterparametergroup/BaseHandlerStd.java
+++ b/aws-rds-dbclusterparametergroup/src/main/java/software/amazon/rds/dbclusterparametergroup/BaseHandlerStd.java
@@ -41,6 +41,8 @@ import software.amazon.rds.common.printer.FilteredJsonPrinter;
 public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
     protected static final BiFunction<ResourceModel, ProxyClient<RdsClient>, ResourceModel> EMPTY_CALL = (model, proxyClient) -> model;
     protected static final String AVAILABLE = "available";
+    protected static final String RESOURCE_IDENTIFIER = "dbclusterparametergroup";
+    protected static final String STACK_NAME = "rds";
     protected static final int MAX_LENGTH_GROUP_NAME = 255;
     // 5 min for waiting propagation according to https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_ModifyDBClusterParameterGroup.html
     protected static final int CALLBACK_DELAY_SECONDS = 5 * 60;

--- a/aws-rds-dbclusterparametergroup/src/main/java/software/amazon/rds/dbclusterparametergroup/UpdateHandler.java
+++ b/aws-rds-dbclusterparametergroup/src/main/java/software/amazon/rds/dbclusterparametergroup/UpdateHandler.java
@@ -1,8 +1,5 @@
 package software.amazon.rds.dbclusterparametergroup;
 
-import java.util.HashSet;
-import java.util.Map;
-
 import software.amazon.awssdk.services.rds.RdsClient;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.Logger;

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/BaseHandlerStd.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/BaseHandlerStd.java
@@ -56,7 +56,6 @@ import software.amazon.cloudformation.proxy.Logger;
 import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
-import software.amazon.cloudformation.resource.IdentifierUtils;
 import software.amazon.rds.common.error.ErrorCode;
 import software.amazon.rds.common.error.ErrorRuleSet;
 import software.amazon.rds.common.error.ErrorStatus;
@@ -127,16 +126,6 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
                     DbInstanceAlreadyExistsException.class)
             .build()
             .orElse(Commons.DEFAULT_ERROR_RULE_SET);
-
-    protected static final ErrorRuleSet CREATE_DB_INSTANCE_ERROR_RULE_SET = ErrorRuleSet.builder()
-            .withErrorCodes(ErrorStatus.failWith(HandlerErrorCode.AlreadyExists),
-                    ErrorCode.DBInstanceAlreadyExists)
-            .withErrorClasses(
-                    ErrorStatus.failWith(HandlerErrorCode.AlreadyExists),
-                    DbInstanceAlreadyExistsException.class)
-            .build()
-            .orElse(DEFAULT_DB_INSTANCE_ERROR_RULE_SET);
-
     public static final ErrorRuleSet RESTORE_DB_INSTANCE_ERROR_RULE_SET = ErrorRuleSet.builder()
             .withErrorCodes(ErrorStatus.failWith(HandlerErrorCode.AlreadyExists),
                     ErrorCode.DBInstanceAlreadyExists)
@@ -150,7 +139,14 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
                     InvalidRestoreException.class)
             .build()
             .orElse(DEFAULT_DB_INSTANCE_ERROR_RULE_SET);
-
+    protected static final ErrorRuleSet CREATE_DB_INSTANCE_ERROR_RULE_SET = ErrorRuleSet.builder()
+            .withErrorCodes(ErrorStatus.failWith(HandlerErrorCode.AlreadyExists),
+                    ErrorCode.DBInstanceAlreadyExists)
+            .withErrorClasses(
+                    ErrorStatus.failWith(HandlerErrorCode.AlreadyExists),
+                    DbInstanceAlreadyExistsException.class)
+            .build()
+            .orElse(DEFAULT_DB_INSTANCE_ERROR_RULE_SET);
     protected static final ErrorRuleSet CREATE_DB_INSTANCE_READ_REPLICA_ERROR_RULE_SET = ErrorRuleSet.builder()
             .withErrorCodes(ErrorStatus.failWith(HandlerErrorCode.AlreadyExists),
                     ErrorCode.DBInstanceAlreadyExists)
@@ -212,10 +208,8 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
                     DbSnapshotAlreadyExistsException.class)
             .build()
             .orElse(DEFAULT_DB_INSTANCE_ERROR_RULE_SET);
-
-    protected HandlerConfig config;
-
     private final FilteredJsonPrinter PARAMETERS_FILTER = new FilteredJsonPrinter("MasterUsername", "MasterUserPassword", "TdeCredentialPassword");
+    protected HandlerConfig config;
 
     public BaseHandlerStd(final HandlerConfig config) {
         super();
@@ -617,16 +611,5 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
         }
 
         return progress;
-    }
-
-    protected String generateResourceIdentifier(
-            final String stackId,
-            final String logicalResourceId,
-            final String clientRequestToken,
-            final int maxLength
-    ) {
-        return IdentifierUtils
-                .generateResourceIdentifier(stackId, logicalResourceId, clientRequestToken, maxLength)
-                .replaceAll("-{2,}", "-");
     }
 }

--- a/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/CreateHandlerTest.java
+++ b/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/CreateHandlerTest.java
@@ -82,12 +82,10 @@ public class CreateHandlerTest extends AbstractHandlerTest {
 
     @BeforeEach
     public void setup() {
-        handler = new CreateHandler(
-                HandlerConfig.builder()
-                        .probingEnabled(false)
-                        .backoff(TEST_BACKOFF_DELAY)
-                        .build()
-        );
+        handler = new CreateHandler(HandlerConfig.builder()
+                .probingEnabled(false)
+                .backoff(TEST_BACKOFF_DELAY)
+                .build());
         proxy = new AmazonWebServicesClientProxy(logger, MOCK_CREDENTIALS, () -> Duration.ofSeconds(600).toMillis());
         rdsClient = mock(RdsClient.class);
         ec2Client = mock(Ec2Client.class);

--- a/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/DeleteHandlerTest.java
+++ b/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/DeleteHandlerTest.java
@@ -67,10 +67,7 @@ public class DeleteHandlerTest extends AbstractHandlerTest {
         handler = new DeleteHandler(
                 HandlerConfig.builder()
                         .probingEnabled(false)
-                        .backoff(Constant.of()
-                                .delay(Duration.ofSeconds(1))
-                                .timeout(Duration.ofSeconds(120))
-                                .build())
+                        .backoff(TEST_BACKOFF_DELAY)
                         .build()
         );
         proxy = new AmazonWebServicesClientProxy(logger, MOCK_CREDENTIALS, () -> Duration.ofSeconds(600).toMillis());

--- a/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/ListHandlerTest.java
+++ b/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/ListHandlerTest.java
@@ -31,29 +31,23 @@ import software.amazon.cloudformation.proxy.ProxyClient;
 @ExtendWith(MockitoExtension.class)
 public class ListHandlerTest extends AbstractHandlerTest {
 
+    final String DB_INSTANCE_IDENTIFIER = "test-db-instance-identifier";
+    final String DESCRIBE_DB_INSTANCES_MARKER = "test-describe-db-instances-marker";
     @Mock
     @Getter
     private AmazonWebServicesClientProxy proxy;
-
     @Mock
     @Getter
     private ProxyClient<RdsClient> rdsProxy;
-
     @Mock
     @Getter
     private ProxyClient<Ec2Client> ec2Proxy;
-
     @Mock
     private RdsClient rdsClient;
-
     @Mock
     private Ec2Client ec2Client;
-
     @Getter
     private ListHandler handler;
-
-    final String DB_INSTANCE_IDENTIFIER = "test-db-instance-identifier";
-    final String DESCRIBE_DB_INSTANCES_MARKER = "test-describe-db-instances-marker";
 
     @BeforeEach
     public void setup() {

--- a/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/UpdateHandlerTest.java
+++ b/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/UpdateHandlerTest.java
@@ -64,7 +64,6 @@ import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.HandlerErrorCode;
 import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
-import software.amazon.cloudformation.proxy.delay.Constant;
 import software.amazon.rds.common.error.ErrorCode;
 import software.amazon.rds.common.handler.HandlerConfig;
 
@@ -94,15 +93,10 @@ public class UpdateHandlerTest extends AbstractHandlerTest {
 
     @BeforeEach
     public void setup() {
-        handler = new UpdateHandler(
-                HandlerConfig.builder()
-                        .probingEnabled(false)
-                        .backoff(Constant.of()
-                                .delay(Duration.ofSeconds(1))
-                                .timeout(Duration.ofSeconds(120))
-                                .build())
-                        .build()
-        );
+        handler = new UpdateHandler(HandlerConfig.builder()
+                .probingEnabled(false)
+                .backoff(TEST_BACKOFF_DELAY)
+                .build());
         proxy = new AmazonWebServicesClientProxy(logger, MOCK_CREDENTIALS, () -> Duration.ofSeconds(600).toMillis());
         rdsClient = mock(RdsClient.class);
         ec2Client = mock(Ec2Client.class);

--- a/aws-rds-dbparametergroup/src/main/java/software/amazon/rds/dbparametergroup/BaseHandlerStd.java
+++ b/aws-rds-dbparametergroup/src/main/java/software/amazon/rds/dbparametergroup/BaseHandlerStd.java
@@ -57,6 +57,9 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
     protected static final int NO_CALLBACK_DELAY = 0;
     protected static final int MAX_PARAMETERS_PER_REQUEST = 20;
 
+    protected static final String RESOURCE_IDENTIFIER = "dbparametergroup";
+    protected static final String STACK_NAME = "rds";
+
     protected HandlerConfig config;
 
     private final FilteredJsonPrinter PARAMETERS_FILTER = new FilteredJsonPrinter();

--- a/aws-rds-dbparametergroup/src/main/java/software/amazon/rds/dbparametergroup/CreateHandler.java
+++ b/aws-rds-dbparametergroup/src/main/java/software/amazon/rds/dbparametergroup/CreateHandler.java
@@ -1,7 +1,6 @@
 package software.amazon.rds.dbparametergroup;
 
 import java.util.HashSet;
-import java.util.Optional;
 
 import com.amazonaws.util.StringUtils;
 import software.amazon.awssdk.services.rds.RdsClient;
@@ -9,16 +8,20 @@ import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
-import software.amazon.cloudformation.resource.IdentifierUtils;
 import software.amazon.rds.common.handler.Commons;
 import software.amazon.rds.common.handler.HandlerConfig;
 import software.amazon.rds.common.handler.Tagging;
 import software.amazon.rds.common.logging.RequestLogger;
+import software.amazon.rds.common.util.IdentifierFactory;
 
 
 public class CreateHandler extends BaseHandlerStd {
 
-    public static final String DEFAULT_LOGICAL_IDENTIFIER = "dbparametergroup";
+    private static final IdentifierFactory groupIdentifierFactory = new IdentifierFactory(
+            STACK_NAME,
+            RESOURCE_IDENTIFIER,
+            MAX_LENGTH_GROUP_NAME
+    );
 
     public CreateHandler() {
         this(HandlerConfig.builder().build());
@@ -79,12 +82,11 @@ public class CreateHandler extends BaseHandlerStd {
                                                                                          final ResourceModel model,
                                                                                          final ProgressEvent<ResourceModel, CallbackContext> progress) {
         if (StringUtils.isNullOrEmpty(model.getDBParameterGroupName()))
-            model.setDBParameterGroupName(IdentifierUtils.generateResourceIdentifier(
-                    request.getStackId(),
-                    Optional.ofNullable(request.getLogicalResourceIdentifier()).orElse(DEFAULT_LOGICAL_IDENTIFIER),
-                    request.getClientRequestToken(),
-                    MAX_LENGTH_GROUP_NAME
-            ).toLowerCase());
+            model.setDBParameterGroupName(groupIdentifierFactory.newIdentifier()
+                    .withStackId(request.getStackId())
+                    .withResourceId(request.getLogicalResourceIdentifier())
+                    .withRequestToken(request.getClientRequestToken())
+                    .toString());
         return ProgressEvent.progress(model, progress.getCallbackContext());
     }
 }

--- a/aws-rds-dbsubnetgroup/src/main/java/software/amazon/rds/dbsubnetgroup/BaseHandlerStd.java
+++ b/aws-rds-dbsubnetgroup/src/main/java/software/amazon/rds/dbsubnetgroup/BaseHandlerStd.java
@@ -27,6 +27,8 @@ import software.amazon.rds.common.printer.FilteredJsonPrinter;
 public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
     protected static final int DB_SUBNET_GROUP_NAME_LENGTH = 255;
     protected static final String DB_SUBNET_GROUP_STATUS_COMPLETE = "Complete";
+    protected static final String STACK_NAME = "rds";
+    protected static final String RESOURCE_IDENTIFIER = "dbsubnetgroup";
 
     protected static final ErrorRuleSet DEFAULT_DB_SUBNET_GROUP_ERROR_RULE_SET = ErrorRuleSet.builder()
             .withErrorClasses(ErrorStatus.failWith(HandlerErrorCode.AlreadyExists),

--- a/aws-rds-dbsubnetgroup/src/test/java/software/amazon/rds/dbsubnetgroup/AbstractTestBase.java
+++ b/aws-rds-dbsubnetgroup/src/test/java/software/amazon/rds/dbsubnetgroup/AbstractTestBase.java
@@ -1,13 +1,17 @@
 package software.amazon.rds.dbsubnetgroup;
 
 
-import com.google.common.collect.Lists;
+import java.time.Duration;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+
 import org.mockito.internal.util.collections.Sets;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.collect.Lists;
 import software.amazon.awssdk.awscore.AwsRequest;
 import software.amazon.awssdk.awscore.AwsResponse;
 import software.amazon.awssdk.core.ResponseBytes;
@@ -18,16 +22,18 @@ import software.amazon.awssdk.services.rds.model.DBSubnetGroup;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.Credentials;
 import software.amazon.cloudformation.proxy.LoggerProxy;
-
-import org.slf4j.LoggerFactory;
 import software.amazon.cloudformation.proxy.ProxyClient;
+import software.amazon.cloudformation.proxy.delay.Constant;
 
 public class AbstractTestBase {
     protected static final Credentials MOCK_CREDENTIALS;
     protected static final org.slf4j.Logger delegate;
     protected static final LoggerProxy logger;
 
-
+    protected static final Constant TEST_BACKOFF_DELAY = Constant.of()
+            .delay(Duration.ofSeconds(1L))
+            .timeout(Duration.ofSeconds(10L))
+            .build();
 
     protected static final ResourceModel RESOURCE_MODEL;
     protected static final ResourceModel RESOURCE_MODEL_ALTERNATIVE;
@@ -65,20 +71,20 @@ public class AbstractTestBase {
 
     static Map<String, String> translateTagsToMap(final Set<Tag> tags) {
         return tags.stream()
-            .collect(Collectors.toMap(Tag::getKey, Tag::getValue));
+                .collect(Collectors.toMap(Tag::getKey, Tag::getValue));
 
     }
 
     static ProxyClient<RdsClient> MOCK_PROXY(
-        final AmazonWebServicesClientProxy proxy,
-        final RdsClient rdsClient
+            final AmazonWebServicesClientProxy proxy,
+            final RdsClient rdsClient
     ) {
         return new ProxyClient<RdsClient>() {
             @Override
             public <RequestT extends AwsRequest, ResponseT extends AwsResponse>
             ResponseT
             injectCredentialsAndInvokeV2(RequestT request,
-                Function<RequestT, ResponseT> requestFunction) {
+                                         Function<RequestT, ResponseT> requestFunction) {
                 return proxy.injectCredentialsAndInvokeV2(request, requestFunction);
             }
 
@@ -86,7 +92,7 @@ public class AbstractTestBase {
             public <RequestT extends AwsRequest, ResponseT extends AwsResponse>
             CompletableFuture<ResponseT>
             injectCredentialsAndInvokeV2Async(RequestT request,
-                Function<RequestT, CompletableFuture<ResponseT>> requestFunction) {
+                                              Function<RequestT, CompletableFuture<ResponseT>> requestFunction) {
                 throw new UnsupportedOperationException();
             }
 
@@ -94,21 +100,21 @@ public class AbstractTestBase {
             public <RequestT extends AwsRequest, ResponseT extends AwsResponse, IterableT extends SdkIterable<ResponseT>>
             IterableT
             injectCredentialsAndInvokeIterableV2(RequestT request,
-                Function<RequestT, IterableT> requestFunction) {
+                                                 Function<RequestT, IterableT> requestFunction) {
                 return proxy.injectCredentialsAndInvokeIterableV2(request, requestFunction);
             }
 
             @Override
             public <RequestT extends AwsRequest, ResponseT extends AwsResponse> ResponseInputStream<ResponseT>
             injectCredentialsAndInvokeV2InputStream(RequestT requestT,
-                Function<RequestT, ResponseInputStream<ResponseT>> function) {
+                                                    Function<RequestT, ResponseInputStream<ResponseT>> function) {
                 throw new UnsupportedOperationException();
             }
 
             @Override
             public <RequestT extends AwsRequest, ResponseT extends AwsResponse> ResponseBytes<ResponseT>
             injectCredentialsAndInvokeV2Bytes(RequestT requestT,
-                Function<RequestT, ResponseBytes<ResponseT>> function) {
+                                              Function<RequestT, ResponseBytes<ResponseT>> function) {
                 throw new UnsupportedOperationException();
             }
 

--- a/aws-rds-dbsubnetgroup/src/test/java/software/amazon/rds/dbsubnetgroup/CreateHandlerTest.java
+++ b/aws-rds-dbsubnetgroup/src/test/java/software/amazon/rds/dbsubnetgroup/CreateHandlerTest.java
@@ -37,24 +37,26 @@ import software.amazon.cloudformation.proxy.OperationStatus;
 import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
+import software.amazon.rds.common.handler.HandlerConfig;
 
 @ExtendWith(MockitoExtension.class)
 public class CreateHandlerTest extends AbstractTestBase {
 
     @Mock
+    RdsClient rds;
+    @Mock
     private AmazonWebServicesClientProxy proxy;
-
     @Mock
     private ProxyClient<RdsClient> proxyRdsClient;
-
-    @Mock
-    RdsClient rds;
-
     private CreateHandler handler;
 
     @BeforeEach
     public void setup() {
-        handler = new CreateHandler();
+        handler = new CreateHandler(HandlerConfig.builder()
+                .probingEnabled(false)
+                .backoff(TEST_BACKOFF_DELAY)
+                .build());
+
         rds = mock(RdsClient.class);
         proxy = new AmazonWebServicesClientProxy(logger, MOCK_CREDENTIALS, () -> Duration.ofSeconds(600).toMillis());
         proxyRdsClient = MOCK_PROXY(proxy, rds);

--- a/aws-rds-dbsubnetgroup/src/test/java/software/amazon/rds/dbsubnetgroup/DeleteHandlerTest.java
+++ b/aws-rds-dbsubnetgroup/src/test/java/software/amazon/rds/dbsubnetgroup/DeleteHandlerTest.java
@@ -29,24 +29,25 @@ import software.amazon.cloudformation.proxy.OperationStatus;
 import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
+import software.amazon.rds.common.handler.HandlerConfig;
 
 @ExtendWith(MockitoExtension.class)
 public class DeleteHandlerTest extends AbstractTestBase {
 
     @Mock
+    RdsClient rds;
+    @Mock
     private AmazonWebServicesClientProxy proxy;
-
     @Mock
     private ProxyClient<RdsClient> proxyRdsClient;
-
-    @Mock
-    RdsClient rds;
-
     private DeleteHandler handler;
 
     @BeforeEach
     public void setup() {
-        handler = new DeleteHandler();
+        handler = new DeleteHandler(HandlerConfig.builder()
+                .probingEnabled(false)
+                .backoff(TEST_BACKOFF_DELAY)
+                .build());
         rds = mock(RdsClient.class);
         proxy = new AmazonWebServicesClientProxy(logger, MOCK_CREDENTIALS, () -> Duration.ofSeconds(600).toMillis());
         proxyRdsClient = MOCK_PROXY(proxy, rds);

--- a/aws-rds-dbsubnetgroup/src/test/java/software/amazon/rds/dbsubnetgroup/UpdateHandlerTest.java
+++ b/aws-rds-dbsubnetgroup/src/test/java/software/amazon/rds/dbsubnetgroup/UpdateHandlerTest.java
@@ -30,32 +30,31 @@ import software.amazon.awssdk.services.rds.model.ListTagsForResourceRequest;
 import software.amazon.awssdk.services.rds.model.ListTagsForResourceResponse;
 import software.amazon.awssdk.services.rds.model.ModifyDbSubnetGroupRequest;
 import software.amazon.awssdk.services.rds.model.ModifyDbSubnetGroupResponse;
-import software.amazon.awssdk.services.rds.model.RemoveTagsFromResourceRequest;
-import software.amazon.awssdk.services.rds.model.RemoveTagsFromResourceResponse;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.HandlerErrorCode;
 import software.amazon.cloudformation.proxy.OperationStatus;
 import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
+import software.amazon.rds.common.handler.HandlerConfig;
 
 @ExtendWith(MockitoExtension.class)
 public class UpdateHandlerTest extends AbstractTestBase {
 
     @Mock
+    RdsClient rds;
+    @Mock
     private AmazonWebServicesClientProxy proxy;
-
     @Mock
     private ProxyClient<RdsClient> proxyRdsClient;
-
-    @Mock
-    RdsClient rds;
-
     private UpdateHandler handler;
 
     @BeforeEach
     public void setup() {
-        handler = new UpdateHandler();
+        handler = new UpdateHandler(HandlerConfig.builder()
+                .probingEnabled(false)
+                .backoff(TEST_BACKOFF_DELAY)
+                .build());
         rds = mock(RdsClient.class);
         proxy = new AmazonWebServicesClientProxy(logger, MOCK_CREDENTIALS, () -> Duration.ofSeconds(600).toMillis());
         proxyRdsClient = MOCK_PROXY(proxy, rds);

--- a/aws-rds-eventsubscription/docs/README.md
+++ b/aws-rds-eventsubscription/docs/README.md
@@ -112,7 +112,7 @@ _Required_: No
 
 _Type_: String
 
-_Allowed Values_: <code>db-instance</code> | <code>db-parameter-group</code> | <code>db-security-group</code> | <code>db-snapshot</code>
+_Allowed Values_: <code>custom-engine-version</code> | <code>db-cluster</code> | <code>db-cluster-snapshot</code> | <code>db-instance</code> | <code>db-proxy</code> | <code>db-parameter-group</code> | <code>db-security-group</code> | <code>db-snapshot</code>
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 

--- a/aws-rds-eventsubscription/src/main/java/software/amazon/rds/eventsubscription/BaseHandlerStd.java
+++ b/aws-rds-eventsubscription/src/main/java/software/amazon/rds/eventsubscription/BaseHandlerStd.java
@@ -26,6 +26,10 @@ import software.amazon.rds.common.printer.FilteredJsonPrinter;
 public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
     protected static final BiFunction<ResourceModel, ProxyClient<RdsClient>, ResourceModel> EMPTY_CALL = (model, proxyClient) -> model;
 
+    protected static final String STACK_NAME = "rds";
+    protected static final String RESOURCE_IDENTIFIER = "eventsubscription";
+    protected static final int MAX_LENGTH_EVENT_SUBSCRIPTION = 255;
+
     protected static final ErrorRuleSet DEFAULT_EVENT_SUBSCRIPTION_ERROR_RULE_SET = ErrorRuleSet.builder()
             .withErrorClasses(ErrorStatus.failWith(HandlerErrorCode.AlreadyExists),
                     SubscriptionAlreadyExistException.class)
@@ -70,8 +74,8 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
 
     protected boolean isStabilized(final ResourceModel model, final ProxyClient<RdsClient> proxyClient) {
         final String status = proxyClient.injectCredentialsAndInvokeV2(
-                Translator.describeEventSubscriptionsRequest(model),
-                proxyClient.client()::describeEventSubscriptions)
+                        Translator.describeEventSubscriptionsRequest(model),
+                        proxyClient.client()::describeEventSubscriptions)
                 .eventSubscriptionsList().stream().findFirst().get().status();
         return status.equals("active");
     }

--- a/aws-rds-eventsubscription/src/main/java/software/amazon/rds/eventsubscription/CreateHandler.java
+++ b/aws-rds-eventsubscription/src/main/java/software/amazon/rds/eventsubscription/CreateHandler.java
@@ -1,7 +1,6 @@
 package software.amazon.rds.eventsubscription;
 
 import java.util.HashSet;
-import java.util.Optional;
 
 import com.amazonaws.util.StringUtils;
 import software.amazon.awssdk.services.rds.RdsClient;
@@ -10,13 +9,17 @@ import software.amazon.cloudformation.proxy.Logger;
 import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
-import software.amazon.cloudformation.resource.IdentifierUtils;
 import software.amazon.rds.common.handler.Commons;
 import software.amazon.rds.common.handler.Tagging;
+import software.amazon.rds.common.util.IdentifierFactory;
 
 public class CreateHandler extends BaseHandlerStd {
 
-    private static final int MAX_LENGTH_EVENT_SUBSCRIPTION = 255;
+    private final static IdentifierFactory subscriptionNameFactory = new IdentifierFactory(
+            STACK_NAME,
+            RESOURCE_IDENTIFIER,
+            MAX_LENGTH_EVENT_SUBSCRIPTION
+    );
 
     protected ProgressEvent<ResourceModel, CallbackContext> handleRequest(
             final AmazonWebServicesClientProxy proxy,
@@ -65,12 +68,11 @@ public class CreateHandler extends BaseHandlerStd {
     ) {
         ResourceModel model = progress.getResourceModel();
         if (StringUtils.isNullOrEmpty(model.getSubscriptionName())) {
-            model.setSubscriptionName(IdentifierUtils.generateResourceIdentifier(
-                    Optional.ofNullable(request.getStackId()).orElse("rds"),
-                    Optional.ofNullable(request.getLogicalResourceIdentifier()).orElse("eventsubscription"),
-                    request.getClientRequestToken(),
-                    MAX_LENGTH_EVENT_SUBSCRIPTION
-            ).toLowerCase());
+            model.setSubscriptionName(subscriptionNameFactory.newIdentifier()
+                    .withStackId(request.getStackId())
+                    .withResourceId(request.getLogicalResourceIdentifier())
+                    .withRequestToken(request.getClientRequestToken())
+                    .toString());
         }
         return progress;
     }

--- a/aws-rds-globalcluster/pom.xml
+++ b/aws-rds-globalcluster/pom.xml
@@ -20,6 +20,12 @@
 
     <dependencies>
         <dependency>
+            <groupId>software.amazon.rds.common</groupId>
+            <artifactId>aws-rds-cfn-common</artifactId>
+            <version>1.0</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>rds</artifactId>
             <version>2.17.121</version>
@@ -132,44 +138,6 @@
                         <goals>
                             <goal>shade</goal>
                         </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>exec-maven-plugin</artifactId>
-                <version>1.6.0</version>
-                <executions>
-                    <execution>
-                        <id>generate</id>
-                        <phase>generate-sources</phase>
-                        <goals>
-                            <goal>exec</goal>
-                        </goals>
-                        <configuration>
-                            <executable>cfn</executable>
-                            <commandlineArgs>generate</commandlineArgs>
-                            <workingDirectory>${project.basedir}</workingDirectory>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>build-helper-maven-plugin</artifactId>
-                <version>3.0.0</version>
-                <executions>
-                    <execution>
-                        <id>add-source</id>
-                        <phase>generate-sources</phase>
-                        <goals>
-                            <goal>add-source</goal>
-                        </goals>
-                        <configuration>
-                            <sources>
-                                <source>${project.basedir}/target/generated-sources/rpdk</source>
-                            </sources>
-                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/aws-rds-globalcluster/src/main/java/software/amazon/rds/globalcluster/BaseHandlerStd.java
+++ b/aws-rds-globalcluster/src/main/java/software/amazon/rds/globalcluster/BaseHandlerStd.java
@@ -29,6 +29,8 @@ import java.util.List;
 public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
   protected static final int GLOBAL_CLUSTER_ID_MAX_LENGTH = 63;
   protected static final int PAUSE_TIME_SECONDS = 60;
+  protected static final String STACK_NAME = "rds";
+  protected static final String RESOURCE_IDENTIFIER = "globalcluster";
   protected static final Constant BACKOFF_STRATEGY = Constant.of().timeout(Duration.ofMinutes(180L)).delay(Duration.ofSeconds(30L)).build();
   private static final String MESSAGE_FORMAT_FAILED_TO_STABILIZE = "GlobalCluster %s failed to stabilize.";
   protected static final BiFunction<ResourceModel, ProxyClient<RdsClient>, ResourceModel> EMPTY_CALL = (model, proxyClient) -> model;

--- a/aws-rds-globalcluster/src/main/java/software/amazon/rds/globalcluster/CreateHandler.java
+++ b/aws-rds-globalcluster/src/main/java/software/amazon/rds/globalcluster/CreateHandler.java
@@ -7,9 +7,15 @@ import software.amazon.cloudformation.proxy.Logger;
 import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
-import software.amazon.cloudformation.resource.IdentifierUtils;
+import software.amazon.rds.common.util.IdentifierFactory;
 
 public class CreateHandler extends BaseHandlerStd {
+
+    private final static IdentifierFactory clusterIdentifierFactory = new IdentifierFactory(
+            STACK_NAME,
+            RESOURCE_IDENTIFIER,
+            GLOBAL_CLUSTER_ID_MAX_LENGTH
+    );
 
     protected ProgressEvent<ResourceModel, CallbackContext> handleRequest(final AmazonWebServicesClientProxy proxy,
                                                                           final ResourceHandlerRequest<ResourceModel> request,
@@ -19,21 +25,24 @@ public class CreateHandler extends BaseHandlerStd {
 
         ResourceModel model = request.getDesiredResourceState();
 
-        if(StringUtils.isNullOrEmpty(model.getGlobalClusterIdentifier())) {
-            model.setGlobalClusterIdentifier(IdentifierUtils.generateResourceIdentifier(request.getLogicalResourceIdentifier(),
-                    request.getClientRequestToken(), GLOBAL_CLUSTER_ID_MAX_LENGTH).toLowerCase());
+        if (StringUtils.isNullOrEmpty(model.getGlobalClusterIdentifier())) {
+            model.setGlobalClusterIdentifier(clusterIdentifierFactory.newIdentifier()
+                    .withStackId(request.getStackId())
+                    .withResourceId(request.getLogicalResourceIdentifier())
+                    .withRequestToken(request.getClientRequestToken())
+                    .toString());
         }
 
         return ProgressEvent.progress(model, callbackContext)
                 .then(progress -> {
-                    if(!validateSourceDBClusterIdentifier(progress.getResourceModel())) {
+                    if (!validateSourceDBClusterIdentifier(progress.getResourceModel())) {
                         return createGlobalClusterWithSourceDBCluster(proxy, proxyClient, progress);
                     }
                     return progress;
                 })
                 .then(progress -> {
                     //check if source cluster identifier is null or is in arn format
-                    if(validateSourceDBClusterIdentifier(progress.getResourceModel())) {
+                    if (validateSourceDBClusterIdentifier(progress.getResourceModel())) {
                         return createGlobalCluster(proxy, proxyClient, progress);
                     }
                     return progress;

--- a/aws-rds-optiongroup/src/main/java/software/amazon/rds/optiongroup/CreateHandler.java
+++ b/aws-rds-optiongroup/src/main/java/software/amazon/rds/optiongroup/CreateHandler.java
@@ -1,7 +1,5 @@
 package software.amazon.rds.optiongroup;
 
-import java.util.Optional;
-
 import com.amazonaws.util.CollectionUtils;
 import com.amazonaws.util.StringUtils;
 import software.amazon.awssdk.services.rds.RdsClient;
@@ -10,11 +8,17 @@ import software.amazon.cloudformation.proxy.Logger;
 import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
-import software.amazon.cloudformation.resource.IdentifierUtils;
 import software.amazon.rds.common.handler.Commons;
 import software.amazon.rds.common.handler.HandlerConfig;
+import software.amazon.rds.common.util.IdentifierFactory;
 
 public class CreateHandler extends BaseHandlerStd {
+
+    private static final IdentifierFactory groupIdentifierFactory = new IdentifierFactory(
+            STACK_NAME,
+            RESOURCE_IDENTIFIER,
+            RESOURCE_ID_MAX_LENGTH
+    );
 
     public CreateHandler() {
         this(HandlerConfig.builder()
@@ -37,12 +41,11 @@ public class CreateHandler extends BaseHandlerStd {
                 .then(progress -> {
                     final ResourceModel model = request.getDesiredResourceState();
                     if (StringUtils.isNullOrEmpty(model.getOptionGroupName())) {
-                        model.setOptionGroupName(IdentifierUtils.generateResourceIdentifier(
-                                Optional.ofNullable(request.getStackId()).orElse(STACK_NAME),
-                                Optional.ofNullable(request.getLogicalResourceIdentifier()).orElse(RESOURCE_IDENTIFIER),
-                                request.getClientRequestToken(),
-                                RESOURCE_ID_MAX_LENGTH
-                        ).toLowerCase());
+                        model.setOptionGroupName(groupIdentifierFactory.newIdentifier()
+                                .withStackId(request.getStackId())
+                                .withResourceId(request.getLogicalResourceIdentifier())
+                                .withRequestToken(request.getClientRequestToken())
+                                .toString());
                     }
                     return ProgressEvent.progress(model, progress.getCallbackContext());
                 })


### PR DESCRIPTION
This commit introduces a new util factory class called `IdentifierFactory`. The aim is to provide a generic and safe approach
for new identifier generation.

The current approach, which is adopted across all RDS CFN resources, uses cloudofrmation `IdentifierUtils` utility, which appears to be missing the double hyphens case and performs no null-safety checks on identifier components: stack id, logical resource identifier and request token.

The newly added util class generalizes the identifier generation approach and hides null-safety checks.

This commit affects all RDS CFN resources. Some areas of the code were changed due to an auto-formatting and auto-rearranges.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Signed-off-by: Oleg Sidorov <sidorovo@amazon.com>