### PR TITLE
[DBClusterEndpoint] Use `Tagging.safeCreate`

### DIFF
--- a/aws-rds-dbclusterendpoint/src/main/java/software/amazon/rds/dbclusterendpoint/CallbackContext.java
+++ b/aws-rds-dbclusterendpoint/src/main/java/software/amazon/rds/dbclusterendpoint/CallbackContext.java
@@ -1,12 +1,31 @@
 package software.amazon.rds.dbclusterendpoint;
 
 import software.amazon.cloudformation.proxy.StdCallbackContext;
+import software.amazon.rds.common.handler.TaggingContext;
 
 @lombok.Getter
 @lombok.Setter
 @lombok.ToString
 @lombok.EqualsAndHashCode(callSuper = true)
-public class CallbackContext extends StdCallbackContext {
-    private boolean createTagComplete;
+public class CallbackContext extends StdCallbackContext implements TaggingContext.Provider {
     private String dbClusterEndpointArn;
+    private TaggingContext taggingContext;
+
+    public CallbackContext() {
+        super();
+        this.taggingContext = new TaggingContext();
+    }
+
+    @Override
+    public TaggingContext getTaggingContext() {
+        return taggingContext;
+    }
+
+    public boolean isAddTagsComplete() {
+        return taggingContext.isAddTagsComplete();
+    }
+
+    public void setAddTagsComplete(final boolean addTagsComplete) {
+        this.taggingContext.setAddTagsComplete(addTagsComplete);
+    }
 }

--- a/aws-rds-dbclusterendpoint/src/test/java/software/amazon/rds/dbclusterendpoint/CreateHandlerTest.java
+++ b/aws-rds-dbclusterendpoint/src/test/java/software/amazon/rds/dbclusterendpoint/CreateHandlerTest.java
@@ -25,6 +25,7 @@ import software.amazon.awssdk.services.rds.model.ListTagsForResourceResponse;
 import software.amazon.awssdk.services.rds.model.RdsException;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.HandlerErrorCode;
+import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 import software.amazon.rds.common.error.ErrorCode;
@@ -185,7 +186,7 @@ public class CreateHandlerTest extends AbstractHandlerTest {
                 .resourceTags(TAG_SET.getResourceTags())
                 .build();
 
-        test_handleRequest_base(
+        final ProgressEvent<ResourceModel, CallbackContext> progress = test_handleRequest_base(
                 new CallbackContext(),
                 ResourceHandlerRequest.<ResourceModel>builder()
                         .systemTags(Translator.translateTagsToRequest(Translator.translateTagsFromSdk(TAG_SET.getSystemTags())))
@@ -197,6 +198,9 @@ public class CreateHandlerTest extends AbstractHandlerTest {
                         .build(),
                 expectSuccess()
         );
+
+        Assertions.assertThat(progress.getCallbackContext().isAddTagsComplete()).isTrue();
+        Assertions.assertThat(progress.getCallbackContext().getTaggingContext().isSoftFailTags()).isTrue();
 
         ArgumentCaptor<CreateDbClusterEndpointRequest> createCaptor = ArgumentCaptor.forClass(CreateDbClusterEndpointRequest.class);
         verify(rdsProxy.client(), times(2)).createDBClusterEndpoint(createCaptor.capture());


### PR DESCRIPTION
This commit introduces no functional changes, but switches DBClusterEndpoint `CreateHandler` from a locally-implemented safeCreate method to the library version from the commons package.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
