### PR TITLE
[All resources] Coalesce primary identifiers to lowercase to prevent false drift detection

### DIFF
--- a/aws-rds-dbcluster/aws-rds-dbcluster.json
+++ b/aws-rds-dbcluster/aws-rds-dbcluster.json
@@ -313,6 +313,13 @@
     }
   },
   "additionalProperties": false,
+  "propertyTransform": {
+    "/properties/DBClusterIdentifier": "$lowercase(DBClusterIdentifier)",
+    "/properties/DBClusterParameterGroupName": "$lowercase(DBClusterParameterGroupName)",
+    "/properties/DBSubnetGroupName": "$lowercase(DBSubnetGroupName)",
+    "/properties/SnapshotIdentifier": "$lowercase(SnapshotIdentifier)",
+    "/properties/SourceDBClusterIdentifier": "$lowercase(SourceDBClusterIdentifier)"
+  },
   "readOnlyProperties": [
     "/properties/Endpoint",
     "/properties/Endpoint/Address",

--- a/aws-rds-dbclusterendpoint/aws-rds-dbclusterendpoint.json
+++ b/aws-rds-dbclusterendpoint/aws-rds-dbclusterendpoint.json
@@ -92,6 +92,10 @@
     }
   },
   "additionalProperties": false,
+  "propertyTransform": {
+    "/properties/DBClusterIdentifier": "$lowercase(DBClusterIdentifier)",
+    "/properties/DBClusterEndpointIdentifier": "$lowercase(DBClusterEndpointIdentifier)"
+  },
   "required": [
     "DBClusterIdentifier",
     "EndpointType"

--- a/aws-rds-dbclusterparametergroup/aws-rds-dbclusterparametergroup.json
+++ b/aws-rds-dbclusterparametergroup/aws-rds-dbclusterparametergroup.json
@@ -54,6 +54,9 @@
     }
   },
   "additionalProperties": false,
+  "propertyTransform": {
+    "/properties/DBClusterParameterGroupName": "$lowercase(DBClusterParameterGroupName)"
+  },
   "required": [
     "Description",
     "Family",

--- a/aws-rds-dbinstance/aws-rds-dbinstance.json
+++ b/aws-rds-dbinstance/aws-rds-dbinstance.json
@@ -340,6 +340,15 @@
     }
   },
   "additionalProperties": false,
+  "propertyTransform": {
+    "/properties/DBClusterIdentifier": "$lowercase(DBClusterIdentifier)",
+    "/properties/DBInstanceIdentifier": "$lowercase(DBInstanceIdentifier)",
+    "/properties/DBParameterGroupName": "$lowercase(DBParameterGroupName)",
+    "/properties/DBSubnetGroupName": "$lowercase(DBSubnetGroupName)",
+    "/properties/DBSnapshotIdentifier": "$lowercase(DBSnapshotIdentifier)",
+    "/properties/OptionGroupName": "$lowercase(OptionGroupName)",
+    "/properties/SourceDBInstanceIdentifier": "$lowercase(SourceDBInstanceIdentifier)"
+  },
   "createOnlyProperties": [
     "/properties/AvailabilityZone",
     "/properties/CharacterSetName",

--- a/aws-rds-dbparametergroup/aws-rds-dbparametergroup.json
+++ b/aws-rds-dbparametergroup/aws-rds-dbparametergroup.json
@@ -55,6 +55,9 @@
       }
     }
   },
+  "propertyTransform": {
+    "/properties/DBParameterGroupName": "$lowercase(DBParameterGroupName)"
+  },
   "required": [
     "Family",
     "Description"

--- a/aws-rds-dbsubnetgroup/aws-rds-dbsubnetgroup.json
+++ b/aws-rds-dbsubnetgroup/aws-rds-dbsubnetgroup.json
@@ -57,6 +57,9 @@
     "DBSubnetGroupDescription",
     "SubnetIds"
   ],
+  "propertyTransform": {
+    "/properties/DBSubnetGroupName": "$lowercase(DBSubnetGroupName)"
+  },
   "createOnlyProperties": [
     "/properties/DBSubnetGroupName"
   ],

--- a/aws-rds-eventsubscription/aws-rds-eventsubscription.json
+++ b/aws-rds-eventsubscription/aws-rds-eventsubscription.json
@@ -73,6 +73,9 @@
     }
   },
   "additionalProperties": false,
+  "propertyTransform": {
+    "/properties/SubscriptionName": "$lowercase(SubscriptionName)"
+  },
   "required": [
     "SnsTopicArn"
   ],

--- a/aws-rds-optiongroup/aws-rds-optiongroup.json
+++ b/aws-rds-optiongroup/aws-rds-optiongroup.json
@@ -124,6 +124,9 @@
     }
   },
   "additionalProperties": false,
+  "propertyTransform": {
+    "/properties/OptionGroupName": "$lowercase(OptionGroupName)"
+  },
   "required": [
     "EngineName",
     "MajorEngineVersion",


### PR DESCRIPTION
Drift detection falsely detects drift when the spelling of case-insensitive identifiers have been changed. To prevent that, we lowercase relevant identifiers.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
