### PR TITLE
[DBCluster][DBInstance] Use exponential backoff when long running stabilization is happening

### DIFF
--- a/aws-rds-cfn-common/src/main/java/software/amazon/rds/common/handler/HandlerConfig.java
+++ b/aws-rds-cfn-common/src/main/java/software/amazon/rds/common/handler/HandlerConfig.java
@@ -4,6 +4,7 @@ import java.time.Duration;
 
 import lombok.Builder;
 import lombok.Getter;
+import software.amazon.cloudformation.proxy.Delay;
 import software.amazon.cloudformation.proxy.delay.Constant;
 
 @Builder
@@ -15,7 +16,7 @@ public class HandlerConfig {
 
     @Getter
     @Builder.Default
-    final private Constant backoff = Constant.of()
+    final private Delay backoff = Constant.of()
             .delay(Duration.ofSeconds(30))
             .timeout(Duration.ofMinutes(90))
             .build();

--- a/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/BaseHandlerStd.java
+++ b/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/BaseHandlerStd.java
@@ -45,6 +45,7 @@ import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 import software.amazon.cloudformation.proxy.delay.Constant;
+import software.amazon.cloudformation.proxy.delay.Exponential;
 import software.amazon.rds.common.error.ErrorCode;
 import software.amazon.rds.common.error.ErrorRuleSet;
 import software.amazon.rds.common.error.ErrorStatus;
@@ -106,7 +107,10 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
             .build();
 
     protected final static HandlerConfig DB_CLUSTER_HANDLER_CONFIG_36H = HandlerConfig.builder()
-            .backoff(Constant.of().delay(Duration.ofSeconds(30)).timeout(Duration.ofHours(36)).build())
+            .backoff(Exponential.of()
+                    .minDelay(Duration.ofSeconds(30))
+                    .timeout(Duration.ofHours(36))
+                    .build())
             .build();
 
     private static final String DB_CLUSTER_FAILED_TO_STABILIZE = "DBCluster %s failed to stabilize.";

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/BaseHandlerStd.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/BaseHandlerStd.java
@@ -62,6 +62,7 @@ import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 import software.amazon.cloudformation.proxy.delay.Constant;
+import software.amazon.cloudformation.proxy.delay.Exponential;
 import software.amazon.rds.common.error.ErrorCode;
 import software.amazon.rds.common.error.ErrorRuleSet;
 import software.amazon.rds.common.error.ErrorStatus;
@@ -106,7 +107,10 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
             .build();
 
     protected final static HandlerConfig DB_INSTANCE_HANDLER_CONFIG_36H = HandlerConfig.builder()
-            .backoff(Constant.of().delay(Duration.ofSeconds(30)).timeout(Duration.ofHours(36)).build())
+            .backoff(Exponential.of()
+                    .minDelay(Duration.ofSeconds(30))
+                    .timeout(Duration.ofHours(36))
+                    .build())
             .build();
 
     protected static final RuntimeException MISSING_METHOD_VERSION_EXCEPTION = new RuntimeException("Missing method version");


### PR DESCRIPTION
The reasoning behind this PR is that during 36 hour stabilization we execute the handler up to 4320 times when instance takes a long time to stabilize. While using Exponential backoff, this number will be 13 times at most, greatly reducing cost for customers.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
