### PR TITLE
[DBInstance] Pass DeleteAutomatedBackups parameter

### DIFF
--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/Translator.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/Translator.java
@@ -403,7 +403,8 @@ public class Translator {
             final String finalDBSnapshotIdentifier
     ) {
         final DeleteDbInstanceRequest.Builder builder = DeleteDbInstanceRequest.builder()
-                .dbInstanceIdentifier(model.getDBInstanceIdentifier());
+                .dbInstanceIdentifier(model.getDBInstanceIdentifier())
+                .deleteAutomatedBackups(model.getDeleteAutomatedBackups());
         if (StringUtils.isEmpty(finalDBSnapshotIdentifier)) {
             builder.skipFinalSnapshot(true);
         } else {


### PR DESCRIPTION
This commit adds `DeleteAutomatedBackups` attribute to the `DeleteDBInstance` request constructor. The current version is missing this parameter so no automated backup deletion policy is set.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Signed-off-by: Oleg Sidorov <sidorovo@amazon.com>