### PR TITLE
[DBCluster] Fix failing `AddRoleToDBCluster` stabilization

### DIFF
--- a/aws-rds-dbcluster/src/test/java/software/amazon/rds/dbcluster/AbstractHandlerTest.java
+++ b/aws-rds-dbcluster/src/test/java/software/amazon/rds/dbcluster/AbstractHandlerTest.java
@@ -56,6 +56,7 @@ public abstract class AbstractHandlerTest extends AbstractTestBase<DBCluster, Re
     protected static final String ROLE_ARN;
     protected static final String ROLE_FEATURE;
     protected static final DBClusterRole ROLE;
+    protected static final DBClusterRole ROLE_WITH_EMPTY_FEATURE;
 
     protected static final ResourceModel RESOURCE_MODEL;
     protected static final ResourceModel RESOURCE_MODEL_ON_RESTORE;
@@ -100,6 +101,7 @@ public abstract class AbstractHandlerTest extends AbstractTestBase<DBCluster, Re
         ROLE_ARN = "sampleArn";
         ROLE_FEATURE = "sampleFeature";
         ROLE = DBClusterRole.builder().roleArn(ROLE_ARN).featureName(ROLE_FEATURE).build();
+        ROLE_WITH_EMPTY_FEATURE = DBClusterRole.builder().roleArn(ROLE_ARN).build();
 
         RESOURCE_MODEL = ResourceModel.builder()
                 .associatedRoles(Lists.newArrayList(ROLE))


### PR DESCRIPTION
This commit fixes an error in `DBClusterRole` comparison utility. It is being used by the `UpdateHandler` stabilization checker.

The faulty implementation compared the inner representation of `DBClusterRole` to the SDK version it received from `DescribeDBClusters` call. Upon a comparison, both `Arn` and `FeatureName` from the internal representation were safe-wrapped by `Optional` with a fallback to an empty string. The same null-safe wrapping was not performed for the SDK
representation, causing an empty string being compared to null. This comparison never succeeded, hence the handler timed out the resource stabilization.

This commit alters the comparison technique. It uses `Objects.equals` utility instead, which provides both null-safety and correctness in case any of the arguments is null.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Signed-off-by: Oleg Sidorov <sidorovo@amazon.com>