### PR TITLE
[DBCluster] Add `rds:DescribeDBSubnetGroups` to permissions

### DIFF
--- a/aws-rds-dbcluster/aws-rds-dbcluster.json
+++ b/aws-rds-dbcluster/aws-rds-dbcluster.json
@@ -384,6 +384,7 @@
         "rds:AddRoleToDBCluster",
         "rds:AddTagsToResource",
         "rds:DescribeDBClusters",
+        "rds:DescribeDBSubnetGroups",
         "rds:ModifyDBCluster",
         "rds:ModifyDBInstance",
         "rds:RemoveFromGlobalCluster",

--- a/aws-rds-dbcluster/resource-role.yaml
+++ b/aws-rds-dbcluster/resource-role.yaml
@@ -31,6 +31,7 @@ Resources:
                 - "rds:DeleteDBCluster"
                 - "rds:DeleteDBInstance"
                 - "rds:DescribeDBClusters"
+                - "rds:DescribeDBSubnetGroups"
                 - "rds:ModifyDBCluster"
                 - "rds:ModifyDBInstance"
                 - "rds:RemoveFromGlobalCluster"


### PR DESCRIPTION
This commit adds a missing `rds:DescribeDBSubnetGroups` FAS policy to the list of the requested permissions for Update requests.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Signed-off-by: Oleg Sidorov <sidorovo@amazon.com>