### PR TITLE
[OptionGroup] relax EngineName enum restrictions

### DIFF
--- a/aws-rds-optiongroup/aws-rds-optiongroup.json
+++ b/aws-rds-optiongroup/aws-rds-optiongroup.json
@@ -101,23 +101,7 @@
     },
     "EngineName": {
       "description": "Indicates the name of the engine that this option group can be applied to.",
-      "type": "string",
-      "enum": [
-        "aurora",
-        "aurora-mysql",
-        "aurora-postgresql",
-        "mariadb",
-        "mysql",
-        "oracle-ee",
-        "oracle-se2",
-        "oracle-se1",
-        "oracle-se",
-        "postgres",
-        "sqlserver-ee",
-        "sqlserver-se",
-        "sqlserver-ex",
-        "sqlserver-web"
-      ]
+      "type": "string"
     },
     "MajorEngineVersion": {
       "description": "Indicates the major engine version associated with this option group.",

--- a/aws-rds-optiongroup/docs/README.md
+++ b/aws-rds-optiongroup/docs/README.md
@@ -55,8 +55,6 @@ _Required_: Yes
 
 _Type_: String
 
-_Allowed Values_: <code>aurora</code> | <code>aurora-mysql</code> | <code>aurora-postgresql</code> | <code>mariadb</code> | <code>mysql</code> | <code>oracle-ee</code> | <code>oracle-se2</code> | <code>oracle-se1</code> | <code>oracle-se</code> | <code>postgres</code> | <code>sqlserver-ee</code> | <code>sqlserver-se</code> | <code>sqlserver-ex</code> | <code>sqlserver-web</code>
-
 _Update requires_: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
 
 #### MajorEngineVersion


### PR DESCRIPTION
This commit introduces a series of changes that are aiming to restore the
backwards compatibility in the resource implementation.

Removed strict enum-based Engine type validation: using an enum enforces a case sensitive validation and breaks existing clients.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Signed-off-by: Tieg O'Sullivan [tiegaws@amazon.com](mailto:tiegaws@amazon.com)