### PR TITLE
[DBInstance] Add ResourceHandlerRequest validation

### DIFF
--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/DeleteHandler.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/DeleteHandler.java
@@ -10,11 +10,11 @@ import software.amazon.awssdk.services.rds.RdsClient;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.Logger;
 import software.amazon.cloudformation.proxy.ProgressEvent;
-import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 import software.amazon.rds.common.handler.Commons;
 import software.amazon.rds.common.handler.HandlerConfig;
 import software.amazon.rds.common.util.IdentifierFactory;
 import software.amazon.rds.dbinstance.client.VersionedProxyClient;
+import software.amazon.rds.dbinstance.request.ValidatedRequest;
 import software.amazon.rds.dbinstance.util.ResourceModelHelper;
 
 public class DeleteHandler extends BaseHandlerStd {
@@ -38,7 +38,7 @@ public class DeleteHandler extends BaseHandlerStd {
 
     protected ProgressEvent<ResourceModel, CallbackContext> handleRequest(
             final AmazonWebServicesClientProxy proxy,
-            final ResourceHandlerRequest<ResourceModel> request,
+            final ValidatedRequest<ResourceModel> request,
             final CallbackContext callbackContext,
             final VersionedProxyClient<RdsClient> rdsProxyClient,
             final VersionedProxyClient<Ec2Client> ec2ProxyClient,

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/ListHandler.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/ListHandler.java
@@ -8,9 +8,9 @@ import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.Logger;
 import software.amazon.cloudformation.proxy.OperationStatus;
 import software.amazon.cloudformation.proxy.ProgressEvent;
-import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 import software.amazon.rds.common.handler.HandlerConfig;
 import software.amazon.rds.dbinstance.client.VersionedProxyClient;
+import software.amazon.rds.dbinstance.request.ValidatedRequest;
 
 public class ListHandler extends BaseHandlerStd {
 
@@ -25,7 +25,7 @@ public class ListHandler extends BaseHandlerStd {
     @Override
     public ProgressEvent<ResourceModel, CallbackContext> handleRequest(
             final AmazonWebServicesClientProxy proxy,
-            final ResourceHandlerRequest<ResourceModel> request,
+            final ValidatedRequest<ResourceModel> request,
             final CallbackContext callbackContext,
             final VersionedProxyClient<RdsClient> rdsProxyClient,
             final VersionedProxyClient<Ec2Client> ec2ProxyClient,

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/ReadHandler.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/ReadHandler.java
@@ -6,10 +6,10 @@ import software.amazon.awssdk.services.rds.model.DBInstance;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.Logger;
 import software.amazon.cloudformation.proxy.ProgressEvent;
-import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 import software.amazon.rds.common.handler.Commons;
 import software.amazon.rds.common.handler.HandlerConfig;
 import software.amazon.rds.dbinstance.client.VersionedProxyClient;
+import software.amazon.rds.dbinstance.request.ValidatedRequest;
 
 public class ReadHandler extends BaseHandlerStd {
 
@@ -23,7 +23,7 @@ public class ReadHandler extends BaseHandlerStd {
 
     protected ProgressEvent<ResourceModel, CallbackContext> handleRequest(
             final AmazonWebServicesClientProxy proxy,
-            final ResourceHandlerRequest<ResourceModel> request,
+            final ValidatedRequest<ResourceModel> request,
             final CallbackContext callbackContext,
             final VersionedProxyClient<RdsClient> rdsProxyClient,
             final VersionedProxyClient<Ec2Client> ec2ProxyClient,

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/Translator.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/Translator.java
@@ -91,7 +91,7 @@ public class Translator {
                 .processorFeatures(translateProcessorFeaturesToSdk(model.getProcessorFeatures()))
                 .publiclyAccessible(model.getPubliclyAccessible())
                 .sourceDBInstanceIdentifier(model.getSourceDBInstanceIdentifier())
-                .sourceRegion(model.getSourceRegion())
+                .sourceRegion(StringUtils.isNotBlank(model.getSourceRegion()) ? model.getSourceRegion() : null)
                 .storageType(model.getStorageType())
                 .tags(Tagging.translateTagsToSdk(tagSet))
                 .useDefaultProcessorFeatures(model.getUseDefaultProcessorFeatures())

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/UpdateHandler.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/UpdateHandler.java
@@ -32,6 +32,7 @@ import software.amazon.rds.common.handler.HandlerConfig;
 import software.amazon.rds.common.handler.Tagging;
 import software.amazon.rds.dbinstance.client.ApiVersion;
 import software.amazon.rds.dbinstance.client.VersionedProxyClient;
+import software.amazon.rds.dbinstance.request.ValidatedRequest;
 import software.amazon.rds.dbinstance.util.ImmutabilityHelper;
 
 public class UpdateHandler extends BaseHandlerStd {
@@ -46,7 +47,7 @@ public class UpdateHandler extends BaseHandlerStd {
 
     protected ProgressEvent<ResourceModel, CallbackContext> handleRequest(
             final AmazonWebServicesClientProxy proxy,
-            final ResourceHandlerRequest<ResourceModel> request,
+            final ValidatedRequest<ResourceModel> request,
             final CallbackContext callbackContext,
             final VersionedProxyClient<RdsClient> rdsProxyClient,
             final VersionedProxyClient<Ec2Client> ec2ProxyClient,

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/request/RequestValidationException.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/request/RequestValidationException.java
@@ -1,0 +1,8 @@
+package software.amazon.rds.dbinstance.request;
+
+@SuppressWarnings("serial")
+public class RequestValidationException extends Exception {
+    public RequestValidationException(final String message) {
+        super(message);
+    }
+}

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/request/ValidatedRequest.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/request/ValidatedRequest.java
@@ -1,0 +1,28 @@
+package software.amazon.rds.dbinstance.request;
+
+import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
+
+public class ValidatedRequest<T> extends ResourceHandlerRequest<T> {
+
+    public ValidatedRequest(final ResourceHandlerRequest<T> base) {
+        super(base.getClientRequestToken(),
+                base.getDesiredResourceState(),
+                base.getPreviousResourceState(),
+                base.getDesiredResourceTags(),
+                base.getPreviousResourceTags(),
+                base.getSystemTags(),
+                base.getPreviousSystemTags(),
+                base.getAwsAccountId(),
+                base.getAwsPartition(),
+                base.getLogicalResourceIdentifier(),
+                base.getNextToken(),
+                base.getSnapshotRequested(),
+                base.getRollback(),
+                base.getDriftable(),
+                base.getFeatures(),
+                base.getUpdatePolicy(),
+                base.getCreationPolicy(),
+                base.getRegion(),
+                base.getStackId());
+    }
+}

--- a/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/TranslatorTest.java
+++ b/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/TranslatorTest.java
@@ -173,6 +173,24 @@ class TranslatorTest extends AbstractHandlerTest {
         Assertions.assertNull(request.dbParameterGroupName());
     }
 
+    @Test
+    public void test_createReadReplicaRequest_blankSourceRegionIsNotSet() {
+        final ResourceModel model = ResourceModel.builder()
+                .sourceRegion("")
+                .build();
+        final CreateDbInstanceReadReplicaRequest request = Translator.createDbInstanceReadReplicaRequest(model, Tagging.TagSet.builder().build());
+        Assertions.assertNull(request.sourceRegion());
+    }
+
+    @Test
+    public void test_createReadReplicaRequest_nonBlankSourceRegionIsSet() {
+        final String sourceRegion = "source-region";
+        final ResourceModel model = ResourceModel.builder()
+                .sourceRegion(sourceRegion)
+                .build();
+        final CreateDbInstanceReadReplicaRequest request = Translator.createDbInstanceReadReplicaRequest(model, Tagging.TagSet.builder().build());
+        Assertions.assertEquals(sourceRegion, request.sourceRegion());
+    }
 
     @Test
     public void test_modifyReadReplicaRequest_parameterGroupNotSet() {


### PR DESCRIPTION
This commit adds a request validation layer to the handler execution chain. The motivation is to extend the schema-based validation with a range of more flexible and more dynamic validation methods.

The change introduces a new class `ValidatedRequest` that extends `ResourceHandlerRequest` with 0 overloading: it is here to distinguish a validated request from a raw one.

The change adds a new validation on the `sourceRegion` attribute. If a provided region is incorrect, the validation will refuse such a request well before it reaches the SDK endpoint connection initialization.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Signed-off-by: Oleg Sidorov <sidorovo@amazon.com>