### PR TITLE
[DBCluster] Add `ec2:DescribeSecurityGroups` permission

### DIFF
--- a/aws-rds-dbcluster/aws-rds-dbcluster.json
+++ b/aws-rds-dbcluster/aws-rds-dbcluster.json
@@ -380,6 +380,7 @@
     },
     "update": {
       "permissions": [
+        "ec2:DescribeSecurityGroups",
         "iam:PassRole",
         "rds:AddRoleToDBCluster",
         "rds:AddTagsToResource",

--- a/aws-rds-dbcluster/resource-role.yaml
+++ b/aws-rds-dbcluster/resource-role.yaml
@@ -23,6 +23,7 @@ Resources:
             Statement:
               - Effect: Allow
                 Action:
+                - "ec2:DescribeSecurityGroups"
                 - "iam:PassRole"
                 - "rds:AddRoleToDBCluster"
                 - "rds:AddTagsToResource"


### PR DESCRIPTION
This commit adds `ec2:DescribeSecurityGroups` FAS policy to the list of the requested permissions.

The initial API addition was performed in https://github.com/aws-cloudformation/aws-cloudformation-resource-providers-rds/pull/254, but the schema policy was missing.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Signed-off-by: Oleg Sidorov <sidorovo@amazon.com>