### PR TITLE
[DBCluster] Clean up `safeCreate` tagset builder in `CreateHandler`

### DIFF
--- a/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/CreateHandler.java
+++ b/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/CreateHandler.java
@@ -69,8 +69,8 @@ public class CreateHandler extends BaseHandlerStd {
                 })
                 .then(progress -> Commons.execOnce(progress, () -> {
                     final Tagging.TagSet extraTags = Tagging.TagSet.builder()
-                            .stackTags(Tagging.translateTagsToSdk(request.getDesiredResourceTags()))
-                            .resourceTags(new HashSet<>(Translator.translateTagsToSdk(request.getDesiredResourceState().getTags())))
+                            .stackTags(allTags.getStackTags())
+                            .resourceTags(allTags.getResourceTags())
                             .build();
                     return updateTags(proxy, proxyClient, progress, Tagging.TagSet.emptySet(), extraTags);
                 }, CallbackContext::isAddTagsComplete, CallbackContext::setAddTagsComplete))


### PR DESCRIPTION
This commit cleans up safeCreate method in CreateHandler around the extraTags TagSet buildup. The current version was copied from the original allTags TagSet builder. It contains data type conversions that are no longer required at the stage when extraTags is being constructed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Signed-off-by: Oleg Sidorov <sidorovo@amazon.com>