### PR TITLE
[DBCluster] Restore original dbClusterIdentifier case spelling

### DIFF
--- a/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/ReadHandler.java
+++ b/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/ReadHandler.java
@@ -41,7 +41,10 @@ public class ReadHandler extends BaseHandlerStd {
                 ))
                 .done((describeRequest, describeResponse, proxyInvocation, model, context) -> {
                     final DBCluster dbCluster = describeResponse.dbClusters().stream().findFirst().get();
-                    return ProgressEvent.success(Translator.translateDbClusterFromSdk(dbCluster), context);
+                    return ProgressEvent.success(
+                            restoreIdentifier(Translator.translateDbClusterFromSdk(dbCluster), request.getDesiredResourceState()),
+                            context
+                    );
                 });
     }
 }

--- a/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/UpdateHandler.java
+++ b/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/UpdateHandler.java
@@ -41,15 +41,6 @@ public class UpdateHandler extends BaseHandlerStd {
             final ProxyClient<RdsClient> proxyClient,
             final Logger logger
     ) {
-        if (!ImmutabilityHelper.isChangeMutable(request.getPreviousResourceState(), request.getDesiredResourceState())) {
-            return ProgressEvent.failed(
-                    request.getDesiredResourceState(),
-                    callbackContext,
-                    HandlerErrorCode.NotUpdatable,
-                    "Resource is immutable"
-            );
-        }
-
         final Tagging.TagSet previousTags = Tagging.TagSet.builder()
                 .systemTags(Tagging.translateTagsToSdk(request.getPreviousSystemTags()))
                 .stackTags(Tagging.translateTagsToSdk(request.getPreviousResourceTags()))

--- a/aws-rds-dbcluster/src/test/java/software/amazon/rds/dbcluster/ReadHandlerTest.java
+++ b/aws-rds-dbcluster/src/test/java/software/amazon/rds/dbcluster/ReadHandlerTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 import java.time.Duration;
 
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -20,6 +21,7 @@ import lombok.Getter;
 import software.amazon.awssdk.services.rds.RdsClient;
 import software.amazon.awssdk.services.rds.model.DescribeDbClustersRequest;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
+import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ProxyClient;
 
 @ExtendWith(MockitoExtension.class)
@@ -63,5 +65,20 @@ public class ReadHandlerTest extends AbstractHandlerTest {
         );
 
         verify(rdsProxy.client(), times(1)).describeDBClusters(any(DescribeDbClustersRequest.class));
+    }
+
+    @Test
+    public void handleRequest_RestoreOriginalIdentifier() {
+        final String dbClusterIdentifier = "TestDBClusterIdentifier";
+        final ProgressEvent<ResourceModel, CallbackContext> result = test_handleRequest_base(
+                new CallbackContext(),
+                () -> DBCLUSTER_ACTIVE.toBuilder().dbClusterIdentifier(dbClusterIdentifier.toLowerCase()).build(),
+                () -> RESOURCE_MODEL.toBuilder().dBClusterIdentifier(dbClusterIdentifier).build(),
+                expectSuccess()
+        );
+
+        verify(rdsProxy.client(), times(1)).describeDBClusters(any(DescribeDbClustersRequest.class));
+
+        Assertions.assertThat(result.getResourceModel().getDBClusterIdentifier()).isEqualTo(dbClusterIdentifier);
     }
 }


### PR DESCRIPTION
This commit modifies ReadHandler behavior so it restores the original `dbClusterIdentifier` case spelling. The motivation for this change is to fix CFN side effects caused by RDS coalescing all identifiers to lowercase. In particular, any mixed-case identified resource is a subject for an automatic replacement as an identifier is a replace-only modification for CFN.

This commit substitutes the observed (lowercased) identifier with the one provided in the template (original spelling).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Signed-off-by: Oleg Sidorov <sidorovo@amazon.com>