### PR TITLE
[DBParameterGroup][DBClusterParameterGroup] Make 'Value' in tag definition optional

### DIFF
--- a/aws-rds-dbclusterparametergroup/aws-rds-dbclusterparametergroup.json
+++ b/aws-rds-dbclusterparametergroup/aws-rds-dbclusterparametergroup.json
@@ -21,7 +21,6 @@
         }
       },
       "required": [
-        "Value",
         "Key"
       ],
       "additionalProperties": false

--- a/aws-rds-dbclusterparametergroup/docs/tag.md
+++ b/aws-rds-dbclusterparametergroup/docs/tag.md
@@ -42,7 +42,7 @@ _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormati
 
 The value for the tag. You can specify a value that is 0 to 256 Unicode characters in length and cannot be prefixed with aws:. You can use any of the following characters: the set of Unicode letters, digits, whitespace, _, ., /, =, +, and -.
 
-_Required_: Yes
+_Required_: No
 
 _Type_: String
 

--- a/aws-rds-dbparametergroup/aws-rds-dbparametergroup.json
+++ b/aws-rds-dbparametergroup/aws-rds-dbparametergroup.json
@@ -22,7 +22,6 @@
         }
       },
       "required": [
-        "Value",
         "Key"
       ]
     }

--- a/aws-rds-dbparametergroup/docs/tag.md
+++ b/aws-rds-dbparametergroup/docs/tag.md
@@ -42,7 +42,7 @@ _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormati
 
 The value for the tag. You can specify a value that is 0 to 256 Unicode characters in length and cannot be prefixed with aws:. You can use any of the following characters: the set of Unicode letters, digits, whitespace, _, ., /, =, +, and -.
 
-_Required_: Yes
+_Required_: No
 
 _Type_: String
 


### PR DESCRIPTION
Make `Value` in tag definition optional. In that case value defaults to empty string

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
