### PR TITLE
[DBSubnetGroup] Accept duplicate SubnetIds

### DIFF
--- a/aws-rds-dbsubnetgroup/aws-rds-dbsubnetgroup.json
+++ b/aws-rds-dbsubnetgroup/aws-rds-dbsubnetgroup.json
@@ -12,7 +12,7 @@
     },
     "SubnetIds": {
       "type": "array",
-      "uniqueItems": true,
+      "uniqueItems": false,
       "items": {
         "type": "string"
       }

--- a/aws-rds-dbsubnetgroup/src/main/java/software/amazon/rds/dbsubnetgroup/Translator.java
+++ b/aws-rds-dbsubnetgroup/src/main/java/software/amazon/rds/dbsubnetgroup/Translator.java
@@ -2,6 +2,7 @@ package software.amazon.rds.dbsubnetgroup;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -29,7 +30,7 @@ public class Translator {
         return CreateDbSubnetGroupRequest.builder()
                 .dbSubnetGroupName(model.getDBSubnetGroupName())
                 .dbSubnetGroupDescription(model.getDBSubnetGroupDescription())
-                .subnetIds(model.getSubnetIds())
+                .subnetIds(model.getSubnetIds().stream().sorted().collect(Collectors.toCollection(LinkedHashSet::new)))
                 .tags(Tagging.translateTagsToSdk(tags)).build();
     }
 
@@ -49,7 +50,7 @@ public class Translator {
         return ModifyDbSubnetGroupRequest.builder()
                 .dbSubnetGroupName(model.getDBSubnetGroupName())
                 .dbSubnetGroupDescription(model.getDBSubnetGroupDescription())
-                .subnetIds(model.getSubnetIds())
+                .subnetIds(model.getSubnetIds().stream().sorted().collect(Collectors.toCollection(LinkedHashSet::new)))
                 .build();
     }
 


### PR DESCRIPTION
*Description of changes:*
This commit changes DBSubnetGroup schema to tolerate duplicate `SubnetIds` and drop those duplicate in client request in order to not break current stacks with duplicate `SubnetIds`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
