### PR TITLE
[DBInstance] Ignore `InvalidDBInstanceState` on Delete

### DIFF
--- a/aws-rds-cfn-common/src/main/java/software/amazon/rds/common/error/ConditionalErrorStatus.java
+++ b/aws-rds-cfn-common/src/main/java/software/amazon/rds/common/error/ConditionalErrorStatus.java
@@ -1,0 +1,17 @@
+package software.amazon.rds.common.error;
+
+import java.util.function.Function;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+public class ConditionalErrorStatus implements ErrorStatus {
+    @Getter
+    Function<Exception, ErrorStatus> condition;
+
+    @Override
+    public ErrorStatus interpret(final Exception exception) {
+        return condition.apply(exception);
+    }
+}

--- a/aws-rds-cfn-common/src/main/java/software/amazon/rds/common/error/ErrorStatus.java
+++ b/aws-rds-cfn-common/src/main/java/software/amazon/rds/common/error/ErrorStatus.java
@@ -1,5 +1,7 @@
 package software.amazon.rds.common.error;
 
+import java.util.function.Function;
+
 import software.amazon.cloudformation.proxy.HandlerErrorCode;
 import software.amazon.cloudformation.proxy.OperationStatus;
 
@@ -15,5 +17,13 @@ public interface ErrorStatus {
 
     static ErrorStatus ignore(final OperationStatus status) {
         return new IgnoreErrorStatus(status);
+    }
+
+    static ErrorStatus conditional(Function<Exception, ErrorStatus> condition) {
+        return new ConditionalErrorStatus(condition);
+    }
+
+    default ErrorStatus interpret(final Exception exception) {
+        return this;
     }
 }

--- a/aws-rds-cfn-common/src/test/java/software/amazon/rds/common/error/ErrorStatusTest.java
+++ b/aws-rds-cfn-common/src/test/java/software/amazon/rds/common/error/ErrorStatusTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.Test;
 
+import software.amazon.awssdk.awscore.exception.AwsServiceException;
 import software.amazon.cloudformation.proxy.HandlerErrorCode;
 
 class ErrorStatusTest {
@@ -20,5 +21,17 @@ class ErrorStatusTest {
     void ignore() {
         final ErrorStatus errorStatus = ErrorStatus.ignore();
         assertThat(errorStatus).isInstanceOf(IgnoreErrorStatus.class);
+    }
+
+    @Test
+    void conditional() {
+        final ErrorStatus errorStatus = ErrorStatus.conditional(e -> {
+            if (e instanceof AwsServiceException) {
+                return ErrorStatus.ignore();
+            }
+            return ErrorStatus.failWith(HandlerErrorCode.Unknown);
+        });
+        assertThat(errorStatus.interpret(AwsServiceException.builder().build())).isInstanceOf(IgnoreErrorStatus.class);
+        assertThat(errorStatus.interpret(new RuntimeException())).isInstanceOf(HandlerErrorStatus.class);
     }
 }

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/ListHandler.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/ListHandler.java
@@ -8,10 +8,8 @@ import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.Logger;
 import software.amazon.cloudformation.proxy.OperationStatus;
 import software.amazon.cloudformation.proxy.ProgressEvent;
-import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 import software.amazon.rds.common.handler.HandlerConfig;
-import software.amazon.rds.dbinstance.client.ApiVersion;
 import software.amazon.rds.dbinstance.client.VersionedProxyClient;
 
 public class ListHandler extends BaseHandlerStd {

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/ReadHandler.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/ReadHandler.java
@@ -1,10 +1,8 @@
 package software.amazon.rds.dbinstance;
 
-
 import software.amazon.awssdk.services.ec2.Ec2Client;
 import software.amazon.awssdk.services.rds.RdsClient;
 import software.amazon.awssdk.services.rds.model.DBInstance;
-import software.amazon.awssdk.utils.StringUtils;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.Logger;
 import software.amazon.cloudformation.proxy.ProgressEvent;


### PR DESCRIPTION
This commit changes `DBInstance` Delete ruleset. In particular, we instruct `DeleteHandler` to ignore `InvalidDBInstanceState` exceptions for the sake of handling an out-of-bounds delete. The motivation for the change is to achieve the backwards compatibility with the old implementation, which tolerates this resource state and simply continues to delete stabilization.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Signed-off-by: Oleg Sidorov <sidorovo@amazon.com>