### PR TITLE
[DBInstace] Remove EngineVersion from conditional create only properties

### DIFF
--- a/aws-rds-dbinstance/aws-rds-dbinstance.json
+++ b/aws-rds-dbinstance/aws-rds-dbinstance.json
@@ -370,7 +370,6 @@
     "/properties/BackupRetentionPeriod",
     "/properties/DBParameterGroupName",
     "/properties/Engine",
-    "/properties/EngineVersion",
     "/properties/MonitoringInterval",
     "/properties/MultiAZ",
     "/properties/PerformanceInsightsKMSKeyId",


### PR DESCRIPTION
This PR removes EngineVersion from the list of Conditionally Create-Only properties as there are currently no conditions when the change of EngineVersion will cause replacement. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
