### PR TITLE
[Common] Add `Throttling` ErrorCode

### DIFF
--- a/aws-rds-cfn-common/src/main/java/software/amazon/rds/common/error/ErrorCode.java
+++ b/aws-rds-cfn-common/src/main/java/software/amazon/rds/common/error/ErrorCode.java
@@ -33,7 +33,8 @@ public enum ErrorCode {
     ProvisionedIopsNotAvailableInAZFault("ProvisionedIopsNotAvailableInAZFault"),
     SnapshotQuotaExceeded("SnapshotQuotaExceeded"),
     StorageQuotaExceeded("StorageQuotaExceeded"),
-    ThrottlingException("ThrottlingException");
+    ThrottlingException("ThrottlingException"),
+    Throttling("Throttling");
 
     private final String code;
 

--- a/aws-rds-cfn-common/src/main/java/software/amazon/rds/common/handler/Commons.java
+++ b/aws-rds-cfn-common/src/main/java/software/amazon/rds/common/handler/Commons.java
@@ -26,7 +26,8 @@ public final class Commons {
                     ErrorCode.AccessDeniedException,
                     ErrorCode.NotAuthorized)
             .withErrorCodes(ErrorStatus.failWith(HandlerErrorCode.Throttling),
-                    ErrorCode.ThrottlingException)
+                    ErrorCode.ThrottlingException,
+                    ErrorCode.Throttling)
             .withErrorCodes(ErrorStatus.failWith(HandlerErrorCode.InvalidRequest),
                     ErrorCode.InvalidParameterCombination,
                     ErrorCode.InvalidParameterValue,


### PR DESCRIPTION
This commits adds another item in the `ErrorCode` enum: Throttling. It seems RDS API might return both `ThrottlingException` and `Throttling` as an errorCode when the number of requests exceeds the threshold. Adding this code should let the error handler to catch these cases and return a retriable error.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Signed-off-by: Oleg Sidorov <sidorovo@amazon.com>