### PR TITLE
[DBInstance] Unify stabilization for create and update

### DIFF
--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/CreateHandler.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/CreateHandler.java
@@ -152,7 +152,7 @@ public class CreateHandler extends BaseHandlerStd {
                         proxyInvocation.client()::createDBInstance
                 ))
                 .stabilize((request, response, proxyInvocation, model, context) ->
-                        isDBInstanceStabilizedAfterCreate(proxyInvocation, model))
+                        isDBInstanceStabilizedAfterMutate(proxyInvocation, model))
                 .handleError((request, exception, client, model, context) -> Commons.handleException(
                         ProgressEvent.progress(model, context),
                         exception,
@@ -179,7 +179,7 @@ public class CreateHandler extends BaseHandlerStd {
                         proxyInvocation.client()::createDBInstance
                 ))
                 .stabilize((request, response, proxyInvocation, model, context) ->
-                        isDBInstanceStabilizedAfterCreate(proxyInvocation, model))
+                        isDBInstanceStabilizedAfterMutate(proxyInvocation, model))
                 .handleError((request, exception, client, model, context) -> Commons.handleException(
                         ProgressEvent.progress(model, context),
                         exception,
@@ -206,7 +206,7 @@ public class CreateHandler extends BaseHandlerStd {
                         proxyInvocation.client()::restoreDBInstanceFromDBSnapshot
                 ))
                 .stabilize((request, response, proxyInvocation, model, context) ->
-                        isDBInstanceStabilizedAfterCreate(proxyInvocation, model))
+                        isDBInstanceStabilizedAfterMutate(proxyInvocation, model))
                 .handleError((request, exception, client, model, context) -> Commons.handleException(
                         ProgressEvent.progress(model, context),
                         exception,
@@ -233,7 +233,7 @@ public class CreateHandler extends BaseHandlerStd {
                         proxyInvocation.client()::restoreDBInstanceFromDBSnapshot
                 ))
                 .stabilize((request, response, proxyInvocation, model, context) ->
-                        isDBInstanceStabilizedAfterCreate(proxyInvocation, model))
+                        isDBInstanceStabilizedAfterMutate(proxyInvocation, model))
                 .handleError((request, exception, client, model, context) -> Commons.handleException(
                         ProgressEvent.progress(model, context),
                         exception,
@@ -260,7 +260,7 @@ public class CreateHandler extends BaseHandlerStd {
                         proxyInvocation.client()::createDBInstanceReadReplica
                 ))
                 .stabilize((request, response, proxyInvocation, model, context) ->
-                        isDBInstanceStabilizedAfterCreate(proxyInvocation, model))
+                        isDBInstanceStabilizedAfterMutate(proxyInvocation, model))
                 .handleError((request, exception, client, model, context) -> Commons.handleException(
                         ProgressEvent.progress(model, context),
                         exception,


### PR DESCRIPTION
This PR is a follow-up on the change introduced in https://github.com/aws-cloudformation/aws-cloudformation-resource-providers-rds/pull/251.

The initial change introduced a distinction between create and update stabilization logic. This distinction was not precise enough: a DBInstance can enter pending-reboot state after an update and the existing logic would block as it requires an in-sync state.

This commit introduces a change to the stabilization logic. Any mutating change would be stabilized with the same logic (including creates and updates) and post-reboot gets its own stabilizer that would ensure the minimal set of availability flags and assert an in-sync (rather than "anything but applying") status.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Signed-off-by: Oleg Sidorov <sidorovo@amazon.com>