### PR TITLE
[DBInstance] Do not set EngineVersion upon a rollback

### DIFF
--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/Translator.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/Translator.java
@@ -293,7 +293,6 @@ public class Translator {
                 .domainIAMRoleName(desiredModel.getDomainIAMRoleName())
                 .enableIAMDatabaseAuthentication(desiredModel.getEnableIAMDatabaseAuthentication())
                 .enablePerformanceInsights(desiredModel.getEnablePerformanceInsights())
-                .engineVersion(desiredModel.getEngineVersion())
                 .licenseModel(desiredModel.getLicenseModel())
                 .masterUserPassword(desiredModel.getMasterUserPassword())
                 .maxAllocatedStorage(desiredModel.getMaxAllocatedStorage())
@@ -328,6 +327,7 @@ public class Translator {
             } else {
                 builder.allocatedStorage(getAllocatedStorage(desiredModel));
                 builder.iops(desiredModel.getIops());
+                builder.engineVersion(desiredModel.getEngineVersion());
             }
         }
 


### PR DESCRIPTION
This commit changes the way DBInstance UpdateHandler sets EngineVersion. Engine version change paths are primarily defined for upgrades, not for downgrades. It means that an attempt to set a lower engine version (which is the case upon a rollback after an attempt to upgrade the engine version) will be set for failure. This commit ensures the handler does not alter the engine version if a rollback is requested.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Signed-off-by: Oleg Sidorov <sidorovo@amazon.com>