### PR TITLE
[DBInstance] Change stabilization logic on update

### DIFF
--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/CreateHandler.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/CreateHandler.java
@@ -152,7 +152,7 @@ public class CreateHandler extends BaseHandlerStd {
                         proxyInvocation.client()::createDBInstance
                 ))
                 .stabilize((request, response, proxyInvocation, model, context) ->
-                        isDbInstanceStabilized(proxyInvocation, model))
+                        isDBInstanceStabilizedAfterCreate(proxyInvocation, model))
                 .handleError((request, exception, client, model, context) -> Commons.handleException(
                         ProgressEvent.progress(model, context),
                         exception,
@@ -179,7 +179,7 @@ public class CreateHandler extends BaseHandlerStd {
                         proxyInvocation.client()::createDBInstance
                 ))
                 .stabilize((request, response, proxyInvocation, model, context) ->
-                        isDbInstanceStabilized(proxyInvocation, model))
+                        isDBInstanceStabilizedAfterCreate(proxyInvocation, model))
                 .handleError((request, exception, client, model, context) -> Commons.handleException(
                         ProgressEvent.progress(model, context),
                         exception,
@@ -206,7 +206,7 @@ public class CreateHandler extends BaseHandlerStd {
                         proxyInvocation.client()::restoreDBInstanceFromDBSnapshot
                 ))
                 .stabilize((request, response, proxyInvocation, model, context) ->
-                        isDbInstanceStabilized(proxyInvocation, model))
+                        isDBInstanceStabilizedAfterCreate(proxyInvocation, model))
                 .handleError((request, exception, client, model, context) -> Commons.handleException(
                         ProgressEvent.progress(model, context),
                         exception,
@@ -233,7 +233,7 @@ public class CreateHandler extends BaseHandlerStd {
                         proxyInvocation.client()::restoreDBInstanceFromDBSnapshot
                 ))
                 .stabilize((request, response, proxyInvocation, model, context) ->
-                        isDbInstanceStabilized(proxyInvocation, model))
+                        isDBInstanceStabilizedAfterCreate(proxyInvocation, model))
                 .handleError((request, exception, client, model, context) -> Commons.handleException(
                         ProgressEvent.progress(model, context),
                         exception,
@@ -260,7 +260,7 @@ public class CreateHandler extends BaseHandlerStd {
                         proxyInvocation.client()::createDBInstanceReadReplica
                 ))
                 .stabilize((request, response, proxyInvocation, model, context) ->
-                        isDbInstanceStabilized(proxyInvocation, model))
+                        isDBInstanceStabilizedAfterCreate(proxyInvocation, model))
                 .handleError((request, exception, client, model, context) -> Commons.handleException(
                         ProgressEvent.progress(model, context),
                         exception,

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/DBInstanceStatus.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/DBInstanceStatus.java
@@ -6,12 +6,22 @@ public enum DBInstanceStatus {
     Available("available"),
     Creating("creating"),
     Deleting("deleting"),
-    Failed("failed");
+    Failed("failed", true),
+    IncompatibleRestore("incompatible-restore", true),
+    IncompatibleNetwork("incompatible-network", true),
+    IncompatibleParameters("incompatible-parameters", true),
+    InaccessibleEncryptionCredentials("inaccessible-encryption-credentials", true);
 
-    private String value;
+    private final String value;
+    private final boolean terminal;
 
     DBInstanceStatus(final String value) {
+        this(value, false);
+    }
+
+    DBInstanceStatus(final String value, final boolean terminal) {
         this.value = value;
+        this.terminal = terminal;
     }
 
     @Override
@@ -19,7 +29,19 @@ public enum DBInstanceStatus {
         return value;
     }
 
+    public static DBInstanceStatus fromString(final String status) {
+        try {
+            return DBInstanceStatus.valueOf(status);
+        } catch (IllegalArgumentException e) {
+            return null;
+        }
+    }
+
     public boolean equalsString(final String other) {
         return StringUtils.equals(value, other);
+    }
+
+    public boolean isTerminal() {
+        return this.terminal;
     }
 }

--- a/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/AbstractHandlerTest.java
+++ b/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/AbstractHandlerTest.java
@@ -460,6 +460,7 @@ public abstract class AbstractHandlerTest extends AbstractTestBase<DBInstance, R
                 .storageType(STORAGE_TYPE_STANDARD)
                 .storageEncrypted(STORAGE_ENCRYPTED_NO)
                 .masterUsername(MASTER_USERNAME)
+                .promotionTier(PROMOTION_TIER_DEFAULT)
                 .build();
 
         DB_INSTANCE_DELETING = DB_INSTANCE_ACTIVE.toBuilder()

--- a/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/BaseHandlerStdTest.java
+++ b/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/BaseHandlerStdTest.java
@@ -63,10 +63,18 @@ class BaseHandlerStdTest {
     }
 
     @Test
-    void isPromotionTierUpdated_MismatchingPromotionTierReturnsFalse() {
+    void isPromotionTierUpdated_EmptyModelPromotionTierReturnsTrue() {
         Assertions.assertThat(handler.isPromotionTierUpdated(
                 DBInstance.builder().promotionTier(42).build(),
                 ResourceModel.builder().promotionTier(null).build()
+        )).isTrue();
+    }
+
+    @Test
+    void isPromotionTierUpdated_MismatchingPromotionTierReturnsFalse() {
+        Assertions.assertThat(handler.isPromotionTierUpdated(
+                DBInstance.builder().promotionTier(null).build(),
+                ResourceModel.builder().promotionTier(42).build()
         )).isFalse();
     }
 
@@ -373,21 +381,21 @@ class BaseHandlerStdTest {
 
     @Test
     void isDBParameterGroupSyncComplete_NullParameterGroupsReturnsTrue() {
-        Assertions.assertThat(handler.isDBParameterGroupSyncComplete(
+        Assertions.assertThat(handler.isDBParameterGroupNotApplying(
                 DBInstance.builder().build()
         )).isTrue();
     }
 
     @Test
     void isDBParameterGroupSyncComplete_EmptyParameterGroupsReturnsTrue() {
-        Assertions.assertThat(handler.isDBParameterGroupSyncComplete(
+        Assertions.assertThat(handler.isDBParameterGroupNotApplying(
                 DBInstance.builder().dbParameterGroups(Collections.emptyList()).build()
         )).isTrue();
     }
 
     @Test
     void isDBParameterGroupSyncComplete_NonEmptyParameterGroupsInSyncReturnsTrue() {
-        Assertions.assertThat(handler.isDBParameterGroupSyncComplete(
+        Assertions.assertThat(handler.isDBParameterGroupNotApplying(
                 DBInstance.builder()
                         .dbParameterGroups(
                                 DBParameterGroupStatus.builder().parameterApplyStatus("in-sync").build(),
@@ -399,7 +407,7 @@ class BaseHandlerStdTest {
 
     @Test
     void isDBParameterGroupSyncComplete_NonEmptyParameterGroupsApplyingReturnsFalse() {
-        Assertions.assertThat(handler.isDBParameterGroupSyncComplete(
+        Assertions.assertThat(handler.isDBParameterGroupNotApplying(
                 DBInstance.builder()
                         .dbParameterGroups(
                                 DBParameterGroupStatus.builder().parameterApplyStatus("in-sync").build(),


### PR DESCRIPTION
This commit introduces a distinction between stabilization processes after create and update. The change is introduced for the sake of a complete logic parity with the historical implementation. In particular, the post-update stabilization is:
- DBInstance status is `available`
- DBParameterGroup status is `in-sync`
- OptionGroup status is `in-sync`
- if DBInstance is a member of a DBCluster:
  - DBClusterParameterGroup is `in-sync`

Both stabilizers perform an additional assertion on DBInstance status. The assertion code performs an early process interruption if DBInstance enters one of the following statuses:
- failed
- incompatible-restore
- incompatible-network
- incompatible-parameters
- inaccessible-encryption-credentials

In this case the handler will throw a `CfnNotStabilizedException`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Signed-off-by: Oleg Sidorov <sidorovo@amazon.com>