### PR TITLE
[Common] Add `UnauthorizedOperation` as an AccessDenied status

### DIFF
--- a/aws-rds-cfn-common/src/main/java/software/amazon/rds/common/error/ErrorCode.java
+++ b/aws-rds-cfn-common/src/main/java/software/amazon/rds/common/error/ErrorCode.java
@@ -18,6 +18,7 @@ public enum ErrorCode {
     DBSnapshotNotFound("DBSnapshotNotFound"),
     DBSubnetGroupNotAllowedFault("DBSubnetGroupNotAllowedFault"),
     DBSubnetGroupNotFoundFault("DBSubnetGroupNotFoundFault"),
+    DefaultVpcDoesNotExist("DefaultVpcDoesNotExist"),
     InstanceQuotaExceeded("InstanceQuotaExceeded"),
     InsufficientDBInstanceCapacity("InsufficientDBInstanceCapacity"),
     InternalFailure("InternalFailure"),
@@ -36,9 +37,9 @@ public enum ErrorCode {
     SnapshotQuotaExceeded("SnapshotQuotaExceeded"),
     StorageQuotaExceeded("StorageQuotaExceeded"),
     StorageTypeNotSupportedFault("StorageTypeNotSupportedFault"),
-    ThrottlingException("ThrottlingException"),
     Throttling("Throttling"),
-    DefaultVpcDoesNotExist("DefaultVpcDoesNotExist");
+    ThrottlingException("ThrottlingException"),
+    UnauthorizedOperation("UnauthorizedOperation");
 
     private final String code;
 

--- a/aws-rds-cfn-common/src/main/java/software/amazon/rds/common/handler/Commons.java
+++ b/aws-rds-cfn-common/src/main/java/software/amazon/rds/common/handler/Commons.java
@@ -21,7 +21,8 @@ public final class Commons {
             .withErrorCodes(ErrorStatus.failWith(HandlerErrorCode.AccessDenied),
                     ErrorCode.AccessDenied,
                     ErrorCode.AccessDeniedException,
-                    ErrorCode.NotAuthorized)
+                    ErrorCode.NotAuthorized,
+                    ErrorCode.UnauthorizedOperation)
             .withErrorCodes(ErrorStatus.failWith(HandlerErrorCode.Throttling),
                     ErrorCode.ThrottlingException,
                     ErrorCode.Throttling)


### PR DESCRIPTION
This commit adds `UnauthorizedOperation` to the mapping of known common permission errors interpreted as `HandlerErrorCode.AccessDenied`.

The error code can be returned by EC2 service upon `DescribeSecurityGroups`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Signed-off-by: Oleg Sidorov <sidorovo@amazon.com>