### PR TITLE
[DBClusterEndpoint] Generate primary identifier

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,15 @@
 repos:
-- repo: https://github.com/aws-cloudformation/cfn-python-lint
-  rev: v0.61.0  # The version of cfn-lint to use
-  hooks:
-    - id: cfn-python-lint
-      files: aws-rds-dbclusterendpoint/contract-test-required-resources.template.yaml
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v3.2.0
+    hooks:
+      -   id: trailing-whitespace
+      -   id: end-of-file-fixer
+      -   id: check-yaml
+          exclude: aws-rds-dbclusterendpoint/contract-test-required-resources.template.yaml
+      -   id: check-added-large-files
+
+  - repo: https://github.com/aws-cloudformation/cfn-python-lint
+    rev: v0.61.0  # The version of cfn-lint to use
+    hooks:
+      - id: cfn-python-lint
+        files: aws-rds-dbclusterendpoint/contract-test-required-resources.template.yaml

--- a/aws-rds-dbclusterendpoint/.pre-commit-config.yaml
+++ b/aws-rds-dbclusterendpoint/.pre-commit-config.yaml
@@ -1,6 +1,15 @@
 repos:
-- repo: https://github.com/aws-cloudformation/cfn-python-lint
-  rev: v0.61.0  # The version of cfn-lint to use
-  hooks:
-    - id: cfn-python-lint
-      files: contract-test-required-resources.template.yaml
+    - repo: https://github.com/pre-commit/pre-commit-hooks
+      rev: v3.2.0
+      hooks:
+        -   id: trailing-whitespace
+        -   id: end-of-file-fixer
+        -   id: check-yaml
+            exclude: contract-test-required-resources.template.yaml
+        -   id: check-added-large-files
+
+    - repo: https://github.com/aws-cloudformation/cfn-python-lint
+      rev: v0.61.0  # The version of cfn-lint to use
+      hooks:
+        - id: cfn-python-lint
+          files: contract-test-required-resources.template.yaml

--- a/aws-rds-dbclusterendpoint/aws-rds-dbclusterendpoint.json
+++ b/aws-rds-dbclusterendpoint/aws-rds-dbclusterendpoint.json
@@ -95,7 +95,6 @@
   "additionalProperties": false,
   "required": [
     "DBClusterIdentifier",
-    "DBClusterEndpointIdentifier",
     "EndpointType"
   ],
   "createOnlyProperties": [

--- a/aws-rds-dbclusterendpoint/docs/README.md
+++ b/aws-rds-dbclusterendpoint/docs/README.md
@@ -60,7 +60,7 @@ _Update requires_: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/l
 
 The identifier to use for the new endpoint. This parameter is stored as a lowercase string.
 
-_Required_: Yes
+_Required_: No
 
 _Type_: String
 

--- a/aws-rds-dbclusterendpoint/src/main/java/software/amazon/rds/dbclusterendpoint/BaseHandlerStd.java
+++ b/aws-rds-dbclusterendpoint/src/main/java/software/amazon/rds/dbclusterendpoint/BaseHandlerStd.java
@@ -28,7 +28,9 @@ import java.time.Duration;
 import java.util.Optional;
 
 public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
-
+    protected static final int RESOURCE_ID_MAX_LENGTH = 63;
+    protected static final String RESOURCE_IDENTIFIER = "dbclusterendpoint";
+    protected static final String DEFAULT_STACK_NAME = "rds";
     protected static final String DB_CLUSTER_ENDPOINT_AVAILABLE = "available";
     protected static final String CUSTOM_ENDPOINT = "CUSTOM";
 

--- a/aws-rds-dbclusterendpoint/src/test/java/software/amazon/rds/dbclusterendpoint/CreateHandlerTest.java
+++ b/aws-rds-dbclusterendpoint/src/test/java/software/amazon/rds/dbclusterendpoint/CreateHandlerTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.platform.commons.util.StringUtils;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -105,7 +106,7 @@ public class CreateHandlerTest extends AbstractHandlerTest {
         );
 
         verify(rdsProxy.client(), times(1)).createDBClusterEndpoint(
-                argThat((CreateDbClusterEndpointRequest request) -> !request.dbClusterEndpointIdentifier().isEmpty()));
+                argThat((CreateDbClusterEndpointRequest request) -> StringUtils.isNotBlank(request.dbClusterEndpointIdentifier())));
     }
 
     @Test

--- a/aws-rds-dbclusterendpoint/src/test/java/software/amazon/rds/dbclusterendpoint/CreateHandlerTest.java
+++ b/aws-rds-dbclusterendpoint/src/test/java/software/amazon/rds/dbclusterendpoint/CreateHandlerTest.java
@@ -16,6 +16,7 @@ import software.amazon.awssdk.services.rds.model.AddTagsToResourceRequest;
 import software.amazon.awssdk.services.rds.model.AddTagsToResourceResponse;
 import software.amazon.awssdk.services.rds.model.CreateDbClusterEndpointRequest;
 import software.amazon.awssdk.services.rds.model.CreateDbClusterEndpointResponse;
+import software.amazon.awssdk.services.rds.model.DBClusterEndpoint;
 import software.amazon.awssdk.services.rds.model.DescribeDbClusterEndpointsRequest;
 import software.amazon.awssdk.services.rds.model.InvalidDbClusterStateException;
 import software.amazon.awssdk.services.rds.model.ListTagsForResourceRequest;
@@ -33,6 +34,7 @@ import java.time.Duration;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -86,6 +88,24 @@ public class CreateHandlerTest extends AbstractHandlerTest {
         );
 
         verify(rdsProxy.client(), times(1)).createDBClusterEndpoint(any(CreateDbClusterEndpointRequest.class));
+    }
+
+    @Test
+    public void handleRequest_CreateWithEmptyIdentifier() {
+        when(rdsProxy.client().createDBClusterEndpoint(any(CreateDbClusterEndpointRequest.class)))
+                .thenReturn(CreateDbClusterEndpointResponse.builder().build());
+        when(rdsProxy.client().listTagsForResource(any(ListTagsForResourceRequest.class)))
+                .thenReturn(ListTagsForResourceResponse.builder().build());
+
+        test_handleRequest_base(
+                new CallbackContext(),
+                () -> DB_CLUSTER_ENDPOINT_AVAILABLE,
+                () -> RESOURCE_MODEL_BUILDER().dBClusterEndpointIdentifier("").build(),
+                expectSuccess()
+        );
+
+        verify(rdsProxy.client(), times(1)).createDBClusterEndpoint(
+                argThat((CreateDbClusterEndpointRequest request) -> !request.dbClusterEndpointIdentifier().isEmpty()));
     }
 
     @Test


### PR DESCRIPTION
This pull requests makes `DBClusterEndpoint` primary identifier optional. If the customer does not specify this value explicitly, CFN handler will generate pseudo-random identifier for them.

Pre-commit hooks that were accidentally disabled by `DBClusterEndpoint` resource implementation were restored.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
