### PR TITLE
[DBClusterParameterGroup] Use `commons.Tagging.safeCreate`

### DIFF
--- a/aws-rds-dbclusterparametergroup/src/main/java/software/amazon/rds/dbclusterparametergroup/CallbackContext.java
+++ b/aws-rds-dbclusterparametergroup/src/main/java/software/amazon/rds/dbclusterparametergroup/CallbackContext.java
@@ -1,15 +1,35 @@
 package software.amazon.rds.dbclusterparametergroup;
 
 import software.amazon.cloudformation.proxy.StdCallbackContext;
+import software.amazon.rds.common.handler.TaggingContext;
 
 
 @lombok.Getter
 @lombok.Setter
 @lombok.ToString
 @lombok.EqualsAndHashCode(callSuper = true)
-public class CallbackContext extends StdCallbackContext {
+public class CallbackContext extends StdCallbackContext implements TaggingContext.Provider{
     private boolean parametersApplied;
     private String marker;
     private boolean clusterStabilized;
     private String dbClusterParameterGroupArn;
+    private TaggingContext taggingContext;
+
+    public CallbackContext() {
+        super();
+        this.taggingContext = new TaggingContext();
+    }
+
+    @Override
+    public TaggingContext getTaggingContext() {
+        return taggingContext;
+    }
+
+    public boolean isAddTagsComplete() {
+        return taggingContext.isAddTagsComplete();
+    }
+
+    public void setAddTagsComplete(final boolean addTagsComplete) {
+        this.taggingContext.setAddTagsComplete(addTagsComplete);
+    }
 }

--- a/aws-rds-dbclusterparametergroup/src/main/java/software/amazon/rds/dbclusterparametergroup/CreateHandler.java
+++ b/aws-rds-dbclusterparametergroup/src/main/java/software/amazon/rds/dbclusterparametergroup/CreateHandler.java
@@ -49,12 +49,12 @@ public class CreateHandler extends BaseHandlerStd {
                 .then(progress -> setDbClusterParameterGroupNameIfMissing(request, progress))
                 .then(progress -> Tagging.safeCreate(proxy, proxyClient, this::createDbClusterParameterGroup, progress, allTags))
                 .then(progress -> Commons.execOnce(progress, () -> {
-                            final Tagging.TagSet extraTags = Tagging.TagSet.builder()
-                                    .stackTags(Tagging.translateTagsToSdk(request.getDesiredResourceTags()))
-                                    .resourceTags(new HashSet<>(Translator.translateTagsToSdk(request.getDesiredResourceState().getTags())))
-                                    .build();
-                            return updateTags(proxy, proxyClient, progress, Tagging.TagSet.emptySet(), extraTags);
-                        }, CallbackContext::isAddTagsComplete, CallbackContext::setAddTagsComplete
+                        final Tagging.TagSet extraTags = Tagging.TagSet.builder()
+                            .stackTags(allTags.getStackTags())
+                            .resourceTags(allTags.getResourceTags())
+                            .build();
+                        return updateTags(proxy, proxyClient, progress, Tagging.TagSet.emptySet(), extraTags);
+                    }, CallbackContext::isAddTagsComplete, CallbackContext::setAddTagsComplete
                 ))
                 .then(progress -> applyParameters(proxy, proxyClient, progress.getResourceModel(), progress.getCallbackContext()))
                 .then(progress -> new ReadHandler().handleRequest(proxy, request, callbackContext, proxyClient, logger));

--- a/aws-rds-dbclusterparametergroup/src/main/java/software/amazon/rds/dbclusterparametergroup/CreateHandler.java
+++ b/aws-rds-dbclusterparametergroup/src/main/java/software/amazon/rds/dbclusterparametergroup/CreateHandler.java
@@ -1,6 +1,7 @@
 package software.amazon.rds.dbclusterparametergroup;
 
 import java.util.Collections;
+import java.util.HashSet;
 
 import com.amazonaws.util.StringUtils;
 import software.amazon.awssdk.services.rds.RdsClient;
@@ -46,7 +47,15 @@ public class CreateHandler extends BaseHandlerStd {
 
         return ProgressEvent.progress(request.getDesiredResourceState(), callbackContext)
                 .then(progress -> setDbClusterParameterGroupNameIfMissing(request, progress))
-                .then(progress -> createDbClusterPGWithTags(proxy, proxyClient, progress, allTags))
+                .then(progress -> Tagging.safeCreate(proxy, proxyClient, this::createDbClusterParameterGroup, progress, allTags))
+                .then(progress -> Commons.execOnce(progress, () -> {
+                            final Tagging.TagSet extraTags = Tagging.TagSet.builder()
+                                    .stackTags(Tagging.translateTagsToSdk(request.getDesiredResourceTags()))
+                                    .resourceTags(new HashSet<>(Translator.translateTagsToSdk(request.getDesiredResourceState().getTags())))
+                                    .build();
+                            return updateTags(proxy, proxyClient, progress, Tagging.TagSet.emptySet(), extraTags);
+                        }, CallbackContext::isAddTagsComplete, CallbackContext::setAddTagsComplete
+                ))
                 .then(progress -> applyParameters(proxy, proxyClient, progress.getResourceModel(), progress.getCallbackContext()))
                 .then(progress -> new ReadHandler().handleRequest(proxy, request, callbackContext, proxyClient, logger));
     }
@@ -70,20 +79,6 @@ public class CreateHandler extends BaseHandlerStd {
                     context.setDbClusterParameterGroupArn(paramGroupResponse.dbClusterParameterGroup().dbClusterParameterGroupArn());
                     return ProgressEvent.progress(resourceModel, context);
                 });
-    }
-
-    private ProgressEvent<ResourceModel, CallbackContext> createDbClusterPGWithTags(final AmazonWebServicesClientProxy proxy,
-                                                                                    final ProxyClient<RdsClient> proxyClient,
-                                                                                    final ProgressEvent<ResourceModel, CallbackContext> progress,
-                                                                                    final Tagging.TagSet allTags) {
-        ProgressEvent<ResourceModel, CallbackContext> progressEvent = createDbClusterParameterGroup(proxy, proxyClient, progress, allTags);
-        if (HandlerErrorCode.AccessDenied.equals(progressEvent.getErrorCode())) { //Resource is subject to soft fail on stack level tags.
-            Tagging.TagSet systemTags = Tagging.TagSet.builder().systemTags(allTags.getSystemTags()).build();
-            Tagging.TagSet extraTags = allTags.toBuilder().systemTags(Collections.emptySet()).build();
-            return createDbClusterParameterGroup(proxy, proxyClient, progress, systemTags)
-                    .then(prog -> updateTags(proxy, proxyClient, prog, Tagging.TagSet.emptySet(), extraTags));
-        }
-        return progressEvent;
     }
 
     private ProgressEvent<ResourceModel, CallbackContext> setDbClusterParameterGroupNameIfMissing(final ResourceHandlerRequest<ResourceModel> request,


### PR DESCRIPTION
This commit introduces no functional changes, but switches DBClusterParameterGroup CreateHandler from a locally-implemented safeCreate method to the library version from the commons package.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.