### PR TITLE
[DBCluster] Fix typo in update permissions

### DIFF
--- a/aws-rds-dbcluster/aws-rds-dbcluster.json
+++ b/aws-rds-dbcluster/aws-rds-dbcluster.json
@@ -453,7 +453,7 @@
       "permissions": [
         "iam:PassRole",
         "rds:AddRoleToDBCluster",
-        "rds:AddTagsFromResource",
+        "rds:AddTagsToResource",
         "rds:DescribeDBClusters",
         "rds:ModifyDBCluster",
         "rds:ModifyDBInstance",

--- a/aws-rds-dbcluster/resource-role.yaml
+++ b/aws-rds-dbcluster/resource-role.yaml
@@ -25,7 +25,6 @@ Resources:
                 Action:
                 - "iam:PassRole"
                 - "rds:AddRoleToDBCluster"
-                - "rds:AddTagsFromResource"
                 - "rds:AddTagsToResource"
                 - "rds:CreateDBCluster"
                 - "rds:CreateDBInstance"


### PR DESCRIPTION
Update permissions for DB Cluster resource had a typo in it. Changed permissions to feature correct role.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
