### PR TITLE
[DBInstance] Remove edge-version AssertJ API use

### DIFF
--- a/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/BaseHandlerStdTest.java
+++ b/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/BaseHandlerStdTest.java
@@ -493,9 +493,9 @@ class BaseHandlerStdTest {
         request.setDesiredResourceState(ResourceModel.builder()
                 .sourceRegion("")
                 .build());
-        Assertions.assertThatNoException().isThrownBy(() -> {
+        Assertions.assertThatCode(() -> {
             handler.validateRequest(request);
-        });
+        }).doesNotThrowAnyException();
     }
 
     @Test


### PR DESCRIPTION
This commit fixes an issue in BaseHandlerTest. In particular, `assertThatNoException` is being replaced by `assertThatCode.doesNotThrowAnyException`. The motivation for this change is to avoid locking on the edge-version of AssertJ and stick to the older API.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Signed-off-by: Oleg Sidorov <sidorovo@amazon.com>