### PR TITLE
[DBInstance] Soft fail tagging `AccessDenied` on create

### DIFF
--- a/aws-rds-cfn-common/src/main/java/software/amazon/rds/common/handler/HandlerMethod.java
+++ b/aws-rds-cfn-common/src/main/java/software/amazon/rds/common/handler/HandlerMethod.java
@@ -1,0 +1,15 @@
+package software.amazon.rds.common.handler;
+
+import software.amazon.awssdk.services.rds.RdsClient;
+import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
+import software.amazon.cloudformation.proxy.ProgressEvent;
+import software.amazon.cloudformation.proxy.ProxyClient;
+
+public interface HandlerMethod<M, C> {
+    ProgressEvent<M, C> invoke(
+            final AmazonWebServicesClientProxy proxy,
+            final ProxyClient<RdsClient> rdsProxyClient,
+            final ProgressEvent<M, C> progress,
+            final Tagging.TagSet tagSet
+    );
+}

--- a/aws-rds-cfn-common/src/main/java/software/amazon/rds/common/handler/Tagging.java
+++ b/aws-rds-cfn-common/src/main/java/software/amazon/rds/common/handler/Tagging.java
@@ -47,28 +47,6 @@ public final class Tagging {
                     ErrorCode.AccessDeniedException
             ).build();
 
-    @Builder(toBuilder = true)
-    @AllArgsConstructor
-    @Data
-    public static class TagSet {
-        @Builder.Default
-        private Set<Tag> systemTags = new LinkedHashSet<>();
-        @Builder.Default
-        private Set<Tag> stackTags = new LinkedHashSet<>();
-        @Builder.Default
-        private Set<Tag> resourceTags = new LinkedHashSet<>();
-
-        public boolean isEmpty() {
-            return systemTags.isEmpty() &&
-                    stackTags.isEmpty() &&
-                    resourceTags.isEmpty();
-        }
-
-        public static TagSet emptySet() {
-            return TagSet.builder().build();
-        }
-    }
-
     public static TagSet exclude(final TagSet from, final TagSet what) {
         final Set<Tag> systemTags = new LinkedHashSet<>(from.getSystemTags());
         systemTags.removeAll(what.getSystemTags());
@@ -222,9 +200,31 @@ public final class Tagging {
         return hardFailErrorRuleSet;
     }
 
-    private static void addToMapIfAbsent(Map<String, Tag> allTags, Collection<Tag> tags){
-        for(Tag tag : tags) {
+    private static void addToMapIfAbsent(Map<String, Tag> allTags, Collection<Tag> tags) {
+        for (Tag tag : tags) {
             allTags.putIfAbsent(tag.key(), tag);
+        }
+    }
+
+    @Builder(toBuilder = true)
+    @AllArgsConstructor
+    @Data
+    public static class TagSet {
+        @Builder.Default
+        private Set<Tag> systemTags = new LinkedHashSet<>();
+        @Builder.Default
+        private Set<Tag> stackTags = new LinkedHashSet<>();
+        @Builder.Default
+        private Set<Tag> resourceTags = new LinkedHashSet<>();
+
+        public static TagSet emptySet() {
+            return TagSet.builder().build();
+        }
+
+        public boolean isEmpty() {
+            return systemTags.isEmpty() &&
+                    stackTags.isEmpty() &&
+                    resourceTags.isEmpty();
         }
     }
 }

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/CallbackContext.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/CallbackContext.java
@@ -15,6 +15,7 @@ public class CallbackContext extends StdCallbackContext {
     private boolean updatedRoles;
     private boolean updated;
     private boolean rebooted;
+    private boolean createTagComplete;
 
     private Map<String, Integer> probes;
 

--- a/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/AbstractHandlerTest.java
+++ b/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/AbstractHandlerTest.java
@@ -11,6 +11,7 @@ import java.util.function.Supplier;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import software.amazon.awssdk.services.ec2.Ec2Client;
 import software.amazon.awssdk.services.rds.RdsClient;
 import software.amazon.awssdk.services.rds.model.DBInstance;
@@ -24,6 +25,7 @@ import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 import software.amazon.cloudformation.proxy.delay.Constant;
+import software.amazon.rds.common.handler.Tagging;
 import software.amazon.rds.common.test.AbstractTestBase;
 
 public abstract class AbstractHandlerTest extends AbstractTestBase<DBInstance, ResourceModel, CallbackContext> {
@@ -37,6 +39,7 @@ public abstract class AbstractHandlerTest extends AbstractTestBase<DBInstance, R
     protected static final List<Tag> TAG_LIST_EMPTY;
     protected static final List<Tag> TAG_LIST;
     protected static final List<Tag> TAG_LIST_ALTER;
+    protected static final Tagging.TagSet TAG_SET;
 
     protected static final Integer ALLOCATED_STORAGE = 10;
     protected static final Integer ALLOCATED_STORAGE_INCR = 20;
@@ -180,6 +183,21 @@ public abstract class AbstractHandlerTest extends AbstractTestBase<DBInstance, R
                 Tag.builder().key("foo-4").value("bar-4").build(),
                 Tag.builder().key("foo-5").value("bar-5").build()
         );
+
+        TAG_SET = Tagging.TagSet.builder()
+                .systemTags(ImmutableSet.of(
+                        software.amazon.awssdk.services.rds.model.Tag.builder().key("system-tag-1").value("system-tag-value1").build(),
+                        software.amazon.awssdk.services.rds.model.Tag.builder().key("system-tag-2").value("system-tag-value2").build(),
+                        software.amazon.awssdk.services.rds.model.Tag.builder().key("system-tag-3").value("system-tag-value3").build()
+                )).stackTags(ImmutableSet.of(
+                        software.amazon.awssdk.services.rds.model.Tag.builder().key("stack-tag-1").value("stack-tag-value1").build(),
+                        software.amazon.awssdk.services.rds.model.Tag.builder().key("stack-tag-2").value("stack-tag-value2").build(),
+                        software.amazon.awssdk.services.rds.model.Tag.builder().key("stack-tag-3").value("stack-tag-value3").build()
+                )).resourceTags(ImmutableSet.of(
+                        software.amazon.awssdk.services.rds.model.Tag.builder().key("resource-tag-1").value("resource-tag-value1").build(),
+                        software.amazon.awssdk.services.rds.model.Tag.builder().key("resource-tag-2").value("resource-tag-value2").build(),
+                        software.amazon.awssdk.services.rds.model.Tag.builder().key("resource-tag-3").value("resource-tag-value3").build()
+                )).build();
 
         ASSOCIATED_ROLES = ImmutableList.of(
                 DBInstanceRole.builder()


### PR DESCRIPTION
This commit changes the tagging soft fail algorithm. RDS resources implement tagging with a best-effort support: the handler code will attempt to create the resource with system tags only and then add the remaining tags separately. We are changing this approach to a 2-attempt run: initially the handler will attempt to create a resource with all tags, and if it fails, we will re-create the resource with system tags only (same as now) and attempt to invoke `AddTagsToResource` with the old soft-failing mechanism (silent failure).

This allows RDS to handle cases where customer FAS policies provide an additional condition enforcing presence of particular tags in `Create*` requests.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Signed-off-by: Oleg Sidorov <sidorovo@amazon.com>