### PR TITLE
[OptionGroup] Use `commons.Tagging.safeCreate`

### DIFF
--- a/aws-rds-optiongroup/src/main/java/software/amazon/rds/optiongroup/CallbackContext.java
+++ b/aws-rds-optiongroup/src/main/java/software/amazon/rds/optiongroup/CallbackContext.java
@@ -1,10 +1,30 @@
 package software.amazon.rds.optiongroup;
 
 import software.amazon.cloudformation.proxy.StdCallbackContext;
+import software.amazon.rds.common.handler.TaggingContext;
 
 @lombok.Getter
 @lombok.Setter
 @lombok.ToString
 @lombok.EqualsAndHashCode(callSuper = true)
-public class CallbackContext extends StdCallbackContext {
+public class CallbackContext extends StdCallbackContext implements TaggingContext.Provider {
+    private TaggingContext taggingContext;
+
+    public CallbackContext() {
+        super();
+        this.taggingContext = new TaggingContext();
+    }
+
+    @Override
+    public TaggingContext getTaggingContext() {
+        return taggingContext;
+    }
+
+    public boolean isAddTagsComplete() {
+        return taggingContext.isAddTagsComplete();
+    }
+
+    public void setAddTagsComplete(final boolean addTagsComplete) {
+        this.taggingContext.setAddTagsComplete(addTagsComplete);
+    }
 }

--- a/aws-rds-optiongroup/src/main/java/software/amazon/rds/optiongroup/CreateHandler.java
+++ b/aws-rds-optiongroup/src/main/java/software/amazon/rds/optiongroup/CreateHandler.java
@@ -53,7 +53,15 @@ public class CreateHandler extends BaseHandlerStd {
 
         return ProgressEvent.progress(request.getDesiredResourceState(), callbackContext)
                 .then(progress -> setOptionGroupNameIfEmpty(request, progress))
-                .then(progress -> safeCreateOptionGroup(proxy, proxyClient, progress, allTags))
+                .then(progress -> Tagging.safeCreate(proxy, proxyClient, this::createOptionGroup, progress, allTags))
+                .then(progress -> Commons.execOnce(progress, () -> {
+                            final Tagging.TagSet extraTags = Tagging.TagSet.builder()
+                                    .stackTags(allTags.getStackTags())
+                                    .resourceTags(allTags.getResourceTags())
+                                    .build();
+                            return updateTags(proxy, proxyClient, progress, Tagging.TagSet.emptySet(), extraTags);
+                        }, CallbackContext::isAddTagsComplete, CallbackContext::setAddTagsComplete
+                ))
                 .then(progress -> {
                     if (CollectionUtils.isNullOrEmpty(progress.getResourceModel().getOptionConfigurations())) {
                         return progress;
@@ -61,20 +69,6 @@ public class CreateHandler extends BaseHandlerStd {
                     return updateOptionGroupConfigurations(proxy, proxyClient, progress);
                 })
                 .then(progress -> new ReadHandler().handleRequest(proxy, request, callbackContext, proxyClient, logger));
-    }
-
-    private ProgressEvent<ResourceModel, CallbackContext> safeCreateOptionGroup(final AmazonWebServicesClientProxy proxy,
-                                                                                final ProxyClient<RdsClient> proxyClient,
-                                                                                final ProgressEvent<ResourceModel, CallbackContext> progress,
-                                                                                final Tagging.TagSet allTags) {
-        ProgressEvent<ResourceModel, CallbackContext> progressEvent = createOptionGroup(proxy, proxyClient, progress, allTags);
-        if (HandlerErrorCode.AccessDenied.equals(progressEvent.getErrorCode())) { //Resource is subject to soft fail on stack level tags.
-            Tagging.TagSet systemTags = Tagging.TagSet.builder().systemTags(allTags.getSystemTags()).build();
-            Tagging.TagSet extraTags = allTags.toBuilder().systemTags(Collections.emptySet()).build();
-            return createOptionGroup(proxy, proxyClient, progress, systemTags)
-                    .then(prog -> updateTags(proxy, proxyClient, prog, Tagging.TagSet.emptySet(), extraTags));
-        }
-        return progressEvent;
     }
 
     private ProgressEvent<ResourceModel, CallbackContext> createOptionGroup(final AmazonWebServicesClientProxy proxy,


### PR DESCRIPTION
This commit introduces no functional changes, but switches OptionGroup CreateHandler from a locally-implemented safeCreate method to the library version from the commons package.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
