### PR TITLE
[DBInstance] Handle StorageTypeNotSupportedFault

### DIFF
--- a/aws-rds-cfn-common/src/main/java/software/amazon/rds/common/error/ErrorCode.java
+++ b/aws-rds-cfn-common/src/main/java/software/amazon/rds/common/error/ErrorCode.java
@@ -34,6 +34,7 @@ public enum ErrorCode {
     ProvisionedIopsNotAvailableInAZFault("ProvisionedIopsNotAvailableInAZFault"),
     SnapshotQuotaExceeded("SnapshotQuotaExceeded"),
     StorageQuotaExceeded("StorageQuotaExceeded"),
+    StorageTypeNotSupportedFault("StorageTypeNotSupportedFault"),
     ThrottlingException("ThrottlingException"),
     Throttling("Throttling"),
     DefaultVpcDoesNotExist("DefaultVpcDoesNotExist");

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/BaseHandlerStd.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/BaseHandlerStd.java
@@ -159,7 +159,8 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
                     ErrorCode.InvalidVPCNetworkStateFault,
                     ErrorCode.KMSKeyNotAccessibleFault,
                     ErrorCode.MissingParameter,
-                    ErrorCode.ProvisionedIopsNotAvailableInAZFault)
+                    ErrorCode.ProvisionedIopsNotAvailableInAZFault,
+                    ErrorCode.StorageTypeNotSupportedFault)
             .withErrorCodes(ErrorStatus.failWith(HandlerErrorCode.NotFound),
                     ErrorCode.DBClusterNotFoundFault,
                     ErrorCode.DBParameterGroupNotFound,

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/util/ImmutabilityHelper.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/util/ImmutabilityHelper.java
@@ -42,7 +42,6 @@ public final class ImmutabilityHelper {
     }
 
     static boolean isPerformanceInsightsKMSKeyIdMutable(final ResourceModel previous, final ResourceModel desired) {
-
         return StringUtils.isNullOrEmpty(previous.getPerformanceInsightsKMSKeyId()) ||
                 Objects.equal(previous.getPerformanceInsightsKMSKeyId(), desired.getPerformanceInsightsKMSKeyId());
     }

--- a/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/CreateHandlerTest.java
+++ b/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/CreateHandlerTest.java
@@ -1508,4 +1508,23 @@ public class CreateHandlerTest extends AbstractHandlerTest {
 
         verify(rdsProxy.client(), times(1)).createDBInstance(any(CreateDbInstanceRequest.class));
     }
+
+    @Test
+    public void handleRequest_CreateDBInstance_StorageTypeNotSupportedFault() {
+        when(rdsProxy.client().createDBInstance(any(CreateDbInstanceRequest.class)))
+                .thenThrow(AwsServiceException.builder()
+                        .awsErrorDetails(AwsErrorDetails.builder()
+                                .errorCode(ErrorCode.StorageTypeNotSupportedFault.toString())
+                                .build())
+                        .build());
+
+        test_handleRequest_base(
+                new CallbackContext(),
+                null,
+                () -> RESOURCE_MODEL_BLDR().build(),
+                expectFailed(HandlerErrorCode.InvalidRequest)
+        );
+
+        verify(rdsProxy.client(), times(1)).createDBInstance(any(CreateDbInstanceRequest.class));
+    }
 }


### PR DESCRIPTION
This commit adds a definition for `StorageTypeNotSupportedFault` error code to DBInstance default error set. It could be returned by RDS API in case when a storage type is not supported by the engine or disabled.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Signed-off-by: Oleg Sidorov <sidorovo@amazon.com>