### PR TITLE
[EventSubscription] Use `commons.Tagging.safeCreate`

### DIFF
--- a/aws-rds-eventsubscription/src/main/java/software/amazon/rds/eventsubscription/CallbackContext.java
+++ b/aws-rds-eventsubscription/src/main/java/software/amazon/rds/eventsubscription/CallbackContext.java
@@ -1,11 +1,32 @@
 package software.amazon.rds.eventsubscription;
 
 import software.amazon.cloudformation.proxy.StdCallbackContext;
+import software.amazon.rds.common.handler.TaggingContext;
 
 @lombok.Getter
 @lombok.Setter
 @lombok.ToString
 @lombok.EqualsAndHashCode(callSuper = true)
-public class CallbackContext extends StdCallbackContext {
+public class CallbackContext extends StdCallbackContext implements TaggingContext.Provider {
     private String eventSubscriptionArn;
+
+    private TaggingContext taggingContext;
+
+    public CallbackContext() {
+        super();
+        this.taggingContext = new TaggingContext();
+    }
+
+    @Override
+    public TaggingContext getTaggingContext() {
+        return taggingContext;
+    }
+
+    public boolean isAddTagsComplete() {
+        return taggingContext.isAddTagsComplete();
+    }
+
+    public void setAddTagsComplete(final boolean addTagsComplete) {
+        taggingContext.setAddTagsComplete(addTagsComplete);
+    }
 }

--- a/aws-rds-eventsubscription/src/main/java/software/amazon/rds/eventsubscription/CreateHandler.java
+++ b/aws-rds-eventsubscription/src/main/java/software/amazon/rds/eventsubscription/CreateHandler.java
@@ -1,12 +1,10 @@
 package software.amazon.rds.eventsubscription;
 
-import java.util.Collections;
 import java.util.HashSet;
 
 import com.amazonaws.util.StringUtils;
 import software.amazon.awssdk.services.rds.RdsClient;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
-import software.amazon.cloudformation.proxy.HandlerErrorCode;
 import software.amazon.cloudformation.proxy.Logger;
 import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ProxyClient;
@@ -46,24 +44,23 @@ public class CreateHandler extends BaseHandlerStd {
     }
 
     private ProgressEvent<ResourceModel, CallbackContext> safeCreateEventSubscription(final AmazonWebServicesClientProxy proxy,
-                                                                                     final ProxyClient<RdsClient> proxyClient,
-                                                                                     final ProgressEvent<ResourceModel, CallbackContext> progress,
-                                                                                     final Tagging.TagSet allTags) {
-        ProgressEvent<ResourceModel, CallbackContext> progressEvent = createEventSubscription(proxy, proxyClient, progress, allTags);
-        if (HandlerErrorCode.AccessDenied.equals(progressEvent.getErrorCode())) { //Resource is subject to soft fail on stack level tags.
-            Tagging.TagSet systemTags = Tagging.TagSet.builder().systemTags(allTags.getSystemTags()).build();
-            Tagging.TagSet extraTags = allTags.toBuilder().systemTags(Collections.emptySet()).build();
-            return createEventSubscription(proxy, proxyClient, progress, systemTags)
-                    .then(prog -> updateTags(proxy, proxyClient, prog, Tagging.TagSet.emptySet(), extraTags));
-        }
-        return progressEvent;
+                                                                                      final ProxyClient<RdsClient> proxyClient,
+                                                                                      final ProgressEvent<ResourceModel, CallbackContext> progress,
+                                                                                      final Tagging.TagSet allTags) {
+        return Tagging.safeCreate(proxy, proxyClient, this::createEventSubscription, progress, allTags)
+                .then(p -> Commons.execOnce(p, () -> {
+                    final Tagging.TagSet extraTags = Tagging.TagSet.builder()
+                            .stackTags(allTags.getStackTags())
+                            .resourceTags(allTags.getResourceTags())
+                            .build();
+                    return updateTags(proxy, proxyClient, p, Tagging.TagSet.emptySet(), extraTags);
+                }, CallbackContext::isAddTagsComplete, CallbackContext::setAddTagsComplete));
     }
 
     private ProgressEvent<ResourceModel, CallbackContext> createEventSubscription(final AmazonWebServicesClientProxy proxy,
                                                                                   final ProxyClient<RdsClient> proxyClient,
                                                                                   final ProgressEvent<ResourceModel, CallbackContext> progress,
-                                                                                  final Tagging.TagSet tags
-    ) {
+                                                                                  final Tagging.TagSet tags) {
         return proxy.initiate("rds::create-event-subscription", proxyClient, progress.getResourceModel(), progress.getCallbackContext())
                 .translateToServiceRequest((resourceModel) -> Translator.createEventSubscriptionRequest(resourceModel, tags))
                 .makeServiceCall((createEventSubscriptionRequest, proxyInvocation) -> proxyInvocation.injectCredentialsAndInvokeV2(createEventSubscriptionRequest, proxyInvocation.client()::createEventSubscription))


### PR DESCRIPTION
This commit introduces no functional changes, but switches EventSubscription CreateHandler from a locally-implemented safeCreate method to the library version from the commons package.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Signed-off-by: Oleg Sidorov <sidorovo@amazon.com>