### PR TITLE
[DBCluster] Fix wrong Assert import

### DIFF
--- a/aws-rds-dbcluster/src/test/java/software/amazon/rds/dbcluster/CreateHandlerTest.java
+++ b/aws-rds-dbcluster/src/test/java/software/amazon/rds/dbcluster/CreateHandlerTest.java
@@ -12,8 +12,7 @@ import java.time.Duration;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
-import junit.framework.Assert;
-
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -214,7 +213,7 @@ public class CreateHandlerTest extends AbstractHandlerTest {
         verify(rdsProxy.client(), times(1)).restoreDBClusterFromSnapshot(argumentCaptor.capture());
         verify(rdsProxy.client(), times(2)).describeDBClusters(any(DescribeDbClustersRequest.class));
 
-        Assert.assertEquals(argumentCaptor.getValue().kmsKeyId(), kmsKeyId);
+        Assertions.assertThat(argumentCaptor.getValue().kmsKeyId()).isEqualTo(kmsKeyId);
     }
 
     @Test


### PR DESCRIPTION
This commit fixes a wrong unit test code assert import. The import was added by mistake. The library that was meant to be imported is `org.assertj.core.api.Assertions`. Due to a distinction in the CI/CD pipeline environments and imported suite, the pipeline experienced failures. This commit ensures the same Assertions library is used across all resources.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Signed-off-by: Oleg Sidorov <sidorovo@amazon.com>