### PR TITLE
[DBClusterParameterGroup] Fix premature DBCluster stabilization

### DIFF
--- a/aws-rds-dbclusterparametergroup/src/main/java/software/amazon/rds/dbclusterparametergroup/CallbackContext.java
+++ b/aws-rds-dbclusterparametergroup/src/main/java/software/amazon/rds/dbclusterparametergroup/CallbackContext.java
@@ -1,5 +1,8 @@
 package software.amazon.rds.dbclusterparametergroup;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import software.amazon.cloudformation.proxy.StdCallbackContext;
 import software.amazon.rds.common.handler.TaggingContext;
 
@@ -8,16 +11,33 @@ import software.amazon.rds.common.handler.TaggingContext;
 @lombok.Setter
 @lombok.ToString
 @lombok.EqualsAndHashCode(callSuper = true)
-public class CallbackContext extends StdCallbackContext implements TaggingContext.Provider{
-    private boolean parametersApplied;
+public class CallbackContext extends StdCallbackContext implements TaggingContext.Provider {
     private String marker;
-    private boolean clusterStabilized;
     private String dbClusterParameterGroupArn;
+
+    private boolean parametersApplied;
+    private boolean clusterStabilized;
+    private boolean parametersModified;
+    private Map<String, Integer> probes;
+
     private TaggingContext taggingContext;
 
     public CallbackContext() {
         super();
+        this.probes = new HashMap<>();
         this.taggingContext = new TaggingContext();
+    }
+
+    public int getProbes(final String sampleName) {
+        return this.probes.getOrDefault(sampleName, 0);
+    }
+
+    public int incProbes(final String sampleName) {
+        return this.probes.merge(sampleName, 1, Integer::sum);
+    }
+
+    public void flushProbes(final String sampleName) {
+        this.probes.remove(sampleName);
     }
 
     @Override

--- a/aws-rds-dbclusterparametergroup/src/main/java/software/amazon/rds/dbclusterparametergroup/DeleteHandler.java
+++ b/aws-rds-dbclusterparametergroup/src/main/java/software/amazon/rds/dbclusterparametergroup/DeleteHandler.java
@@ -12,7 +12,7 @@ import software.amazon.rds.common.handler.HandlerConfig;
 public class DeleteHandler extends BaseHandlerStd {
 
     public DeleteHandler() {
-        this(HandlerConfig.builder().build());
+        this(DEFAULT_HANDLER_CONFIG);
     }
 
     public DeleteHandler(final HandlerConfig config) {

--- a/aws-rds-dbclusterparametergroup/src/main/java/software/amazon/rds/dbclusterparametergroup/ListHandler.java
+++ b/aws-rds-dbclusterparametergroup/src/main/java/software/amazon/rds/dbclusterparametergroup/ListHandler.java
@@ -1,22 +1,22 @@
 package software.amazon.rds.dbclusterparametergroup;
 
+import java.util.stream.Collectors;
+
 import software.amazon.awssdk.services.rds.RdsClient;
 import software.amazon.awssdk.services.rds.model.DescribeDbClusterParameterGroupsResponse;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.Logger;
-import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.OperationStatus;
+import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 import software.amazon.rds.common.handler.Commons;
 import software.amazon.rds.common.handler.HandlerConfig;
 
-import java.util.stream.Collectors;
-
 public class ListHandler extends BaseHandlerStd {
 
     public ListHandler() {
-        this(HandlerConfig.builder().build());
+        this(DEFAULT_HANDLER_CONFIG);
     }
 
     public ListHandler(final HandlerConfig config) {
@@ -25,18 +25,18 @@ public class ListHandler extends BaseHandlerStd {
 
     @Override
     public ProgressEvent<ResourceModel, CallbackContext> handleRequest(
-        final AmazonWebServicesClientProxy proxy,
-        final ResourceHandlerRequest<ResourceModel> request,
-        final CallbackContext callbackContext,
-        final ProxyClient<RdsClient> proxyClient,
-        final Logger logger) {
+            final AmazonWebServicesClientProxy proxy,
+            final ResourceHandlerRequest<ResourceModel> request,
+            final CallbackContext callbackContext,
+            final ProxyClient<RdsClient> proxyClient,
+            final Logger logger) {
 
         DescribeDbClusterParameterGroupsResponse describeDbClusterParameterGroupsResponse;
-        try{
+        try {
             describeDbClusterParameterGroupsResponse = proxy
                     .injectCredentialsAndInvokeV2(Translator.describeDbClusterParameterGroupsRequest(request.getNextToken()),
                             proxyClient.client()::describeDBClusterParameterGroups);
-        } catch (Exception exception){
+        } catch (Exception exception) {
             return Commons.handleException(
                     ProgressEvent.progress(request.getDesiredResourceState(), callbackContext),
                     exception,

--- a/aws-rds-dbclusterparametergroup/src/main/java/software/amazon/rds/dbclusterparametergroup/ReadHandler.java
+++ b/aws-rds-dbclusterparametergroup/src/main/java/software/amazon/rds/dbclusterparametergroup/ReadHandler.java
@@ -16,7 +16,7 @@ import software.amazon.rds.common.handler.Tagging;
 public class ReadHandler extends BaseHandlerStd {
 
     public ReadHandler() {
-        this(HandlerConfig.builder().build());
+        this(DEFAULT_HANDLER_CONFIG);
     }
 
     public ReadHandler(final HandlerConfig config) {

--- a/aws-rds-dbclusterparametergroup/src/main/java/software/amazon/rds/dbclusterparametergroup/UpdateHandler.java
+++ b/aws-rds-dbclusterparametergroup/src/main/java/software/amazon/rds/dbclusterparametergroup/UpdateHandler.java
@@ -6,13 +6,14 @@ import software.amazon.cloudformation.proxy.Logger;
 import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
+import software.amazon.rds.common.handler.Commons;
 import software.amazon.rds.common.handler.HandlerConfig;
 import software.amazon.rds.common.handler.Tagging;
 
 public class UpdateHandler extends BaseHandlerStd {
 
     public UpdateHandler() {
-        this(HandlerConfig.builder().build());
+        this(DEFAULT_HANDLER_CONFIG);
     }
 
     public UpdateHandler(final HandlerConfig config) {
@@ -42,7 +43,8 @@ public class UpdateHandler extends BaseHandlerStd {
         return ProgressEvent.progress(model, callbackContext)
                 .then(progress -> updateTags(proxy, proxyClient, progress, previousTags, desiredTags))
                 .then(progress -> resetAllParameters(progress, proxy, proxyClient))
-                .then(progress -> applyParameters(proxy, proxyClient, progress.getResourceModel(), progress.getCallbackContext()))
+                .then(progress -> Commons.execOnce(progress, () -> applyParameters(proxy, proxyClient, progress.getResourceModel(), progress.getCallbackContext()),
+                        CallbackContext::isParametersApplied, CallbackContext::setParametersApplied))
                 .then(progress -> new ReadHandler().handleRequest(proxy, request, callbackContext, proxyClient, logger));
     }
 }

--- a/aws-rds-dbclusterparametergroup/src/test/java/software/amazon/rds/dbclusterparametergroup/AbstractTestBase.java
+++ b/aws-rds-dbclusterparametergroup/src/test/java/software/amazon/rds/dbclusterparametergroup/AbstractTestBase.java
@@ -1,6 +1,7 @@
 package software.amazon.rds.dbclusterparametergroup;
 
 
+import java.time.Duration;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -25,9 +26,9 @@ import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.Credentials;
 import software.amazon.cloudformation.proxy.LoggerProxy;
 import software.amazon.cloudformation.proxy.ProxyClient;
+import software.amazon.cloudformation.proxy.delay.Constant;
 
 public class AbstractTestBase {
-
     protected static final Credentials MOCK_CREDENTIALS;
     protected static final org.slf4j.Logger delegate;
     protected static final LoggerProxy logger;
@@ -45,6 +46,10 @@ public class AbstractTestBase {
     protected static final Parameter PARAM_1, PARAM_2;
     protected static final DBClusterParameterGroup DB_CLUSTER_PARAMETER_GROUP;
 
+    protected static Constant TEST_BACKOFF_DELAY = Constant.of()
+            .delay(Duration.ofMillis(1L))
+            .timeout(Duration.ofSeconds(10L))
+            .build();
 
     static {
         System.setProperty("org.slf4j.simpleLogger.showDateTime", "true");
@@ -154,5 +159,14 @@ public class AbstractTestBase {
                 return rdsClient;
             }
         };
+    }
+
+    protected List<Parameter> translateParamMapToCollection(final Map<String, Object> params) {
+        return params.entrySet().stream().map(entry -> Parameter.builder()
+                        .parameterName(entry.getKey())
+                        .parameterValue((String) entry.getValue())
+                        .applyType(ParameterType.Dynamic.toString())
+                        .build())
+                .collect(Collectors.toList());
     }
 }

--- a/aws-rds-dbclusterparametergroup/src/test/java/software/amazon/rds/dbclusterparametergroup/ListHandlerTest.java
+++ b/aws-rds-dbclusterparametergroup/src/test/java/software/amazon/rds/dbclusterparametergroup/ListHandlerTest.java
@@ -1,25 +1,30 @@
 package software.amazon.rds.dbclusterparametergroup;
 
-import org.junit.jupiter.api.AfterEach;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
 
-import software.amazon.awssdk.services.rds.RdsClient;
-import software.amazon.awssdk.services.rds.model.DescribeDbClusterParameterGroupsRequest;
-import software.amazon.awssdk.services.rds.model.DescribeDbClusterParameterGroupsResponse;
-import software.amazon.cloudformation.proxy.*;
+import java.time.Duration;
+
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.time.Duration;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import software.amazon.awssdk.services.rds.RdsClient;
+import software.amazon.awssdk.services.rds.model.DescribeDbClusterParameterGroupsRequest;
+import software.amazon.awssdk.services.rds.model.DescribeDbClusterParameterGroupsResponse;
+import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
+import software.amazon.cloudformation.proxy.OperationStatus;
+import software.amazon.cloudformation.proxy.ProgressEvent;
+import software.amazon.cloudformation.proxy.ProxyClient;
+import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
+import software.amazon.rds.common.handler.HandlerConfig;
 
 @ExtendWith(MockitoExtension.class)
 public class ListHandlerTest extends AbstractTestBase {
@@ -35,31 +40,35 @@ public class ListHandlerTest extends AbstractTestBase {
 
     private ListHandler handler;
 
-    @AfterEach
-    public void post_execute() {
-        verifyNoMoreInteractions(proxyRdsClient.client());
-    }
-
     @BeforeEach
     public void setup() {
-        handler = new ListHandler();
+        handler = new ListHandler(HandlerConfig.builder()
+                .probingEnabled(false)
+                .backoff(TEST_BACKOFF_DELAY)
+                .build());
+
         rds = mock(RdsClient.class);
         proxy = new AmazonWebServicesClientProxy(logger, MOCK_CREDENTIALS, () -> Duration.ofSeconds(600).toMillis());
         proxyRdsClient = MOCK_PROXY(proxy, rds);
     }
 
+    @AfterEach
+    public void post_execute() {
+        verifyNoMoreInteractions(proxyRdsClient.client());
+    }
+
     @Test
-    public void handleRequest_SimpleSuccess() {
+    public void handleRequest_Success() {
         final DescribeDbClusterParameterGroupsResponse describeDbClusterParameterGroupsResponse = DescribeDbClusterParameterGroupsResponse.builder().build();
         when(proxyRdsClient.client().describeDBClusterParameterGroups(any(DescribeDbClusterParameterGroupsRequest.class))).thenReturn(describeDbClusterParameterGroupsResponse);
         final ResourceModel model = ResourceModel.builder().build();
 
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
-            .desiredResourceState(model)
-            .build();
+                .desiredResourceState(model)
+                .build();
 
         final ProgressEvent<ResourceModel, CallbackContext> response =
-            handler.handleRequest(proxy, request, new CallbackContext(), proxyRdsClient, logger);
+                handler.handleRequest(proxy, request, new CallbackContext(), proxyRdsClient, logger);
 
         assertThat(response).isNotNull();
         assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);

--- a/aws-rds-dbclusterparametergroup/src/test/java/software/amazon/rds/dbclusterparametergroup/UpdateHandlerTest.java
+++ b/aws-rds-dbclusterparametergroup/src/test/java/software/amazon/rds/dbclusterparametergroup/UpdateHandlerTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
@@ -25,39 +26,37 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import software.amazon.awssdk.services.rds.RdsClient;
 import software.amazon.awssdk.services.rds.model.AddTagsToResourceRequest;
 import software.amazon.awssdk.services.rds.model.AddTagsToResourceResponse;
+import software.amazon.awssdk.services.rds.model.DBCluster;
 import software.amazon.awssdk.services.rds.model.DBClusterParameterGroup;
 import software.amazon.awssdk.services.rds.model.DescribeDbClusterParameterGroupsRequest;
 import software.amazon.awssdk.services.rds.model.DescribeDbClusterParameterGroupsResponse;
 import software.amazon.awssdk.services.rds.model.DescribeDbClusterParametersRequest;
 import software.amazon.awssdk.services.rds.model.DescribeDbClusterParametersResponse;
-import software.amazon.awssdk.services.rds.model.DescribeEngineDefaultClusterParametersRequest;
-import software.amazon.awssdk.services.rds.model.DescribeEngineDefaultClusterParametersResponse;
-import software.amazon.awssdk.services.rds.model.EngineDefaults;
+import software.amazon.awssdk.services.rds.model.DescribeDbClustersRequest;
+import software.amazon.awssdk.services.rds.model.DescribeDbClustersResponse;
 import software.amazon.awssdk.services.rds.model.ListTagsForResourceRequest;
 import software.amazon.awssdk.services.rds.model.ListTagsForResourceResponse;
-import software.amazon.awssdk.services.rds.model.Parameter;
 import software.amazon.awssdk.services.rds.model.ResetDbClusterParameterGroupRequest;
-import software.amazon.awssdk.services.rds.paginators.DescribeDBClusterParametersIterable;
+import software.amazon.awssdk.services.rds.model.ResetDbClusterParameterGroupResponse;
+import software.amazon.awssdk.services.rds.paginators.DescribeDBClustersIterable;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.OperationStatus;
 import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
+import software.amazon.rds.common.handler.HandlerConfig;
 
 @ExtendWith(MockitoExtension.class)
 public class UpdateHandlerTest extends AbstractTestBase {
+
     private static final List<Tag> UPDATED_TAG_SET = Lists.newArrayList(Tag.builder().key("updated_key").value("updated_value").build());
-    ;
-
-    @Mock
-    private AmazonWebServicesClientProxy proxy;
-
-    @Mock
-    private ProxyClient<RdsClient> proxyRdsClient;
 
     @Mock
     RdsClient rds;
-
+    @Mock
+    private AmazonWebServicesClientProxy proxy;
+    @Mock
+    private ProxyClient<RdsClient> proxyRdsClient;
     private UpdateHandler handler;
 
     private ResourceModel RESOURCE_MODEL_PREV;
@@ -70,16 +69,13 @@ public class UpdateHandlerTest extends AbstractTestBase {
     private ResourceHandlerRequest<ResourceModel> requestSameParams;
     private ResourceHandlerRequest<ResourceModel> requestUpdParams;
 
-    @AfterEach
-    public void post_execute() {
-        verify(rds, atLeastOnce()).serviceName();
-        verifyNoMoreInteractions(proxyRdsClient.client());
-    }
-
     @BeforeEach
     public void setup() {
+        handler = new UpdateHandler(HandlerConfig.builder()
+                .probingEnabled(false)
+                .backoff(TEST_BACKOFF_DELAY)
+                .build());
 
-        handler = new UpdateHandler();
         rds = mock(RdsClient.class);
         proxy = new AmazonWebServicesClientProxy(logger, MOCK_CREDENTIALS, () -> Duration.ofSeconds(600).toMillis());
         proxyRdsClient = MOCK_PROXY(proxy, rds);
@@ -126,8 +122,14 @@ public class UpdateHandlerTest extends AbstractTestBase {
                 .logicalResourceIdentifier("logicalId").build();
     }
 
+    @AfterEach
+    public void post_execute() {
+        verify(rds, atLeastOnce()).serviceName();
+        verifyNoMoreInteractions(proxyRdsClient.client());
+    }
+
     @Test
-    public void handleRequest_SimpleSuccess() {
+    public void handleRequest_Success() {
 
         CallbackContext callbackContext = new CallbackContext();
         callbackContext.setParametersApplied(true);
@@ -151,50 +153,75 @@ public class UpdateHandlerTest extends AbstractTestBase {
         assertThat(response.getMessage()).isNull();
         assertThat(response.getErrorCode()).isNull();
 
-
         verify(proxyRdsClient.client()).describeDBClusterParameterGroups(any(DescribeDbClusterParameterGroupsRequest.class));
         verify(proxyRdsClient.client()).resetDBClusterParameterGroup(any(ResetDbClusterParameterGroupRequest.class));
         verify(proxyRdsClient.client()).addTagsToResource(any(AddTagsToResourceRequest.class));
     }
 
+    @Test
+    public void handleRequest_StabilizeDBClusters() {
+        when(rds.resetDBClusterParameterGroup(any(ResetDbClusterParameterGroupRequest.class)))
+                .thenReturn(ResetDbClusterParameterGroupResponse.builder().build());
 
-    private void mockDescribeDbClusterParametersResponse(String firstParamApplyType,
-                                                         String secondParamApplyType,
-                                                         boolean isModifiable) {
-        Parameter param1 = Parameter.builder()
-                .parameterName("param")
-                .parameterValue("system_value")
-                .isModifiable(isModifiable)
-                .applyType(firstParamApplyType)
+        when(rds.describeDBClusterParameters(any(DescribeDbClusterParametersRequest.class)))
+                .thenReturn(DescribeDbClusterParametersResponse.builder()
+                        .parameters(translateParamMapToCollection(PARAMS))
+                        .build());
+
+        when(rds.describeDBClusterParameterGroups(any(DescribeDbClusterParameterGroupsRequest.class)))
+                .thenReturn(DescribeDbClusterParameterGroupsResponse.builder()
+                        .dbClusterParameterGroups(DBClusterParameterGroup.builder()
+                                .dbClusterParameterGroupName("group")
+                                .dbClusterParameterGroupArn("arn")
+                                .build())
+                        .build());
+
+        when(rds.listTagsForResource(any(ListTagsForResourceRequest.class)))
+                .thenReturn(ListTagsForResourceResponse.builder().build());
+
+        final DBCluster dbCluster = DBCluster.builder()
+                .dbClusterIdentifier("db-cluster-identifier")
+                .dbClusterParameterGroup("group")
                 .build();
-        Parameter param2 = Parameter.builder()
-                .parameterName("param2")
-                .parameterValue("system_value")
-                .isModifiable(isModifiable)
-                .applyType(secondParamApplyType)
+
+        final DescribeDBClustersIterable describeDbClustersResponseModifying = mock(DescribeDBClustersIterable.class);
+        when(describeDbClustersResponseModifying.stream())
+                .thenReturn(Stream.<DescribeDbClustersResponse>builder().add(DescribeDbClustersResponse.builder()
+                        .dbClusters(dbCluster.toBuilder().status("modifying").build())
+                        .build()).build());
+
+        final DescribeDBClustersIterable describeDbClustersResponseAvailable = mock(DescribeDBClustersIterable.class);
+        when(describeDbClustersResponseAvailable.stream())
+                .thenReturn(Stream.<DescribeDbClustersResponse>builder().add(DescribeDbClustersResponse.builder()
+                        .dbClusters(dbCluster.toBuilder().status("available").build())
+                        .build()).build());
+
+        when(rds.describeDBClustersPaginator(any(DescribeDbClustersRequest.class)))
+                .thenReturn(describeDbClustersResponseModifying)
+                .thenReturn(describeDbClustersResponseAvailable);
+
+        final ResourceHandlerRequest<ResourceModel> handlerRequest = ResourceHandlerRequest.<ResourceModel>builder()
+                .clientRequestToken("token")
+                .previousResourceState(RESOURCE_MODEL.toBuilder().dBClusterParameterGroupName("group").parameters(PARAMS).tags(null).build())
+                .desiredResourceState(UPDATED_RESOURCE_MODEL.toBuilder().dBClusterParameterGroupName("group").parameters(UPDATED_PARAMS).tags(null).build())
+                .logicalResourceIdentifier("logicalId")
                 .build();
 
-        final DescribeEngineDefaultClusterParametersResponse describeEngineDefaultParametersResponse = DescribeEngineDefaultClusterParametersResponse.builder()
-                .engineDefaults(EngineDefaults.builder()
-                        .parameters(param1, param2)
-                        .build()
-                ).build();
-        when(proxyRdsClient.client().describeEngineDefaultClusterParameters(any(DescribeEngineDefaultClusterParametersRequest.class)))
-                .thenReturn(describeEngineDefaultParametersResponse);
+        final CallbackContext context = new CallbackContext();
 
-        if (!isModifiable)
-            return;
+        final ProgressEvent<ResourceModel, CallbackContext> handlerResponse = handler.handleRequest(proxy, handlerRequest, context, proxyRdsClient, logger);
 
-        final DescribeDbClusterParametersResponse describeDbClusterParametersResponse = DescribeDbClusterParametersResponse.builder().marker(null)
-                .parameters(param1, param2).build();
+        assertThat(handlerResponse).isNotNull();
+        assertThat(handlerResponse.getStatus()).isEqualTo(OperationStatus.SUCCESS);
+        assertThat(handlerResponse.getCallbackDelaySeconds()).isEqualTo(0);
+        assertThat(handlerResponse.getResourceModels()).isNull();
+        assertThat(handlerResponse.getMessage()).isNull();
+        assertThat(handlerResponse.getErrorCode()).isNull();
 
-        final DescribeDBClusterParametersIterable describeDbClusterParametersIterable = mock(DescribeDBClusterParametersIterable.class);
-        when(describeDbClusterParametersIterable.stream())
-                .thenReturn(Stream.<DescribeDbClusterParametersResponse>builder()
-                        .add(describeDbClusterParametersResponse)
-                        .build()
-                );
-        when(proxyRdsClient.client().describeDBClusterParametersPaginator(any(DescribeDbClusterParametersRequest.class))).thenReturn(describeDbClusterParametersIterable);
+        verify(proxyRdsClient.client()).resetDBClusterParameterGroup(any(ResetDbClusterParameterGroupRequest.class));
+        verify(proxyRdsClient.client()).describeDBClusterParameters(any(DescribeDbClusterParametersRequest.class));
+        verify(proxyRdsClient.client(), times(2)).describeDBClustersPaginator(any(DescribeDbClustersRequest.class));
+        verify(proxyRdsClient.client()).describeDBClusterParameterGroups(any(DescribeDbClusterParameterGroupsRequest.class));
+        verify(proxyRdsClient.client()).listTagsForResource(any(ListTagsForResourceRequest.class));
     }
-
 }


### PR DESCRIPTION
This commit fixes an issue with the final stage of `applyParameters`.

Once the parameters have been applied, the handler code stabilizes on the list of `DBCluster` objects that might depend on this `DBClusterParameterGroup`. This stabilization is being short-circuited by a flag used for unit testing purposes: a re-entrant chain invocation skips the stabilization and reports an update complete status. Any upcoming `ModifyDBCluster` calls on a dependant cluster object will cause a `DB cluster isn't available for modification with status modifying` API rejection.

This commit fixes the eager flag set (set too early).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Signed-off-by: Oleg Sidorov <sidorovo@amazon.com>