### PR TITLE
[DBInstance] Handle DBClusterNotFoundFault service error code

### DIFF
--- a/aws-rds-cfn-common/src/main/java/software/amazon/rds/common/error/ErrorCode.java
+++ b/aws-rds-cfn-common/src/main/java/software/amazon/rds/common/error/ErrorCode.java
@@ -9,6 +9,7 @@ public enum ErrorCode {
     AccessDeniedException("AccessDeniedException"),
     ClientUnavailable("ClientUnavailable"),
     DBClusterAlreadyExistsFault("DBClusterAlreadyExistsFault"),
+    DBClusterNotFoundFault("DBClusterNotFoundFault"),
     DBInstanceAlreadyExists("DBInstanceAlreadyExists"),
     DBInstanceNotFound("DBInstanceNotFound"),
     DBParameterGroupNotFound("DBParameterGroupNotFound"),

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/BaseHandlerStd.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/BaseHandlerStd.java
@@ -152,6 +152,7 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
                     ErrorCode.MissingParameter,
                     ErrorCode.ProvisionedIopsNotAvailableInAZFault)
             .withErrorCodes(ErrorStatus.failWith(HandlerErrorCode.NotFound),
+                    ErrorCode.DBClusterNotFoundFault,
                     ErrorCode.DBParameterGroupNotFound,
                     ErrorCode.DBSecurityGroupNotFound,
                     ErrorCode.DBSnapshotNotFound,

--- a/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/CreateHandlerTest.java
+++ b/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/CreateHandlerTest.java
@@ -26,6 +26,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import com.google.common.collect.Iterables;
 import lombok.Getter;
 import software.amazon.awssdk.awscore.exception.AwsErrorDetails;
+import software.amazon.awssdk.awscore.exception.AwsServiceException;
 import software.amazon.awssdk.core.util.SdkAutoConstructList;
 import software.amazon.awssdk.services.ec2.Ec2Client;
 import software.amazon.awssdk.services.rds.RdsClient;
@@ -1356,7 +1357,7 @@ public class CreateHandlerTest extends AbstractHandlerTest {
     }
 
     @Test
-    public void handleRequest_CreateDbCluster_DomainNotFoundException() {
+    public void handleRequest_CreateDBInstance_DomainNotFoundException() {
         when(rdsProxy.client().createDBInstance(any(CreateDbInstanceRequest.class)))
                 .thenThrow(DomainNotFoundException.builder().message("Requested domain some_domain does not exist").build());
 
@@ -1487,5 +1488,24 @@ public class CreateHandlerTest extends AbstractHandlerTest {
         ArgumentCaptor<ModifyDbInstanceRequest> captor = ArgumentCaptor.forClass(ModifyDbInstanceRequest.class);
         verify(rdsProxy.client(), times(1)).modifyDBInstance(captor.capture());
         Assertions.assertThat(captor.getValue().engineVersion()).isEqualTo(requestedEngineVersion);
+    }
+
+    @Test
+    public void handleRequest_CreateDBInstance_DBClusterNotFoundFault() {
+        when(rdsProxy.client().createDBInstance(any(CreateDbInstanceRequest.class)))
+                .thenThrow(AwsServiceException.builder()
+                        .awsErrorDetails(AwsErrorDetails.builder()
+                                .errorCode(ErrorCode.DBClusterNotFoundFault.toString())
+                                .build())
+                        .build());
+
+        test_handleRequest_base(
+                new CallbackContext(),
+                null,
+                () -> RESOURCE_MODEL_BLDR().build(),
+                expectFailed(HandlerErrorCode.NotFound)
+        );
+
+        verify(rdsProxy.client(), times(1)).createDBInstance(any(CreateDbInstanceRequest.class));
     }
 }


### PR DESCRIPTION
This commit adds a new ErrorCode: `DBClusterNotFoundFault`. RDS API can communication this error using 2 distinct classes of errors:
- `DbClusterNotFoundException` (native SDK-shipped exception class)
- `AwsSdkException` with a code `DBClusterNotFoundFault`.

Prior to this change the handler interpreted `DBClusterNotFoundFault` error codes as a `GeneralServiceException`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Signed-off-by: Oleg Sidorov <sidorovo@amazon.com>