### PR TITLE
[AllResources] Make value in tag definition optional

### DIFF
--- a/aws-rds-dbcluster/aws-rds-dbcluster.json
+++ b/aws-rds-dbcluster/aws-rds-dbcluster.json
@@ -386,8 +386,7 @@
         }
       },
       "required": [
-        "Key",
-        "Value"
+        "Key"
       ]
     }
   },

--- a/aws-rds-dbcluster/docs/tag.md
+++ b/aws-rds-dbcluster/docs/tag.md
@@ -42,7 +42,7 @@ _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormati
 
 The value for the tag. You can specify a value that is 0 to 256 Unicode characters in length and cannot be prefixed with aws:. You can use any of the following characters: the set of Unicode letters, digits, whitespace, _, ., /, =, +, and -.
 
-_Required_: Yes
+_Required_: No
 
 _Type_: String
 

--- a/aws-rds-dbclusterendpoint/aws-rds-dbclusterendpoint.json
+++ b/aws-rds-dbclusterendpoint/aws-rds-dbclusterendpoint.json
@@ -25,8 +25,7 @@
         }
       },
       "required": [
-        "Key",
-        "Value"
+        "Key"
       ],
       "additionalProperties": false
     }

--- a/aws-rds-dbclusterendpoint/docs/tag.md
+++ b/aws-rds-dbclusterendpoint/docs/tag.md
@@ -42,7 +42,7 @@ _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormati
 
 The value for the tag. You can specify a value that is 0 to 256 Unicode characters in length and cannot be prefixed with aws:. You can use any of the following characters: the set of Unicode letters, digits, whitespace, _, ., /, =, +, and -.
 
-_Required_: Yes
+_Required_: No
 
 _Type_: String
 

--- a/aws-rds-dbinstance/aws-rds-dbinstance.json
+++ b/aws-rds-dbinstance/aws-rds-dbinstance.json
@@ -76,8 +76,7 @@
         }
       },
       "required": [
-        "Key",
-        "Value"
+        "Key"
       ]
     }
   },

--- a/aws-rds-dbinstance/docs/tag.md
+++ b/aws-rds-dbinstance/docs/tag.md
@@ -42,7 +42,7 @@ _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormati
 
 The value for the tag. You can specify a value that is 0 to 256 Unicode characters in length and cannot be prefixed with aws:. You can use any of the following characters: the set of Unicode letters, digits, whitespace, _, ., /, =, +, and -.
 
-_Required_: Yes
+_Required_: No
 
 _Type_: String
 

--- a/aws-rds-dbsubnetgroup/aws-rds-dbsubnetgroup.json
+++ b/aws-rds-dbsubnetgroup/aws-rds-dbsubnetgroup.json
@@ -48,8 +48,7 @@
         }
       },
       "required": [
-        "Key",
-        "Value"
+        "Key"
       ]
     }
   },

--- a/aws-rds-dbsubnetgroup/docs/tag.md
+++ b/aws-rds-dbsubnetgroup/docs/tag.md
@@ -42,7 +42,7 @@ _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormati
 
 The value for the tag. You can specify a value that is 0 to 256 Unicode characters in length and cannot be prefixed with aws:. You can use any of the following characters: the set of Unicode letters, digits, whitespace, _, ., /, =, +, and -.
 
-_Required_: Yes
+_Required_: No
 
 _Type_: String
 

--- a/aws-rds-eventsubscription/aws-rds-eventsubscription.json
+++ b/aws-rds-eventsubscription/aws-rds-eventsubscription.json
@@ -21,7 +21,7 @@
         }
       },
       "required": [
-        "Value"
+        "Key"
       ]
     }
   },

--- a/aws-rds-eventsubscription/aws-rds-eventsubscription.json
+++ b/aws-rds-eventsubscription/aws-rds-eventsubscription.json
@@ -21,8 +21,7 @@
         }
       },
       "required": [
-        "Value",
-        "Key"
+        "Value"
       ]
     }
   },

--- a/aws-rds-eventsubscription/docs/tag.md
+++ b/aws-rds-eventsubscription/docs/tag.md
@@ -49,4 +49,3 @@ _Type_: String
 _Maximum_: <code>256</code>
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
-

--- a/aws-rds-eventsubscription/docs/tag.md
+++ b/aws-rds-eventsubscription/docs/tag.md
@@ -28,7 +28,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 
 The key name of the tag. You can specify a value that is 1 to 128 Unicode characters in length and cannot be prefixed with aws:. You can use any of the following characters: the set of Unicode letters, digits, whitespace, _, ., /, =, +, and -.
 
-_Required_: No
+_Required_: Yes
 
 _Type_: String
 
@@ -42,10 +42,11 @@ _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormati
 
 The value for the tag. You can specify a value that is 0 to 256 Unicode characters in length and cannot be prefixed with aws:. You can use any of the following characters: the set of Unicode letters, digits, whitespace, _, ., /, =, +, and -.
 
-_Required_: Yes
+_Required_: No
 
 _Type_: String
 
 _Maximum_: <code>256</code>
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+

--- a/aws-rds-eventsubscription/docs/tag.md
+++ b/aws-rds-eventsubscription/docs/tag.md
@@ -28,7 +28,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 
 The key name of the tag. You can specify a value that is 1 to 128 Unicode characters in length and cannot be prefixed with aws:. You can use any of the following characters: the set of Unicode letters, digits, whitespace, _, ., /, =, +, and -.
 
-_Required_: Yes
+_Required_: No
 
 _Type_: String
 

--- a/aws-rds-optiongroup/aws-rds-optiongroup.json
+++ b/aws-rds-optiongroup/aws-rds-optiongroup.json
@@ -85,8 +85,7 @@
         }
       },
       "required": [
-        "Key",
-        "Value"
+        "Key"
       ]
     }
   },

--- a/aws-rds-optiongroup/docs/tag.md
+++ b/aws-rds-optiongroup/docs/tag.md
@@ -42,7 +42,7 @@ _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormati
 
 The value for the tag. You can specify a value that is 0 to 256 Unicode characters in length and cannot be prefixed with aws:. You can use any of the following characters: the set of Unicode letters, digits, whitespace, _, ., /, =, +, and -.
 
-_Required_: Yes
+_Required_: No
 
 _Type_: String
 


### PR DESCRIPTION
This pull request replicates changes from #229 to all resources. When tag value is not specified, value defaults to empty string.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
