### PR TITLE
[DBInstance][DBCluster] Remove restore original identifier

### DIFF
--- a/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/BaseHandlerStd.java
+++ b/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/BaseHandlerStd.java
@@ -138,23 +138,6 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
             final Logger logger
     );
 
-    protected ResourceModel restoreIdentifier(final ResourceModel observed, final ResourceModel original) {
-        if (StringUtils.isBlank(original.getDBClusterIdentifier()) ||
-                StringUtils.equals(original.getDBClusterIdentifier(), observed.getDBClusterIdentifier())) {
-            return observed;
-        }
-        observed.setDBClusterIdentifier(original.getDBClusterIdentifier());
-        return observed;
-    }
-
-    protected DBCluster restoreIdentifier(final DBCluster dbCluster, final ResourceModel model) {
-        if (StringUtils.isBlank(dbCluster.dbClusterIdentifier()) ||
-                StringUtils.equals(model.getDBClusterIdentifier(), dbCluster.dbClusterIdentifier())) {
-            return dbCluster;
-        }
-        return dbCluster.toBuilder().dbClusterIdentifier(model.getDBClusterIdentifier()).build();
-    }
-
     protected DBCluster fetchDBCluster(
             final ProxyClient<RdsClient> proxyClient,
             final ResourceModel model
@@ -163,7 +146,7 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
                 Translator.describeDbClustersRequest(model),
                 proxyClient.client()::describeDBClusters
         );
-        return restoreIdentifier(response.dbClusters().stream().findFirst().get(), model);
+        return response.dbClusters().get(0);
     }
 
     protected boolean isGlobalClusterMember(final ResourceModel model) {

--- a/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/ReadHandler.java
+++ b/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/ReadHandler.java
@@ -41,11 +41,8 @@ public class ReadHandler extends BaseHandlerStd {
                         DEFAULT_DB_CLUSTER_ERROR_RULE_SET
                 ))
                 .done((describeRequest, describeResponse, proxyInvocation, model, context) -> {
-                    final DBCluster dbCluster = describeResponse.dbClusters().stream().findFirst().get();
-                    return ProgressEvent.success(
-                            restoreIdentifier(Translator.translateDbClusterFromSdk(dbCluster), request.getDesiredResourceState()),
-                            context
-                    );
+                    final DBCluster dbCluster = describeResponse.dbClusters().get(0);
+                    return ProgressEvent.success(Translator.translateDbClusterFromSdk(dbCluster), context);
                 });
     }
 }

--- a/aws-rds-dbcluster/src/test/java/software/amazon/rds/dbcluster/ReadHandlerTest.java
+++ b/aws-rds-dbcluster/src/test/java/software/amazon/rds/dbcluster/ReadHandlerTest.java
@@ -66,19 +66,4 @@ public class ReadHandlerTest extends AbstractHandlerTest {
 
         verify(rdsProxy.client(), times(1)).describeDBClusters(any(DescribeDbClustersRequest.class));
     }
-
-    @Test
-    public void handleRequest_RestoreOriginalIdentifier() {
-        final String dbClusterIdentifier = "TestDBClusterIdentifier";
-        final ProgressEvent<ResourceModel, CallbackContext> result = test_handleRequest_base(
-                new CallbackContext(),
-                () -> DBCLUSTER_ACTIVE.toBuilder().dbClusterIdentifier(dbClusterIdentifier.toLowerCase()).build(),
-                () -> RESOURCE_MODEL.toBuilder().dBClusterIdentifier(dbClusterIdentifier).build(),
-                expectSuccess()
-        );
-
-        verify(rdsProxy.client(), times(1)).describeDBClusters(any(DescribeDbClustersRequest.class));
-
-        Assertions.assertThat(result.getResourceModel().getDBClusterIdentifier()).isEqualTo(dbClusterIdentifier);
-    }
 }

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/BaseHandlerStd.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/BaseHandlerStd.java
@@ -430,39 +430,6 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
         return StringUtils.isNotBlank(model.getDBClusterIdentifier());
     }
 
-    protected ResourceModel restoreIdentifier(final ResourceModel observed, final ResourceModel original) {
-        if (StringUtils.isBlank(original.getDBInstanceIdentifier()) ||
-                StringUtils.equals(observed.getDBInstanceIdentifier(), original.getDBInstanceIdentifier())) {
-            return observed;
-        }
-        observed.setDBInstanceIdentifier(original.getDBInstanceIdentifier());
-        return observed;
-    }
-
-    protected DBInstance restoreIdentifier(final DBInstance dbInstance, final ResourceModel model) {
-        if (StringUtils.isBlank(model.getDBInstanceIdentifier()) ||
-                StringUtils.equals(dbInstance.dbInstanceIdentifier(), model.getDBInstanceIdentifier())) {
-            return dbInstance;
-        }
-        return dbInstance.toBuilder().dbInstanceIdentifier(model.getDBInstanceIdentifier()).build();
-    }
-
-    protected DBCluster restoreIdentifier(final DBCluster dbCluster, final ResourceModel model) {
-        if (StringUtils.isBlank(model.getDBClusterIdentifier()) ||
-                StringUtils.equals(dbCluster.dbClusterIdentifier(), model.getDBClusterIdentifier())) {
-            return dbCluster;
-        }
-        return dbCluster.toBuilder().dbClusterIdentifier(model.getDBClusterIdentifier()).build();
-    }
-
-    protected DBSnapshot restoreIdentifier(final DBSnapshot dbSnapshot, final ResourceModel model) {
-        if (StringUtils.isBlank(model.getDBSnapshotIdentifier()) ||
-                StringUtils.equals(dbSnapshot.dbSnapshotIdentifier(), model.getDBSnapshotIdentifier())) {
-            return dbSnapshot;
-        }
-        return dbSnapshot.toBuilder().dbSnapshotIdentifier(model.getDBSnapshotIdentifier()).build();
-    }
-
     protected DBInstance fetchDBInstance(
             final ProxyClient<RdsClient> rdsProxyClient,
             final ResourceModel model
@@ -471,7 +438,7 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
                 Translator.describeDbInstancesRequest(model),
                 rdsProxyClient.client()::describeDBInstances
         );
-        return restoreIdentifier(response.dbInstances().stream().findFirst().get(), model);
+        return response.dbInstances().get(0);
     }
 
     protected DBCluster fetchDBCluster(
@@ -482,7 +449,7 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
                 Translator.describeDbClustersRequest(model),
                 rdsProxyClient.client()::describeDBClusters
         );
-        return restoreIdentifier(response.dbClusters().stream().findFirst().get(), model);
+        return response.dbClusters().get(0);
     }
 
     protected DBSnapshot fetchDBSnapshot(
@@ -493,7 +460,7 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
                 Translator.describeDbSnapshotsRequest(model),
                 rdsProxyClient.client()::describeDBSnapshots
         );
-        return restoreIdentifier(response.dbSnapshots().stream().findFirst().get(), model);
+        return response.dbSnapshots().get(0);
     }
 
     protected SecurityGroup fetchSecurityGroup(

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/ReadHandler.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/ReadHandler.java
@@ -41,10 +41,8 @@ public class ReadHandler extends BaseHandlerStd {
                         DEFAULT_DB_INSTANCE_ERROR_RULE_SET
                 ))
                 .done((describeRequest, describeResponse, proxyInvocation, resourceModel, context) -> {
-                    final DBInstance dbInstance = describeResponse.dbInstances().stream().findFirst().get();
-                    return ProgressEvent.success(
-                            restoreIdentifier(Translator.translateDbInstanceFromSdk(dbInstance), request.getDesiredResourceState()),
-                            context);
+                    final DBInstance dbInstance = describeResponse.dbInstances().get(0);
+                    return ProgressEvent.success(Translator.translateDbInstanceFromSdk(dbInstance), context);
                 });
     }
 }

--- a/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/CreateHandlerTest.java
+++ b/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/CreateHandlerTest.java
@@ -1270,25 +1270,4 @@ public class CreateHandlerTest extends AbstractHandlerTest {
         verify(rdsProxy.client(), times(1)).createDBInstance(argument.capture());
         Assertions.assertThat(argument.getValue().port()).isNull();
     }
-
-    @Test
-    public void handleRequest_CreateDBInstance_RestoreOriginalIdentifier() {
-        final CallbackContext context = new CallbackContext();
-        context.setCreated(false);
-        context.setUpdated(true);
-        context.setRebooted(true);
-        context.setUpdatedRoles(true);
-
-        final String dbInstanceIdentifier = "TestIdentifierInMixedCase";
-
-        final ProgressEvent<ResourceModel, CallbackContext> progressEvent = test_handleRequest_base(
-                context,
-                () -> DB_INSTANCE_ACTIVE.toBuilder().dbInstanceIdentifier(dbInstanceIdentifier.toLowerCase(Locale.getDefault())).build(),
-                () -> RESOURCE_MODEL_BLDR().dBInstanceIdentifier(dbInstanceIdentifier).build(),
-                expectSuccess()
-        );
-
-        verify(rdsProxy.client(), times(1)).createDBInstance(any(CreateDbInstanceRequest.class));
-        Assertions.assertThat(progressEvent.getResourceModel().getDBInstanceIdentifier()).isEqualTo(dbInstanceIdentifier);
-    }
 }

--- a/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/ReadHandlerTest.java
+++ b/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/ReadHandlerTest.java
@@ -78,17 +78,4 @@ public class ReadHandlerTest extends AbstractHandlerTest {
 
         verify(rdsProxy.client(), times(1)).describeDBInstances(any(DescribeDbInstancesRequest.class));
     }
-
-    @Test
-    public void handleRequest_RestoreOriginalIdentifier() {
-        final String dbInstanceIdentifier = "TestIdentifierInMixedCase";
-        final ProgressEvent<ResourceModel, CallbackContext> progressEvent = test_handleRequest_base(
-                new CallbackContext(),
-                () -> DB_INSTANCE_ACTIVE.toBuilder().dbInstanceIdentifier(dbInstanceIdentifier.toLowerCase(Locale.getDefault())).build(),
-                () -> RESOURCE_MODEL_BLDR().dBInstanceIdentifier(dbInstanceIdentifier).build(),
-                expectSuccess()
-        );
-
-        Assertions.assertThat(progressEvent.getResourceModel().getDBInstanceIdentifier()).isEqualTo(dbInstanceIdentifier);
-    }
 }

--- a/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/UpdateHandlerTest.java
+++ b/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/UpdateHandlerTest.java
@@ -1012,30 +1012,4 @@ public class UpdateHandlerTest extends AbstractHandlerTest {
         verify(rdsProxy.client(), times(5)).describeDBInstances(any(DescribeDbInstancesRequest.class));
         verify(rdsProxy.client(), times(2)).describeDBClusters(any(DescribeDbClustersRequest.class));
     }
-
-    @Test
-    public void handleRequest_modifyDbInstance_RestoreOriginalIdentifier() {
-        when(rdsProxy.client().modifyDBInstance(any(ModifyDbInstanceRequest.class)))
-                .thenReturn(ModifyDbInstanceResponse.builder().build());
-
-        final CallbackContext context = new CallbackContext();
-        context.setUpdated(false);
-        context.setRebooted(true);
-        context.setUpdatedRoles(true);
-
-        final String dbInstanceIdentifier = "TestIdentifierInMixedCase";
-
-        final ProgressEvent<ResourceModel, CallbackContext> progressEvent = test_handleRequest_base(
-                context,
-                () -> DB_INSTANCE_ACTIVE.toBuilder().dbInstanceIdentifier(dbInstanceIdentifier.toLowerCase(Locale.getDefault())).build(),
-                () -> RESOURCE_MODEL_BLDR().dBInstanceIdentifier(dbInstanceIdentifier).build(),
-                () -> RESOURCE_MODEL_BLDR().dBInstanceIdentifier(dbInstanceIdentifier).build(),
-                expectSuccess()
-        );
-
-        verify(rdsProxy.client(), times(2)).describeDBInstances(any(DescribeDbInstancesRequest.class));
-        verify(rdsProxy.client()).modifyDBInstance(any(ModifyDbInstanceRequest.class));
-
-        Assertions.assertThat(progressEvent.getResourceModel().getDBInstanceIdentifier()).isEqualTo(dbInstanceIdentifier);
-    }
 }


### PR DESCRIPTION
This commit is effectively a rollback for https://github.com/aws-cloudformation/aws-cloudformation-resource-providers-rds/pull/196.

The approach used in this fix proved to be insufficient and hence the corresponding fix was made on a lower level of CFN instead.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Signed-off-by: Oleg Sidorov <sidorovo@amazon.com>