### PR TITLE
[OptionGroup] Implement Soft Fail on stack tags

### DIFF
--- a/aws-rds-optiongroup/src/main/java/software/amazon/rds/optiongroup/CallbackContext.java
+++ b/aws-rds-optiongroup/src/main/java/software/amazon/rds/optiongroup/CallbackContext.java
@@ -7,4 +7,5 @@ import software.amazon.cloudformation.proxy.StdCallbackContext;
 @lombok.ToString
 @lombok.EqualsAndHashCode(callSuper = true)
 public class CallbackContext extends StdCallbackContext {
+    private String optionGroupArn;
 }

--- a/aws-rds-optiongroup/src/main/java/software/amazon/rds/optiongroup/ReadHandler.java
+++ b/aws-rds-optiongroup/src/main/java/software/amazon/rds/optiongroup/ReadHandler.java
@@ -12,6 +12,8 @@ import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 import software.amazon.rds.common.handler.Commons;
 import software.amazon.rds.common.handler.HandlerConfig;
 
+import software.amazon.rds.common.handler.Tagging;
+
 public class ReadHandler extends BaseHandlerStd {
 
     public ReadHandler() {
@@ -47,6 +49,7 @@ public class ReadHandler extends BaseHandlerStd {
                     final OptionGroup optionGroup = describeResponse.optionGroupsList().stream().findFirst().get();
                     final List<OptionConfiguration> optionConfigurations = Translator.translateOptionConfigurationsFromSdk(optionGroup.options());
                     final List<Tag> tags = listTags(proxyInvocation, optionGroup.optionGroupArn());
+                    context.setOptionGroupArn(optionGroup.optionGroupArn());
                     return ProgressEvent.success(
                             ResourceModel.builder()
                                     .optionGroupName(optionGroup.optionGroupName())

--- a/aws-rds-optiongroup/src/main/java/software/amazon/rds/optiongroup/Translator.java
+++ b/aws-rds-optiongroup/src/main/java/software/amazon/rds/optiongroup/Translator.java
@@ -1,13 +1,8 @@
 package software.amazon.rds.optiongroup;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import software.amazon.awssdk.services.rds.model.AddTagsToResourceRequest;
 import software.amazon.awssdk.services.rds.model.CreateOptionGroupRequest;
@@ -18,16 +13,17 @@ import software.amazon.awssdk.services.rds.model.ListTagsForResourceRequest;
 import software.amazon.awssdk.services.rds.model.ModifyOptionGroupRequest;
 import software.amazon.awssdk.services.rds.model.RemoveTagsFromResourceRequest;
 import software.amazon.awssdk.services.rds.model.VpcSecurityGroupMembership;
+import software.amazon.rds.common.handler.Tagging;
 
 public class Translator {
 
-    static CreateOptionGroupRequest createOptionGroupRequest(final ResourceModel model, final Map<String, String> tags) {
+    static CreateOptionGroupRequest createOptionGroupRequest(final ResourceModel model, final Tagging.TagSet tags) {
         return CreateOptionGroupRequest.builder()
                 .optionGroupName(model.getOptionGroupName())
                 .engineName(model.getEngineName())
                 .majorEngineVersion(model.getMajorEngineVersion())
                 .optionGroupDescription(model.getOptionGroupDescription())
-                .tags(translateTagsToSdk(tags))
+                .tags(Tagging.translateTagsToSdk(tags))
                 .build();
     }
 
@@ -160,7 +156,8 @@ public class Translator {
                         .key(entry.getKey())
                         .value(entry.getValue())
                         .build())
-                .collect(Collectors.toSet());
+                .collect(Collectors.toCollection(LinkedHashSet::new));
+//                .collect(Collectors.toSet());
     }
 
     static Set<software.amazon.awssdk.services.rds.model.Tag> translateTagsToSdk(final Map<String, String> tags) {
@@ -180,6 +177,17 @@ public class Translator {
                         .key(tag.key())
                         .value(tag.value())
                         .build()).collect(Collectors.toList());
+    }
+
+    private static <T> Stream<T> streamOfOrEmpty(final Collection<T> collection) {
+        return Optional.ofNullable(collection)
+                .map(Collection::stream)
+                .orElseGet(Stream::empty);
+    }
+
+    public static Map<String, String> translateTagsToRequest(final Collection<Tag> tags) {
+        return streamOfOrEmpty(tags)
+                .collect(Collectors.toMap(Tag::getKey, Tag::getValue, (v1, v2) -> v2, LinkedHashMap::new));
     }
 
     static AddTagsToResourceRequest addTagsToResourceRequest(final String arn, final Set<Tag> tags) {

--- a/aws-rds-optiongroup/src/test/java/software/amazon/rds/optiongroup/CreateHandlerTest.java
+++ b/aws-rds-optiongroup/src/test/java/software/amazon/rds/optiongroup/CreateHandlerTest.java
@@ -1,5 +1,6 @@
 package software.amazon.rds.optiongroup;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
@@ -9,26 +10,35 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import java.time.Duration;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
+import jdk.nashorn.internal.runtime.regexp.joni.exception.InternalException;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import lombok.Getter;
+import software.amazon.awssdk.awscore.exception.AwsErrorDetails;
 import software.amazon.awssdk.services.rds.RdsClient;
+import software.amazon.awssdk.services.rds.model.*;
+import software.amazon.cloudformation.proxy.*;
+import software.amazon.rds.common.error.ErrorCode;
+import software.amazon.rds.common.handler.HandlerConfig;
+
 import software.amazon.awssdk.services.rds.model.CreateOptionGroupRequest;
 import software.amazon.awssdk.services.rds.model.CreateOptionGroupResponse;
-import software.amazon.awssdk.services.rds.model.ListTagsForResourceRequest;
-import software.amazon.awssdk.services.rds.model.ListTagsForResourceResponse;
-import software.amazon.awssdk.services.rds.model.ModifyOptionGroupRequest;
-import software.amazon.awssdk.services.rds.model.OptionGroupAlreadyExistsException;
-import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
-import software.amazon.cloudformation.proxy.HandlerErrorCode;
-import software.amazon.cloudformation.proxy.ProxyClient;
-import software.amazon.rds.common.handler.HandlerConfig;
+import software.amazon.rds.common.handler.Tagging;
 
 @ExtendWith(MockitoExtension.class)
 public class CreateHandlerTest extends AbstractTestBase {
@@ -69,55 +79,245 @@ public class CreateHandlerTest extends AbstractTestBase {
     public void handleRequest_CreateSuccess() {
         when(proxyClient.client().createOptionGroup(any(CreateOptionGroupRequest.class)))
                 .thenReturn(CreateOptionGroupResponse.builder().build());
+
+        final DescribeOptionGroupsResponse describeDbClusterParameterGroupsResponse = DescribeOptionGroupsResponse.builder()
+                .optionGroupsList(OPTION_GROUP_ACTIVE).build();
+        when(proxyClient.client().describeOptionGroups(any(DescribeOptionGroupsRequest.class))).thenReturn(describeDbClusterParameterGroupsResponse);
+
         when(proxyClient.client().listTagsForResource(any(ListTagsForResourceRequest.class)))
                 .thenReturn(ListTagsForResourceResponse.builder().build());
 
-        test_handleRequest_base(
-                new CallbackContext(),
-                () -> OPTION_GROUP_ACTIVE,
-                () -> RESOURCE_MODEL,
-                expectSuccess()
-        );
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+                .clientRequestToken(randomString(32, ALPHA))
+                .desiredResourceState(RESOURCE_MODEL)
+                .stackId(randomString(32, ALPHA))
+                .logicalResourceIdentifier(randomString(32, ALPHA))
+                .build();
+        final ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);
+
+        assertThat(response).isNotNull();
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
+        assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
+        assertThat(response.getResourceModels()).isNull();
+        assertThat(response.getMessage()).isNull();
+        assertThat(response.getErrorCode()).isNull();
 
         verify(proxyClient.client(), times(1)).createOptionGroup(any(CreateOptionGroupRequest.class));
+        verify(proxyClient.client(), times(2)).describeOptionGroups(any(DescribeOptionGroupsRequest.class));
+        verify(proxyClient.client(), times(1)).listTagsForResource(any(ListTagsForResourceRequest.class));
+    }
+
+    @Test
+    public void handleRequest_CreateSuccess_NoOptionGroupName() {
+        when(proxyClient.client().createOptionGroup(any(CreateOptionGroupRequest.class)))
+                .thenReturn(CreateOptionGroupResponse.builder().build());
+
+        final DescribeOptionGroupsResponse describeDbClusterParameterGroupsResponse = DescribeOptionGroupsResponse.builder()
+                .optionGroupsList(OPTION_GROUP_ACTIVE).build();
+        when(proxyClient.client().describeOptionGroups(any(DescribeOptionGroupsRequest.class))).thenReturn(describeDbClusterParameterGroupsResponse);
+
+        when(proxyClient.client().listTagsForResource(any(ListTagsForResourceRequest.class)))
+                .thenReturn(ListTagsForResourceResponse.builder().build());
+
+        final String clientRequestToken = randomString(32, ALPHA);
+        final String stackId = randomString(32, ALPHA);
+        final String logicalResourceIdentifier = randomString(32, ALPHA);
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+                .clientRequestToken(clientRequestToken)
+                .desiredResourceState(RESOURCE_MODEL_NO_OPTION_GROUP_NAME)
+                .stackId(stackId)
+                .logicalResourceIdentifier(logicalResourceIdentifier)
+                .build();
+        final ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);
+
+        assertThat(response).isNotNull();
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
+        assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
+        assertThat(response.getResourceModels()).isNull();
+        assertThat(response.getMessage()).isNull();
+        assertThat(response.getErrorCode()).isNull();
+
+        verify(proxyClient.client(), times(1)).createOptionGroup(any(CreateOptionGroupRequest.class));
+        verify(proxyClient.client(), times(2)).describeOptionGroups(any(DescribeOptionGroupsRequest.class));
+        verify(proxyClient.client(), times(1)).listTagsForResource(any(ListTagsForResourceRequest.class));
+    }
+
+    @Test
+    public void handleRequest_CreateSuccess_RequiresModify() {
+        when(proxyClient.client().createOptionGroup(any(CreateOptionGroupRequest.class)))
+                .thenReturn(CreateOptionGroupResponse.builder().build());
+
+        final DescribeOptionGroupsResponse describeDbClusterParameterGroupsResponse = DescribeOptionGroupsResponse.builder()
+                .optionGroupsList(OPTION_GROUP_ACTIVE).build();
+        when(proxyClient.client().describeOptionGroups(any(DescribeOptionGroupsRequest.class))).thenReturn(describeDbClusterParameterGroupsResponse);
+
+        when(proxyClient.client().modifyOptionGroup(any(ModifyOptionGroupRequest.class)))
+                .thenReturn(ModifyOptionGroupResponse.builder().build());
+
+        when(proxyClient.client().listTagsForResource(any(ListTagsForResourceRequest.class)))
+                .thenReturn(ListTagsForResourceResponse.builder().build());
+
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+                .clientRequestToken(randomString(32, ALPHA))
+                .desiredResourceState(RESOURCE_MODEL_WITH_CONFIGURATIONS)
+                .stackId(randomString(32, ALPHA))
+                .logicalResourceIdentifier(randomString(32, ALPHA))
+                .build();
+        final ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);
+
+        assertThat(response).isNotNull();
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
+        assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
+        assertThat(response.getResourceModels()).isNull();
+        assertThat(response.getMessage()).isNull();
+        assertThat(response.getErrorCode()).isNull();
+
+        verify(proxyClient.client(), times(1)).createOptionGroup(any(CreateOptionGroupRequest.class));
+        verify(proxyClient.client(), times(2)).describeOptionGroups(any(DescribeOptionGroupsRequest.class));
         verify(proxyClient.client(), times(1)).modifyOptionGroup(any(ModifyOptionGroupRequest.class));
         verify(proxyClient.client(), times(1)).listTagsForResource(any(ListTagsForResourceRequest.class));
     }
 
     @Test
-    public void handleRequest_SkipUpdateOnEmptyOptionConfigurations() {
+    public void handleRequest_SoftFailingTagging() {
         when(proxyClient.client().createOptionGroup(any(CreateOptionGroupRequest.class)))
                 .thenReturn(CreateOptionGroupResponse.builder().build());
+
+        final DescribeOptionGroupsResponse describeDbClusterParameterGroupsResponse = DescribeOptionGroupsResponse.builder()
+                .optionGroupsList(OPTION_GROUP_ACTIVE).build();
+        when(proxyClient.client().describeOptionGroups(any(DescribeOptionGroupsRequest.class))).thenReturn(describeDbClusterParameterGroupsResponse);
+
+        when(proxyClient.client().addTagsToResource(any(AddTagsToResourceRequest.class)))
+                .thenThrow(
+                        RdsException.builder()
+                                .awsErrorDetails(AwsErrorDetails.builder()
+                                        .errorCode(ErrorCode.AccessDeniedException.toString())
+                                        .build()
+                                ).build())
+                .thenReturn(AddTagsToResourceResponse.builder().build());
+
         when(proxyClient.client().listTagsForResource(any(ListTagsForResourceRequest.class)))
                 .thenReturn(ListTagsForResourceResponse.builder().build());
 
-        test_handleRequest_base(
-                new CallbackContext(),
-                () -> OPTION_GROUP_ACTIVE,
-                () -> RESOURCE_MODEL_NO_OPTION_CONFIGURATIONS,
-                expectSuccess()
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+                .clientRequestToken(randomString(32, ALPHA))
+                .systemTags(Translator.translateTagsToRequest(Translator.translateTagsFromSdk(TAG_SET.getSystemTags())))
+                .desiredResourceTags(Translator.translateTagsToRequest(Translator.translateTagsFromSdk(TAG_SET.getStackTags())))
+                .desiredResourceState(RESOURCE_MODEL)
+                .stackId(randomString(32, ALPHA))
+                .logicalResourceIdentifier(randomString(32, ALPHA))
+                .build();
+        final ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);
+
+        assertThat(response).isNotNull();
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
+        assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
+        assertThat(response.getResourceModels()).isNull();
+        assertThat(response.getMessage()).isNull();
+        assertThat(response.getErrorCode()).isNull();
+
+        verify(proxyClient.client(), times(1)).addTagsToResource(any(AddTagsToResourceRequest.class));
+        verify(proxyClient.client(), times(1)).createOptionGroup(any(CreateOptionGroupRequest.class));
+        verify(proxyClient.client(), times(2)).describeOptionGroups(any(DescribeOptionGroupsRequest.class));
+        verify(proxyClient.client(), times(1)).listTagsForResource(any(ListTagsForResourceRequest.class));
+
+        ArgumentCaptor<CreateOptionGroupRequest> createOptionGroupCaptor = ArgumentCaptor.forClass(CreateOptionGroupRequest.class);
+        verify(proxyClient.client(), times(1)).createOptionGroup(createOptionGroupCaptor.capture());
+        final CreateOptionGroupRequest createOptionGroupWithSystemTags = createOptionGroupCaptor.getAllValues().get(0);
+        Assertions.assertThat(createOptionGroupWithSystemTags.tags()).containsExactlyInAnyOrder(
+                Iterables.toArray(TAG_SET.getSystemTags(), software.amazon.awssdk.services.rds.model.Tag.class)
         );
 
+        ArgumentCaptor<AddTagsToResourceRequest> addTagsCaptor = ArgumentCaptor.forClass(AddTagsToResourceRequest.class);
+        verify(proxyClient.client(), times(1)).addTagsToResource(addTagsCaptor.capture());
+        final AddTagsToResourceRequest requestWithAllTags = addTagsCaptor.getAllValues().get(0);
+        Assertions.assertThat(requestWithAllTags.tags()).containsExactlyInAnyOrder(
+                Iterables.toArray(TAG_SET.getStackTags(), software.amazon.awssdk.services.rds.model.Tag.class)
+        );
+    }
+
+    @Test
+    public void handleRequest_HardFailingTagging() {
+        when(proxyClient.client().createOptionGroup(any(CreateOptionGroupRequest.class)))
+                .thenReturn(CreateOptionGroupResponse.builder().build());
+
+        final DescribeOptionGroupsResponse describeDbClusterParameterGroupsResponse = DescribeOptionGroupsResponse.builder()
+                .optionGroupsList(OPTION_GROUP_ACTIVE).build();
+        when(proxyClient.client().describeOptionGroups(any(DescribeOptionGroupsRequest.class))).thenReturn(describeDbClusterParameterGroupsResponse);
+
+        when(proxyClient.client().addTagsToResource(any(AddTagsToResourceRequest.class)))
+                .thenThrow(
+                        RdsException.builder()
+                                .awsErrorDetails(AwsErrorDetails.builder()
+                                        .errorCode(ErrorCode.AccessDeniedException.toString())
+                                        .build()
+                                ).build());
+
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+                .clientRequestToken(randomString(32, ALPHA))
+                .systemTags(Translator.translateTagsToRequest(Translator.translateTagsFromSdk(TAG_SET.getSystemTags())))
+                .desiredResourceState(RESOURCE_MODEL_WITH_RESOURCE_TAGS)
+                .stackId(randomString(32, ALPHA))
+                .logicalResourceIdentifier(randomString(32, ALPHA))
+                .build();
+        final ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);
+
+        Assertions.assertThat(response).isNotNull();
+        Assertions.assertThat(response.getStatus()).isEqualTo(OperationStatus.FAILED);
+        Assertions.assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
+        Assertions.assertThat(response.getMessage()).isNotNull();
+        Assertions.assertThat(response.getErrorCode()).isEqualTo(HandlerErrorCode.AccessDenied);
+        Assertions.assertThat(response.getResourceModels()).isNull();
+
+        verify(proxyClient.client(), times(1)).addTagsToResource(any(AddTagsToResourceRequest.class));
         verify(proxyClient.client(), times(1)).createOptionGroup(any(CreateOptionGroupRequest.class));
-        verify(proxyClient.client(), times(1)).listTagsForResource(any(ListTagsForResourceRequest.class));
+        verify(proxyClient.client(), times(1)).describeOptionGroups(any(DescribeOptionGroupsRequest.class));
+
+        ArgumentCaptor<CreateOptionGroupRequest> createOptionGroupCaptor = ArgumentCaptor.forClass(CreateOptionGroupRequest.class);
+        verify(proxyClient.client(), times(1)).createOptionGroup(createOptionGroupCaptor.capture());
+        final CreateOptionGroupRequest createOptionGroupWithSystemTags = createOptionGroupCaptor.getAllValues().get(0);
+        Assertions.assertThat(createOptionGroupWithSystemTags.tags()).containsExactlyInAnyOrder(
+                Iterables.toArray(TAG_SET.getSystemTags(), software.amazon.awssdk.services.rds.model.Tag.class)
+        );
+
+        ArgumentCaptor<AddTagsToResourceRequest> addTagsCaptor = ArgumentCaptor.forClass(AddTagsToResourceRequest.class);
+        verify(proxyClient.client(), times(1)).addTagsToResource(addTagsCaptor.capture());
+        final AddTagsToResourceRequest requestWithAllTags = addTagsCaptor.getAllValues().get(0);
+        Assertions.assertThat(requestWithAllTags.tags()).containsExactlyInAnyOrder(
+                Iterables.toArray(TAG_SET.getResourceTags(), software.amazon.awssdk.services.rds.model.Tag.class)
+        );
     }
 
     @Test
     public void handleRequest_AlreadyExists() {
         when(proxyClient.client().createOptionGroup(any(CreateOptionGroupRequest.class)))
                 .thenThrow(OptionGroupAlreadyExistsException.class);
+
+        final DescribeOptionGroupsResponse describeDbClusterParameterGroupsResponse = DescribeOptionGroupsResponse.builder()
+                .optionGroupsList(OPTION_GROUP_ACTIVE).build();
+        when(proxyClient.client().describeOptionGroups(any(DescribeOptionGroupsRequest.class))).thenReturn(describeDbClusterParameterGroupsResponse);
+
         when(proxyClient.client().listTagsForResource(any(ListTagsForResourceRequest.class)))
                 .thenReturn(ListTagsForResourceResponse.builder().build());
 
-        test_handleRequest_base(
-                new CallbackContext(),
-                () -> OPTION_GROUP_ACTIVE,
-                () -> RESOURCE_MODEL,
-                expectSuccess()
-        );
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+                .clientRequestToken(randomString(32, ALPHA))
+                .systemTags(Translator.translateTagsToRequest(Translator.translateTagsFromSdk(TAG_SET.getSystemTags())))
+                .desiredResourceState(RESOURCE_MODEL)
+                .stackId(randomString(32, ALPHA))
+                .logicalResourceIdentifier(randomString(32, ALPHA))
+                .build();
+        final ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);
+
+        assertThat(response).isNotNull();
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
+        assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
+        assertThat(response.getResourceModels()).isNull();
+        assertThat(response.getMessage()).isNull();
+        assertThat(response.getErrorCode()).isNull();
 
         verify(proxyClient.client(), times(1)).createOptionGroup(any(CreateOptionGroupRequest.class));
-        verify(proxyClient.client(), times(1)).modifyOptionGroup(any(ModifyOptionGroupRequest.class));
+        verify(proxyClient.client(), times(2)).describeOptionGroups(any(DescribeOptionGroupsRequest.class));
         verify(proxyClient.client(), times(1)).listTagsForResource(any(ListTagsForResourceRequest.class));
     }
 
@@ -126,12 +326,21 @@ public class CreateHandlerTest extends AbstractTestBase {
         when(proxyClient.client().createOptionGroup(any(CreateOptionGroupRequest.class)))
                 .thenThrow(new RuntimeException("test exception"));
 
-        test_handleRequest_base(
-                new CallbackContext(),
-                null,
-                () -> RESOURCE_MODEL,
-                expectFailed(HandlerErrorCode.InternalFailure)
-        );
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+                .clientRequestToken(randomString(32, ALPHA))
+                .systemTags(Translator.translateTagsToRequest(Translator.translateTagsFromSdk(TAG_SET.getSystemTags())))
+                .desiredResourceState(RESOURCE_MODEL)
+                .stackId(randomString(32, ALPHA))
+                .logicalResourceIdentifier(randomString(32, ALPHA))
+                .build();
+        final ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);
+
+        Assertions.assertThat(response).isNotNull();
+        Assertions.assertThat(response.getStatus()).isEqualTo(OperationStatus.FAILED);
+        Assertions.assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
+        Assertions.assertThat(response.getMessage()).isNotNull();
+        Assertions.assertThat(response.getErrorCode()).isEqualTo(HandlerErrorCode.InternalFailure);
+        Assertions.assertThat(response.getResourceModels()).isNull();
 
         verify(proxyClient.client(), times(1)).createOptionGroup(any(CreateOptionGroupRequest.class));
     }


### PR DESCRIPTION
**Description of changes**:

Soft fails means ignoring permission denied exception and proceed with resource logic.This PR implements soft fail in OptionGroup:
- Hard fail on add/remove resource tags
- Soft fail on add/remove system tags
- Soft fail on add/remove stack level tags

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Signed-off-by: Tieg O'Sullivan [tiegaws@amazon.com](mailto:tiegaws@amazon.com)