### PR TITLE
[DBInstance] Fix `AllocatedStorage` validation

### DIFF
--- a/aws-rds-dbinstance/aws-rds-dbinstance.json
+++ b/aws-rds-dbinstance/aws-rds-dbinstance.json
@@ -83,7 +83,8 @@
   "properties": {
     "AllocatedStorage": {
       "type": "string",
-      "description": "The amount of storage (in gigabytes) to be initially allocated for the database instance."
+      "description": "The amount of storage (in gigabytes) to be initially allocated for the database instance.",
+      "pattern": "^[0-9]*$"
     },
     "AllowMajorVersionUpgrade": {
       "type": "boolean",

--- a/aws-rds-dbinstance/docs/README.md
+++ b/aws-rds-dbinstance/docs/README.md
@@ -149,6 +149,8 @@ _Required_: No
 
 _Type_: String
 
+_Pattern_: <code>^[0-9]*$</code>
+
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 
 #### AllowMajorVersionUpgrade


### PR DESCRIPTION
This commit adds a numeric validator on `AllocatedStorage` attribute. The motivation for this change is to ensure the value looks like a valid numeric argument and could be parsed into an Integer upon a request construction.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Signed-off-by: Oleg Sidorov <sidorovo@amazon.com>