### PR TITLE
[DBClusterParameterGroup] Add default ruleset to DBCluster stabilization

### DIFF
--- a/aws-rds-dbclusterparametergroup/src/main/java/software/amazon/rds/dbclusterparametergroup/BaseHandlerStd.java
+++ b/aws-rds-dbclusterparametergroup/src/main/java/software/amazon/rds/dbclusterparametergroup/BaseHandlerStd.java
@@ -45,7 +45,6 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
     protected static final String STACK_NAME = "rds";
     protected static final int MAX_LENGTH_GROUP_NAME = 255;
     // 5 min for waiting propagation according to https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_ModifyDBClusterParameterGroup.html
-    protected static final int CALLBACK_DELAY_SECONDS = 5 * 60;
     protected static final int NO_CALLBACK_DELAY = 0;
     protected static final int MAX_PARAMETERS_PER_REQUEST = 20;
 
@@ -69,7 +68,8 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
                     ErrorCode.NotAuthorized)
             .withErrorClasses(ErrorStatus.failWith(HandlerErrorCode.NotStabilized),
                     Exception.class)
-            .build();
+            .build()
+            .orElse(Commons.DEFAULT_ERROR_RULE_SET);
 
     protected static final ErrorRuleSet SOFT_FAIL_IN_PROGRESS_ERROR_RULE_SET = ErrorRuleSet.builder()
             .withErrorCodes(ErrorStatus.ignore(OperationStatus.IN_PROGRESS),
@@ -217,7 +217,7 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
                                 exception,
                                 DEFAULT_DB_CLUSTER_PARAMETER_GROUP_ERROR_RULE_SET))
                 .done((describeDbClusterParameterGroupsRequest, describeDbClusterParameterGroupsResponse, proxyInvocation, resourceModel, context) -> {
-                    try{
+                    try {
                         currentDBClusterParameters.putAll(
                                 describeDbClusterParameterGroupsResponse.stream()
                                         .flatMap(describeDbClusterParametersResponse -> describeDbClusterParametersResponse.parameters().stream())

--- a/aws-rds-dbclusterparametergroup/src/main/java/software/amazon/rds/dbclusterparametergroup/CreateHandler.java
+++ b/aws-rds-dbclusterparametergroup/src/main/java/software/amazon/rds/dbclusterparametergroup/CreateHandler.java
@@ -1,12 +1,8 @@
 package software.amazon.rds.dbclusterparametergroup;
 
-import java.util.Collections;
-import java.util.HashSet;
-
 import com.amazonaws.util.StringUtils;
 import software.amazon.awssdk.services.rds.RdsClient;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
-import software.amazon.cloudformation.proxy.HandlerErrorCode;
 import software.amazon.cloudformation.proxy.Logger;
 import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ProxyClient;
@@ -49,12 +45,12 @@ public class CreateHandler extends BaseHandlerStd {
                 .then(progress -> setDbClusterParameterGroupNameIfMissing(request, progress))
                 .then(progress -> Tagging.safeCreate(proxy, proxyClient, this::createDbClusterParameterGroup, progress, allTags))
                 .then(progress -> Commons.execOnce(progress, () -> {
-                        final Tagging.TagSet extraTags = Tagging.TagSet.builder()
-                            .stackTags(allTags.getStackTags())
-                            .resourceTags(allTags.getResourceTags())
-                            .build();
-                        return updateTags(proxy, proxyClient, progress, Tagging.TagSet.emptySet(), extraTags);
-                    }, CallbackContext::isAddTagsComplete, CallbackContext::setAddTagsComplete
+                            final Tagging.TagSet extraTags = Tagging.TagSet.builder()
+                                    .stackTags(allTags.getStackTags())
+                                    .resourceTags(allTags.getResourceTags())
+                                    .build();
+                            return updateTags(proxy, proxyClient, progress, Tagging.TagSet.emptySet(), extraTags);
+                        }, CallbackContext::isAddTagsComplete, CallbackContext::setAddTagsComplete
                 ))
                 .then(progress -> applyParameters(proxy, proxyClient, progress.getResourceModel(), progress.getCallbackContext()))
                 .then(progress -> new ReadHandler().handleRequest(proxy, request, callbackContext, proxyClient, logger));


### PR DESCRIPTION
This commit alters the error handling ruleset that is being used in `waitForDbClustersStabilization`. The current implementation declares a stand-alone error rule set that is missing rule declarations for low-level issues like throttling and networking issues. This commit adds an alternative or-branch to DB_CLUSTERS_STABILIZATION_ERROR_RULE_SET so the aforementioned exceptions can be handled.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Signed-off-by: Oleg Sidorov <sidorovo@amazon.com>