### PR TITLE
[DBCluster] Enforce final snapshot if not explicitly requested

### DIFF
--- a/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/DeleteHandler.java
+++ b/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/DeleteHandler.java
@@ -84,7 +84,7 @@ public class DeleteHandler extends BaseHandlerStd {
     ) {
         String snapshotIdentifier = null;
 
-        if (BooleanUtils.isTrue(request.getSnapshotRequested())) {
+        if (BooleanUtils.isNotFalse(request.getSnapshotRequested())) {
             snapshotIdentifier = snapshotIdentifierFactory.newIdentifier()
                     .withStackId(request.getStackId())
                     .withResourceId(StringUtils.prependIfMissing(request.getLogicalResourceIdentifier(), SNAPSHOT_PREFIX))


### PR DESCRIPTION
This PR replicates logic in #271 for DBCluster resource.

This commit enforces the final snapshot creation on DBCluster delete in case the request contains no data on whether a final snapshot creation is requested or not. The reason for this change is the referential value type returned by ResourceHandlerRequest.getSnapshotRequested(). The return value is a Boolean, meaning it can be yes/no/null(no data). This commit addresses the latter case where the invocation request is neither asking for a final snapshot nor disclaiming it.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
