### PR TITLE
[OptionGroup] Add defensive statement for a customer not using option versioning

### DIFF
--- a/aws-rds-optiongroup/src/main/java/software/amazon/rds/optiongroup/OptionVersion.java
+++ b/aws-rds-optiongroup/src/main/java/software/amazon/rds/optiongroup/OptionVersion.java
@@ -10,8 +10,8 @@ public class OptionVersion implements Comparable<OptionVersion> {
 
     @Override
     public int compareTo(OptionVersion other) {
-        // Customer doesn't use versioning
-        if (version == null && other.version == null) {
+        // Customer doesn't use versioning or is only starting to version
+        if (version == null) {
             return 0;
         }
 

--- a/aws-rds-optiongroup/src/main/java/software/amazon/rds/optiongroup/OptionVersion.java
+++ b/aws-rds-optiongroup/src/main/java/software/amazon/rds/optiongroup/OptionVersion.java
@@ -10,8 +10,8 @@ public class OptionVersion implements Comparable<OptionVersion> {
 
     @Override
     public int compareTo(OptionVersion other) {
-        // Customer doesn't use versioning or is only starting to version
-        if (version == null) {
+        // 1) Customer doesn't use versioning or 2) Is starting to version or 3) Is no longer versioning
+        if (version == null || other.version == null) {
             return 0;
         }
 

--- a/aws-rds-optiongroup/src/main/java/software/amazon/rds/optiongroup/OptionVersion.java
+++ b/aws-rds-optiongroup/src/main/java/software/amazon/rds/optiongroup/OptionVersion.java
@@ -10,6 +10,11 @@ public class OptionVersion implements Comparable<OptionVersion> {
 
     @Override
     public int compareTo(OptionVersion other) {
+        // Customer doesn't use versioning
+        if (version == null && other.version == null) {
+            return 0;
+        }
+
         //version string are dot connected with a ending like .v[0-9]+
         //eg:      5.1.2.v1      4.2.6.v1
         String[] vals1 = version.split("\\.");

--- a/aws-rds-optiongroup/src/test/java/software/amazon/rds/optiongroup/UpdateHandlerTest.java
+++ b/aws-rds-optiongroup/src/test/java/software/amazon/rds/optiongroup/UpdateHandlerTest.java
@@ -106,6 +106,50 @@ public class UpdateHandlerTest extends AbstractTestBase {
     }
 
     @Test
+    public void handleRequest_EmptyOptionVersion() {
+        final ResourceModel RESOURCE_MODEL_WITH_CONFIGURATIONS = RESOURCE_MODEL_BUILDER()
+                .optionConfigurations(ImmutableList.of(
+                        OptionConfiguration.builder()
+                                .optionName("APEX")
+                                .optionVersion(null)
+                                .build()
+                )).build();
+        final ResourceModel RESOURCE_MODEL_WITH_UPDATED_CONFIGURATIONS = RESOURCE_MODEL_BUILDER()
+                .optionConfigurations(ImmutableList.of(
+                        OptionConfiguration.builder()
+                                .optionName("APEX")
+                                .optionVersion(null)
+                                .build()
+                )).build();
+
+        when(proxyClient.client().listTagsForResource(any(ListTagsForResourceRequest.class)))
+                .thenReturn(ListTagsForResourceResponse.builder().build());
+        final DescribeOptionGroupsResponse describeDbClusterParameterGroupsResponse = DescribeOptionGroupsResponse.builder()
+                .optionGroupsList(OPTION_GROUP_ACTIVE).build();
+        when(proxyClient.client().describeOptionGroups(any(DescribeOptionGroupsRequest.class))).thenReturn(describeDbClusterParameterGroupsResponse);
+
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+                .clientRequestToken(randomString(32, ALPHA))
+                .previousResourceState(RESOURCE_MODEL_WITH_CONFIGURATIONS)
+                .desiredResourceState(RESOURCE_MODEL_WITH_UPDATED_CONFIGURATIONS)
+                .stackId(randomString(32, ALPHA))
+                .logicalResourceIdentifier(randomString(32, ALPHA))
+                .build();
+        final ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);
+
+        assertThat(response).isNotNull();
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
+        assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
+        assertThat(response.getResourceModels()).isNull();
+        assertThat(response.getMessage()).isNull();
+        assertThat(response.getErrorCode()).isNull();
+
+        verify(proxyClient.client(), times(0)).modifyOptionGroup(any(ModifyOptionGroupRequest.class));
+        verify(proxyClient.client(), times(2)).describeOptionGroups(any(DescribeOptionGroupsRequest.class));
+        verify(proxyClient.client(), times(1)).listTagsForResource(any(ListTagsForResourceRequest.class));
+    }
+
+    @Test
     public void handleRequest_TagUpdate_Success() {
         ResourceModel RESOURCE_MODEL_WITH_RESOURCE_TAGS = RESOURCE_MODEL_WITH_RESOURCE_TAGS_BUILDER().build();
         ResourceModel RESOURCE_MODEL_WITH_UPDATED_RESOURCE_TAGS = RESOURCE_MODEL_BUILDER()

--- a/aws-rds-optiongroup/src/test/java/software/amazon/rds/optiongroup/UpdateHandlerTest.java
+++ b/aws-rds-optiongroup/src/test/java/software/amazon/rds/optiongroup/UpdateHandlerTest.java
@@ -106,7 +106,7 @@ public class UpdateHandlerTest extends AbstractTestBase {
     }
 
     @Test
-    public void handleRequest_EmptyOptionVersion() {
+    public void handleRequest_EmptyPreviousOptionVersion() {
         final ResourceModel RESOURCE_MODEL_WITH_CONFIGURATIONS = RESOURCE_MODEL_BUILDER()
                 .optionConfigurations(ImmutableList.of(
                         OptionConfiguration.builder()
@@ -118,10 +118,12 @@ public class UpdateHandlerTest extends AbstractTestBase {
                 .optionConfigurations(ImmutableList.of(
                         OptionConfiguration.builder()
                                 .optionName("APEX")
-                                .optionVersion(null)
+                                .optionVersion("1.2.3")
                                 .build()
                 )).build();
 
+        when(proxyClient.client().modifyOptionGroup(any(ModifyOptionGroupRequest.class)))
+                .thenReturn(ModifyOptionGroupResponse.builder().build());
         when(proxyClient.client().listTagsForResource(any(ListTagsForResourceRequest.class)))
                 .thenReturn(ListTagsForResourceResponse.builder().build());
         final DescribeOptionGroupsResponse describeDbClusterParameterGroupsResponse = DescribeOptionGroupsResponse.builder()
@@ -144,7 +146,7 @@ public class UpdateHandlerTest extends AbstractTestBase {
         assertThat(response.getMessage()).isNull();
         assertThat(response.getErrorCode()).isNull();
 
-        verify(proxyClient.client(), times(0)).modifyOptionGroup(any(ModifyOptionGroupRequest.class));
+        verify(proxyClient.client(), times(1)).modifyOptionGroup(any(ModifyOptionGroupRequest.class));
         verify(proxyClient.client(), times(2)).describeOptionGroups(any(DescribeOptionGroupsRequest.class));
         verify(proxyClient.client(), times(1)).listTagsForResource(any(ListTagsForResourceRequest.class));
     }


### PR DESCRIPTION
This pr aims to add defensive statement for customers who are not using Option versioning for their option groups