### PR TITLE
[DBParameterGroup] Use `commons.Tagging.safeCreate`

### DIFF
--- a/aws-rds-dbparametergroup/src/main/java/software/amazon/rds/dbparametergroup/CallbackContext.java
+++ b/aws-rds-dbparametergroup/src/main/java/software/amazon/rds/dbparametergroup/CallbackContext.java
@@ -1,12 +1,33 @@
 package software.amazon.rds.dbparametergroup;
 
 import software.amazon.cloudformation.proxy.StdCallbackContext;
+import software.amazon.rds.common.handler.TaggingContext;
 
 @lombok.Getter
 @lombok.Setter
 @lombok.ToString
 @lombok.EqualsAndHashCode(callSuper = true)
-public class CallbackContext extends StdCallbackContext {
+public class CallbackContext extends StdCallbackContext implements TaggingContext.Provider {
     private boolean parametersApplied;
     private String dbParameterGroupArn;
+
+    private TaggingContext taggingContext;
+
+    public CallbackContext() {
+        super();
+        this.taggingContext = new TaggingContext();
+    }
+
+    @Override
+    public TaggingContext getTaggingContext() {
+        return taggingContext;
+    }
+
+    public boolean isAddTagsComplete() {
+        return taggingContext.isAddTagsComplete();
+    }
+
+    public void setAddTagsComplete(final boolean addTagsComplete) {
+        taggingContext.setAddTagsComplete(addTagsComplete);
+    }
 }


### PR DESCRIPTION
This commit introduces no functional changes, but switches DBParameterGroup CreateHandler from a locally-implemented safeCreate method to the library version from the commons package.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Signed-off-by: Oleg Sidorov <sidorovo@amazon.com>