### PR TITLE
[DBInstance] Drop reference-type schema validators

### DIFF
--- a/aws-rds-dbinstance/aws-rds-dbinstance.json
+++ b/aws-rds-dbinstance/aws-rds-dbinstance.json
@@ -125,8 +125,7 @@
     },
     "DBClusterIdentifier": {
       "type": "string",
-      "description": "The identifier of the DB cluster that the instance will belong to.",
-      "pattern": "^$|^[a-zA-Z]{1}(?:-?[a-zA-Z0-9]){0,62}$"
+      "description": "The identifier of the DB cluster that the instance will belong to."
     },
     "DBInstanceClass": {
       "type": "string",
@@ -144,7 +143,6 @@
     },
     "DBParameterGroupName": {
       "type": "string",
-      "pattern": "^$|^[a-zA-Z]{1}(?:[:-]?[a-zA-Z0-9\\.]){0,254}$",
       "description": "The name of an existing DB parameter group or a reference to an AWS::RDS::DBParameterGroup resource created in the template."
     },
     "DBSecurityGroups": {
@@ -157,13 +155,11 @@
     },
     "DBSnapshotIdentifier": {
       "type": "string",
-      "description": "The name or Amazon Resource Name (ARN) of the DB snapshot that's used to restore the DB instance. If you're restoring from a shared manual DB snapshot, you must specify the ARN of the snapshot.",
-      "pattern": "^$|^[a-zA-Z]{1}(?:[:-]?[a-zA-Z0-9]){0,254}$"
+      "description": "The name or Amazon Resource Name (ARN) of the DB snapshot that's used to restore the DB instance. If you're restoring from a shared manual DB snapshot, you must specify the ARN of the snapshot."
     },
     "DBSubnetGroupName": {
       "type": "string",
-      "description": "A DB subnet group to associate with the DB instance. If you update this value, the new subnet group must be a subnet group in a new VPC.",
-      "pattern": "^$|^[a-zA-Z]{1}(?:[-:]?[a-zA-Z0-9_\\.\\s]){0,254}$"
+      "description": "A DB subnet group to associate with the DB instance. If you update this value, the new subnet group must be a subnet group in a new VPC."
     },
     "DeleteAutomatedBackups": {
       "type": "boolean",

--- a/aws-rds-dbinstance/docs/README.md
+++ b/aws-rds-dbinstance/docs/README.md
@@ -241,8 +241,6 @@ _Required_: No
 
 _Type_: String
 
-_Pattern_: <code>^$|^[a-zA-Z]{1}(?:-?[a-zA-Z0-9]){0,62}$</code>
-
 _Update requires_: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
 
 #### DBInstanceClass
@@ -287,8 +285,6 @@ _Required_: No
 
 _Type_: String
 
-_Pattern_: <code>^$|^[a-zA-Z]{1}(?:[:-]?[a-zA-Z0-9\.]){0,254}$</code>
-
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 
 #### DBSecurityGroups
@@ -309,8 +305,6 @@ _Required_: No
 
 _Type_: String
 
-_Pattern_: <code>^$|^[a-zA-Z]{1}(?:[:-]?[a-zA-Z0-9]){0,254}$</code>
-
 _Update requires_: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
 
 #### DBSubnetGroupName
@@ -320,8 +314,6 @@ A DB subnet group to associate with the DB instance. If you update this value, t
 _Required_: No
 
 _Type_: String
-
-_Pattern_: <code>^$|^[a-zA-Z]{1}(?:[-:]?[a-zA-Z0-9_\.\s]){0,254}$</code>
 
 _Update requires_: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
 


### PR DESCRIPTION
This commit removes schema-based validators from DBInstance resource definition. The motivation for this change is to eliminate inter-dependencies and validation logic inconsistency between CFN resources. At the moment, DBInstance performs additional validations on the reference-type properties.

Reference-type properties are effectively borrowed attributes: DBInstance does not own these propoerties (they are effectively pointers on external resources). With this change we are delegating the reference-type validation to the corresponding owning resources or to the RDS API if the resource was created out of CFN scope.

Having this change in place would allow us to consolidate the validation logic in the owning resources and eliminate export issues caused by legacy resources that would no longer pass the validation.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Signed-off-by: Oleg Sidorov <sidorovo@amazon.com>