### PR TITLE
[DBInstance][DBCluster] Return NotFound status when AD domain is not found

### DIFF
--- a/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/BaseHandlerStd.java
+++ b/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/BaseHandlerStd.java
@@ -84,7 +84,8 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
                     DbInstanceNotFoundException.class,
                     DbSubnetGroupNotFoundException.class,
                     DomainNotFoundException.class,
-                    GlobalClusterNotFoundException.class)
+                    GlobalClusterNotFoundException.class,
+                    DomainNotFoundException.class)
             .withErrorClasses(ErrorStatus.failWith(HandlerErrorCode.ServiceLimitExceeded),
                     DbClusterQuotaExceededException.class,
                     InsufficientStorageClusterCapacityException.class,

--- a/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/BaseHandlerStd.java
+++ b/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/BaseHandlerStd.java
@@ -84,8 +84,7 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
                     DbInstanceNotFoundException.class,
                     DbSubnetGroupNotFoundException.class,
                     DomainNotFoundException.class,
-                    GlobalClusterNotFoundException.class,
-                    DomainNotFoundException.class)
+                    GlobalClusterNotFoundException.class)
             .withErrorClasses(ErrorStatus.failWith(HandlerErrorCode.ServiceLimitExceeded),
                     DbClusterQuotaExceededException.class,
                     InsufficientStorageClusterCapacityException.class,

--- a/aws-rds-dbcluster/src/test/java/software/amazon/rds/dbcluster/CreateHandlerTest.java
+++ b/aws-rds-dbcluster/src/test/java/software/amazon/rds/dbcluster/CreateHandlerTest.java
@@ -35,6 +35,7 @@ import software.amazon.awssdk.services.rds.model.CreateDbClusterResponse;
 import software.amazon.awssdk.services.rds.model.DBCluster;
 import software.amazon.awssdk.services.rds.model.DbClusterAlreadyExistsException;
 import software.amazon.awssdk.services.rds.model.DescribeDbClustersRequest;
+import software.amazon.awssdk.services.rds.model.DomainNotFoundException;
 import software.amazon.awssdk.services.rds.model.ModifyDbClusterRequest;
 import software.amazon.awssdk.services.rds.model.ModifyDbClusterResponse;
 import software.amazon.awssdk.services.rds.model.RdsException;
@@ -464,5 +465,20 @@ public class CreateHandlerTest extends AbstractHandlerTest {
         );
 
         verify(rdsProxy.client(), times(1)).restoreDBClusterToPointInTime(any(RestoreDbClusterToPointInTimeRequest.class));
+    }
+
+    @Test
+    public void handleRequest_CreateDbCluster_DomainNotFoundException() {
+        when(rdsProxy.client().createDBCluster(any(CreateDbClusterRequest.class)))
+                .thenThrow(DomainNotFoundException.builder().message("Requested domain some_domain does not exist").build());
+
+        test_handleRequest_base(
+                new CallbackContext(),
+                null,
+                () -> RESOURCE_MODEL,
+                expectFailed(HandlerErrorCode.NotFound)
+        );
+
+        verify(rdsProxy.client(), times(1)).createDBCluster(any(CreateDbClusterRequest.class));
     }
 }

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/BaseHandlerStd.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/BaseHandlerStd.java
@@ -38,6 +38,7 @@ import software.amazon.awssdk.services.rds.model.DbUpgradeDependencyFailureExcep
 import software.amazon.awssdk.services.rds.model.DescribeDbClustersResponse;
 import software.amazon.awssdk.services.rds.model.DescribeDbInstancesResponse;
 import software.amazon.awssdk.services.rds.model.DescribeDbSnapshotsResponse;
+import software.amazon.awssdk.services.rds.model.DomainNotFoundException;
 import software.amazon.awssdk.services.rds.model.InstanceQuotaExceededException;
 import software.amazon.awssdk.services.rds.model.InsufficientDbInstanceCapacityException;
 import software.amazon.awssdk.services.rds.model.InvalidDbClusterStateException;
@@ -161,7 +162,8 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
                     DbSecurityGroupNotFoundException.class,
                     DbSnapshotNotFoundException.class,
                     DbSubnetGroupNotFoundException.class,
-                    OptionGroupNotFoundException.class)
+                    OptionGroupNotFoundException.class,
+                    DomainNotFoundException.class)
             .withErrorClasses(ErrorStatus.failWith(HandlerErrorCode.ServiceLimitExceeded),
                     DbInstanceAutomatedBackupQuotaExceededException.class,
                     InsufficientDbInstanceCapacityException.class,

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/BaseHandlerStd.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/BaseHandlerStd.java
@@ -162,8 +162,8 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
                     DbSecurityGroupNotFoundException.class,
                     DbSnapshotNotFoundException.class,
                     DbSubnetGroupNotFoundException.class,
-                    OptionGroupNotFoundException.class,
-                    DomainNotFoundException.class)
+                    DomainNotFoundException.class,
+                    OptionGroupNotFoundException.class)
             .withErrorClasses(ErrorStatus.failWith(HandlerErrorCode.ServiceLimitExceeded),
                     DbInstanceAutomatedBackupQuotaExceededException.class,
                     InsufficientDbInstanceCapacityException.class,

--- a/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/CreateHandlerTest.java
+++ b/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/CreateHandlerTest.java
@@ -44,6 +44,7 @@ import software.amazon.awssdk.services.rds.model.DescribeDbInstancesRequest;
 import software.amazon.awssdk.services.rds.model.DescribeDbInstancesResponse;
 import software.amazon.awssdk.services.rds.model.DescribeDbSnapshotsRequest;
 import software.amazon.awssdk.services.rds.model.DescribeDbSnapshotsResponse;
+import software.amazon.awssdk.services.rds.model.DomainNotFoundException;
 import software.amazon.awssdk.services.rds.model.ModifyDbInstanceRequest;
 import software.amazon.awssdk.services.rds.model.ModifyDbInstanceResponse;
 import software.amazon.awssdk.services.rds.model.OptionGroupNotFoundException;
@@ -1347,6 +1348,21 @@ public class CreateHandlerTest extends AbstractHandlerTest {
                 () -> RESOURCE_MODEL_BAREBONE_BLDR()
                         .optionGroupName(OPTION_GROUP_NAME_MYSQL_DEFAULT)
                         .build(),
+                expectFailed(HandlerErrorCode.NotFound)
+        );
+
+        verify(rdsProxy.client(), times(1)).createDBInstance(any(CreateDbInstanceRequest.class));
+    }
+
+    @Test
+    public void handleRequest_CreateDbCluster_DomainNotFoundException() {
+        when(rdsProxy.client().createDBInstance(any(CreateDbInstanceRequest.class)))
+                .thenThrow(DomainNotFoundException.builder().message("Requested domain some_domain does not exist").build());
+
+        test_handleRequest_base(
+                new CallbackContext(),
+                null,
+                () -> RESOURCE_MODEL_BLDR().build(),
                 expectFailed(HandlerErrorCode.NotFound)
         );
 


### PR DESCRIPTION
This PR addresses an oversight is Error Rule Set that was interpreting DomainNotFoundException as Internal Error. It is now being interpreted as NotFound.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
