### PR TITLE
[DBCluster] Set default Vpc SecurityGroup Id if not specified. Only a…

### DIFF
--- a/aws-rds-dbcluster/pom.xml
+++ b/aws-rds-dbcluster/pom.xml
@@ -31,6 +31,11 @@
             <artifactId>rds</artifactId>
             <version>2.17.121</version>
         </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>ec2</artifactId>
+            <version>2.17.121</version>
+        </dependency>
         <!-- https://mvnrepository.com/artifact/software.amazon.cloudformation/aws-cloudformation-rpdk-java-plugin -->
         <dependency>
             <groupId>software.amazon.cloudformation</groupId>

--- a/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/DBClusterStatus.java
+++ b/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/DBClusterStatus.java
@@ -5,7 +5,7 @@ public enum DBClusterStatus {
     Creating("creating"),
     Deleted("deleted");
 
-    private String value;
+    private final String value;
 
     DBClusterStatus(String value) {
         this.value = value;

--- a/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/DeleteHandler.java
+++ b/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/DeleteHandler.java
@@ -3,6 +3,7 @@ package software.amazon.rds.dbcluster;
 import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
 
+import software.amazon.awssdk.services.ec2.Ec2Client;
 import software.amazon.awssdk.services.rds.RdsClient;
 import software.amazon.awssdk.services.rds.model.DBCluster;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
@@ -39,23 +40,22 @@ public class DeleteHandler extends BaseHandlerStd {
             final AmazonWebServicesClientProxy proxy,
             final ResourceHandlerRequest<ResourceModel> request,
             final CallbackContext callbackContext,
-            final ProxyClient<RdsClient> proxyClient,
-            final Logger logger
-    ) {
+            final ProxyClient<RdsClient> rdsProxyClient,
+            final ProxyClient<Ec2Client> ec2ProxyClient, final Logger logger) {
         return ProgressEvent.progress(request.getDesiredResourceState(), callbackContext)
                 .then(progress -> Commons.execOnce(progress, () ->
-                                ensureDeletionProtectionDisabled(proxyClient, progress),
+                                ensureDeletionProtectionDisabled(rdsProxyClient, progress),
                         CallbackContext::isDeleting,
                         CallbackContext::setDeleting)
                 )
                 .then(progress -> {
                     final ResourceModel model = progress.getResourceModel();
                     if (isGlobalClusterMember(model)) {
-                        return removeFromGlobalCluster(proxy, proxyClient, progress, model.getGlobalClusterIdentifier());
+                        return removeFromGlobalCluster(proxy, rdsProxyClient, progress, model.getGlobalClusterIdentifier());
                     }
                     return progress;
                 })
-                .then(progress -> deleteDbCluster(proxy, request, proxyClient, progress));
+                .then(progress -> deleteDbCluster(proxy, request, rdsProxyClient, progress));
     }
 
     private ProgressEvent<ResourceModel, CallbackContext> ensureDeletionProtectionDisabled(

--- a/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/Ec2ClientBuilder.java
+++ b/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/Ec2ClientBuilder.java
@@ -1,0 +1,12 @@
+package software.amazon.rds.dbcluster;
+
+import software.amazon.awssdk.services.ec2.Ec2Client;
+import software.amazon.cloudformation.LambdaWrapper;
+
+public class Ec2ClientBuilder {
+    public static Ec2Client getClient() {
+        return Ec2Client.builder()
+                .httpClient(LambdaWrapper.HTTP_CLIENT)
+                .build();
+    }
+}

--- a/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/ListHandler.java
+++ b/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/ListHandler.java
@@ -2,6 +2,7 @@ package software.amazon.rds.dbcluster;
 
 import java.util.stream.Collectors;
 
+import software.amazon.awssdk.services.ec2.Ec2Client;
 import software.amazon.awssdk.services.rds.RdsClient;
 import software.amazon.awssdk.services.rds.model.DescribeDbClustersResponse;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
@@ -27,12 +28,11 @@ public class ListHandler extends BaseHandlerStd {
             final AmazonWebServicesClientProxy proxy,
             final ResourceHandlerRequest<ResourceModel> request,
             final CallbackContext callbackContext,
-            final ProxyClient<RdsClient> proxyClient,
-            final Logger logger
-    ) {
+            final ProxyClient<RdsClient> rdsProxyClient,
+            final ProxyClient<Ec2Client> ec2ProxyClient, final Logger logger) {
         final DescribeDbClustersResponse describeDbClustersResponse = proxy.injectCredentialsAndInvokeV2(
                 Translator.describeDbClustersRequest(request.getNextToken()),
-                proxyClient.client()::describeDBClusters
+                rdsProxyClient.client()::describeDBClusters
         );
 
         return ProgressEvent.<ResourceModel, CallbackContext>builder()

--- a/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/RdsClientBuilder.java
+++ b/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/RdsClientBuilder.java
@@ -3,10 +3,10 @@ package software.amazon.rds.dbcluster;
 import software.amazon.awssdk.services.rds.RdsClient;
 import software.amazon.cloudformation.LambdaWrapper;
 
-public class ClientBuilder {
+public class RdsClientBuilder {
     public static RdsClient getClient() {
         return RdsClient.builder()
-            .httpClient(LambdaWrapper.HTTP_CLIENT)
-            .build();
+                .httpClient(LambdaWrapper.HTTP_CLIENT)
+                .build();
     }
 }

--- a/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/ReadHandler.java
+++ b/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/ReadHandler.java
@@ -1,5 +1,6 @@
 package software.amazon.rds.dbcluster;
 
+import software.amazon.awssdk.services.ec2.Ec2Client;
 import software.amazon.awssdk.services.rds.RdsClient;
 import software.amazon.awssdk.services.rds.model.DBCluster;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
@@ -25,10 +26,9 @@ public class ReadHandler extends BaseHandlerStd {
             final AmazonWebServicesClientProxy proxy,
             final ResourceHandlerRequest<ResourceModel> request,
             final CallbackContext callbackContext,
-            final ProxyClient<RdsClient> proxyClient,
-            final Logger logger
-    ) {
-        return proxy.initiate("rds::describe-db-cluster", proxyClient, request.getDesiredResourceState(), callbackContext)
+            final ProxyClient<RdsClient> rdsProxyClient,
+            final ProxyClient<Ec2Client> ec2ProxyClient, final Logger logger) {
+        return proxy.initiate("rds::describe-db-cluster", rdsProxyClient, request.getDesiredResourceState(), callbackContext)
                 .translateToServiceRequest(Translator::describeDbClustersRequest)
                 .backoffDelay(config.getBackoff())
                 .makeServiceCall((describeRequest, proxyInvocation) -> proxyInvocation.injectCredentialsAndInvokeV2(

--- a/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/util/ImmutabilityHelper.java
+++ b/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/util/ImmutabilityHelper.java
@@ -14,7 +14,7 @@ public final class ImmutabilityHelper {
 
     static boolean isGlobalClusterMutable(final ResourceModel previous, final ResourceModel desired) {
         if (StringUtils.hasValue(previous.getGlobalClusterIdentifier()) &&
-            StringUtils.isNullOrEmpty(desired.getGlobalClusterIdentifier())) {
+                StringUtils.isNullOrEmpty(desired.getGlobalClusterIdentifier())) {
             // This would be handled by calling remove-from-global-cluster explicitly
             return true;
         }

--- a/aws-rds-dbcluster/src/test/java/software/amazon/rds/dbcluster/AbstractHandlerTest.java
+++ b/aws-rds-dbcluster/src/test/java/software/amazon/rds/dbcluster/AbstractHandlerTest.java
@@ -17,6 +17,7 @@ import software.amazon.awssdk.awscore.AwsResponse;
 import software.amazon.awssdk.core.ResponseBytes;
 import software.amazon.awssdk.core.ResponseInputStream;
 import software.amazon.awssdk.core.pagination.sync.SdkIterable;
+import software.amazon.awssdk.services.ec2.Ec2Client;
 import software.amazon.awssdk.services.rds.RdsClient;
 import software.amazon.awssdk.services.rds.model.DBCluster;
 import software.amazon.awssdk.services.rds.model.DBClusterSnapshot;
@@ -319,12 +320,14 @@ public abstract class AbstractHandlerTest extends AbstractTestBase<DBCluster, Re
 
     protected abstract ProxyClient<RdsClient> getRdsProxy();
 
+    protected abstract ProxyClient<Ec2Client> getEc2Proxy();
+
     @Override
     protected ProgressEvent<ResourceModel, CallbackContext> invokeHandleRequest(
             final ResourceHandlerRequest<ResourceModel> request,
             final CallbackContext context
     ) {
-        return getHandler().handleRequest(getProxy(), request, context, getRdsProxy(), logger);
+        return getHandler().handleRequest(getProxy(), request, context, getRdsProxy(), getEc2Proxy(), logger);
     }
 
     @Override

--- a/aws-rds-dbcluster/src/test/java/software/amazon/rds/dbcluster/CreateHandlerTest.java
+++ b/aws-rds-dbcluster/src/test/java/software/amazon/rds/dbcluster/CreateHandlerTest.java
@@ -24,6 +24,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import com.google.common.collect.Iterables;
 import lombok.Getter;
 import software.amazon.awssdk.awscore.exception.AwsErrorDetails;
+import software.amazon.awssdk.services.ec2.Ec2Client;
 import software.amazon.awssdk.services.rds.RdsClient;
 import software.amazon.awssdk.services.rds.model.AddRoleToDbClusterRequest;
 import software.amazon.awssdk.services.rds.model.AddRoleToDbClusterResponse;
@@ -62,6 +63,9 @@ public class CreateHandlerTest extends AbstractHandlerTest {
     @Mock
     @Getter
     private ProxyClient<RdsClient> rdsProxy;
+    @Mock
+    @Getter
+    private ProxyClient<Ec2Client> ec2Proxy;
     @Getter
     private CreateHandler handler;
 

--- a/aws-rds-dbcluster/src/test/java/software/amazon/rds/dbcluster/DeleteHandlerTest.java
+++ b/aws-rds-dbcluster/src/test/java/software/amazon/rds/dbcluster/DeleteHandlerTest.java
@@ -22,6 +22,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import lombok.Getter;
+import software.amazon.awssdk.services.ec2.Ec2Client;
 import software.amazon.awssdk.services.rds.RdsClient;
 import software.amazon.awssdk.services.rds.model.DBCluster;
 import software.amazon.awssdk.services.rds.model.DbClusterNotFoundException;
@@ -50,7 +51,9 @@ public class DeleteHandlerTest extends AbstractHandlerTest {
     @Mock
     @Getter
     private ProxyClient<RdsClient> rdsProxy;
-
+    @Mock
+    @Getter
+    private ProxyClient<Ec2Client> ec2Proxy;
     @Mock
     @Getter
     RdsClient rdsClient;

--- a/aws-rds-dbcluster/src/test/java/software/amazon/rds/dbcluster/ListHandlerTest.java
+++ b/aws-rds-dbcluster/src/test/java/software/amazon/rds/dbcluster/ListHandlerTest.java
@@ -19,6 +19,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import lombok.Getter;
+import software.amazon.awssdk.services.ec2.Ec2Client;
 import software.amazon.awssdk.services.rds.RdsClient;
 import software.amazon.awssdk.services.rds.model.DescribeDbClustersRequest;
 import software.amazon.awssdk.services.rds.model.DescribeDbClustersResponse;
@@ -36,6 +37,10 @@ public class ListHandlerTest extends AbstractHandlerTest {
     @Mock
     @Getter
     private ProxyClient<RdsClient> rdsProxy;
+
+    @Mock
+    @Getter
+    private ProxyClient<Ec2Client> ec2Proxy;
 
     @Mock
     RdsClient rdsClient;

--- a/aws-rds-dbcluster/src/test/java/software/amazon/rds/dbcluster/ReadHandlerTest.java
+++ b/aws-rds-dbcluster/src/test/java/software/amazon/rds/dbcluster/ReadHandlerTest.java
@@ -9,7 +9,6 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 import java.time.Duration;
 
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -18,10 +17,10 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import lombok.Getter;
+import software.amazon.awssdk.services.ec2.Ec2Client;
 import software.amazon.awssdk.services.rds.RdsClient;
 import software.amazon.awssdk.services.rds.model.DescribeDbClustersRequest;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
-import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ProxyClient;
 
 @ExtendWith(MockitoExtension.class)
@@ -34,6 +33,10 @@ public class ReadHandlerTest extends AbstractHandlerTest {
     @Mock
     @Getter
     private ProxyClient<RdsClient> rdsProxy;
+
+    @Mock
+    @Getter
+    private ProxyClient<Ec2Client> ec2Proxy;
 
     @Mock
     RdsClient rdsClient;

--- a/aws-rds-dbcluster/src/test/java/software/amazon/rds/dbcluster/UpdateHandlerTest.java
+++ b/aws-rds-dbcluster/src/test/java/software/amazon/rds/dbcluster/UpdateHandlerTest.java
@@ -23,6 +23,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import lombok.Getter;
+import software.amazon.awssdk.services.ec2.Ec2Client;
 import software.amazon.awssdk.services.rds.RdsClient;
 import software.amazon.awssdk.services.rds.model.AddRoleToDbClusterRequest;
 import software.amazon.awssdk.services.rds.model.AddRoleToDbClusterResponse;
@@ -55,9 +56,15 @@ public class UpdateHandlerTest extends AbstractHandlerTest {
     @Mock
     @Getter
     private AmazonWebServicesClientProxy proxy;
+
     @Mock
     @Getter
     private ProxyClient<RdsClient> rdsProxy;
+
+    @Mock
+    @Getter
+    private ProxyClient<Ec2Client> ec2Proxy;
+
     @Getter
     private UpdateHandler handler;
 


### PR DESCRIPTION
*Description of changes:*
This commit includes two main cahnges:
- Set up default vpc security group id if customer did not specify any vpc security group id.
- Send vpc security group id in modify only if customer changed.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
