### PR TITLE
[DBInstance] Enable recovery from storage-full state

### DIFF
--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/BaseHandlerStd.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/BaseHandlerStd.java
@@ -132,6 +132,8 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
 
     protected static final String UNKNOWN_SOURCE_REGION_ERROR = "Unknown source region";
 
+    protected static final String INSTANCE_IS_IN_STORAGE_FULL_STATE_ERROR_MSG = "Instance is in storage-full state. Please increase Allocated size and try the update again";
+
     protected final HandlerConfig config;
 
     private final ApiVersionDispatcher<ResourceModel, CallbackContext> apiVersionDispatcher;

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/BaseHandlerStd.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/BaseHandlerStd.java
@@ -96,6 +96,7 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
     static final String IN_SYNC_STATUS = "in-sync";
     static final String PENDING_REBOOT_STATUS = "pending-reboot";
     static final String READ_REPLICA_STATUS = "read replication";
+    static final String STORAGE_FULL_STATUS = "storage-full";
     static final String READ_REPLICA_STATUS_REPLICATING = "replicating";
     static final String VPC_SECURITY_GROUP_STATUS_ACTIVE = "active";
     static final String DOMAIN_MEMBERSHIP_JOINED = "joined";

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/BaseHandlerStd.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/BaseHandlerStd.java
@@ -132,8 +132,6 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
 
     protected static final String UNKNOWN_SOURCE_REGION_ERROR = "Unknown source region";
 
-    protected static final String INSTANCE_IS_IN_STORAGE_FULL_STATE_ERROR_MSG = "Instance is in storage-full state. Please increase Allocated size and try the update again";
-
     protected final HandlerConfig config;
 
     private final ApiVersionDispatcher<ResourceModel, CallbackContext> apiVersionDispatcher;

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/CallbackContext.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/CallbackContext.java
@@ -13,6 +13,8 @@ public class CallbackContext extends StdCallbackContext implements TaggingContex
     private boolean updatedRoles;
     private boolean updated;
     private boolean rebooted;
+    private boolean storageFullHandled;
+    private boolean storageFullInProgress;
 
     private TaggingContext taggingContext;
 

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/CallbackContext.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/CallbackContext.java
@@ -13,8 +13,8 @@ public class CallbackContext extends StdCallbackContext implements TaggingContex
     private boolean updatedRoles;
     private boolean updated;
     private boolean rebooted;
-    private boolean storageFullHandled;
-    private boolean storageFullInProgress;
+    private boolean storageAllocated;
+    private boolean allocatingStorage;
 
     private TaggingContext taggingContext;
 

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/Translator.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/Translator.java
@@ -281,7 +281,9 @@ public class Translator {
 
     public static ModifyDbInstanceRequest updateAllocatedStorageRequest(final ResourceModel desiredModel) {
         return ModifyDbInstanceRequest.builder()
+                .dbInstanceIdentifier(desiredModel.getDBInstanceIdentifier())
                 .allocatedStorage(getAllocatedStorage(desiredModel))
+                .applyImmediately(Boolean.TRUE)
                 .build();
     }
 

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/Translator.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/Translator.java
@@ -279,6 +279,12 @@ public class Translator {
         return builder.build();
     }
 
+    public static ModifyDbInstanceRequest updateAllocatedStorageRequest(final ResourceModel desiredModel) {
+        return ModifyDbInstanceRequest.builder()
+                .allocatedStorage(getAllocatedStorage(desiredModel))
+                .build();
+    }
+
     public static ModifyDbInstanceRequest modifyDbInstanceRequest(
             final ResourceModel previousModel,
             final ResourceModel desiredModel,

--- a/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/AbstractHandlerTest.java
+++ b/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/AbstractHandlerTest.java
@@ -81,6 +81,7 @@ public abstract class AbstractHandlerTest extends AbstractTestBase<DBInstance, R
     protected static final String DB_INSTANCE_STATUS_DELETING = "deleting";
     protected static final String DB_INSTANCE_STATUS_MODIFYING = "modifying";
     protected static final String DB_INSTANCE_STATUS_FAILED = "failed";
+    protected static final String DB_INSTANCE_STATUS_STORAGE_FULL = "storage-full";
     protected static final String DB_NAME = "db-instance-db-name";
     protected static final String DB_PARAMETER_GROUP_NAME_DEFAULT = "default";
     protected static final String DB_PARAMETER_GROUP_NAME_ALTER = "alternative-parameter-group";
@@ -175,6 +176,7 @@ public abstract class AbstractHandlerTest extends AbstractTestBase<DBInstance, R
     protected static final DBInstance DB_INSTANCE_DELETING;
     protected static final DBInstance DB_INSTANCE_MODIFYING;
     protected static final DBInstance DB_INSTANCE_EMPTY_PORT;
+    protected static final DBInstance DB_INSTANCE_STORAGE_FULL;
 
     protected static Constant TEST_BACKOFF_DELAY = Constant.of()
             .delay(Duration.ofMillis(1L))
@@ -488,6 +490,10 @@ public abstract class AbstractHandlerTest extends AbstractTestBase<DBInstance, R
                                 .port(PORT_DEFAULT_INT)
                                 .build()
                 )
+                .build();
+
+        DB_INSTANCE_STORAGE_FULL = DB_INSTANCE_ACTIVE.toBuilder()
+                .dbInstanceStatus(DB_INSTANCE_STATUS_STORAGE_FULL)
                 .build();
     }
 

--- a/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/UpdateHandlerTest.java
+++ b/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/UpdateHandlerTest.java
@@ -157,7 +157,7 @@ public class UpdateHandlerTest extends AbstractHandlerTest {
         context.setUpdated(false);
         context.setRebooted(true);
         context.setUpdatedRoles(true);
-        context.setStorageFullHandled(true);
+        context.setStorageAllocated(true);
 
         test_handleRequest_base(
                 context,
@@ -189,7 +189,7 @@ public class UpdateHandlerTest extends AbstractHandlerTest {
         context.setUpdated(false);
         context.setRebooted(true);
         context.setUpdatedRoles(true);
-        context.setStorageFullHandled(true);
+        context.setStorageAllocated(true);
 
         test_handleRequest_base(
                 context,
@@ -224,7 +224,7 @@ public class UpdateHandlerTest extends AbstractHandlerTest {
         context.setUpdated(false);
         context.setRebooted(true);
         context.setUpdatedRoles(true);
-        context.setStorageFullHandled(true);
+        context.setStorageAllocated(true);
 
         test_handleRequest_base(
                 context,
@@ -256,7 +256,7 @@ public class UpdateHandlerTest extends AbstractHandlerTest {
         context.setUpdated(true);
         context.setRebooted(true);
         context.setUpdatedRoles(true);
-        context.setStorageFullHandled(true);
+        context.setStorageAllocated(true);
 
         test_handleRequest_base(
                 context,
@@ -282,7 +282,7 @@ public class UpdateHandlerTest extends AbstractHandlerTest {
         context.setUpdated(true);
         context.setRebooted(true);
         context.setUpdatedRoles(true);
-        context.setStorageFullHandled(true);
+        context.setStorageAllocated(true);
 
         test_handleRequest_base(
                 context,
@@ -325,7 +325,7 @@ public class UpdateHandlerTest extends AbstractHandlerTest {
         final CallbackContext context = new CallbackContext();
         context.setUpdated(true);
         context.setRebooted(true);
-        context.setStorageFullHandled(true);
+        context.setStorageAllocated(true);
 
         test_handleRequest_base(
                 context,
@@ -389,7 +389,7 @@ public class UpdateHandlerTest extends AbstractHandlerTest {
         final CallbackContext context = new CallbackContext();
         context.setUpdated(true);
         context.setRebooted(true);
-        context.setStorageFullHandled(true);
+        context.setStorageAllocated(true);
 
         test_handleRequest_base(
                 context,
@@ -412,7 +412,7 @@ public class UpdateHandlerTest extends AbstractHandlerTest {
         final CallbackContext context = new CallbackContext();
         context.setUpdated(true);
         context.setRebooted(true);
-        context.setStorageFullHandled(true);
+        context.setStorageAllocated(true);
 
         test_handleRequest_base(
                 context,
@@ -440,7 +440,7 @@ public class UpdateHandlerTest extends AbstractHandlerTest {
         context.setUpdated(true);
         context.setRebooted(true);
         context.setUpdatedRoles(false);
-        context.setStorageFullHandled(true);
+        context.setStorageAllocated(true);
 
         test_handleRequest_base(
                 context,
@@ -485,7 +485,7 @@ public class UpdateHandlerTest extends AbstractHandlerTest {
         final CallbackContext context = new CallbackContext();
         context.setUpdated(true);
         context.setRebooted(true);
-        context.setStorageFullHandled(true);
+        context.setStorageAllocated(true);
 
         test_handleRequest_base(
                 context,
@@ -532,7 +532,7 @@ public class UpdateHandlerTest extends AbstractHandlerTest {
         context.setUpdated(true);
         context.setRebooted(false);
         context.setUpdatedRoles(true);
-        context.setStorageFullHandled(true);
+        context.setStorageAllocated(true);
 
         test_handleRequest_base(
                 context,
@@ -562,7 +562,7 @@ public class UpdateHandlerTest extends AbstractHandlerTest {
         final CallbackContext context = new CallbackContext();
         context.setRebooted(true);
         context.setUpdatedRoles(true);
-        context.setStorageFullHandled(true);
+        context.setStorageAllocated(true);
 
         test_handleRequest_base(
                 context,
@@ -603,7 +603,7 @@ public class UpdateHandlerTest extends AbstractHandlerTest {
 
         final CallbackContext context = new CallbackContext();
         context.setUpdated(true); // this is an emulation of a re-entrance
-        context.setStorageFullHandled(true);
+        context.setStorageAllocated(true);
 
         test_handleRequest_base(
                 context,
@@ -633,7 +633,7 @@ public class UpdateHandlerTest extends AbstractHandlerTest {
 
         final CallbackContext context = new CallbackContext();
         context.setUpdated(true); // this is an emulation of a re-entrance
-        context.setStorageFullHandled(true);
+        context.setStorageAllocated(true);
 
         test_handleRequest_base(
                 context,
@@ -715,7 +715,7 @@ public class UpdateHandlerTest extends AbstractHandlerTest {
 
         final CallbackContext context = new CallbackContext();
         context.setUpdated(true); // this is an emulation of a re-entrance
-        context.setStorageFullHandled(true);
+        context.setStorageAllocated(true);
 
         test_handleRequest_base(
                 context,
@@ -744,7 +744,7 @@ public class UpdateHandlerTest extends AbstractHandlerTest {
 
         final CallbackContext context = new CallbackContext();
         context.setUpdated(true); // this is an emulation of a re-entrance
-        context.setStorageFullHandled(true);
+        context.setStorageAllocated(true);
 
 
         // Altering the db parameter group name attribute invokes setParameterGroupName
@@ -780,7 +780,7 @@ public class UpdateHandlerTest extends AbstractHandlerTest {
 
         final CallbackContext context = new CallbackContext();
         context.setUpdated(true); // this is an emulation of a re-entrance
-        context.setStorageFullHandled(true);
+        context.setStorageAllocated(true);
 
         test_handleRequest_base(
                 context,
@@ -802,7 +802,7 @@ public class UpdateHandlerTest extends AbstractHandlerTest {
     public void handleRequest_NoDefaultVpcIdForClusterInstance() {
         final CallbackContext context = new CallbackContext();
         context.setUpdated(true);
-        context.setStorageFullHandled(true);
+        context.setStorageAllocated(true);
 
         test_handleRequest_base(
                 context,
@@ -1036,7 +1036,7 @@ public class UpdateHandlerTest extends AbstractHandlerTest {
     public void handleRequest_EmptyVpcSecurityGroupIdList() {
         final CallbackContext context = new CallbackContext();
         context.setUpdated(false);
-        context.setStorageFullHandled(true);
+        context.setStorageAllocated(true);
 
         test_handleRequest_base(
                 context,
@@ -1082,7 +1082,7 @@ public class UpdateHandlerTest extends AbstractHandlerTest {
             final HandlerErrorCode expectResponseCode
     ) {
         final CallbackContext context = new CallbackContext();
-        context.setStorageFullHandled(true);
+        context.setStorageAllocated(true);
 
         test_handleRequest_error(
                 context,

--- a/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/UpdateHandlerTest.java
+++ b/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/UpdateHandlerTest.java
@@ -49,6 +49,7 @@ import software.amazon.awssdk.services.rds.model.DBInstance;
 import software.amazon.awssdk.services.rds.model.DBParameterGroup;
 import software.amazon.awssdk.services.rds.model.DBParameterGroupStatus;
 import software.amazon.awssdk.services.rds.model.DBSubnetGroup;
+import software.amazon.awssdk.services.rds.model.DbInstanceNotFoundException;
 import software.amazon.awssdk.services.rds.model.DbInstanceRoleAlreadyExistsException;
 import software.amazon.awssdk.services.rds.model.DbInstanceRoleNotFoundException;
 import software.amazon.awssdk.services.rds.model.DescribeDbClustersRequest;
@@ -1151,7 +1152,7 @@ public class UpdateHandlerTest extends AbstractHandlerTest {
     }
 
     @Test
-    public void handleRequest_StorageFullRequestDoesNotAlterStorage() {
+    public void handleRequest_StorageFullRequestFetchingInstanceFails() {
         expectServiceInvocation = false;
         final CallbackContext context = new CallbackContext();
         context.setUpdated(true);
@@ -1160,10 +1161,10 @@ public class UpdateHandlerTest extends AbstractHandlerTest {
 
         test_handleRequest_base(
                 context,
-                () -> DB_INSTANCE_STORAGE_FULL,
+                () -> { throw DbInstanceNotFoundException.builder().message(MSG_NOT_FOUND_ERR).build(); },
                 () -> RESOURCE_MODEL_BLDR().build(),
                 () -> RESOURCE_MODEL_BLDR().build(),
-                expectFailed(HandlerErrorCode.InvalidRequest)
+                expectFailed(HandlerErrorCode.NotFound)
         );
 
         verify(rdsProxy.client(), times(1)).describeDBInstances(any(DescribeDbInstancesRequest.class));

--- a/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/UpdateHandlerTest.java
+++ b/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/UpdateHandlerTest.java
@@ -157,6 +157,7 @@ public class UpdateHandlerTest extends AbstractHandlerTest {
         context.setUpdated(false);
         context.setRebooted(true);
         context.setUpdatedRoles(true);
+        context.setStorageFullHandled(true);
 
         test_handleRequest_base(
                 context,
@@ -188,6 +189,7 @@ public class UpdateHandlerTest extends AbstractHandlerTest {
         context.setUpdated(false);
         context.setRebooted(true);
         context.setUpdatedRoles(true);
+        context.setStorageFullHandled(true);
 
         test_handleRequest_base(
                 context,
@@ -222,6 +224,7 @@ public class UpdateHandlerTest extends AbstractHandlerTest {
         context.setUpdated(false);
         context.setRebooted(true);
         context.setUpdatedRoles(true);
+        context.setStorageFullHandled(true);
 
         test_handleRequest_base(
                 context,
@@ -253,6 +256,7 @@ public class UpdateHandlerTest extends AbstractHandlerTest {
         context.setUpdated(true);
         context.setRebooted(true);
         context.setUpdatedRoles(true);
+        context.setStorageFullHandled(true);
 
         test_handleRequest_base(
                 context,
@@ -278,6 +282,7 @@ public class UpdateHandlerTest extends AbstractHandlerTest {
         context.setUpdated(true);
         context.setRebooted(true);
         context.setUpdatedRoles(true);
+        context.setStorageFullHandled(true);
 
         test_handleRequest_base(
                 context,
@@ -320,6 +325,7 @@ public class UpdateHandlerTest extends AbstractHandlerTest {
         final CallbackContext context = new CallbackContext();
         context.setUpdated(true);
         context.setRebooted(true);
+        context.setStorageFullHandled(true);
 
         test_handleRequest_base(
                 context,
@@ -383,6 +389,7 @@ public class UpdateHandlerTest extends AbstractHandlerTest {
         final CallbackContext context = new CallbackContext();
         context.setUpdated(true);
         context.setRebooted(true);
+        context.setStorageFullHandled(true);
 
         test_handleRequest_base(
                 context,
@@ -405,6 +412,7 @@ public class UpdateHandlerTest extends AbstractHandlerTest {
         final CallbackContext context = new CallbackContext();
         context.setUpdated(true);
         context.setRebooted(true);
+        context.setStorageFullHandled(true);
 
         test_handleRequest_base(
                 context,
@@ -432,6 +440,7 @@ public class UpdateHandlerTest extends AbstractHandlerTest {
         context.setUpdated(true);
         context.setRebooted(true);
         context.setUpdatedRoles(false);
+        context.setStorageFullHandled(true);
 
         test_handleRequest_base(
                 context,
@@ -476,6 +485,7 @@ public class UpdateHandlerTest extends AbstractHandlerTest {
         final CallbackContext context = new CallbackContext();
         context.setUpdated(true);
         context.setRebooted(true);
+        context.setStorageFullHandled(true);
 
         test_handleRequest_base(
                 context,
@@ -522,6 +532,7 @@ public class UpdateHandlerTest extends AbstractHandlerTest {
         context.setUpdated(true);
         context.setRebooted(false);
         context.setUpdatedRoles(true);
+        context.setStorageFullHandled(true);
 
         test_handleRequest_base(
                 context,
@@ -551,6 +562,7 @@ public class UpdateHandlerTest extends AbstractHandlerTest {
         final CallbackContext context = new CallbackContext();
         context.setRebooted(true);
         context.setUpdatedRoles(true);
+        context.setStorageFullHandled(true);
 
         test_handleRequest_base(
                 context,
@@ -591,6 +603,7 @@ public class UpdateHandlerTest extends AbstractHandlerTest {
 
         final CallbackContext context = new CallbackContext();
         context.setUpdated(true); // this is an emulation of a re-entrance
+        context.setStorageFullHandled(true);
 
         test_handleRequest_base(
                 context,
@@ -620,6 +633,7 @@ public class UpdateHandlerTest extends AbstractHandlerTest {
 
         final CallbackContext context = new CallbackContext();
         context.setUpdated(true); // this is an emulation of a re-entrance
+        context.setStorageFullHandled(true);
 
         test_handleRequest_base(
                 context,
@@ -701,6 +715,7 @@ public class UpdateHandlerTest extends AbstractHandlerTest {
 
         final CallbackContext context = new CallbackContext();
         context.setUpdated(true); // this is an emulation of a re-entrance
+        context.setStorageFullHandled(true);
 
         test_handleRequest_base(
                 context,
@@ -729,6 +744,8 @@ public class UpdateHandlerTest extends AbstractHandlerTest {
 
         final CallbackContext context = new CallbackContext();
         context.setUpdated(true); // this is an emulation of a re-entrance
+        context.setStorageFullHandled(true);
+
 
         // Altering the db parameter group name attribute invokes setParameterGroupName
         final ResourceModel desiredModel = RESOURCE_MODEL_BLDR()
@@ -763,6 +780,7 @@ public class UpdateHandlerTest extends AbstractHandlerTest {
 
         final CallbackContext context = new CallbackContext();
         context.setUpdated(true); // this is an emulation of a re-entrance
+        context.setStorageFullHandled(true);
 
         test_handleRequest_base(
                 context,
@@ -784,6 +802,7 @@ public class UpdateHandlerTest extends AbstractHandlerTest {
     public void handleRequest_NoDefaultVpcIdForClusterInstance() {
         final CallbackContext context = new CallbackContext();
         context.setUpdated(true);
+        context.setStorageFullHandled(true);
 
         test_handleRequest_base(
                 context,
@@ -1017,6 +1036,7 @@ public class UpdateHandlerTest extends AbstractHandlerTest {
     public void handleRequest_EmptyVpcSecurityGroupIdList() {
         final CallbackContext context = new CallbackContext();
         context.setUpdated(false);
+        context.setStorageFullHandled(true);
 
         test_handleRequest_base(
                 context,
@@ -1061,8 +1081,11 @@ public class UpdateHandlerTest extends AbstractHandlerTest {
             final Object requestException,
             final HandlerErrorCode expectResponseCode
     ) {
+        final CallbackContext context = new CallbackContext();
+        context.setStorageFullHandled(true);
+
         test_handleRequest_error(
-                new CallbackContext(),
+                context,
                 () -> RESOURCE_MODEL_BLDR().build(),
                 () -> RESOURCE_MODEL_ALTER,
                 ModifyDbInstanceRequest.class,
@@ -1070,5 +1093,79 @@ public class UpdateHandlerTest extends AbstractHandlerTest {
                 requestException,
                 expectResponseCode
         );
+    }
+
+    @Test
+    public void handleRequest_StorageFull() {
+        final CallbackContext context = new CallbackContext();
+        context.setUpdated(true);
+        context.setRebooted(true);
+        context.setUpdatedRoles(true);
+
+        final Queue<DBInstance> transitions = new ConcurrentLinkedQueue<>();
+
+        transitions.add(DB_INSTANCE_STORAGE_FULL);
+        transitions.add(DB_INSTANCE_ACTIVE);
+        transitions.add(DB_INSTANCE_ACTIVE); // one extra for the read handler
+
+        test_handleRequest_base(
+                context,
+                transitions::remove,
+                () -> RESOURCE_MODEL_BLDR().build(),
+                () -> RESOURCE_MODEL_BLDR().
+                        allocatedStorage(ALLOCATED_STORAGE_INCR.toString()).build(),
+                expectSuccess()
+        );
+
+        verify(rdsProxy.client(), times(3)).describeDBInstances(any(DescribeDbInstancesRequest.class));
+
+        ArgumentCaptor<ModifyDbInstanceRequest> captor = ArgumentCaptor.forClass(ModifyDbInstanceRequest.class);
+        verify(rdsProxy.client()).modifyDBInstance(captor.capture());
+
+        final ModifyDbInstanceRequest expected = ModifyDbInstanceRequest.builder()
+                .dbInstanceIdentifier(DB_INSTANCE_IDENTIFIER_NON_EMPTY)
+                .allocatedStorage(ALLOCATED_STORAGE_INCR)
+                .applyImmediately(true)
+                .build();
+
+        Assertions.assertThat(captor.getValue().equalsBySdkFields(expected)).isTrue();
+    }
+
+    @Test
+    public void handleRequest_StorageIsNotFull() {
+        final CallbackContext context = new CallbackContext();
+        context.setUpdated(true);
+        context.setRebooted(true);
+        context.setUpdatedRoles(true);
+
+        test_handleRequest_base(
+                context,
+                () -> DB_INSTANCE_ACTIVE,
+                () -> RESOURCE_MODEL_BLDR().build(),
+                () -> RESOURCE_MODEL_BLDR().
+                        allocatedStorage(ALLOCATED_STORAGE_INCR.toString()).build(),
+                expectSuccess()
+        );
+
+        verify(rdsProxy.client(), times(2)).describeDBInstances(any(DescribeDbInstancesRequest.class));
+    }
+
+    @Test
+    public void handleRequest_StorageFullRequestDoesNotAlterStorage() {
+        expectServiceInvocation = false;
+        final CallbackContext context = new CallbackContext();
+        context.setUpdated(true);
+        context.setRebooted(true);
+        context.setUpdatedRoles(true);
+
+        test_handleRequest_base(
+                context,
+                () -> DB_INSTANCE_STORAGE_FULL,
+                () -> RESOURCE_MODEL_BLDR().build(),
+                () -> RESOURCE_MODEL_BLDR().build(),
+                expectFailed(HandlerErrorCode.InvalidRequest)
+        );
+
+        verify(rdsProxy.client(), times(1)).describeDBInstances(any(DescribeDbInstancesRequest.class));
     }
 }


### PR DESCRIPTION
This PR enables the possibility of recovery from `storage-full` state. In order to do so, Update handler attempts to perform `AllocatedSize` only update on the instance. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
