### PR TITLE
[DBInstance] Set `engineVersion` after restoring an instance from a snapshot

### DIFF
--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/Translator.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/Translator.java
@@ -323,22 +323,18 @@ public class Translator {
         );
         builder.cloudwatchLogsExportConfiguration(cloudwatchLogsExportConfiguration);
 
-        if (previousModel != null) {
-            if (BooleanUtils.isTrue(isRollback)) {
-                builder.allocatedStorage(
-                        canUpdateAllocatedStorage(previousModel.getAllocatedStorage(), desiredModel.getAllocatedStorage()) ? getAllocatedStorage(desiredModel) : getAllocatedStorage(previousModel)
-                );
-                builder.iops(
-                        canUpdateIops(previousModel.getIops(), desiredModel.getIops()) ? desiredModel.getIops() : previousModel.getIops()
-                );
-            } else {
-                builder.allocatedStorage(getAllocatedStorage(desiredModel));
-                builder.iops(desiredModel.getIops());
-                builder.engineVersion(desiredModel.getEngineVersion());
-            }
+
+        if (BooleanUtils.isTrue(isRollback)) {
+            builder.allocatedStorage(
+                    canUpdateAllocatedStorage(previousModel.getAllocatedStorage(), desiredModel.getAllocatedStorage()) ? getAllocatedStorage(desiredModel) : getAllocatedStorage(previousModel)
+            );
+            builder.iops(
+                    canUpdateIops(previousModel.getIops(), desiredModel.getIops()) ? desiredModel.getIops() : previousModel.getIops()
+            );
         } else {
             builder.allocatedStorage(getAllocatedStorage(desiredModel));
             builder.iops(desiredModel.getIops());
+            builder.engineVersion(desiredModel.getEngineVersion());
         }
 
         if (shouldSetProcessorFeatures(previousModel, desiredModel)) {


### PR DESCRIPTION
This commit updates `ModifyDBInstance` request construction after create. In particular, `EngineVersion` was missing from the consecutive modify-after-create request, causing instances restored from snapshots to have an inconsistent `engineVersion` with the template data.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Signed-off-by: Oleg Sidorov <sidorovo@amazon.com>