### PR TITLE
[DBClusterParameterGroup+4] Handle tags with empty value

### DIFF
--- a/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/Configuration.java
+++ b/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/Configuration.java
@@ -1,7 +1,7 @@
 package software.amazon.rds.dbcluster;
 
+import java.util.HashMap;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 import org.json.JSONObject;
 import org.json.JSONTokener;
@@ -23,8 +23,10 @@ class Configuration extends BaseConfiguration {
             return null;
         }
 
-        return model.getTags()
-                .stream()
-                .collect(Collectors.toMap(Tag::getKey, Tag::getValue, (v1, v2) -> v2));
+        final Map<String, String> tagMap = new HashMap<>();
+        for (final Tag tag : model.getTags()) {
+            tagMap.put(tag.getKey(), tag.getValue());
+        }
+        return tagMap;
     }
 }

--- a/aws-rds-dbcluster/src/test/java/software/amazon/rds/dbcluster/ConfigurationTest.java
+++ b/aws-rds-dbcluster/src/test/java/software/amazon/rds/dbcluster/ConfigurationTest.java
@@ -1,0 +1,20 @@
+package software.amazon.rds.dbcluster;
+
+import java.util.Map;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import com.google.common.collect.ImmutableSet;
+
+class ConfigurationTest {
+
+    @Test
+    public void test_resourceDefinedTags_tagWithEmptyValue() {
+        final Configuration configuration = new Configuration();
+        final Map<String, String> tags = configuration.resourceDefinedTags(ResourceModel.builder()
+                .tags(ImmutableSet.of(new Tag("tag-key", null)))
+                .build());
+        Assertions.assertThat(tags).containsExactly(Assertions.entry("tag-key", null));
+    }
+}

--- a/aws-rds-dbclusterparametergroup/src/main/java/software/amazon/rds/dbclusterparametergroup/Configuration.java
+++ b/aws-rds-dbclusterparametergroup/src/main/java/software/amazon/rds/dbclusterparametergroup/Configuration.java
@@ -1,7 +1,7 @@
 package software.amazon.rds.dbclusterparametergroup;
 
+import java.util.HashMap;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 import org.json.JSONObject;
 import org.json.JSONTokener;
@@ -23,8 +23,10 @@ class Configuration extends BaseConfiguration {
             return null;
         }
 
-        return model.getTags()
-                .stream()
-                .collect(Collectors.toMap(Tag::getKey, Tag::getValue, (v1, v2) -> v2));
+        final Map<String, String> tagMap = new HashMap<>();
+        for (final Tag tag : model.getTags()) {
+            tagMap.put(tag.getKey(), tag.getValue());
+        }
+        return tagMap;
     }
 }

--- a/aws-rds-dbclusterparametergroup/src/test/java/software/amazon/rds/dbclusterparametergroup/ConfigurationTest.java
+++ b/aws-rds-dbclusterparametergroup/src/test/java/software/amazon/rds/dbclusterparametergroup/ConfigurationTest.java
@@ -8,6 +8,8 @@ import java.util.Map;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import com.google.common.collect.ImmutableList;
+
 class ConfigurationTest {
 
     @Test
@@ -37,5 +39,14 @@ class ConfigurationTest {
         final Map<String, String> tags = configuration.resourceDefinedTags(ResourceModel.builder().build());
 
         assertThat(tags).isNull();
+    }
+
+    @Test
+    public void test_resourceDefinedTags_tagWithEmptyValue() {
+        final Configuration configuration = new Configuration();
+        final Map<String, String> tags = configuration.resourceDefinedTags(ResourceModel.builder()
+                .tags(ImmutableList.of(new Tag("tag-key", null)))
+                .build());
+        Assertions.assertThat(tags).containsExactly(Assertions.entry("tag-key", null));
     }
 }

--- a/aws-rds-dbsubnetgroup/src/main/java/software/amazon/rds/dbsubnetgroup/Configuration.java
+++ b/aws-rds-dbsubnetgroup/src/main/java/software/amazon/rds/dbsubnetgroup/Configuration.java
@@ -1,8 +1,8 @@
 package software.amazon.rds.dbsubnetgroup;
 
 
+import java.util.HashMap;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 import com.amazonaws.util.CollectionUtils;
 
@@ -12,12 +12,14 @@ class Configuration extends BaseConfiguration {
         super("aws-rds-dbsubnetgroup.json");
     }
 
-    public Map<String, String> resourceDefinedTags(final ResourceModel resourceModel) {
-        if (CollectionUtils.isNullOrEmpty(resourceModel.getTags()))
+    public Map<String, String> resourceDefinedTags(final ResourceModel model) {
+        if (CollectionUtils.isNullOrEmpty(model.getTags()))
             return null;
 
-        return resourceModel.getTags()
-                .stream()
-                .collect(Collectors.toMap(Tag::getKey, Tag::getValue, (v1, v2) -> v2));
+        final Map<String, String> tagMap = new HashMap<>();
+        for (final Tag tag : model.getTags()) {
+            tagMap.put(tag.getKey(), tag.getValue());
+        }
+        return tagMap;
     }
 }

--- a/aws-rds-dbsubnetgroup/src/test/java/software/amazon/rds/dbsubnetgroup/ConfigurationTest.java
+++ b/aws-rds-dbsubnetgroup/src/test/java/software/amazon/rds/dbsubnetgroup/ConfigurationTest.java
@@ -8,6 +8,8 @@ import java.util.Map;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import com.google.common.collect.ImmutableList;
+
 class ConfigurationTest {
 
     @Test
@@ -37,5 +39,14 @@ class ConfigurationTest {
         final Map<String, String> tags = configuration.resourceDefinedTags(ResourceModel.builder().build());
 
         assertThat(tags).isNull();
+    }
+
+    @Test
+    public void test_resourceDefinedTags_tagWithEmptyValue() {
+        final Configuration configuration = new Configuration();
+        final Map<String, String> tags = configuration.resourceDefinedTags(ResourceModel.builder()
+                .tags(ImmutableList.of(new Tag("tag-key", null)))
+                .build());
+        Assertions.assertThat(tags).containsExactly(Assertions.entry("tag-key", null));
     }
 }

--- a/aws-rds-eventsubscription/src/main/java/software/amazon/rds/eventsubscription/Configuration.java
+++ b/aws-rds-eventsubscription/src/main/java/software/amazon/rds/eventsubscription/Configuration.java
@@ -1,7 +1,7 @@
 package software.amazon.rds.eventsubscription;
 
+import java.util.HashMap;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 import com.amazonaws.util.CollectionUtils;
 
@@ -11,12 +11,14 @@ class Configuration extends BaseConfiguration {
         super("aws-rds-eventsubscription.json");
     }
 
-    public Map<String, String> resourceDefinedTags(final ResourceModel resourceModel) {
-        if (CollectionUtils.isNullOrEmpty(resourceModel.getTags()))
+    public Map<String, String> resourceDefinedTags(final ResourceModel model) {
+        if (CollectionUtils.isNullOrEmpty(model.getTags()))
             return null;
 
-        return resourceModel.getTags()
-                .stream()
-                .collect(Collectors.toMap(Tag::getKey, Tag::getValue, (v1, v2) -> v2));
+        final Map<String, String> tagMap = new HashMap<>();
+        for (final Tag tag : model.getTags()) {
+            tagMap.put(tag.getKey(), tag.getValue());
+        }
+        return tagMap;
     }
 }

--- a/aws-rds-eventsubscription/src/test/java/software/amazon/rds/eventsubscription/ConfigurationTest.java
+++ b/aws-rds-eventsubscription/src/test/java/software/amazon/rds/eventsubscription/ConfigurationTest.java
@@ -8,6 +8,9 @@ import java.util.Map;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+
 class ConfigurationTest {
 
     @Test
@@ -37,5 +40,14 @@ class ConfigurationTest {
         final Map<String, String> tags = configuration.resourceDefinedTags(ResourceModel.builder().build());
 
         assertThat(tags).isNull();
+    }
+
+    @Test
+    public void test_resourceDefinedTags_tagWithEmptyValue() {
+        final Configuration configuration = new Configuration();
+        final Map<String, String> tags = configuration.resourceDefinedTags(ResourceModel.builder()
+                .tags(ImmutableList.of(new Tag("tag-key", null)))
+                .build());
+        Assertions.assertThat(tags).containsExactly(Assertions.entry("tag-key", null));
     }
 }

--- a/aws-rds-optiongroup/src/main/java/software/amazon/rds/optiongroup/Configuration.java
+++ b/aws-rds-optiongroup/src/main/java/software/amazon/rds/optiongroup/Configuration.java
@@ -1,12 +1,12 @@
 package software.amazon.rds.optiongroup;
 
-import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
-import java.util.Optional;
-import java.util.stream.Collectors;
 
 import org.json.JSONObject;
 import org.json.JSONTokener;
+
+import com.amazonaws.util.CollectionUtils;
 
 class Configuration extends BaseConfiguration {
 
@@ -20,9 +20,14 @@ class Configuration extends BaseConfiguration {
     }
 
     public Map<String, String> resourceDefinedTags(final ResourceModel model) {
-        return Optional.ofNullable(model.getTags())
-                .orElse(Collections.emptyList())
-                .stream()
-                .collect(Collectors.toMap(Tag::getKey, Tag::getValue, (v1, v2) -> v2));
+        if (CollectionUtils.isNullOrEmpty(model.getTags())) {
+            return null;
+        }
+
+        final Map<String, String> tagMap = new HashMap<>();
+        for (final Tag tag : model.getTags()) {
+            tagMap.put(tag.getKey(), tag.getValue());
+        }
+        return tagMap;
     }
 }

--- a/aws-rds-optiongroup/src/test/java/software/amazon/rds/optiongroup/ConfigurationTest.java
+++ b/aws-rds-optiongroup/src/test/java/software/amazon/rds/optiongroup/ConfigurationTest.java
@@ -1,0 +1,20 @@
+package software.amazon.rds.optiongroup;
+
+import java.util.Map;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import com.google.common.collect.ImmutableList;
+
+class ConfigurationTest {
+
+    @Test
+    public void test_resourceDefinedTags_tagWithEmptyValue() {
+        final Configuration configuration = new Configuration();
+        final Map<String, String> tags = configuration.resourceDefinedTags(ResourceModel.builder()
+                .tags(ImmutableList.of(new Tag("tag-key", null)))
+                .build());
+        Assertions.assertThat(tags).containsExactly(Assertions.entry("tag-key", null));
+    }
+}


### PR DESCRIPTION
This commit is a follow-up on https://github.com/aws-cloudformation/aws-cloudformation-resource-providers-rds/pull/230.

It fixes a bug in `Configuration` class that failed to merge tag maps with null-values.

Affected resources:
  - AWS::RDS::DBCluster
  - AWS::RDS::DBClusterParameterGroup
  - AWS::RDS::DBSubnetGroup
  - AWS::RDS::EventSubscription
  - AWS::RDS::OptionGroup

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Signed-off-by: Oleg Sidorov <sidorovo@amazon.com>