### PR TITLE
[DBInstance] Rework error handling tests

### DIFF
--- a/aws-rds-cfn-common/src/main/java/software/amazon/rds/common/error/ErrorCode.java
+++ b/aws-rds-cfn-common/src/main/java/software/amazon/rds/common/error/ErrorCode.java
@@ -16,6 +16,7 @@ public enum ErrorCode {
     DBSecurityGroupNotFound("DBSecurityGroupNotFound"),
     DBSnapshotAlreadyExists("DBSnapshotAlreadyExists"),
     DBSnapshotNotFound("DBSnapshotNotFound"),
+    DBSubnetGroupNotAllowedFault("DBSubnetGroupNotAllowedFault"),
     DBSubnetGroupNotFoundFault("DBSubnetGroupNotFoundFault"),
     InstanceQuotaExceeded("InstanceQuotaExceeded"),
     InsufficientDBInstanceCapacity("InsufficientDBInstanceCapacity"),

--- a/aws-rds-cfn-common/src/main/java/software/amazon/rds/common/test/AbstractTestBase.java
+++ b/aws-rds-cfn-common/src/main/java/software/amazon/rds/common/test/AbstractTestBase.java
@@ -123,5 +123,4 @@ public abstract class AbstractTestBase<ResourceT, ModelT, CallbackT> {
 
         return response;
     }
-
 }

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/BaseHandlerStd.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/BaseHandlerStd.java
@@ -154,6 +154,7 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
                     ErrorCode.SnapshotQuotaExceeded,
                     ErrorCode.StorageQuotaExceeded)
             .withErrorCodes(ErrorStatus.failWith(HandlerErrorCode.InvalidRequest),
+                    ErrorCode.DBSubnetGroupNotAllowedFault,
                     ErrorCode.InvalidParameterCombination,
                     ErrorCode.InvalidParameterValue,
                     ErrorCode.InvalidVPCNetworkStateFault,

--- a/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/DeleteHandlerTest.java
+++ b/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/DeleteHandlerTest.java
@@ -11,11 +11,17 @@ import static org.mockito.Mockito.when;
 
 import java.time.Duration;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Stream;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+import org.junit.jupiter.params.provider.ArgumentsSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -142,76 +148,7 @@ public class DeleteHandlerTest extends AbstractHandlerTest {
         verify(rdsProxy.client(), times(1)).describeDBInstances(any(DescribeDbInstancesRequest.class));
     }
 
-    @Test
-    public void handleRequest_InvalidDBInstanceState() {
-        when(rdsProxy.client().deleteDBInstance(any(DeleteDbInstanceRequest.class))).thenThrow(
-                RdsException.builder()
-                        .awsErrorDetails(AwsErrorDetails.builder()
-                                .errorCode(ErrorCode.InvalidDBInstanceState.toString())
-                                .build()
-                        ).build());
 
-        test_handleRequest_base(
-                new CallbackContext(),
-                null,
-                () -> RESOURCE_MODEL_BLDR().build(),
-                expectFailed(HandlerErrorCode.ResourceConflict)
-        );
-
-        verify(rdsProxy.client(), times(1)).deleteDBInstance(any(DeleteDbInstanceRequest.class));
-    }
-
-    @Test
-    public void handleRequest_InvalidParameterValue() {
-        when(rdsProxy.client().deleteDBInstance(any(DeleteDbInstanceRequest.class))).thenThrow(
-                RdsException.builder()
-                        .awsErrorDetails(AwsErrorDetails.builder()
-                                .errorCode(ErrorCode.InvalidParameterValue.toString())
-                                .build()
-                        ).build());
-
-        final ProgressEvent<ResourceModel, CallbackContext> response = test_handleRequest_base(
-                new CallbackContext(),
-                null,
-                () -> RESOURCE_MODEL_BLDR().build(),
-                expectFailed(HandlerErrorCode.InvalidRequest)
-        );
-
-        verify(rdsProxy.client(), times(1)).deleteDBInstance(any(DeleteDbInstanceRequest.class));
-    }
-
-    @Test
-    public void handleRequest_DBSnapshotAlreadyExists() {
-        when(rdsProxy.client().deleteDBInstance(any(DeleteDbInstanceRequest.class))).thenThrow(
-                RdsException.builder()
-                        .awsErrorDetails(AwsErrorDetails.builder()
-                                .errorCode(ErrorCode.DBSnapshotAlreadyExists.toString())
-                                .build()
-                        ).build());
-
-        test_handleRequest_base(
-                new CallbackContext(),
-                null,
-                () -> RESOURCE_MODEL_BLDR().build(),
-                expectFailed(HandlerErrorCode.InvalidRequest)
-        );
-
-        verify(rdsProxy.client(), times(1)).deleteDBInstance(any(DeleteDbInstanceRequest.class));
-    }
-
-    @Test
-    public void handleRequest_RuntimeException() {
-        when(rdsProxy.client().deleteDBInstance(any(DeleteDbInstanceRequest.class))).thenThrow(new RuntimeException(MSG_RUNTIME_ERR));
-
-        test_handleRequest_base(
-                new CallbackContext(),
-                null,
-                () -> RESOURCE_MODEL_BLDR().build(),
-                expectFailed(HandlerErrorCode.InternalFailure)
-        );
-
-        verify(rdsProxy.client(), times(1)).deleteDBInstance(any(DeleteDbInstanceRequest.class));
-    }
 
     @Test
     public void handleRequest_IsDeleting_Stabilize() {
@@ -335,5 +272,35 @@ public class DeleteHandlerTest extends AbstractHandlerTest {
 
         assertThat(argument.getValue().skipFinalSnapshot()).isTrue();
         assertThat(argument.getValue().finalDBSnapshotIdentifier()).isNull();
+    }
+
+    static class DeleteDBInstanceExceptionArgumentProvider implements ArgumentsProvider {
+        @Override
+        public Stream<? extends Arguments> provideArguments(ExtensionContext extensionContext) throws Exception {
+            return Stream.of(
+                    // Put error codes below
+                    Arguments.of(ErrorCode.DBSnapshotAlreadyExists, HandlerErrorCode.InvalidRequest),
+                    Arguments.of(ErrorCode.InvalidDBInstanceState, HandlerErrorCode.ResourceConflict),
+                    Arguments.of(ErrorCode.InvalidParameterValue, HandlerErrorCode.InvalidRequest),
+                    // Put exception classes below
+                    Arguments.of(new RuntimeException(MSG_RUNTIME_ERR), HandlerErrorCode.InternalFailure)
+            );
+        }
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(DeleteDBInstanceExceptionArgumentProvider.class)
+    public void handleRequest_DeleteDBInstance_HandleException(
+            final Object requestException,
+            final HandlerErrorCode expectResponseCode
+    ) {
+        test_handleRequest_error(
+                new CallbackContext(),
+                () -> RESOURCE_MODEL_BLDR().build(),
+                DeleteDbInstanceRequest.class,
+                "deleteDBInstance",
+                requestException,
+                expectResponseCode
+        );
     }
 }

--- a/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/ListHandlerTest.java
+++ b/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/ListHandlerTest.java
@@ -67,7 +67,7 @@ public class ListHandlerTest extends AbstractHandlerTest {
     }
 
     @Test
-    public void handleRequest_SimpleSuccess() {
+    public void handleRequest_Success() {
         final DescribeDbInstancesResponse describeDbInstanceResponse = DescribeDbInstancesResponse.builder()
                 .dbInstances(Collections.singletonList(
                         DBInstance.builder()


### PR DESCRIPTION
This commit performs a deep rework of the error handling test code. In particular, the commit adds a new method called
`test_handleRequest_error` and introduces a set of parametrized tests exercising distinct RDS API exception classes and error codes. The error codes and classes are provided in a declarative way (rather than an independent test method per single error code/exception).

The motivation for this change is to encourage a more exhaustive test coverage on distinct error codes/classes. With the current implementation adding a new test for an error code/class requires writing a new test method with a minimal bootstrap and validation. The new approach allows one to add a new entry into a static mapping of `ErrorCode` -> `HandlerErrorCode` and the bootstrap would be performed automatically.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Signed-off-by: Oleg Sidorov <sidorovo@amazon.com>