### PR TITLE
[DBClusterParameterGroup] Handle tags with empty value

### DIFF
--- a/aws-rds-dbclusterparametergroup/src/main/java/software/amazon/rds/dbclusterparametergroup/Configuration.java
+++ b/aws-rds-dbclusterparametergroup/src/main/java/software/amazon/rds/dbclusterparametergroup/Configuration.java
@@ -1,7 +1,7 @@
 package software.amazon.rds.dbclusterparametergroup;
 
+import java.util.HashMap;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 import org.json.JSONObject;
 import org.json.JSONTokener;
@@ -22,9 +22,10 @@ class Configuration extends BaseConfiguration {
         if (CollectionUtils.isNullOrEmpty(model.getTags())) {
             return null;
         }
-
-        return model.getTags()
-                .stream()
-                .collect(Collectors.toMap(Tag::getKey, Tag::getValue, (v1, v2) -> v2));
+        final Map<String, String> tagMap = new HashMap<>();
+        for (final Tag tag : model.getTags()) {
+            tagMap.put(tag.getKey(), tag.getValue());
+        }
+        return tagMap;
     }
 }

--- a/aws-rds-dbclusterparametergroup/src/test/java/software/amazon/rds/dbclusterparametergroup/ConfigurationTest.java
+++ b/aws-rds-dbclusterparametergroup/src/test/java/software/amazon/rds/dbclusterparametergroup/ConfigurationTest.java
@@ -38,4 +38,16 @@ class ConfigurationTest {
 
         assertThat(tags).isNull();
     }
+
+    @Test
+    public void tagWithEmptyValue() {
+        final Configuration configuration = new Configuration();
+        final Map<String, String> tags = configuration.resourceDefinedTags(ResourceModel.builder()
+                        .tags(Arrays.asList(new Tag("tag-key", null)))
+                .build());
+
+        assertThat(tags).hasSize(1);
+        assertThat(tags).containsExactly(
+                Assertions.entry("tag-key", null));
+    }
 }


### PR DESCRIPTION
This commit is a follow-up on https://github.com/aws-cloudformation/aws-cloudformation-resource-providers-rds/pull/230

It fixes a bug in `Configuration` class that failed to merge tag maps with null-values.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Signed-off-by: Oleg Sidorov <sidorovo@amazon.com>