### PR TITLE
[DBInstance] Remove junit.framework.Assert

### DIFF
--- a/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/BaseHandlerStdTest.java
+++ b/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/BaseHandlerStdTest.java
@@ -3,10 +3,10 @@ package software.amazon.rds.dbinstance;
 import java.time.Instant;
 import java.util.Collections;
 
-import junit.framework.Assert;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
+import org.assertj.core.api.Assertions;
 
 import software.amazon.awssdk.services.ec2.Ec2Client;
 import software.amazon.awssdk.services.rds.RdsClient;
@@ -48,59 +48,59 @@ class BaseHandlerStdTest {
 
     @Test
     void isPromotionTierUpdated_NullPromotionTierReturnsTrue() {
-        Assert.assertTrue(handler.isPromotionTierUpdated(
+        Assertions.assertThat(handler.isPromotionTierUpdated(
                 DBInstance.builder().build(),
                 ResourceModel.builder().build()
-        ));
+        )).isTrue();
     }
 
     @Test
     void isPromotionTierUpdated_MatchingPromotionTiedReturnsTrue() {
-        Assert.assertTrue(handler.isPromotionTierUpdated(
+        Assertions.assertThat(handler.isPromotionTierUpdated(
                 DBInstance.builder().promotionTier(42).build(),
                 ResourceModel.builder().promotionTier(42).build()
-        ));
+        )).isTrue();
     }
 
     @Test
     void isPromotionTierUpdated_MismatchingPromotionTierReturnsFalse() {
-        Assert.assertFalse(handler.isPromotionTierUpdated(
+        Assertions.assertThat(handler.isPromotionTierUpdated(
                 DBInstance.builder().promotionTier(42).build(),
                 ResourceModel.builder().promotionTier(null).build()
-        ));
+        )).isFalse();
     }
 
     @Test
     void isDomainMembershipsJoined_NullDomainMembershipReturnsTrue() {
-        Assert.assertTrue(handler.isDomainMembershipsJoined(
+        Assertions.assertThat(handler.isDomainMembershipsJoined(
                 DBInstance.builder().build()
-        ));
+        )).isTrue();
     }
 
     @Test
     void isDomainMembershipsJoined_EmptyDomainMembershipReturnsTrue() {
-        Assert.assertTrue(handler.isDomainMembershipsJoined(
+        Assertions.assertThat(handler.isDomainMembershipsJoined(
                 DBInstance.builder()
                         .domainMemberships(Collections.emptyList())
                         .build()
-        ));
+        )).isTrue();
     }
 
     @Test
     void isDomainMembershipsJoined_NonEmptyListJoinedAndKerberosReturnsTrue() {
-        Assert.assertTrue(handler.isDomainMembershipsJoined(
+        Assertions.assertThat(handler.isDomainMembershipsJoined(
                 DBInstance.builder()
                         .domainMemberships(
                                 DomainMembership.builder().status("joined").build(),
                                 DomainMembership.builder().status("kerberos-enabled").build()
                         )
                         .build()
-        ));
+        )).isTrue();
     }
 
     @Test
     void isDomainMembershipsJoined_NonEmptyListJoinedAndKerberosAndAnythingElseReturnsFalse() {
-        Assert.assertFalse(handler.isDomainMembershipsJoined(
+        Assertions.assertThat(handler.isDomainMembershipsJoined(
                 DBInstance.builder()
                         .domainMemberships(
                                 DomainMembership.builder().status("joined").build(),
@@ -108,336 +108,336 @@ class BaseHandlerStdTest {
                                 DomainMembership.builder().status("something else").build()
                         )
                         .build()
-        ));
+        )).isFalse();
     }
 
     @Test
     void isVpcSecurityGroupsActive_NullVpcSecurityGroupsReturnsTrue() {
-        Assert.assertTrue(handler.isVpcSecurityGroupsActive(
+        Assertions.assertThat(handler.isVpcSecurityGroupsActive(
                 DBInstance.builder().build()
-        ));
+        )).isTrue();
     }
 
     @Test
     void isVpcSecurityGroupsActive_EmptyVpcSecurityGroupsReturnsTrue() {
-        Assert.assertTrue(handler.isVpcSecurityGroupsActive(
+        Assertions.assertThat(handler.isVpcSecurityGroupsActive(
                 DBInstance.builder()
                         .vpcSecurityGroups(Collections.emptyList())
                         .build()
-        ));
+        )).isTrue();
     }
 
     @Test
     void isVpcSecurityGroupsActive_NonEmptyVpcSecurityGroupsActiveReturnsTrue() {
-        Assert.assertTrue(handler.isVpcSecurityGroupsActive(
+        Assertions.assertThat(handler.isVpcSecurityGroupsActive(
                 DBInstance.builder()
                         .vpcSecurityGroups(
                                 VpcSecurityGroupMembership.builder().status("active").build(),
                                 VpcSecurityGroupMembership.builder().status("active").build()
                         )
                         .build()
-        ));
+        )).isTrue();
     }
 
     @Test
     void isVpcSecurityGroupsActive_NonEmptyVpcSecurityGroupsNotActiveReturnsFalse() {
-        Assert.assertFalse(handler.isVpcSecurityGroupsActive(
+        Assertions.assertThat(handler.isVpcSecurityGroupsActive(
                 DBInstance.builder()
                         .vpcSecurityGroups(
                                 VpcSecurityGroupMembership.builder().status("active").build(),
                                 VpcSecurityGroupMembership.builder().status(null).build()
                         )
                         .build()
-        ));
+        )).isFalse();
     }
 
     @Test
     void isNoPendingChanges_NullPendingChangesReturnsTrue() {
-        Assert.assertTrue(handler.isNoPendingChanges(
+        Assertions.assertThat(handler.isNoPendingChanges(
                 DBInstance.builder().build()
-        ));
+        )).isTrue();
     }
 
     @Test
     void isNoPendingChanges_EmptyPendingChangesReturnsTrue() {
-        Assert.assertTrue(handler.isNoPendingChanges(
+        Assertions.assertThat(handler.isNoPendingChanges(
                 DBInstance.builder()
                         .pendingModifiedValues(PendingModifiedValues.builder().build())
                         .build()
-        ));
+        )).isTrue();
     }
 
     @Test
     void isNoPendingChanges_NonEmptyAllocatedStorageReturnsFalse() {
-        Assert.assertFalse(handler.isNoPendingChanges(
+        Assertions.assertThat(handler.isNoPendingChanges(
                 DBInstance.builder()
                         .pendingModifiedValues(
                                 PendingModifiedValues.builder()
                                         .allocatedStorage(42)
                                         .build())
                         .build()
-        ));
+        )).isFalse();
     }
 
     @Test
     void isNoPendingChanges_NonEmptyCACertificateIdentifierReturnsFalse() {
-        Assert.assertFalse(handler.isNoPendingChanges(
+        Assertions.assertThat(handler.isNoPendingChanges(
                 DBInstance.builder()
                         .pendingModifiedValues(
                                 PendingModifiedValues.builder()
                                         .caCertificateIdentifier("certificate")
                                         .build())
                         .build()
-        ));
+        )).isFalse();
     }
 
     @Test
     void isNoPendingChanges_NonEmptyMasterUserPasswordReturnsFalse() {
-        Assert.assertFalse(handler.isNoPendingChanges(
+        Assertions.assertThat(handler.isNoPendingChanges(
                 DBInstance.builder()
                         .pendingModifiedValues(
                                 PendingModifiedValues.builder()
                                         .masterUserPassword("password")
                                         .build())
                         .build()
-        ));
+        )).isFalse();
     }
 
     @Test
     void isNoPendingChanges_NonEmptyBackupRetentionPeriodReturnsFalse() {
-        Assert.assertFalse(handler.isNoPendingChanges(
+        Assertions.assertThat(handler.isNoPendingChanges(
                 DBInstance.builder()
                         .pendingModifiedValues(
                                 PendingModifiedValues.builder()
                                         .backupRetentionPeriod(42)
                                         .build())
                         .build()
-        ));
+        )).isFalse();
     }
 
     @Test
     void isNoPendingChanges_NonEmptyMultiAZReturnsFalse() {
-        Assert.assertFalse(handler.isNoPendingChanges(
+        Assertions.assertThat(handler.isNoPendingChanges(
                 DBInstance.builder()
                         .pendingModifiedValues(
                                 PendingModifiedValues.builder()
                                         .multiAZ(true)
                                         .build())
                         .build()
-        ));
+        )).isFalse();
     }
 
     @Test
     void isNoPendingChanges_NonEmptyEngineVersionReturnsFalse() {
-        Assert.assertFalse(handler.isNoPendingChanges(
+        Assertions.assertThat(handler.isNoPendingChanges(
                 DBInstance.builder()
                         .pendingModifiedValues(
                                 PendingModifiedValues.builder()
                                         .engineVersion("1.2.3")
                                         .build())
                         .build()
-        ));
+        )).isFalse();
     }
 
     @Test
     void isNoPendingChanges_NonEmptyIopsReturnsFalse() {
-        Assert.assertFalse(handler.isNoPendingChanges(
+        Assertions.assertThat(handler.isNoPendingChanges(
                 DBInstance.builder()
                         .pendingModifiedValues(
                                 PendingModifiedValues.builder()
                                         .iops(42)
                                         .build())
                         .build()
-        ));
+        )).isFalse();
     }
 
     @Test
     void isNoPendingChanges_NonEmptyDBInstanceIdentifierReturnsFalse() {
-        Assert.assertFalse(handler.isNoPendingChanges(
+        Assertions.assertThat(handler.isNoPendingChanges(
                 DBInstance.builder()
                         .pendingModifiedValues(
                                 PendingModifiedValues.builder()
                                         .dbInstanceIdentifier("dbinstance")
                                         .build())
                         .build()
-        ));
+        )).isFalse();
     }
 
     @Test
     void isNoPendingChanges_NonEmptyLicenseModelReturnsFalse() {
-        Assert.assertFalse(handler.isNoPendingChanges(
+        Assertions.assertThat(handler.isNoPendingChanges(
                 DBInstance.builder()
                         .pendingModifiedValues(
                                 PendingModifiedValues.builder()
                                         .licenseModel("license model")
                                         .build())
                         .build()
-        ));
+        )).isFalse();
     }
 
     @Test
     void isNoPendingChanges_NonEmptyStorageTypeReturnsFalse() {
-        Assert.assertFalse(handler.isNoPendingChanges(
+        Assertions.assertThat(handler.isNoPendingChanges(
                 DBInstance.builder()
                         .pendingModifiedValues(
                                 PendingModifiedValues.builder()
                                         .storageType("storage type")
                                         .build())
                         .build()
-        ));
+        )).isFalse();
     }
 
     @Test
     void isNoPendingChanges_NonEmptyDBSubnetGroupNameReturnsFalse() {
-        Assert.assertFalse(handler.isNoPendingChanges(
+        Assertions.assertThat(handler.isNoPendingChanges(
                 DBInstance.builder()
                         .pendingModifiedValues(
                                 PendingModifiedValues.builder()
                                         .dbSubnetGroupName("db-subnet-group-name")
                                         .build())
                         .build()
-        ));
+        )).isFalse();
     }
 
     @Test
     void isNoPendingChanges_NonEmptyPendingCloudWatchLogsExportsReturnsFalse() {
-        Assert.assertFalse(handler.isNoPendingChanges(
+        Assertions.assertThat(handler.isNoPendingChanges(
                 DBInstance.builder()
                         .pendingModifiedValues(
                                 PendingModifiedValues.builder()
                                         .pendingCloudwatchLogsExports(PendingCloudwatchLogsExports.builder().build())
                                         .build())
                         .build()
-        ));
+        )).isFalse();
     }
 
     @Test
     void isNoPendingChanges_EmptyProcessorFeaturesReturnsTrue() {
-        Assert.assertTrue(handler.isNoPendingChanges(
+        Assertions.assertThat(handler.isNoPendingChanges(
                 DBInstance.builder()
                         .pendingModifiedValues(
                                 PendingModifiedValues.builder()
                                         .processorFeatures(Collections.emptyList())
                                         .build())
                         .build()
-        ));
+        )).isTrue();
     }
 
     @Test
     void isNoPendingChanges_NonEmptyIamDatabaseAutenticationEnabledReturnsFalse() {
-        Assert.assertFalse(handler.isNoPendingChanges(
+        Assertions.assertThat(handler.isNoPendingChanges(
                 DBInstance.builder()
                         .pendingModifiedValues(
                                 PendingModifiedValues.builder()
                                         .iamDatabaseAuthenticationEnabled(true)
                                         .build())
                         .build()
-        ));
+        )).isFalse();
     }
 
     @Test
     void isNoPendingChanges_NonEmptyAutomationModeReturnsFalse() {
-        Assert.assertFalse(handler.isNoPendingChanges(
+        Assertions.assertThat(handler.isNoPendingChanges(
                 DBInstance.builder()
                         .pendingModifiedValues(
                                 PendingModifiedValues.builder()
                                         .automationMode("automation mode")
                                         .build())
                         .build()
-        ));
+        )).isFalse();
     }
 
     @Test
     void isNoPendingChanges_NonEmptyResumeFullAutomationModeTimeReturnsFalse() {
-        Assert.assertFalse(handler.isNoPendingChanges(
+        Assertions.assertThat(handler.isNoPendingChanges(
                 DBInstance.builder()
                         .pendingModifiedValues(
                                 PendingModifiedValues.builder()
                                         .resumeFullAutomationModeTime(Instant.now())
                                         .build())
                         .build()
-        ));
+        )).isFalse();
     }
 
     @Test
     void isNoPendingChanges_NonEmptyReturnsFalse() {
-        Assert.assertFalse(handler.isNoPendingChanges(
+        Assertions.assertThat(handler.isNoPendingChanges(
                 DBInstance.builder()
                         .pendingModifiedValues(
                                 PendingModifiedValues.builder()
                                         .processorFeatures(ProcessorFeature.builder().build())
                                         .build())
                         .build()
-        ));
+        )).isFalse();
     }
 
     @Test
     void isDBParameterGroupSyncComplete_NullParameterGroupsReturnsTrue() {
-        Assert.assertTrue(handler.isDBParameterGroupSyncComplete(
+        Assertions.assertThat(handler.isDBParameterGroupSyncComplete(
                 DBInstance.builder().build()
-        ));
+        )).isTrue();
     }
 
     @Test
     void isDBParameterGroupSyncComplete_EmptyParameterGroupsReturnsTrue() {
-        Assert.assertTrue(handler.isDBParameterGroupSyncComplete(
+        Assertions.assertThat(handler.isDBParameterGroupSyncComplete(
                 DBInstance.builder().dbParameterGroups(Collections.emptyList()).build()
-        ));
+        )).isTrue();
     }
 
     @Test
     void isDBParameterGroupSyncComplete_NonEmptyParameterGroupsInSyncReturnsTrue() {
-        Assert.assertTrue(handler.isDBParameterGroupSyncComplete(
+        Assertions.assertThat(handler.isDBParameterGroupSyncComplete(
                 DBInstance.builder()
                         .dbParameterGroups(
                                 DBParameterGroupStatus.builder().parameterApplyStatus("in-sync").build(),
                                 DBParameterGroupStatus.builder().parameterApplyStatus("in-sync").build()
                         )
                         .build()
-        ));
+        )).isTrue();
     }
 
     @Test
     void isDBParameterGroupSyncComplete_NonEmptyParameterGroupsApplyingReturnsFalse() {
-        Assert.assertFalse(handler.isDBParameterGroupSyncComplete(
+        Assertions.assertThat(handler.isDBParameterGroupSyncComplete(
                 DBInstance.builder()
                         .dbParameterGroups(
                                 DBParameterGroupStatus.builder().parameterApplyStatus("in-sync").build(),
                                 DBParameterGroupStatus.builder().parameterApplyStatus("applying").build()
                         )
                         .build()
-        ));
+        )).isFalse();
     }
 
     @Test
     void isReplicationComplete_NullStatusInfoReturnsTrue() {
-        Assert.assertTrue(handler.isReplicationComplete(
+        Assertions.assertThat(handler.isReplicationComplete(
                 DBInstance.builder().build()
-        ));
+        )).isTrue();
     }
 
     @Test
     void isReplicationComplete_EmptyStatusInfoReturnsTrue() {
-        Assert.assertTrue(handler.isReplicationComplete(
+        Assertions.assertThat(handler.isReplicationComplete(
                 DBInstance.builder().statusInfos(Collections.emptyList()).build()
-        ));
+        )).isTrue();
     }
 
     @Test
     void isReplicationComplete_NonEmptyListNoReadReplicaInfoReturnsTrue() {
-        Assert.assertTrue(handler.isReplicationComplete(
+        Assertions.assertThat(handler.isReplicationComplete(
                 DBInstance.builder()
                         .statusInfos(DBInstanceStatusInfo.builder()
                                 .statusType("something else")
                                 .status("not replicating")
                                 .build())
                         .build()
-        ));
+        )).isTrue();
     }
 
     @Test
     void isReplicationComplete_NonEmptyListContainingReplicaInfoReplicatingReturnsTrue() {
-        Assert.assertTrue(handler.isReplicationComplete(
+        Assertions.assertThat(handler.isReplicationComplete(
                 DBInstance.builder()
                         .statusInfos(
                                 DBInstanceStatusInfo.builder()
@@ -450,12 +450,12 @@ class BaseHandlerStdTest {
                                         .build()
                         )
                         .build()
-        ));
+        )).isTrue();
     }
 
     @Test
     void isReplicationComplete_NonEmptyListContainingReplicaInfoNotReplicatingReturnsFalse() {
-        Assert.assertFalse(handler.isReplicationComplete(
+        Assertions.assertThat(handler.isReplicationComplete(
                 DBInstance.builder()
                         .statusInfos(
                                 DBInstanceStatusInfo.builder()
@@ -468,6 +468,6 @@ class BaseHandlerStdTest {
                                         .build()
                         )
                         .build()
-        ));
+        )).isFalse();
     }
 }


### PR DESCRIPTION
This commit removes usage of junit.framework.Assert accidentally added by https://github.com/aws-cloudformation/aws-cloudformation-resource-providers-rds/pull/243

The assertion framework in use is org.assertj.core.api.Assertions.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Signed-off-by: Oleg Sidorov <sidorovo@amazon.com>