### PR TITLE
[DBInstance] Fix resource drift stabilization

### DIFF
--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/BaseHandlerStd.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/BaseHandlerStd.java
@@ -414,11 +414,12 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
     ) {
         final DBCluster dbCluster = fetchDBCluster(rdsProxyClient, model);
         final List<DBClusterMember> dbClusterMembers = dbCluster.dbClusterMembers();
-        if (!CollectionUtils.isNullOrEmpty(dbClusterMembers)) {
-            for (DBClusterMember member : dbClusterMembers) {
-                if (model.getDBInstanceIdentifier().equals(member.dbInstanceIdentifier())) {
-                    return IN_SYNC_STATUS.equals(member.dbClusterParameterGroupStatus());
-                }
+        if (CollectionUtils.isNullOrEmpty(dbClusterMembers)) {
+            return true;
+        }
+        for (DBClusterMember member : dbClusterMembers) {
+            if (model.getDBInstanceIdentifier().equals(member.dbInstanceIdentifier())) {
+                return IN_SYNC_STATUS.equals(member.dbClusterParameterGroupStatus());
             }
         }
         return false;

--- a/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/UpdateHandlerTest.java
+++ b/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/UpdateHandlerTest.java
@@ -700,6 +700,12 @@ public class UpdateHandlerTest extends AbstractHandlerTest {
         transitions.add(DB_INSTANCE_ACTIVE.toBuilder()
                 .dbParameterGroups(DBParameterGroupStatus.builder()
                         .dbParameterGroupName("test-db-parameter-group")
+                        .parameterApplyStatus("pending-reboot")
+                        .build())
+                .build());
+        transitions.add(DB_INSTANCE_ACTIVE.toBuilder()
+                .dbParameterGroups(DBParameterGroupStatus.builder()
+                        .dbParameterGroupName("test-db-parameter-group")
                         .parameterApplyStatus("applying")
                         .build())
                 .build());
@@ -719,12 +725,6 @@ public class UpdateHandlerTest extends AbstractHandlerTest {
                 .optionGroupMemberships(OptionGroupMembership.builder()
                         .optionGroupName("test-option-group")
                         .status("in-sync")
-                        .build())
-                .build());
-        transitions.add(DB_INSTANCE_ACTIVE.toBuilder()
-                .dbParameterGroups(DBParameterGroupStatus.builder()
-                        .dbParameterGroupName("test-db-parameter-group")
-                        .parameterApplyStatus("pending-reboot")
                         .build())
                 .build());
         transitions.add(DB_INSTANCE_ACTIVE.toBuilder()
@@ -747,13 +747,19 @@ public class UpdateHandlerTest extends AbstractHandlerTest {
         );
 
 
-        verify(rdsProxy.client(), times(7)).describeDBInstances(any(DescribeDbInstancesRequest.class));
+        verify(rdsProxy.client(), times(6)).describeDBInstances(any(DescribeDbInstancesRequest.class));
         verify(rdsProxy.client(), times(1)).rebootDBInstance(any(RebootDbInstanceRequest.class));
     }
 
     @Test
     public void handleRequest_ResourceDriftClusterInstance() {
         final Queue<DBInstance> transitions = new ConcurrentLinkedQueue<>();
+        transitions.add(DB_INSTANCE_ACTIVE.toBuilder()
+                .dbParameterGroups(DBParameterGroupStatus.builder()
+                        .dbParameterGroupName("test-db-parameter-group")
+                        .parameterApplyStatus("pending-reboot")
+                        .build())
+                .build());
         transitions.add(DB_INSTANCE_ACTIVE.toBuilder()
                 .dbParameterGroups(DBParameterGroupStatus.builder()
                         .dbParameterGroupName("test-db-parameter-group")
@@ -776,12 +782,6 @@ public class UpdateHandlerTest extends AbstractHandlerTest {
                 .optionGroupMemberships(OptionGroupMembership.builder()
                         .optionGroupName("test-option-group")
                         .status("in-sync")
-                        .build())
-                .build());
-        transitions.add(DB_INSTANCE_ACTIVE.toBuilder()
-                .dbParameterGroups(DBParameterGroupStatus.builder()
-                        .dbParameterGroupName("test-db-parameter-group")
-                        .parameterApplyStatus("pending-reboot")
                         .build())
                 .build());
         transitions.add(DB_INSTANCE_ACTIVE.toBuilder()
@@ -821,7 +821,7 @@ public class UpdateHandlerTest extends AbstractHandlerTest {
                 expectSuccess()
         );
 
-        verify(rdsProxy.client(), times(7)).describeDBInstances(any(DescribeDbInstancesRequest.class));
+        verify(rdsProxy.client(), times(6)).describeDBInstances(any(DescribeDbInstancesRequest.class));
         verify(rdsProxy.client(), times(2)).describeDBClusters(any(DescribeDbClustersRequest.class));
         verify(rdsProxy.client(), times(1)).rebootDBInstance(any(RebootDbInstanceRequest.class));
     }
@@ -871,14 +871,6 @@ public class UpdateHandlerTest extends AbstractHandlerTest {
                         .dbClusters(DBCluster.builder()
                                 .dbClusterMembers(DBClusterMember.builder()
                                         .dbInstanceIdentifier(DB_INSTANCE_ACTIVE.dbInstanceIdentifier())
-                                        .dbClusterParameterGroupStatus("in-sync")
-                                        .build())
-                                .build())
-                        .build())
-                .thenReturn(DescribeDbClustersResponse.builder()
-                        .dbClusters(DBCluster.builder()
-                                .dbClusterMembers(DBClusterMember.builder()
-                                        .dbInstanceIdentifier(DB_INSTANCE_ACTIVE.dbInstanceIdentifier())
                                         .dbClusterParameterGroupStatus("pending-reboot")
                                         .build())
                                 .build())
@@ -901,8 +893,8 @@ public class UpdateHandlerTest extends AbstractHandlerTest {
                 expectSuccess()
         );
 
-        verify(rdsProxy.client(), times(7)).describeDBInstances(any(DescribeDbInstancesRequest.class));
-        verify(rdsProxy.client(), times(2)).describeDBClusters(any(DescribeDbClustersRequest.class));
         verify(rdsProxy.client(), times(1)).rebootDBInstance(any(RebootDbInstanceRequest.class));
+        verify(rdsProxy.client(), times(5)).describeDBInstances(any(DescribeDbInstancesRequest.class));
+        verify(rdsProxy.client(), times(2)).describeDBClusters(any(DescribeDbClustersRequest.class));
     }
 }


### PR DESCRIPTION
This commit fixes DBInstance UpdateHandler behavior when it is being invoked with `driftable=true` flag. This is a special case that occurs when CFN detects a resource drift and executes an additional series of stabilization loops. The entire idea behind this check is to see if the instance is required a reboot and ensuring it completes successfully.

In the current implementation reboot and stabilization loops are placed in a wrong order, causing the handler to wait forever upon a `pending-reboot` status and never reaching the point of the actual reboot. This fix changes this order and ensures the reboot is performed before the stabilization chain is started.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Signed-off-by: Oleg Sidorov <sidorovo@amazon.com>