### PR TITLE
[DBParameterGroup] Bump lambda max memory constraint to 1024MB

### DIFF
--- a/aws-rds-dbclusterparametergroup/template.yml
+++ b/aws-rds-dbclusterparametergroup/template.yml
@@ -4,8 +4,8 @@ Description: AWS SAM template for the AWS::RDS::DBClusterParameterGroup resource
 
 Globals:
   Function:
-    Timeout: 60  # docker start-up times can be long for SAM CLI
-    MemorySize: 512
+    Timeout: 180  # docker start-up times can be long for SAM CLI
+    MemorySize: 1024
 Resources:
   TypeFunction:
     Type: AWS::Serverless::Function

--- a/aws-rds-dbparametergroup/template.yml
+++ b/aws-rds-dbparametergroup/template.yml
@@ -5,7 +5,7 @@ Description: AWS SAM template for the AWS::RDS::DBParameterGroup resource type
 Globals:
   Function:
     Timeout: 180  # docker start-up times can be long for SAM CLI
-    MemorySize: 256
+    MemorySize: 1024
 
 Resources:
   TypeFunction:


### PR DESCRIPTION
This commit updates `DBParameterGroup` and `DBClusterParameterGroup` lambda templates in order to increase max memory limit to 1024MB.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Signed-off-by: Oleg Sidorov <sidorovo@amazon.com>