### PR TITLE
[DBInstance] Restore original `dbInstanceIdentifier` case spelling

### DIFF
--- a/aws-rds-dbinstance/inputs/inputs_1_create.json
+++ b/aws-rds-dbinstance/inputs/inputs_1_create.json
@@ -1,7 +1,7 @@
 {
   "AllocatedStorage": "5",
   "AutoMinorVersionUpgrade": false,
-  "DBInstanceIdentifier": "dbinstance-contract-test",
+  "DBInstanceIdentifier": "test-db-instance",
   "DBInstanceClass": "db.t3.micro",
   "DBName": "testdbname",
   "Engine": "postgres",

--- a/aws-rds-dbinstance/inputs/inputs_1_update.json
+++ b/aws-rds-dbinstance/inputs/inputs_1_update.json
@@ -1,7 +1,7 @@
 {
   "AllocatedStorage": "5",
   "AutoMinorVersionUpgrade": false,
-  "DBInstanceIdentifier": "dbinstance-contract-test",
+  "DBInstanceIdentifier": "test-db-instance",
   "DBInstanceClass": "db.t3.micro",
   "DBName": "testdbname",
   "EnablePerformanceInsights": true,

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/BaseHandlerStd.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/BaseHandlerStd.java
@@ -399,6 +399,39 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
         return StringUtils.isNotBlank(model.getDBClusterIdentifier());
     }
 
+    protected ResourceModel restoreIdentifier(final ResourceModel observed, final ResourceModel original) {
+        if (StringUtils.isBlank(original.getDBInstanceIdentifier()) ||
+            StringUtils.equals(observed.getDBInstanceIdentifier(), original.getDBInstanceIdentifier())) {
+            return observed;
+        }
+        observed.setDBInstanceIdentifier(original.getDBInstanceIdentifier());
+        return observed;
+    }
+
+    protected DBInstance restoreIdentifier(final DBInstance dbInstance, final ResourceModel model) {
+        if (StringUtils.isBlank(model.getDBInstanceIdentifier()) ||
+                StringUtils.equals(dbInstance.dbInstanceIdentifier(), model.getDBInstanceIdentifier())) {
+            return dbInstance;
+        }
+        return dbInstance.toBuilder().dbInstanceIdentifier(model.getDBInstanceIdentifier()).build();
+    }
+
+    protected DBCluster restoreIdentifier(final DBCluster dbCluster, final ResourceModel model) {
+        if (StringUtils.isBlank(model.getDBClusterIdentifier()) ||
+                StringUtils.equals(dbCluster.dbClusterIdentifier(), model.getDBClusterIdentifier())) {
+            return dbCluster;
+        }
+        return dbCluster.toBuilder().dbClusterIdentifier(model.getDBClusterIdentifier()).build();
+    }
+
+    protected DBSnapshot restoreIdentifier(final DBSnapshot dbSnapshot, final ResourceModel model) {
+        if (StringUtils.isBlank(model.getDBSnapshotIdentifier()) ||
+                StringUtils.equals(dbSnapshot.dbSnapshotIdentifier(), model.getDBSnapshotIdentifier())) {
+            return dbSnapshot;
+        }
+        return dbSnapshot.toBuilder().dbSnapshotIdentifier(model.getDBSnapshotIdentifier()).build();
+    }
+
     protected DBInstance fetchDBInstance(
             final ProxyClient<RdsClient> rdsProxyClient,
             final ResourceModel model
@@ -407,7 +440,7 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
                 Translator.describeDbInstancesRequest(model),
                 rdsProxyClient.client()::describeDBInstances
         );
-        return response.dbInstances().stream().findFirst().get();
+        return restoreIdentifier(response.dbInstances().stream().findFirst().get(), model);
     }
 
     protected DBCluster fetchDBCluster(
@@ -418,7 +451,7 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
                 Translator.describeDbClustersRequest(model),
                 rdsProxyClient.client()::describeDBClusters
         );
-        return response.dbClusters().stream().findFirst().get();
+        return restoreIdentifier(response.dbClusters().stream().findFirst().get(), model);
     }
 
     protected DBSnapshot fetchDBSnapshot(
@@ -429,7 +462,7 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
                 Translator.describeDbSnapshotsRequest(model),
                 rdsProxyClient.client()::describeDBSnapshots
         );
-        return response.dbSnapshots().stream().findFirst().get();
+        return restoreIdentifier(response.dbSnapshots().stream().findFirst().get(), model);
     }
 
     protected SecurityGroup fetchSecurityGroup(

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/ReadHandler.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/ReadHandler.java
@@ -4,6 +4,7 @@ package software.amazon.rds.dbinstance;
 import software.amazon.awssdk.services.ec2.Ec2Client;
 import software.amazon.awssdk.services.rds.RdsClient;
 import software.amazon.awssdk.services.rds.model.DBInstance;
+import software.amazon.awssdk.utils.StringUtils;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.Logger;
 import software.amazon.cloudformation.proxy.ProgressEvent;
@@ -43,7 +44,9 @@ public class ReadHandler extends BaseHandlerStd {
                 ))
                 .done((describeRequest, describeResponse, proxyInvocation, resourceModel, context) -> {
                     final DBInstance dbInstance = describeResponse.dbInstances().stream().findFirst().get();
-                    return ProgressEvent.success(Translator.translateDbInstanceFromSdk(dbInstance), context);
+                    return ProgressEvent.success(
+                            restoreIdentifier(Translator.translateDbInstanceFromSdk(dbInstance), request.getDesiredResourceState()),
+                            context);
                 });
     }
 }

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/UpdateHandler.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/UpdateHandler.java
@@ -177,7 +177,7 @@ public class UpdateHandler extends BaseHandlerStd {
         final DBCluster dbCluster = fetchDBCluster(proxyClient, progress.getResourceModel());
         if (!CollectionUtils.isNullOrEmpty(dbCluster.dbClusterMembers())) {
             for (final DBClusterMember member : dbCluster.dbClusterMembers()) {
-                if (dbInstanceIdentifier.equals(member.dbInstanceIdentifier())) {
+                if (dbInstanceIdentifier.equalsIgnoreCase(member.dbInstanceIdentifier())) {
                     return PENDING_REBOOT_STATUS.equals(member.dbClusterParameterGroupStatus());
                 }
             }
@@ -224,7 +224,7 @@ public class UpdateHandler extends BaseHandlerStd {
         final String engine = progress.getResourceModel().getEngine();
         final String engineVersion = progress.getResourceModel().getEngineVersion();
 
-        DescribeDbParameterGroupsResponse response = rdsProxyClient.injectCredentialsAndInvokeV2(
+        final DescribeDbParameterGroupsResponse response = rdsProxyClient.injectCredentialsAndInvokeV2(
                 Translator.describeDbParameterGroupsRequest(dbParameterGroupName),
                 rdsProxyClient.client()::describeDBParameterGroups
         );


### PR DESCRIPTION
This commit alters ReadHandler behavior in a way it interprets a response from RDS API. RDS and CFN primary identifier contract differs significantly: whereas CFN treats primary identifiers as unconditionally immutable, RDS operates in a case-insensitive mode and coalesces all primary identifiers to lowercase. This contract-level disagreement causes an unpredictable behavior and triggers a drift detector immediately.

This commit instructs the read handler to restore the original `dbInstanceIdentifier` from `ResourceModel` in the resulting `ProgressEvent`. Having this in place allows RDS to keep operating in case-insensitive mode and return the original identifier matching the customer template value back to CFN.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Signed-off-by: Oleg Sidorov <sidorovo@amazon.com>