### PR TITLE
[DBInstance] Set storage type on restore from snapshot with subsequent modify call

### DIFF
--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/BaseHandlerStd.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/BaseHandlerStd.java
@@ -79,6 +79,8 @@ import software.amazon.rds.dbinstance.client.Ec2ClientProvider;
 import software.amazon.rds.dbinstance.client.RdsClientProvider;
 import software.amazon.rds.dbinstance.client.VersionedProxyClient;
 
+import static software.amazon.rds.dbinstance.util.UpdateAfterCreateHelper.isRestoreFromSnapshot;
+
 public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
 
     public static final String RESOURCE_IDENTIFIER = "dbinstance";
@@ -374,14 +376,6 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
                         MODIFY_DB_INSTANCE_ERROR_RULE_SET
                 ))
                 .progress();
-    }
-
-    protected boolean isReadReplica(final ResourceModel model) {
-        return StringUtils.isNotBlank(model.getSourceDBInstanceIdentifier());
-    }
-
-    protected boolean isRestoreFromSnapshot(final ResourceModel model) {
-        return StringUtils.isNotBlank(model.getDBSnapshotIdentifier());
     }
 
     protected boolean isDBClusterMember(final ResourceModel model) {

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/BaseHandlerStd.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/BaseHandlerStd.java
@@ -78,8 +78,7 @@ import software.amazon.rds.dbinstance.client.ApiVersionDispatcher;
 import software.amazon.rds.dbinstance.client.Ec2ClientProvider;
 import software.amazon.rds.dbinstance.client.RdsClientProvider;
 import software.amazon.rds.dbinstance.client.VersionedProxyClient;
-
-import static software.amazon.rds.dbinstance.util.ResourceModelHelper.isRestoreFromSnapshot;
+import software.amazon.rds.dbinstance.util.ResourceModelHelper;
 
 public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
 
@@ -758,7 +757,7 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
     ) {
         final ResourceModel model = progress.getResourceModel();
         if (StringUtils.isEmpty(model.getEngine())) {
-            if (isRestoreFromSnapshot(model)) {
+            if (ResourceModelHelper.isRestoreFromSnapshot(model)) {
                 try {
                     final DBInstance dbInstance = fetchDBInstance(rdsProxyClient, model);
                     model.setEngine(dbInstance.engine());

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/BaseHandlerStd.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/BaseHandlerStd.java
@@ -79,7 +79,7 @@ import software.amazon.rds.dbinstance.client.Ec2ClientProvider;
 import software.amazon.rds.dbinstance.client.RdsClientProvider;
 import software.amazon.rds.dbinstance.client.VersionedProxyClient;
 
-import static software.amazon.rds.dbinstance.util.UpdateAfterCreateHelper.isRestoreFromSnapshot;
+import static software.amazon.rds.dbinstance.util.ResourceModelHelper.isRestoreFromSnapshot;
 
 public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
 

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/CreateHandler.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/CreateHandler.java
@@ -23,7 +23,7 @@ import software.amazon.rds.common.handler.Tagging;
 import software.amazon.rds.common.util.IdentifierFactory;
 import software.amazon.rds.dbinstance.client.ApiVersion;
 import software.amazon.rds.dbinstance.client.VersionedProxyClient;
-import software.amazon.rds.dbinstance.util.UpdateAfterCreateHelper;
+import software.amazon.rds.dbinstance.util.ResourceModelHelper;
 
 public class CreateHandler extends BaseHandlerStd {
 
@@ -74,11 +74,11 @@ public class CreateHandler extends BaseHandlerStd {
 
         return ProgressEvent.progress(model, callbackContext)
                 .then(progress -> Commons.execOnce(progress, () -> {
-                    if (UpdateAfterCreateHelper.isReadReplica(progress.getResourceModel())) {
+                    if (ResourceModelHelper.isReadReplica(progress.getResourceModel())) {
                         // createDBInstanceReadReplica is not a versioned call, unlike the others.
                         return safeAddTags(this::createDbInstanceReadReplica)
                                 .invoke(proxy, rdsProxyClient.defaultClient(), progress, allTags);
-                    } else if (UpdateAfterCreateHelper.isRestoreFromSnapshot(progress.getResourceModel())) {
+                    } else if (ResourceModelHelper.isRestoreFromSnapshot(progress.getResourceModel())) {
                         if (model.getMultiAZ() == null) {
                             try {
                                 final DBSnapshot snapshot = fetchDBSnapshot(rdsProxyClient.defaultClient(), model);
@@ -107,7 +107,7 @@ public class CreateHandler extends BaseHandlerStd {
                 }, CallbackContext::isAddTagsComplete, CallbackContext::setAddTagsComplete))
                 .then(progress -> ensureEngineSet(rdsProxyClient.defaultClient(), progress))
                 .then(progress -> {
-                    if (UpdateAfterCreateHelper.shouldUpdateAfterCreate(progress.getResourceModel())) {
+                    if (ResourceModelHelper.shouldUpdateAfterCreate(progress.getResourceModel())) {
                         return Commons.execOnce(progress, () ->
                                                 versioned(proxy, rdsProxyClient, progress, null, ImmutableMap.of(
                                                         ApiVersion.V12, (pxy, pcl, prg, tgs) -> updateDbInstanceV12(pxy, request, pcl, prg),

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/DeleteHandler.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/DeleteHandler.java
@@ -15,6 +15,7 @@ import software.amazon.rds.common.handler.Commons;
 import software.amazon.rds.common.handler.HandlerConfig;
 import software.amazon.rds.common.util.IdentifierFactory;
 import software.amazon.rds.dbinstance.client.VersionedProxyClient;
+import software.amazon.rds.dbinstance.util.UpdateAfterCreateHelper;
 
 public class DeleteHandler extends BaseHandlerStd {
 
@@ -49,7 +50,7 @@ public class DeleteHandler extends BaseHandlerStd {
         // For AWS::RDS::DBInstance resources that don't specify the DBClusterIdentifier property, the default policy is Snapshot.
         // Final snapshots are not allowed for read replicas and cluster instances.
         if (BooleanUtils.isTrue(request.getSnapshotRequested()) &&
-                !isReadReplica(resourceModel) &&
+                !UpdateAfterCreateHelper.isReadReplica(resourceModel) &&
                 !isDBClusterMember(resourceModel)) {
             snapshotIdentifier = snapshotIdentifierFactory.newIdentifier()
                     .withStackId(request.getStackId())

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/DeleteHandler.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/DeleteHandler.java
@@ -15,7 +15,7 @@ import software.amazon.rds.common.handler.Commons;
 import software.amazon.rds.common.handler.HandlerConfig;
 import software.amazon.rds.common.util.IdentifierFactory;
 import software.amazon.rds.dbinstance.client.VersionedProxyClient;
-import software.amazon.rds.dbinstance.util.UpdateAfterCreateHelper;
+import software.amazon.rds.dbinstance.util.ResourceModelHelper;
 
 public class DeleteHandler extends BaseHandlerStd {
 
@@ -50,7 +50,7 @@ public class DeleteHandler extends BaseHandlerStd {
         // For AWS::RDS::DBInstance resources that don't specify the DBClusterIdentifier property, the default policy is Snapshot.
         // Final snapshots are not allowed for read replicas and cluster instances.
         if (BooleanUtils.isTrue(request.getSnapshotRequested()) &&
-                !UpdateAfterCreateHelper.isReadReplica(resourceModel) &&
+                !ResourceModelHelper.isReadReplica(resourceModel) &&
                 !isDBClusterMember(resourceModel)) {
             snapshotIdentifier = snapshotIdentifierFactory.newIdentifier()
                     .withStackId(request.getStackId())

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/Translator.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/Translator.java
@@ -36,12 +36,9 @@ import software.amazon.awssdk.services.rds.model.RemoveRoleFromDbInstanceRequest
 import software.amazon.awssdk.services.rds.model.RestoreDbInstanceFromDbSnapshotRequest;
 import software.amazon.awssdk.utils.StringUtils;
 import software.amazon.rds.common.handler.Tagging;
-import software.amazon.rds.dbinstance.util.UpdateAfterCreateHelper;
+import software.amazon.rds.dbinstance.util.ResourceModelHelper;
 
 public class Translator {
-
-    private final static String STORAGE_TYPE_IO1 = "io1";
-
     public static DescribeDbInstancesRequest describeDbInstancesRequest(final ResourceModel model) {
         return DescribeDbInstancesRequest.builder()
                 .dbInstanceIdentifier(model.getDBInstanceIdentifier())
@@ -119,9 +116,10 @@ public class Translator {
                 .optionGroupName(model.getOptionGroupName())
                 .port(translatePortToSdk(model.getPort()));
 
-        if (!Objects.equals(model.getStorageType(), STORAGE_TYPE_IO1) && UpdateAfterCreateHelper.shouldUpdateAfterCreate(model)) {
+        if (ResourceModelHelper.shouldSetStorageTypeOnRestoreFromSnapshot(model)) {
             builder.storageType(model.getStorageType());
         }
+
         return builder.build();
     }
 
@@ -156,7 +154,7 @@ public class Translator {
                 .useDefaultProcessorFeatures(model.getUseDefaultProcessorFeatures())
                 .vpcSecurityGroupIds(CollectionUtils.isNotEmpty(model.getVPCSecurityGroups()) ? model.getVPCSecurityGroups() : null);
 
-        if (!Objects.equals(model.getStorageType(), STORAGE_TYPE_IO1) && UpdateAfterCreateHelper.shouldUpdateAfterCreate(model)) {
+        if (ResourceModelHelper.shouldSetStorageTypeOnRestoreFromSnapshot(model)) {
             builder.storageType(model.getStorageType());
         }
 

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/Translator.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/Translator.java
@@ -39,9 +39,6 @@ import software.amazon.rds.common.handler.Tagging;
 import software.amazon.rds.dbinstance.util.UpdateAfterCreateHelper;
 
 public class Translator {
-
-    private final static String STORAGE_TYPE_IO1 = "io1";
-
     public static DescribeDbInstancesRequest describeDbInstancesRequest(final ResourceModel model) {
         return DescribeDbInstancesRequest.builder()
                 .dbInstanceIdentifier(model.getDBInstanceIdentifier())
@@ -119,7 +116,7 @@ public class Translator {
                 .optionGroupName(model.getOptionGroupName())
                 .port(translatePortToSdk(model.getPort()));
 
-        if (!Objects.equals(model.getStorageType(), STORAGE_TYPE_IO1) && UpdateAfterCreateHelper.shouldUpdateAfterCreate(model)) {
+        if (UpdateAfterCreateHelper.shouldUpdateAfterCreate(model)) {
             builder.storageType(model.getStorageType());
         }
         return builder.build();
@@ -156,7 +153,7 @@ public class Translator {
                 .useDefaultProcessorFeatures(model.getUseDefaultProcessorFeatures())
                 .vpcSecurityGroupIds(CollectionUtils.isNotEmpty(model.getVPCSecurityGroups()) ? model.getVPCSecurityGroups() : null);
 
-        if (!Objects.equals(model.getStorageType(), STORAGE_TYPE_IO1) && UpdateAfterCreateHelper.shouldUpdateAfterCreate(model)) {
+        if (UpdateAfterCreateHelper.shouldUpdateAfterCreate(model)) {
             builder.storageType(model.getStorageType());
         }
 

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/Translator.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/Translator.java
@@ -39,6 +39,9 @@ import software.amazon.rds.common.handler.Tagging;
 import software.amazon.rds.dbinstance.util.UpdateAfterCreateHelper;
 
 public class Translator {
+
+    private final static String STORAGE_TYPE_IO1 = "io1";
+
     public static DescribeDbInstancesRequest describeDbInstancesRequest(final ResourceModel model) {
         return DescribeDbInstancesRequest.builder()
                 .dbInstanceIdentifier(model.getDBInstanceIdentifier())
@@ -116,7 +119,7 @@ public class Translator {
                 .optionGroupName(model.getOptionGroupName())
                 .port(translatePortToSdk(model.getPort()));
 
-        if (UpdateAfterCreateHelper.shouldUpdateAfterCreate(model)) {
+        if (!Objects.equals(model.getStorageType(), STORAGE_TYPE_IO1) && UpdateAfterCreateHelper.shouldUpdateAfterCreate(model)) {
             builder.storageType(model.getStorageType());
         }
         return builder.build();
@@ -153,7 +156,7 @@ public class Translator {
                 .useDefaultProcessorFeatures(model.getUseDefaultProcessorFeatures())
                 .vpcSecurityGroupIds(CollectionUtils.isNotEmpty(model.getVPCSecurityGroups()) ? model.getVPCSecurityGroups() : null);
 
-        if (UpdateAfterCreateHelper.shouldUpdateAfterCreate(model)) {
+        if (!Objects.equals(model.getStorageType(), STORAGE_TYPE_IO1) && UpdateAfterCreateHelper.shouldUpdateAfterCreate(model)) {
             builder.storageType(model.getStorageType());
         }
 

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/Translator.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/Translator.java
@@ -36,8 +36,11 @@ import software.amazon.awssdk.services.rds.model.RemoveRoleFromDbInstanceRequest
 import software.amazon.awssdk.services.rds.model.RestoreDbInstanceFromDbSnapshotRequest;
 import software.amazon.awssdk.utils.StringUtils;
 import software.amazon.rds.common.handler.Tagging;
+import software.amazon.rds.dbinstance.util.UpdateAfterCreateHelper;
 
 public class Translator {
+
+    private final static String STORAGE_TYPE_IO1 = "io1";
 
     public static DescribeDbInstancesRequest describeDbInstancesRequest(final ResourceModel model) {
         return DescribeDbInstancesRequest.builder()
@@ -102,7 +105,7 @@ public class Translator {
     public static RestoreDbInstanceFromDbSnapshotRequest restoreDbInstanceFromSnapshotRequestV12(
             final ResourceModel model
     ) {
-        return RestoreDbInstanceFromDbSnapshotRequest.builder()
+        final RestoreDbInstanceFromDbSnapshotRequest.Builder builder = RestoreDbInstanceFromDbSnapshotRequest.builder()
                 .autoMinorVersionUpgrade(model.getAutoMinorVersionUpgrade())
                 .availabilityZone(model.getAvailabilityZone())
                 .dbInstanceClass(model.getDBInstanceClass())
@@ -114,15 +117,19 @@ public class Translator {
                 .licenseModel(model.getLicenseModel())
                 .multiAZ(model.getMultiAZ())
                 .optionGroupName(model.getOptionGroupName())
-                .port(translatePortToSdk(model.getPort()))
-                .build();
+                .port(translatePortToSdk(model.getPort()));
+
+        if (!Objects.equals(model.getStorageType(), STORAGE_TYPE_IO1) && UpdateAfterCreateHelper.shouldUpdateAfterCreate(model)) {
+            builder.storageType(model.getStorageType());
+        }
+        return builder.build();
     }
 
     public static RestoreDbInstanceFromDbSnapshotRequest restoreDbInstanceFromSnapshotRequest(
             final ResourceModel model,
             final Tagging.TagSet tagSet
     ) {
-        return RestoreDbInstanceFromDbSnapshotRequest.builder()
+        final RestoreDbInstanceFromDbSnapshotRequest.Builder builder = RestoreDbInstanceFromDbSnapshotRequest.builder()
                 .autoMinorVersionUpgrade(model.getAutoMinorVersionUpgrade())
                 .availabilityZone(model.getAvailabilityZone())
                 .dbInstanceClass(model.getDBInstanceClass())
@@ -147,8 +154,13 @@ public class Translator {
                 .tdeCredentialArn(model.getTdeCredentialArn())
                 .tdeCredentialPassword(model.getTdeCredentialPassword())
                 .useDefaultProcessorFeatures(model.getUseDefaultProcessorFeatures())
-                .vpcSecurityGroupIds(CollectionUtils.isNotEmpty(model.getVPCSecurityGroups()) ? model.getVPCSecurityGroups() : null)
-                .build();
+                .vpcSecurityGroupIds(CollectionUtils.isNotEmpty(model.getVPCSecurityGroups()) ? model.getVPCSecurityGroups() : null);
+
+        if (!Objects.equals(model.getStorageType(), STORAGE_TYPE_IO1) && UpdateAfterCreateHelper.shouldUpdateAfterCreate(model)) {
+            builder.storageType(model.getStorageType());
+        }
+
+        return builder.build();
     }
 
     public static CreateDbInstanceRequest createDbInstanceRequestV12(

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/util/ResourceModelHelper.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/util/ResourceModelHelper.java
@@ -4,9 +4,11 @@ import com.amazonaws.util.StringUtils;
 import software.amazon.awssdk.utils.CollectionUtils;
 import software.amazon.rds.dbinstance.ResourceModel;
 
+import java.util.Objects;
 import java.util.Optional;
 
-public final class UpdateAfterCreateHelper {
+public final class ResourceModelHelper {
+    private final static String STORAGE_TYPE_IO1 = "io1";
     public static boolean shouldUpdateAfterCreate(final ResourceModel model) {
         return (isReadReplica(model) || isRestoreFromSnapshot(model) || isCertificateAuthorityApplied(model)) &&
                 (
@@ -30,10 +32,14 @@ public final class UpdateAfterCreateHelper {
 
 
     public static boolean isReadReplica(final ResourceModel model) {
-        return software.amazon.awssdk.utils.StringUtils.isNotBlank(model.getSourceDBInstanceIdentifier());
+        return StringUtils.hasValue(model.getSourceDBInstanceIdentifier());
     }
 
     public static boolean isRestoreFromSnapshot(final ResourceModel model) {
-        return software.amazon.awssdk.utils.StringUtils.isNotBlank(model.getDBSnapshotIdentifier());
+        return StringUtils.hasValue(model.getDBSnapshotIdentifier());
+    }
+
+    public static boolean shouldSetStorageTypeOnRestoreFromSnapshot(final ResourceModel model) {
+        return !Objects.equals(model.getStorageType(), STORAGE_TYPE_IO1) && shouldUpdateAfterCreate(model);
     }
 }

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/util/ResourceModelHelper.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/util/ResourceModelHelper.java
@@ -9,6 +9,7 @@ import java.util.Optional;
 
 public final class ResourceModelHelper {
     private final static String STORAGE_TYPE_IO1 = "io1";
+
     public static boolean shouldUpdateAfterCreate(final ResourceModel model) {
         return (isReadReplica(model) || isRestoreFromSnapshot(model) || isCertificateAuthorityApplied(model)) &&
                 (
@@ -29,7 +30,6 @@ public final class ResourceModelHelper {
     private static boolean isCertificateAuthorityApplied(final ResourceModel model) {
         return StringUtils.hasValue(model.getCACertificateIdentifier());
     }
-
 
     public static boolean isReadReplica(final ResourceModel model) {
         return StringUtils.hasValue(model.getSourceDBInstanceIdentifier());

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/util/UpdateAfterCreateHelper.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/util/UpdateAfterCreateHelper.java
@@ -1,0 +1,39 @@
+package software.amazon.rds.dbinstance.util;
+
+import com.amazonaws.util.StringUtils;
+import software.amazon.awssdk.utils.CollectionUtils;
+import software.amazon.rds.dbinstance.ResourceModel;
+
+import java.util.Optional;
+
+public final class UpdateAfterCreateHelper {
+    public static boolean shouldUpdateAfterCreate(final ResourceModel model) {
+        return (isReadReplica(model) || isRestoreFromSnapshot(model) || isCertificateAuthorityApplied(model)) &&
+                (
+                        !CollectionUtils.isNullOrEmpty(model.getDBSecurityGroups()) ||
+                                StringUtils.hasValue(model.getAllocatedStorage()) ||
+                                StringUtils.hasValue(model.getCACertificateIdentifier()) ||
+                                StringUtils.hasValue(model.getDBParameterGroupName()) ||
+                                StringUtils.hasValue(model.getEngineVersion()) ||
+                                StringUtils.hasValue(model.getMasterUserPassword()) ||
+                                StringUtils.hasValue(model.getPreferredBackupWindow()) ||
+                                StringUtils.hasValue(model.getPreferredMaintenanceWindow()) ||
+                                Optional.ofNullable(model.getBackupRetentionPeriod()).orElse(0) > 0 ||
+                                Optional.ofNullable(model.getIops()).orElse(0) > 0 ||
+                                Optional.ofNullable(model.getMaxAllocatedStorage()).orElse(0) > 0
+                );
+    }
+
+    private static boolean isCertificateAuthorityApplied(final ResourceModel model) {
+        return StringUtils.hasValue(model.getCACertificateIdentifier());
+    }
+
+
+    public static boolean isReadReplica(final ResourceModel model) {
+        return software.amazon.awssdk.utils.StringUtils.isNotBlank(model.getSourceDBInstanceIdentifier());
+    }
+
+    public static boolean isRestoreFromSnapshot(final ResourceModel model) {
+        return software.amazon.awssdk.utils.StringUtils.isNotBlank(model.getDBSnapshotIdentifier());
+    }
+}

--- a/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/TranslatorTest.java
+++ b/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/TranslatorTest.java
@@ -184,7 +184,7 @@ class TranslatorTest extends AbstractHandlerTest {
 
     @Test
     public void test_restoreFromSnapshotRequest_storageTypeIO1() {
-        final ResourceModel model = RESOURCE_MODEL_BLDR()
+        final ResourceModel model = ResourceModel.builder()
                 .dBSnapshotIdentifier("snapshot")
                 .storageType("io1")
                 .build();
@@ -195,7 +195,7 @@ class TranslatorTest extends AbstractHandlerTest {
 
     @Test
     public void test_restoreFromSnapshotRequestV12_storageTypeIO1() {
-        final ResourceModel model = RESOURCE_MODEL_BLDR()
+        final ResourceModel model = ResourceModel.builder()
                 .dBSnapshotIdentifier("snapshot")
                 .storageType("io1")
                 .build();
@@ -206,9 +206,10 @@ class TranslatorTest extends AbstractHandlerTest {
 
     @Test
     public void test_restoreFromSnapshotRequest_storageTypeGp2() {
-        final ResourceModel model = RESOURCE_MODEL_BLDR()
+        final ResourceModel model = ResourceModel.builder()
                 .dBSnapshotIdentifier("snapshot")
                 .storageType("gp2")
+                .allocatedStorage("123")
                 .build();
 
         final RestoreDbInstanceFromDbSnapshotRequest request = Translator.restoreDbInstanceFromSnapshotRequest(model, Tagging.TagSet.emptySet());
@@ -217,8 +218,9 @@ class TranslatorTest extends AbstractHandlerTest {
 
     @Test
     public void test_restoreFromSnapshotRequestV12_storageTypeGp2() {
-        final ResourceModel model = RESOURCE_MODEL_BLDR()
+        final ResourceModel model = ResourceModel.builder()
                 .dBSnapshotIdentifier("snapshot")
+                .allocatedStorage("123")
                 .storageType("gp2")
                 .build();
 

--- a/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/TranslatorTest.java
+++ b/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/TranslatorTest.java
@@ -10,6 +10,7 @@ import software.amazon.awssdk.services.rds.RdsClient;
 import software.amazon.awssdk.services.rds.model.CreateDbInstanceReadReplicaRequest;
 import software.amazon.awssdk.services.rds.model.CreateDbInstanceRequest;
 import software.amazon.awssdk.services.rds.model.ModifyDbInstanceRequest;
+import software.amazon.awssdk.services.rds.model.RestoreDbInstanceFromDbSnapshotRequest;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.rds.common.handler.Tagging;
@@ -179,6 +180,50 @@ class TranslatorTest extends AbstractHandlerTest {
 
         final ModifyDbInstanceRequest request = Translator.modifyDbInstanceRequest(null, model, false);
         Assertions.assertEquals("default", request.dbParameterGroupName());
+    }
+
+    @Test
+    public void test_restoreFromSnapshotRequest_storageTypeIO1() {
+        final ResourceModel model = RESOURCE_MODEL_BLDR()
+                .dBSnapshotIdentifier("snapshot")
+                .storageType("io1")
+                .build();
+
+        final RestoreDbInstanceFromDbSnapshotRequest request = Translator.restoreDbInstanceFromSnapshotRequest(model, Tagging.TagSet.emptySet());
+        assertThat(request.storageType()).isNull();
+    }
+
+    @Test
+    public void test_restoreFromSnapshotRequestV12_storageTypeIO1() {
+        final ResourceModel model = RESOURCE_MODEL_BLDR()
+                .dBSnapshotIdentifier("snapshot")
+                .storageType("io1")
+                .build();
+
+        final RestoreDbInstanceFromDbSnapshotRequest request = Translator.restoreDbInstanceFromSnapshotRequestV12(model);
+        assertThat(request.storageType()).isNull();
+    }
+
+    @Test
+    public void test_restoreFromSnapshotRequest_storageTypeGp2() {
+        final ResourceModel model = RESOURCE_MODEL_BLDR()
+                .dBSnapshotIdentifier("snapshot")
+                .storageType("gp2")
+                .build();
+
+        final RestoreDbInstanceFromDbSnapshotRequest request = Translator.restoreDbInstanceFromSnapshotRequest(model, Tagging.TagSet.emptySet());
+        assertThat(request.storageType()).isEqualTo("gp2");
+    }
+
+    @Test
+    public void test_restoreFromSnapshotRequestV12_storageTypeGp2() {
+        final ResourceModel model = RESOURCE_MODEL_BLDR()
+                .dBSnapshotIdentifier("snapshot")
+                .storageType("gp2")
+                .build();
+
+        final RestoreDbInstanceFromDbSnapshotRequest request = Translator.restoreDbInstanceFromSnapshotRequestV12(model);
+        assertThat(request.storageType()).isEqualTo("gp2");
     }
 
     // Stub methods to satisfy the interface. This is a 1-time thing.

--- a/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/TranslatorTest.java
+++ b/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/TranslatorTest.java
@@ -184,7 +184,7 @@ class TranslatorTest extends AbstractHandlerTest {
 
     @Test
     public void test_restoreFromSnapshotRequest_storageTypeIO1() {
-        final ResourceModel model = ResourceModel.builder()
+        final ResourceModel model = RESOURCE_MODEL_BLDR()
                 .dBSnapshotIdentifier("snapshot")
                 .storageType("io1")
                 .build();
@@ -195,7 +195,7 @@ class TranslatorTest extends AbstractHandlerTest {
 
     @Test
     public void test_restoreFromSnapshotRequestV12_storageTypeIO1() {
-        final ResourceModel model = ResourceModel.builder()
+        final ResourceModel model = RESOURCE_MODEL_BLDR()
                 .dBSnapshotIdentifier("snapshot")
                 .storageType("io1")
                 .build();
@@ -206,10 +206,9 @@ class TranslatorTest extends AbstractHandlerTest {
 
     @Test
     public void test_restoreFromSnapshotRequest_storageTypeGp2() {
-        final ResourceModel model = ResourceModel.builder()
+        final ResourceModel model = RESOURCE_MODEL_BLDR()
                 .dBSnapshotIdentifier("snapshot")
                 .storageType("gp2")
-                .allocatedStorage("123")
                 .build();
 
         final RestoreDbInstanceFromDbSnapshotRequest request = Translator.restoreDbInstanceFromSnapshotRequest(model, Tagging.TagSet.emptySet());
@@ -218,9 +217,8 @@ class TranslatorTest extends AbstractHandlerTest {
 
     @Test
     public void test_restoreFromSnapshotRequestV12_storageTypeGp2() {
-        final ResourceModel model = ResourceModel.builder()
+        final ResourceModel model = RESOURCE_MODEL_BLDR()
                 .dBSnapshotIdentifier("snapshot")
-                .allocatedStorage("123")
                 .storageType("gp2")
                 .build();
 

--- a/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/util/ResourceModelHelperTest.java
+++ b/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/util/ResourceModelHelperTest.java
@@ -1,0 +1,103 @@
+package software.amazon.rds.dbinstance.util;
+
+import org.junit.jupiter.api.Test;
+import software.amazon.rds.dbinstance.ResourceModel;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+public class ResourceModelHelperTest {
+
+    @Test
+    public void isReadReplica_whenSourceIdentifierIsSet() {
+        final ResourceModel model = ResourceModel.builder()
+                .sourceDBInstanceIdentifier("identifier")
+                .build();
+
+        assertThat(ResourceModelHelper.isReadReplica(model)).isTrue();
+    }
+
+    @Test
+    public void isReadReplica_whenSourceIdentifierIsEmpty() {
+        final ResourceModel model = ResourceModel.builder()
+                .sourceDBInstanceIdentifier("")
+                .build();
+
+        assertThat(ResourceModelHelper.isReadReplica(model)).isFalse();
+    }
+
+    @Test
+    public void isRestoreFromSnapshot_whenSnapshotIdentifierIsSet() {
+        final ResourceModel model = ResourceModel.builder()
+                .dBSnapshotIdentifier("identifier")
+                .build();
+
+        assertThat(ResourceModelHelper.isRestoreFromSnapshot(model)).isTrue();
+    }
+
+    @Test
+    public void isRestoreFromSnapshot_whenSnapshotIdentifierIsEmpty() {
+        final ResourceModel model = ResourceModel.builder()
+                .dBSnapshotIdentifier("")
+                .build();
+
+        assertThat(ResourceModelHelper.isRestoreFromSnapshot(model)).isFalse();
+    }
+
+    @Test
+    public void shouldUpdateAfterCreate_whenModelIsEmpty() {
+        final ResourceModel model = ResourceModel.builder()
+                .build();
+
+        assertThat(ResourceModelHelper.shouldUpdateAfterCreate(model)).isFalse();
+    }
+
+    @Test
+    public void shouldUpdateAfterCreate_whenRestoreFromSnapshotAndAllocatedStorage() {
+        final ResourceModel model = ResourceModel.builder()
+                .dBSnapshotIdentifier("identifier")
+                .allocatedStorage("100")
+                .build();
+
+        assertThat(ResourceModelHelper.shouldUpdateAfterCreate(model)).isTrue();
+    }
+
+    @Test
+    public void shouldUpdateAfterCreate_whenReadReplicaAndAllocatedStorage() {
+        final ResourceModel model = ResourceModel.builder()
+                .sourceDBInstanceIdentifier("identifier")
+                .allocatedStorage("100")
+                .build();
+
+        assertThat(ResourceModelHelper.shouldUpdateAfterCreate(model)).isTrue();
+    }
+
+    @Test
+    public void shouldUpdateAfterCreate_whenCertificateAuthorityAppliedAndAllocatedStorage() {
+        final ResourceModel model = ResourceModel.builder()
+                .cACertificateIdentifier("identifier")
+                .allocatedStorage("100")
+                .build();
+
+        assertThat(ResourceModelHelper.shouldUpdateAfterCreate(model)).isTrue();
+    }
+
+    @Test
+    public void shouldSetStorageTypeOnRestoreFromSnapshot_whenStorageTypeIO1() {
+        final ResourceModel model = ResourceModel.builder()
+                .storageType("io1")
+                .allocatedStorage("100")
+                .build();
+
+        assertThat(ResourceModelHelper.shouldSetStorageTypeOnRestoreFromSnapshot(model)).isFalse();
+    }
+
+    @Test
+    public void shouldSetStorageTypeOnRestoreFromSnapshot_whenStorageTypeGP2() {
+        final ResourceModel model = ResourceModel.builder()
+                .storageType("gp2")
+                .allocatedStorage("100")
+                .build();
+
+        assertThat(ResourceModelHelper.shouldSetStorageTypeOnRestoreFromSnapshot(model)).isFalse();
+    }
+}


### PR DESCRIPTION
This PR addresses the issue of long storage optimization step when the DBInstance is being restored from snapshot with non-default storage type 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
