### PR TITLE
[DBInstance] updated schema to include min and max length

### DIFF
--- a/aws-rds-dbinstance/aws-rds-dbinstance.json
+++ b/aws-rds-dbinstance/aws-rds-dbinstance.json
@@ -134,6 +134,8 @@
     "DBInstanceIdentifier": {
       "type": "string",
       "pattern": "^$|^[a-zA-Z]{1}(?:-?[a-zA-Z0-9]){0,62}$",
+      "minLength": 1,
+      "maxLength": 63,
       "description": "A name for the DB instance. If you specify a name, AWS CloudFormation converts it to lowercase. If you don't specify a name, AWS CloudFormation generates a unique physical ID and uses that ID for the DB instance."
     },
     "DBName": {

--- a/aws-rds-dbinstance/docs/README.md
+++ b/aws-rds-dbinstance/docs/README.md
@@ -261,6 +261,10 @@ _Required_: No
 
 _Type_: String
 
+_Minimum_: <code>1</code>
+
+_Maximum_: <code>63</code>
+
 _Pattern_: <code>^$|^[a-zA-Z]{1}(?:-?[a-zA-Z0-9]){0,62}$</code>
 
 _Update requires_: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)


### PR DESCRIPTION
This PR addresses an error in the schema of DBInstance. Where the regex for this resource doesn't count hyphens in an accurate way. Leading to a scenario where hyphens aren't counted. This becomes a problem if the additional hyphens takes the total length of the identifier over 63 characters long.