### PR TITLE
[DBCluster] Fix `ReplicationSourceIdentifier` validator

### DIFF
--- a/aws-rds-dbcluster/aws-rds-dbcluster.json
+++ b/aws-rds-dbcluster/aws-rds-dbcluster.json
@@ -292,6 +292,11 @@
           "required": [
             "GlobalClusterIdentifier"
           ]
+        },
+        {
+          "required": [
+            "ReplicationSourceIdentifier"
+          ]
         }
       ]
     }


### PR DESCRIPTION
This commit eliminates a check for `MasterUsername` and `MasterPassword` if `ReplicationSourceIdentifier` is provided.

The reason for change is an incomplete validation schema that still requires the 2 aforementioned attributes to be provided despite that the replication source is set.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Signed-off-by: Oleg Sidorov <sidorovo@amazon.com>