### PR TITLE
[DBCluster] update contract tests to use newer version of aurora-mysql engine

### DIFF
--- a/aws-rds-dbcluster/inputs/inputs_1_create.json
+++ b/aws-rds-dbcluster/inputs/inputs_1_create.json
@@ -1,5 +1,5 @@
 {
-  "Engine": "aurora",
+  "Engine": "aurora-mysql",
   "MasterUsername": "guest",
   "MasterUserPassword": "guest123",
   "DBClusterIdentifier": "dbcluster-contract-test"

--- a/aws-rds-dbcluster/inputs/inputs_1_update.json
+++ b/aws-rds-dbcluster/inputs/inputs_1_update.json
@@ -1,5 +1,5 @@
 {
-  "Engine": "aurora",
+  "Engine": "aurora-mysql",
   "MasterUsername": "guest",
   "MasterUserPassword": "guest1234",
   "DBClusterIdentifier": "dbcluster-contract-test"


### PR DESCRIPTION
Contract tests for DBCluster are using aurora engine, which defaults to mysql 5.6 which soon will reach EOL. This PR upgrades contract tests to use at least aurora-mysql 5.7 engine version.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
