### PR TITLE
[DBClusterParameterGroup] Fix repeating tag updates in UpdateHandler

### DIFF
--- a/aws-rds-dbclusterparametergroup/src/main/java/software/amazon/rds/dbclusterparametergroup/UpdateHandler.java
+++ b/aws-rds-dbclusterparametergroup/src/main/java/software/amazon/rds/dbclusterparametergroup/UpdateHandler.java
@@ -41,7 +41,8 @@ public class UpdateHandler extends BaseHandlerStd {
                 .build();
 
         return ProgressEvent.progress(model, callbackContext)
-                .then(progress -> updateTags(proxy, proxyClient, progress, previousTags, desiredTags))
+                .then(progress -> Commons.execOnce(progress, () -> updateTags(proxy, proxyClient, progress, previousTags, desiredTags),
+                        CallbackContext::isAddTagsComplete, CallbackContext::setAddTagsComplete))
                 .then(progress -> resetAllParameters(progress, proxy, proxyClient))
                 .then(progress -> Commons.execOnce(progress, () -> applyParameters(proxy, proxyClient, progress.getResourceModel(), progress.getCallbackContext()),
                         CallbackContext::isParametersApplied, CallbackContext::setParametersApplied))

--- a/aws-rds-dbclusterparametergroup/src/test/java/software/amazon/rds/dbclusterparametergroup/UpdateHandlerTest.java
+++ b/aws-rds-dbclusterparametergroup/src/test/java/software/amazon/rds/dbclusterparametergroup/UpdateHandlerTest.java
@@ -36,6 +36,8 @@ import software.amazon.awssdk.services.rds.model.DescribeDbClustersRequest;
 import software.amazon.awssdk.services.rds.model.DescribeDbClustersResponse;
 import software.amazon.awssdk.services.rds.model.ListTagsForResourceRequest;
 import software.amazon.awssdk.services.rds.model.ListTagsForResourceResponse;
+import software.amazon.awssdk.services.rds.model.RemoveTagsFromResourceRequest;
+import software.amazon.awssdk.services.rds.model.RemoveTagsFromResourceResponse;
 import software.amazon.awssdk.services.rds.model.ResetDbClusterParameterGroupRequest;
 import software.amazon.awssdk.services.rds.model.ResetDbClusterParameterGroupResponse;
 import software.amazon.awssdk.services.rds.paginators.DescribeDBClustersIterable;
@@ -176,6 +178,10 @@ public class UpdateHandlerTest extends AbstractTestBase {
                                 .build())
                         .build());
 
+        when(rds.addTagsToResource(any(AddTagsToResourceRequest.class)))
+                .thenReturn(AddTagsToResourceResponse.builder().build());
+        when(rds.removeTagsFromResource(any(RemoveTagsFromResourceRequest.class)))
+                .thenReturn(RemoveTagsFromResourceResponse.builder().build());
         when(rds.listTagsForResource(any(ListTagsForResourceRequest.class)))
                 .thenReturn(ListTagsForResourceResponse.builder().build());
 
@@ -202,8 +208,8 @@ public class UpdateHandlerTest extends AbstractTestBase {
 
         final ResourceHandlerRequest<ResourceModel> handlerRequest = ResourceHandlerRequest.<ResourceModel>builder()
                 .clientRequestToken("token")
-                .previousResourceState(RESOURCE_MODEL.toBuilder().dBClusterParameterGroupName("group").parameters(PARAMS).tags(null).build())
-                .desiredResourceState(UPDATED_RESOURCE_MODEL.toBuilder().dBClusterParameterGroupName("group").parameters(UPDATED_PARAMS).tags(null).build())
+                .previousResourceState(RESOURCE_MODEL.toBuilder().dBClusterParameterGroupName("group").parameters(PARAMS).tags(TAG_SET).build())
+                .desiredResourceState(UPDATED_RESOURCE_MODEL.toBuilder().dBClusterParameterGroupName("group").parameters(UPDATED_PARAMS).tags(UPDATED_TAG_SET).build())
                 .logicalResourceIdentifier("logicalId")
                 .build();
 
@@ -223,5 +229,7 @@ public class UpdateHandlerTest extends AbstractTestBase {
         verify(proxyRdsClient.client(), times(2)).describeDBClustersPaginator(any(DescribeDbClustersRequest.class));
         verify(proxyRdsClient.client()).describeDBClusterParameterGroups(any(DescribeDbClusterParameterGroupsRequest.class));
         verify(proxyRdsClient.client()).listTagsForResource(any(ListTagsForResourceRequest.class));
+        verify(proxyRdsClient.client(), times(1)).addTagsToResource(any(AddTagsToResourceRequest.class));
+        verify(proxyRdsClient.client(), times(1)).removeTagsFromResource(any(RemoveTagsFromResourceRequest.class));
     }
 }


### PR DESCRIPTION
This commit fixes unnecessary `AddTagsToResource` and `RemoveTagsFromResource` requests that occur in `UpdateHandler` when a cluster parameter group is being modified. The error happens on re-entrance when the handler enters DBCluster stabilization cycle. Even though adding already existing tags and removing non-existing ones is a no-op, RDS API can probablistically spawn a DBCluster update cycle and this can break a following ModifyDBCluster invocation.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Signed-off-by: Oleg Sidorov <sidorovo@amazon.com>