### PR TITLE
[DBInstance] Allow updates of PerformanceInsightsKMSKeyId if it was not previously specified

### DIFF
--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/util/ImmutabilityHelper.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/util/ImmutabilityHelper.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableList;
+import io.netty.util.internal.StringUtil;
 import software.amazon.rds.dbinstance.ResourceModel;
 
 public final class ImmutabilityHelper {
@@ -40,7 +41,9 @@ public final class ImmutabilityHelper {
     }
 
     static boolean isPerformanceInsightsKMSKeyIdMutable(final ResourceModel previous, final ResourceModel desired) {
-        return Objects.equal(previous.getPerformanceInsightsKMSKeyId(), desired.getPerformanceInsightsKMSKeyId());
+
+        return StringUtil.isNullOrEmpty(previous.getPerformanceInsightsKMSKeyId()) ||
+                Objects.equal(previous.getPerformanceInsightsKMSKeyId(), desired.getPerformanceInsightsKMSKeyId());
     }
 
     public static boolean isChangeMutable(final ResourceModel previous, final ResourceModel desired) {

--- a/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/UpdateHandlerTest.java
+++ b/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/UpdateHandlerTest.java
@@ -100,6 +100,8 @@ public class UpdateHandlerTest extends AbstractHandlerTest {
     @Getter
     private UpdateHandler handler;
 
+    private Boolean expectServiceInvocation;
+
     @Override
     public ProxyClient<RdsClient> getRdsProxy(final String version) {
         switch (version) {
@@ -124,11 +126,15 @@ public class UpdateHandlerTest extends AbstractHandlerTest {
         rdsProxy = mockProxy(proxy, rdsClient);
         rdsProxyV12 = mockProxy(proxy, rdsClientV12);
         ec2Proxy = mockProxy(proxy, ec2Client);
+
+        expectServiceInvocation = true;
     }
 
     @AfterEach
     public void tear_down() {
-        verify(rdsClient, atLeastOnce()).serviceName();
+        if (expectServiceInvocation) {
+            verify(rdsClient, atLeastOnce()).serviceName();
+        }
         verifyNoMoreInteractions(rdsClient);
         verifyNoMoreInteractions(ec2Client);
     }
@@ -695,6 +701,55 @@ public class UpdateHandlerTest extends AbstractHandlerTest {
         );
 
         verify(rdsProxy.client(), times(2)).describeDBInstances(any(DescribeDbInstancesRequest.class));
+    }
+
+    @Test
+    public void handleRequest_PerformanceInsightsKMSId_UpdatedFromEmptyToValue() {
+        final ResourceModel desiredModel = RESOURCE_MODEL_BLDR()
+                .performanceInsightsKMSKeyId("performance_insights_kms_id")
+                .build();
+
+        final ResourceModel previousModel = RESOURCE_MODEL_BLDR()
+                .build();
+
+        final CallbackContext context = new CallbackContext();
+
+        test_handleRequest_base(
+                context,
+                ResourceHandlerRequest.<ResourceModel>builder().rollback(true),
+                () -> DB_INSTANCE_ACTIVE,
+                () -> previousModel,
+                () -> desiredModel,
+                expectSuccess()
+        );
+
+        ArgumentCaptor<ModifyDbInstanceRequest> argumentCaptor = ArgumentCaptor.forClass(ModifyDbInstanceRequest.class);
+
+        verify(rdsProxy.client(), times(1)).modifyDBInstance(argumentCaptor.capture());
+        Assertions.assertThat(argumentCaptor.getValue().performanceInsightsKMSKeyId()).isEqualTo("performance_insights_kms_id");
+    }
+
+    @Test
+    public void handleRequest_PerformanceInsightsKMSId_UpdatedToDifferentValue() {
+        expectServiceInvocation = false;
+        final ResourceModel desiredModel = RESOURCE_MODEL_BLDR()
+                .performanceInsightsKMSKeyId("performance_insights_kms_id")
+                .build();
+
+        final ResourceModel previousModel = RESOURCE_MODEL_BLDR()
+                .performanceInsightsKMSKeyId("old-performance_insights_kms_id")
+                .build();
+
+        final CallbackContext context = new CallbackContext();
+
+        test_handleRequest_base(
+                context,
+                ResourceHandlerRequest.<ResourceModel>builder().rollback(true),
+                null,
+                () -> previousModel,
+                () -> desiredModel,
+                expectFailed(HandlerErrorCode.NotUpdatable)
+        );
     }
 
     @Test


### PR DESCRIPTION
This PR relaxes the restrictions on PerformanceInsightsKMSKeyId, allowing to update it if it was not previously specified.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
