### PR TITLE
[DBCluster] Use `commons.Tagging.safeCreate`

### DIFF
--- a/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/CallbackContext.java
+++ b/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/CallbackContext.java
@@ -1,13 +1,33 @@
 package software.amazon.rds.dbcluster;
 
 import software.amazon.cloudformation.proxy.StdCallbackContext;
+import software.amazon.rds.common.handler.TaggingContext;
 
 @lombok.Getter
 @lombok.Setter
 @lombok.ToString
 @lombok.EqualsAndHashCode(callSuper = true)
-public class CallbackContext extends StdCallbackContext {
+public class CallbackContext extends StdCallbackContext implements TaggingContext.Provider {
     private boolean modified;
     private boolean deleting;
-    private boolean createTagComplete;
+
+    private TaggingContext taggingContext;
+
+    public CallbackContext() {
+        super();
+        this.taggingContext = new TaggingContext();
+    }
+
+    @Override
+    public TaggingContext getTaggingContext() {
+        return taggingContext;
+    }
+
+    public boolean isAddTagsComplete() {
+        return taggingContext.isAddTagsComplete();
+    }
+
+    public void setAddTagsComplete(final boolean addTagsComplete) {
+        taggingContext.setAddTagsComplete(addTagsComplete);
+    }
 }


### PR DESCRIPTION
This commit introduces no functional changes, but switches DBCluster `CreateHandler` from a locally-implemented `safeCreate` method to the library version from the commons package.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Signed-off-by: Oleg Sidorov <sidorovo@amazon.com>