### PR TITLE
[DBInstance] Allow upgrading instance to MultipleAZ without replacement.

### DIFF
--- a/aws-rds-dbinstance/aws-rds-dbinstance.json
+++ b/aws-rds-dbinstance/aws-rds-dbinstance.json
@@ -347,7 +347,6 @@
     "/properties/SourceDBInstanceIdentifier": "$lowercase(SourceDBInstanceIdentifier)"
   },
   "createOnlyProperties": [
-    "/properties/AvailabilityZone",
     "/properties/CharacterSetName",
     "/properties/DBClusterIdentifier",
     "/properties/DBInstanceIdentifier",
@@ -365,6 +364,7 @@
   ],
   "conditionalCreateOnlyProperties": [
     "/properties/AutoMinorVersionUpgrade",
+    "/properties/AvailabilityZone",
     "/properties/BackupRetentionPeriod",
     "/properties/DBParameterGroupName",
     "/properties/Engine",

--- a/aws-rds-dbinstance/docs/README.md
+++ b/aws-rds-dbinstance/docs/README.md
@@ -191,7 +191,7 @@ _Required_: No
 
 _Type_: String
 
-_Update requires_: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 
 #### BackupRetentionPeriod
 

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/util/ImmutabilityHelper.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/util/ImmutabilityHelper.java
@@ -49,7 +49,7 @@ public final class ImmutabilityHelper {
 
     static boolean isAvailabilityZoneChangeMutable(final ResourceModel previous, final ResourceModel desired) {
         return Objects.equal(previous.getAvailabilityZone(), desired.getAvailabilityZone()) ||
-                StringUtils.isNullOrEmpty(previous.getAvailabilityZone()) && desired.getMultiAZ();
+                (StringUtils.isNullOrEmpty(desired.getAvailabilityZone()) && desired.getMultiAZ());
     }
 
     public static boolean isChangeMutable(final ResourceModel previous, final ResourceModel desired) {

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/util/ImmutabilityHelper.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/util/ImmutabilityHelper.java
@@ -2,10 +2,11 @@ package software.amazon.rds.dbinstance.util;
 
 import java.util.List;
 
+import com.amazonaws.util.StringUtils;
 import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableList;
-import io.netty.util.internal.StringUtil;
 import software.amazon.rds.dbinstance.ResourceModel;
+
 
 public final class ImmutabilityHelper {
 
@@ -42,12 +43,18 @@ public final class ImmutabilityHelper {
 
     static boolean isPerformanceInsightsKMSKeyIdMutable(final ResourceModel previous, final ResourceModel desired) {
 
-        return StringUtil.isNullOrEmpty(previous.getPerformanceInsightsKMSKeyId()) ||
+        return StringUtils.isNullOrEmpty(previous.getPerformanceInsightsKMSKeyId()) ||
                 Objects.equal(previous.getPerformanceInsightsKMSKeyId(), desired.getPerformanceInsightsKMSKeyId());
+    }
+
+    static boolean isAvailabilityZoneChangeMutable(final ResourceModel previous, final ResourceModel desired) {
+        return Objects.equal(previous.getAvailabilityZone(), desired.getAvailabilityZone()) ||
+                StringUtils.isNullOrEmpty(previous.getAvailabilityZone()) && desired.getMultiAZ();
     }
 
     public static boolean isChangeMutable(final ResourceModel previous, final ResourceModel desired) {
         return isEngineMutable(previous, desired) &&
-                isPerformanceInsightsKMSKeyIdMutable(previous, desired);
+                isPerformanceInsightsKMSKeyIdMutable(previous, desired) &&
+                isAvailabilityZoneChangeMutable(previous, desired);
     }
 }

--- a/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/util/ImmutabilityHelperTest.java
+++ b/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/util/ImmutabilityHelperTest.java
@@ -140,14 +140,14 @@ class ImmutabilityHelperTest {
                         .expect(false)
                         .build(),
                 ResourceModelTestCase.builder()
-                        .previous(ResourceModel.builder().availabilityZone("").build())
-                        .desired(ResourceModel.builder().multiAZ(true).build())
+                        .previous(ResourceModel.builder().availabilityZone("old").build())
+                        .desired(ResourceModel.builder().availabilityZone(null).multiAZ(true).build())
                         .expect(true)
                         .build(),
                 ResourceModelTestCase.builder()
-                        .previous(ResourceModel.builder().availabilityZone("old").build())
-                        .desired(ResourceModel.builder().multiAZ(true).build())
-                        .expect(false)
+                        .previous(ResourceModel.builder().multiAZ(true).build())
+                        .desired(ResourceModel.builder().multiAZ(false).build())
+                        .expect(true)
                         .build());
         for (final ResourceModelTestCase test : tests) {
             assertThat(ImmutabilityHelper.isChangeMutable(test.previous, test.desired)).isEqualTo(test.expect);

--- a/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/util/ImmutabilityHelperTest.java
+++ b/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/util/ImmutabilityHelperTest.java
@@ -125,4 +125,32 @@ class ImmutabilityHelperTest {
             assertThat(ImmutabilityHelper.isChangeMutable(test.previous, test.desired)).isEqualTo(test.expect);
         }
     }
+
+    @Test
+    public void test_isAvailabilityZoneChangeMutable() {
+        final List<ResourceModelTestCase> tests = Arrays.asList(
+                ResourceModelTestCase.builder()
+                        .previous(ResourceModel.builder().availabilityZone("old").build())
+                        .desired(ResourceModel.builder().availabilityZone("old").build())
+                        .expect(true)
+                        .build(),
+                ResourceModelTestCase.builder()
+                        .previous(ResourceModel.builder().availabilityZone("old").build())
+                        .desired(ResourceModel.builder().availabilityZone("new").build())
+                        .expect(false)
+                        .build(),
+                ResourceModelTestCase.builder()
+                        .previous(ResourceModel.builder().availabilityZone("").build())
+                        .desired(ResourceModel.builder().multiAZ(true).build())
+                        .expect(true)
+                        .build(),
+                ResourceModelTestCase.builder()
+                        .previous(ResourceModel.builder().availabilityZone("old").build())
+                        .desired(ResourceModel.builder().multiAZ(true).build())
+                        .expect(false)
+                        .build());
+        for (final ResourceModelTestCase test : tests) {
+            assertThat(ImmutabilityHelper.isChangeMutable(test.previous, test.desired)).isEqualTo(test.expect);
+        }
+    }
 }


### PR DESCRIPTION
This PR allows the DBInstance to be upgraded to MultiAZ instance without replacement in case when the customer does not explicitly specifies Availability Zone.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
