### PR TITLE
[DBInstance] No `vpcSecurityGroupIds` for dbcluster instance modifications

### DIFF
--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/Translator.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/Translator.java
@@ -303,14 +303,18 @@ public class Translator {
                 .promotionTier(desiredModel.getPromotionTier())
                 .storageType(desiredModel.getStorageType())
                 .tdeCredentialArn(desiredModel.getTdeCredentialArn())
-                .tdeCredentialPassword(desiredModel.getTdeCredentialPassword())
-                .vpcSecurityGroupIds(desiredModel.getVPCSecurityGroups());
+                .tdeCredentialPassword(desiredModel.getTdeCredentialPassword());
 
         final CloudwatchLogsExportConfiguration cloudwatchLogsExportConfiguration = buildTranslateCloudwatchLogsExportConfiguration(
                 Optional.ofNullable(previousModel).map(ResourceModel::getEnableCloudwatchLogsExports).orElse(Collections.emptyList()),
                 desiredModel.getEnableCloudwatchLogsExports()
         );
         builder.cloudwatchLogsExportConfiguration(cloudwatchLogsExportConfiguration);
+
+        // VPC security groups can not be assigned directly on an Aurora instance.
+        if (StringUtils.isBlank(desiredModel.getDBClusterIdentifier())) {
+            builder.vpcSecurityGroupIds(desiredModel.getVPCSecurityGroups());
+        }
 
         if (previousModel != null) {
             if (BooleanUtils.isTrue(isRollback)) {


### PR DESCRIPTION
This commit eliminates `vpcSecurityGroupIds` setting for `ModifyDBInstance` requests if an instance is a member of a DBCluster.

The reason for this change is to avoid a rejection by RDS API as DBCluster instance vpc security groups are managed by the cluster object, not atomic instances.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Signed-off-by: Oleg Sidorov <sidorovo@amazon.com>