### PR TITLE
[DBInstance] Enforce final snapshot if not explicitly requested

### DIFF
--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/DeleteHandler.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/DeleteHandler.java
@@ -49,7 +49,7 @@ public class DeleteHandler extends BaseHandlerStd {
         // https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html
         // For AWS::RDS::DBInstance resources that don't specify the DBClusterIdentifier property, the default policy is Snapshot.
         // Final snapshots are not allowed for read replicas and cluster instances.
-        if (BooleanUtils.isTrue(request.getSnapshotRequested()) &&
+        if (BooleanUtils.isNotFalse(request.getSnapshotRequested()) &&
                 !ResourceModelHelper.isReadReplica(resourceModel) &&
                 !isDBClusterMember(resourceModel)) {
             snapshotIdentifier = snapshotIdentifierFactory.newIdentifier()


### PR DESCRIPTION
This commit enforces the final snapshot creation on DBInstance delete in case the request contains no data on whether a final snapshot creation is requested or not. The reason for this change is the referential value type returned by `ResourceHandlerRequest.getSnapshotRequested()`. The return value is a Boolean, meaning it can be yes/no/null(no data). This commit addresses the latter case where the invocation request is neither asking for a final snapshot nor disclaiming it.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Signed-off-by: Oleg Sidorov <sidorovo@amazon.com>