### PR TITLE
[EventSubscription] Handle create call while stack having IAM role wi…

### DIFF
--- a/aws-rds-eventsubscription/src/main/java/software/amazon/rds/eventsubscription/CreateHandler.java
+++ b/aws-rds-eventsubscription/src/main/java/software/amazon/rds/eventsubscription/CreateHandler.java
@@ -1,10 +1,12 @@
 package software.amazon.rds.eventsubscription;
 
+import java.util.Collections;
 import java.util.HashSet;
 
 import com.amazonaws.util.StringUtils;
 import software.amazon.awssdk.services.rds.RdsClient;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
+import software.amazon.cloudformation.proxy.HandlerErrorCode;
 import software.amazon.cloudformation.proxy.Logger;
 import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ProxyClient;
@@ -30,29 +32,39 @@ public class CreateHandler extends BaseHandlerStd {
 
         final ResourceModel model = request.getDesiredResourceState();
 
-        final Tagging.TagSet systemTags = Tagging.TagSet.builder()
+        final Tagging.TagSet allTags = Tagging.TagSet.builder()
                 .systemTags(Tagging.translateTagsToSdk(request.getSystemTags()))
-                .build();
-
-        final Tagging.TagSet extraTags = Tagging.TagSet.builder()
                 .stackTags(Tagging.translateTagsToSdk(request.getDesiredResourceTags()))
                 .resourceTags(new HashSet<>(Translator.translateTagsToSdk(request.getDesiredResourceState().getTags())))
                 .build();
 
         return ProgressEvent.progress(model, callbackContext)
                 .then(progress -> setEventSubscriptionNameIfEmpty(request, progress))
-                .then(progress -> createEventSubscription(proxy, proxyClient, progress, systemTags))
-                .then(progress -> updateTags(proxy, proxyClient, progress, Tagging.TagSet.emptySet(), extraTags))
+                .then(progress -> safeCreateEventSubscription(proxy, proxyClient, progress, allTags))
                 .then(progress -> new ReadHandler().handleRequest(proxy, request, callbackContext, proxyClient, logger));
+    }
+
+    private ProgressEvent<ResourceModel, CallbackContext> safeCreateEventSubscription(final AmazonWebServicesClientProxy proxy,
+                                                                                     final ProxyClient<RdsClient> proxyClient,
+                                                                                     final ProgressEvent<ResourceModel, CallbackContext> progress,
+                                                                                     final Tagging.TagSet allTags) {
+        ProgressEvent<ResourceModel, CallbackContext> progressEvent = createEventSubscription(proxy, proxyClient, progress, allTags);
+        if (HandlerErrorCode.AccessDenied.equals(progressEvent.getErrorCode())) { //Resource is subject to soft fail on stack level tags.
+            Tagging.TagSet systemTags = Tagging.TagSet.builder().systemTags(allTags.getSystemTags()).build();
+            Tagging.TagSet extraTags = allTags.toBuilder().systemTags(Collections.emptySet()).build();
+            return createEventSubscription(proxy, proxyClient, progress, systemTags)
+                    .then(prog -> updateTags(proxy, proxyClient, prog, Tagging.TagSet.emptySet(), extraTags));
+        }
+        return progressEvent;
     }
 
     private ProgressEvent<ResourceModel, CallbackContext> createEventSubscription(final AmazonWebServicesClientProxy proxy,
                                                                                   final ProxyClient<RdsClient> proxyClient,
                                                                                   final ProgressEvent<ResourceModel, CallbackContext> progress,
-                                                                                  final Tagging.TagSet systemTags
+                                                                                  final Tagging.TagSet tags
     ) {
         return proxy.initiate("rds::create-event-subscription", proxyClient, progress.getResourceModel(), progress.getCallbackContext())
-                .translateToServiceRequest((resourceModel) -> Translator.createEventSubscriptionRequest(resourceModel, systemTags))
+                .translateToServiceRequest((resourceModel) -> Translator.createEventSubscriptionRequest(resourceModel, tags))
                 .makeServiceCall((createEventSubscriptionRequest, proxyInvocation) -> proxyInvocation.injectCredentialsAndInvokeV2(createEventSubscriptionRequest, proxyInvocation.client()::createEventSubscription))
                 .stabilize((createEventSubscriptionRequest, createEventSubscriptionResponse, proxyInvocation, resourceModel, context) ->
                         isStabilized(resourceModel, proxyInvocation))


### PR DESCRIPTION
*Description of changes:*
When customer specify stack IAM role with tag conditions. Create call will fail with `AccessDenied` exception because it contains only system tags and apply other tags by `AddTagsToResource`.

I.e: Customer created this stack with stack level tag `foo -> bar`
```
AWSTemplateFormatVersion: 2010-09-09
Description: RDS EventSubscription Example Stack

Resources:
  RDSEventSubscription:
    Type: AWS::RDS::EventSubscription
    Properties:
        SourceType: "db-parameter-group"
        Enabled: true
        SnsTopicArn:
          Fn::ImportValue: CanarySnsTopicArn1
```

And assigned IAM Role to execute this stack
```
{
    "Version": "2012-10-17",
    "Statement": [
        {
            "Sid": "VisualEditor0",
            "Effect": "Allow",
            "Action": "rds:*",
            "Resource": "*",
            "Condition": {
                "StringEquals": {
                    "rds:req-tag/foo": "bar"
                }
            }
        }
    ]
}
```
That means `CreateEventSubscription` call need to have `--tags foo -> bar` Or the whole call will fail with `AccessDenied` Exception. 

**Approach**
Change create to include all possible tags (Stack, System, and Resource) together.
If failed with access denied that means there is possibility to apply soft fail for stack level tags, We trigger create call again with system tags only to ensure they are attached as they do not need permission. Then code flow will follow regular soft fail procedure for stack level tags.
 
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.