### PR TITLE
[DBInstance] Fix default VPC group for cluster instances

### DIFF
--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/UpdateHandler.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/UpdateHandler.java
@@ -251,7 +251,9 @@ public class UpdateHandler extends BaseHandlerStd {
     }
 
     private boolean shouldSetDefaultVpcId(final ResourceHandlerRequest<ResourceModel> request) {
-        return CollectionUtils.isNullOrEmpty(request.getDesiredResourceState().getVPCSecurityGroups());
+        // DBCluster member instances inherit default vpc security groups from the corresponding umbrella cluster
+        return !isDBClusterMember(request.getDesiredResourceState()) &&
+                CollectionUtils.isNullOrEmpty(request.getDesiredResourceState().getVPCSecurityGroups());
     }
 
     private boolean shouldUnsetMaxAllocatedStorage(final ResourceHandlerRequest<ResourceModel> request) {

--- a/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/UpdateHandlerTest.java
+++ b/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/UpdateHandlerTest.java
@@ -756,6 +756,29 @@ public class UpdateHandlerTest extends AbstractHandlerTest {
     }
 
     @Test
+    public void handleRequest_NoDefaultVpcIdForClusterInstance() {
+        final CallbackContext context = new CallbackContext();
+        context.setUpdated(true);
+
+        test_handleRequest_base(
+                context,
+                () -> DB_INSTANCE_ACTIVE,
+                () -> RESOURCE_MODEL_BLDR()
+                        // A default vpc group won't be set for a db cluster member
+                        .dBClusterIdentifier(DB_CLUSTER_IDENTIFIER_NON_EMPTY)
+                        .vPCSecurityGroups(Collections.emptyList())
+                        .build(),
+                () -> RESOURCE_MODEL_BLDR()
+                        .dBClusterIdentifier(DB_CLUSTER_IDENTIFIER_NON_EMPTY)
+                        .vPCSecurityGroups(Collections.emptyList())
+                        .build(),
+                expectSuccess()
+        );
+
+        verify(rdsProxy.client(), times(2)).describeDBInstances(any(DescribeDbInstancesRequest.class));
+    }
+
+    @Test
     public void handleRequest_ResourceDrift() {
         final Queue<DBInstance> transitions = new ConcurrentLinkedQueue<>();
         transitions.add(DB_INSTANCE_ACTIVE.toBuilder()


### PR DESCRIPTION
This commit fixes a bug in UpdateHandler. Upon an update the handler checks if the instance vpc group set is empty and sets a default group in this case. This broke DBCluster instances as they must inherit the groups from the umbrella DBCluster.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Signed-off-by: Oleg Sidorov <sidorovo@amazon.com>