### PR TITLE
[DBInstance] Set DBInstance DeleteHandler stabilization time to match older implementation

### DIFF
--- a/aws-rds-dbinstance/aws-rds-dbinstance.json
+++ b/aws-rds-dbinstance/aws-rds-dbinstance.json
@@ -468,7 +468,8 @@
       "permissions": [
         "rds:DeleteDBInstance",
         "rds:DescribeDBInstances"
-      ]
+      ],
+      "timeoutInMinutes": 2160
     },
     "list": {
       "permissions": [

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/DeleteHandler.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/DeleteHandler.java
@@ -29,7 +29,7 @@ public class DeleteHandler extends BaseHandlerStd {
     );
 
     public DeleteHandler() {
-        this(DEFAULT_DB_INSTANCE_HANDLER_CONFIG);
+        this(DB_INSTANCE_HANDLER_CONFIG_36H);
     }
 
     public DeleteHandler(final HandlerConfig config) {


### PR DESCRIPTION
DBInstance delete workflow can take very long time. Older implementation of CloudFormation used 36h timeout. This PR applies the same timeout to delete handler.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
