### PR TITLE
[DBInstance] Use default handler config

### DIFF
--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/BaseHandlerStd.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/BaseHandlerStd.java
@@ -1,5 +1,6 @@
 package software.amazon.rds.dbinstance;
 
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -56,6 +57,7 @@ import software.amazon.cloudformation.proxy.Logger;
 import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
+import software.amazon.cloudformation.proxy.delay.Constant;
 import software.amazon.rds.common.error.ErrorCode;
 import software.amazon.rds.common.error.ErrorRuleSet;
 import software.amazon.rds.common.error.ErrorStatus;
@@ -126,6 +128,7 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
                     DbInstanceAlreadyExistsException.class)
             .build()
             .orElse(Commons.DEFAULT_ERROR_RULE_SET);
+
     public static final ErrorRuleSet RESTORE_DB_INSTANCE_ERROR_RULE_SET = ErrorRuleSet.builder()
             .withErrorCodes(ErrorStatus.failWith(HandlerErrorCode.AlreadyExists),
                     ErrorCode.DBInstanceAlreadyExists)
@@ -139,6 +142,7 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
                     InvalidRestoreException.class)
             .build()
             .orElse(DEFAULT_DB_INSTANCE_ERROR_RULE_SET);
+
     protected static final ErrorRuleSet CREATE_DB_INSTANCE_ERROR_RULE_SET = ErrorRuleSet.builder()
             .withErrorCodes(ErrorStatus.failWith(HandlerErrorCode.AlreadyExists),
                     ErrorCode.DBInstanceAlreadyExists)
@@ -147,6 +151,7 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
                     DbInstanceAlreadyExistsException.class)
             .build()
             .orElse(DEFAULT_DB_INSTANCE_ERROR_RULE_SET);
+
     protected static final ErrorRuleSet CREATE_DB_INSTANCE_READ_REPLICA_ERROR_RULE_SET = ErrorRuleSet.builder()
             .withErrorCodes(ErrorStatus.failWith(HandlerErrorCode.AlreadyExists),
                     ErrorCode.DBInstanceAlreadyExists)
@@ -208,7 +213,14 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
                     DbSnapshotAlreadyExistsException.class)
             .build()
             .orElse(DEFAULT_DB_INSTANCE_ERROR_RULE_SET);
+
+    protected final static HandlerConfig DEFAULT_DB_INSTANCE_HANDLER_CONFIG = HandlerConfig.builder()
+            .probingEnabled(true)
+            .backoff(Constant.of().delay(Duration.ofSeconds(30)).timeout(Duration.ofMinutes(180)).build())
+            .build();
+
     private final FilteredJsonPrinter PARAMETERS_FILTER = new FilteredJsonPrinter("MasterUsername", "MasterUserPassword", "TdeCredentialPassword");
+
     protected HandlerConfig config;
 
     public BaseHandlerStd(final HandlerConfig config) {

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/CreateHandler.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/CreateHandler.java
@@ -1,6 +1,5 @@
 package software.amazon.rds.dbinstance;
 
-import java.time.Duration;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Optional;
@@ -18,7 +17,6 @@ import software.amazon.cloudformation.proxy.Logger;
 import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
-import software.amazon.cloudformation.proxy.delay.Constant;
 import software.amazon.rds.common.handler.Commons;
 import software.amazon.rds.common.handler.HandlerConfig;
 import software.amazon.rds.common.handler.Tagging;
@@ -35,10 +33,7 @@ public class CreateHandler extends BaseHandlerStd {
     );
 
     public CreateHandler() {
-        this(HandlerConfig.builder()
-                .probingEnabled(true)
-                .backoff(Constant.of().delay(Duration.ofSeconds(30)).timeout(Duration.ofMinutes(180)).build())
-                .build());
+        this(DEFAULT_DB_INSTANCE_HANDLER_CONFIG);
     }
 
     public CreateHandler(final HandlerConfig config) {

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/DeleteHandler.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/DeleteHandler.java
@@ -26,7 +26,7 @@ public class DeleteHandler extends BaseHandlerStd {
     );
 
     public DeleteHandler() {
-        this(HandlerConfig.builder().probingEnabled(true).build());
+        this(DEFAULT_DB_INSTANCE_HANDLER_CONFIG);
     }
 
     public DeleteHandler(final HandlerConfig config) {

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/ListHandler.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/ListHandler.java
@@ -15,7 +15,7 @@ import software.amazon.rds.common.handler.HandlerConfig;
 public class ListHandler extends BaseHandlerStd {
 
     public ListHandler() {
-        this(HandlerConfig.builder().build());
+        this(DEFAULT_DB_INSTANCE_HANDLER_CONFIG);
     }
 
     public ListHandler(final HandlerConfig config) {

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/ReadHandler.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/ReadHandler.java
@@ -15,7 +15,7 @@ import software.amazon.rds.common.handler.HandlerConfig;
 public class ReadHandler extends BaseHandlerStd {
 
     public ReadHandler() {
-        this(HandlerConfig.builder().probingEnabled(true).build());
+        this(DEFAULT_DB_INSTANCE_HANDLER_CONFIG);
     }
 
     public ReadHandler(final HandlerConfig config) {

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/UpdateHandler.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/UpdateHandler.java
@@ -35,7 +35,7 @@ import software.amazon.rds.dbinstance.util.ImmutabilityHelper;
 public class UpdateHandler extends BaseHandlerStd {
 
     public UpdateHandler() {
-        this(HandlerConfig.builder().probingEnabled(true).build());
+        this(DEFAULT_DB_INSTANCE_HANDLER_CONFIG);
     }
 
     public UpdateHandler(final HandlerConfig config) {


### PR DESCRIPTION
This commit introduces a default value for the handler config. The motivation for the change is that every handler instantiates a custom configuration of `HandlerConfig` with eventually inconsistent config between the handlers. Whereas this was the initial idea, in practice it seems to be more error-proof to declare a unified one-size-fits-all config per resource and tweak the config attributes in a single place.

Test code is still encouraged to override the handler config independently, depending on the use-case.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Signed-off-by: Oleg Sidorov <sidorovo@amazon.com>