### PR TITLE
[DBSubnetGroup] Handle InvalidSubnetException Error

### DIFF
--- a/aws-rds-dbsubnetgroup/src/main/java/software/amazon/rds/dbsubnetgroup/BaseHandlerStd.java
+++ b/aws-rds-dbsubnetgroup/src/main/java/software/amazon/rds/dbsubnetgroup/BaseHandlerStd.java
@@ -9,6 +9,7 @@ import software.amazon.awssdk.services.rds.model.DbSubnetGroupDoesNotCoverEnough
 import software.amazon.awssdk.services.rds.model.DbSubnetGroupNotFoundException;
 import software.amazon.awssdk.services.rds.model.DbSubnetGroupQuotaExceededException;
 import software.amazon.awssdk.services.rds.model.InvalidDbSubnetGroupStateException;
+import software.amazon.awssdk.services.rds.model.InvalidSubnetException;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.HandlerErrorCode;
 import software.amazon.cloudformation.proxy.Logger;
@@ -41,7 +42,8 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
             .withErrorClasses(ErrorStatus.failWith(HandlerErrorCode.ResourceConflict),
                     InvalidDbSubnetGroupStateException.class)
             .withErrorClasses(ErrorStatus.failWith(HandlerErrorCode.InvalidRequest),
-                    DbSubnetGroupDoesNotCoverEnoughAZsException.class)
+                    DbSubnetGroupDoesNotCoverEnoughAZsException.class,
+                    InvalidSubnetException.class)
             .build()
             .orElse(Commons.DEFAULT_ERROR_RULE_SET);
 


### PR DESCRIPTION
*Description of changes:*
This commit handles `InvalidSubnetException` that can happen when stack missing Subnet IDs
Example exception
```
software.amazon.awssdk.services.rds.model.InvalidSubnetException: Subnet IDs are required. (Service: Rds, Status Code: 400, Request ID: 9598d859-72ba-486a-xxxxxx-2a7a2624d690)
at software.amazon.awssdk.core.internal.http.CombinedResponseHandler.handleErrorResponse(CombinedResponseHandler.java:125)
at software.amazon.awssdk.core.internal.http.CombinedResponseHandler.handleResponse(CombinedResponseHandler.java:82)
at software.amazon.awssdk.core.internal.http.CombinedResponseHandler.handle(CombinedResponseHandler.java:60)
at software.amazon.awssdk.core.internal.http.CombinedResponseHandler.handle(CombinedResponseHandler.java:41)
at software.amazon.awssdk.core.internal.http.pipeline.stages.HandleResponseStage.execute(HandleResponseStage.java:40)
at software.amazon.awssdk.core.internal.http.pipeline.stages.HandleResponseStage.execute(HandleResponseStage.java:30)
at software.amazon.awssdk.core.internal.http.pipeline.RequestPipelineBuilder$ComposingRequestPipelineStage.execute(RequestPipelineBuilder.java:206)
at software.amazon.awssdk.core.internal.http.pipeline.stages.ApiCallAttemptTimeoutTrackingStage.execute(ApiCallAttemptTimeoutTrackingStage.java:73)
at software.amazon.awssdk.core.internal.http.pipeline.stages.ApiCallAttemptTimeoutTrackingStage.execute(ApiCallAttemptTimeoutTrackingStage.java:42)
at software.amazon.awssdk.core.internal.http.pipeline.stages.TimeoutExceptionHandlingStage.execute(TimeoutExceptionHandlingStage.java:78)
at software.amazon.awssdk.core.internal.http.pipeline.stages.TimeoutExceptionHandlingStage.execute(TimeoutExceptionHandlingStage.java:40)
at software.amazon.awssdk.core.internal.http.pipeline.stages.ApiCallAttemptMetricCollectionStage.execute(ApiCallAttemptMetricCollectionStage.java:50)
at software.amazon.awssdk.core.internal.http.pipeline.stages.ApiCallAttemptMetricCollectionStage.execute(ApiCallAttemptMetricCollectionStage.java:36)
at software.amazon.awssdk.core.internal.http.pipeline.stages.RetryableStage.execute(RetryableStage.java:81)
at software.amazon.awssdk.core.internal.http.pipeline.stages.RetryableStage.execute(RetryableStage.java:36)
at software.amazon.awssdk.core.internal.http.pipeline.RequestPipelineBuilder$ComposingRequestPipelineStage.execute(RequestPipelineBuilder.java:206)
at software.amazon.awssdk.core.internal.http.StreamManagingStage.execute(StreamManagingStage.java:56)
at software.amazon.awssdk.core.internal.http.StreamManagingStage.execute(StreamManagingStage.java:36)
at software.amazon.awssdk.core.internal.http.pipeline.stages.ApiCallTimeoutTrackingStage.executeWithTimer(ApiCallTimeoutTrackingStage.java:80)
at software.amazon.awssdk.core.internal.http.pipeline.stages.ApiCallTimeoutTrackingStage.execute(ApiCallTimeoutTrackingStage.java:60)
at software.amazon.awssdk.core.internal.http.pipeline.stages.ApiCallTimeoutTrackingStage.execute(ApiCallTimeoutTrackingStage.java:42)
at software.amazon.awssdk.core.internal.http.pipeline.stages.ApiCallMetricCollectionStage.execute(ApiCallMetricCollectionStage.java:48)
at software.amazon.awssdk.core.internal.http.pipeline.stages.ApiCallMetricCollectionStage.execute(ApiCallMetricCollectionStage.java:31)
at software.amazon.awssdk.core.internal.http.pipeline.RequestPipelineBuilder$ComposingRequestPipelineStage.execute(RequestPipelineBuilder.java:206)
at software.amazon.awssdk.core.internal.http.pipeline.RequestPipelineBuilder$ComposingRequestPipelineStage.execute(RequestPipelineBuilder.java:206)
at software.amazon.awssdk.core.internal.http.pipeline.stages.ExecutionFailureExceptionReportingStage.execute(ExecutionFailureExceptionReportingStage.java:37)
at software.amazon.awssdk.core.internal.http.pipeline.stages.ExecutionFailureExceptionReportingStage.execute(ExecutionFailureExceptionReportingStage.java:26)
at software.amazon.awssdk.core.internal.http.AmazonSyncHttpClient$RequestExecutionBuilderImpl.execute(AmazonSyncHttpClient.java:193)
at software.amazon.awssdk.core.internal.handler.BaseSyncClientHandler.invoke(BaseSyncClientHandler.java:103)
at software.amazon.awssdk.core.internal.handler.BaseSyncClientHandler.doExecute(BaseSyncClientHandler.java:167)
at software.amazon.awssdk.core.internal.handler.BaseSyncClientHandler.lambda$execute$1(BaseSyncClientHandler.java:82)
at software.amazon.awssdk.core.internal.handler.BaseSyncClientHandler.measureApiCallSuccess(BaseSyncClientHandler.java:175)
at software.amazon.awssdk.core.internal.handler.BaseSyncClientHandler.execute(BaseSyncClientHandler.java:76)
at software.amazon.awssdk.core.client.handler.SdkSyncClientHandler.execute(SdkSyncClientHandler.java:45)
at software.amazon.awssdk.awscore.client.handler.AwsSyncClientHandler.execute(AwsSyncClientHandler.java:56)
at software.amazon.awssdk.services.rds.DefaultRdsClient.createDBSubnetGroup(DefaultRdsClient.java:2442)
at software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy.injectCredentialsAndInvokeV2(AmazonWebServicesClientProxy.java:484)
at software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy$1.injectCredentialsAndInvokeV2(AmazonWebServicesClientProxy.java:106)
at software.amazon.rds.common.logging.LoggingProxyClient.logAndDelegate(LoggingProxyClient.java:71)
at software.amazon.rds.common.logging.LoggingProxyClient.injectCredentialsAndInvokeV2(LoggingProxyClient.java:25)
at software.amazon.rds.dbsubnetgroup.CreateHandler.lambda$createDbSubnetGroup$5(CreateHandler.java:77)
at software.amazon.cloudformation.proxy.StdCallbackContext.lambda$null$2(StdCallbackContext.java:267)
at java.util.HashMap.computeIfAbsent(HashMap.java:1128)
at java.util.Collections$SynchronizedMap.computeIfAbsent(Collections.java:2674)
at software.amazon.cloudformation.proxy.StdCallbackContext.lambda$response$3(StdCallbackContext.java:267)
at software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy$CallContext$1$1.done(AmazonWebServicesClientProxy.java:379)
at software.amazon.rds.dbsubnetgroup.CreateHandler.createDbSubnetGroup(CreateHandler.java:83)
at software.amazon.rds.dbsubnetgroup.CreateHandler.safeCreateDbSubnetGroup(CreateHandler.java:60)
at software.amazon.rds.dbsubnetgroup.CreateHandler.lambda$handleRequest$1(CreateHandler.java:52)
at software.amazon.cloudformation.proxy.ProgressEvent.then(ProgressEvent.java:192)
at software.amazon.rds.dbsubnetgroup.CreateHandler.handleRequest(CreateHandler.java:52)
at software.amazon.rds.dbsubnetgroup.BaseHandlerStd.lambda$handleRequest$0(BaseHandlerStd.java:69)
at software.amazon.rds.common.logging.RequestLogger.handleRequest(RequestLogger.java:72)
at software.amazon.rds.dbsubnetgroup.BaseHandlerStd.handleRequest(BaseHandlerStd.java:65)
at software.amazon.rds.dbsubnetgroup.BaseHandlerStd.handleRequest(BaseHandlerStd.java:28)
at software.amazon.rds.dbsubnetgroup.HandlerWrapper.invokeHandler(HandlerWrapper.java:86)
at software.amazon.rds.dbsubnetgroup.HandlerWrapper.invokeHandler(HandlerWrapper.java:45)
at software.amazon.cloudformation.AbstractWrapper.wrapInvocationAndHandleErrors(AbstractWrapper.java:366)
at software.amazon.cloudformation.AbstractWrapper.processInvocation(AbstractWrapper.java:334)
at software.amazon.cloudformation.AbstractWrapper.processRequest(AbstractWrapper.java:199)
at software.amazon.cloudformation.LambdaWrapper.handleRequest(LambdaWrapper.java:61)
at sun.reflect.GeneratedMethodAccessor9.invoke(Unknown Source)
at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
at java.lang.reflect.Method.invoke(Method.java:498)
at lambdainternal.EventHandlerLoader$StreamMethodRequestHandler.handleRequest(EventHandlerLoader.java:356)
at lambdainternal.EventHandlerLoader$2.call(EventHandlerLoader.java:903)
at lambdainternal.AWSLambda.startRuntime(AWSLambda.java:349)
at lambdainternal.AWSLambda.<clinit>(AWSLambda.java:70)
at java.lang.Class.forName0(Native Method)
at java.lang.Class.forName(Class.java:348)
at lambdainternal.LambdaRTEntry.main(LambdaRTEntry.java:150)
``` 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
