### PR TITLE
[DBParameterGroup] Update to dependency map to include correct parameter key 'character_set_server'

### DIFF
--- a/aws-rds-dbparametergroup/src/main/java/software/amazon/rds/dbparametergroup/BaseHandlerStd.java
+++ b/aws-rds-dbparametergroup/src/main/java/software/amazon/rds/dbparametergroup/BaseHandlerStd.java
@@ -39,8 +39,8 @@ import software.amazon.rds.dbparametergroup.util.ParameterGrouper;
 public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
     public static final List<Set<String>> DEPENDENCIES = ImmutableList.of(
             ImmutableSet.of("collation_server", "character_set_server"),
-            ImmutableSet.of("gtid-mode", "enforce_gtid_consistency")
-            ImmutableSet.of("password_encryption", "rds.accepted_password_auth_method")
+            ImmutableSet.of("gtid-mode", "enforce_gtid_consistency"),
+            ImmutableSet.of("password_encryption", "rds.accepted_password_auth_method"),
             ImmutableSet.of("ssl_max_protocol_version", "ssl_min_protocol_version")
     );
 

--- a/aws-rds-dbparametergroup/src/main/java/software/amazon/rds/dbparametergroup/BaseHandlerStd.java
+++ b/aws-rds-dbparametergroup/src/main/java/software/amazon/rds/dbparametergroup/BaseHandlerStd.java
@@ -40,6 +40,8 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
     public static final List<Set<String>> DEPENDENCIES = ImmutableList.of(
             ImmutableSet.of("collation_server", "character_set_server"),
             ImmutableSet.of("gtid-mode", "enforce_gtid_consistency")
+            ImmutableSet.of("password_encryption", "rds.accepted_password_auth_method")
+            ImmutableSet.of("ssl_max_protocol_version", "ssl_min_protocol_version")
     );
 
     protected static final ErrorRuleSet DEFAULT_DB_PARAMETER_GROUP_ERROR_RULE_SET = ErrorRuleSet

--- a/aws-rds-dbparametergroup/src/main/java/software/amazon/rds/dbparametergroup/BaseHandlerStd.java
+++ b/aws-rds-dbparametergroup/src/main/java/software/amazon/rds/dbparametergroup/BaseHandlerStd.java
@@ -41,8 +41,7 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
             ImmutableSet.of("collation_server", "character_set_server"),
             ImmutableSet.of("gtid-mode", "enforce_gtid_consistency"),
             ImmutableSet.of("password_encryption", "rds.accepted_password_auth_method"),
-            ImmutableSet.of("ssl_max_protocol_version", "ssl_min_protocol_version"),
-            ImmutableSet.of("rds.change_data_capture_streaming", "binlog_format")
+            ImmutableSet.of("ssl_max_protocol_version", "ssl_min_protocol_version")
     );
 
     protected static final ErrorRuleSet DEFAULT_DB_PARAMETER_GROUP_ERROR_RULE_SET = ErrorRuleSet

--- a/aws-rds-dbparametergroup/src/main/java/software/amazon/rds/dbparametergroup/BaseHandlerStd.java
+++ b/aws-rds-dbparametergroup/src/main/java/software/amazon/rds/dbparametergroup/BaseHandlerStd.java
@@ -41,7 +41,8 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
             ImmutableSet.of("collation_server", "character_set_server"),
             ImmutableSet.of("gtid-mode", "enforce_gtid_consistency"),
             ImmutableSet.of("password_encryption", "rds.accepted_password_auth_method"),
-            ImmutableSet.of("ssl_max_protocol_version", "ssl_min_protocol_version")
+            ImmutableSet.of("ssl_max_protocol_version", "ssl_min_protocol_version"),
+            ImmutableSet.of("rds.change_data_capture_streaming", "binlog_format")
     );
 
     protected static final ErrorRuleSet DEFAULT_DB_PARAMETER_GROUP_ERROR_RULE_SET = ErrorRuleSet

--- a/aws-rds-dbparametergroup/src/main/java/software/amazon/rds/dbparametergroup/BaseHandlerStd.java
+++ b/aws-rds-dbparametergroup/src/main/java/software/amazon/rds/dbparametergroup/BaseHandlerStd.java
@@ -38,7 +38,7 @@ import software.amazon.rds.dbparametergroup.util.ParameterGrouper;
 
 public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
     public static final List<Set<String>> DEPENDENCIES = ImmutableList.of(
-            ImmutableSet.of("collation_server", "character_set"),
+            ImmutableSet.of("collation_server", "character_set_server"),
             ImmutableSet.of("gtid-mode", "enforce_gtid_consistency")
     );
 


### PR DESCRIPTION
This change attempts to address an incorrect key for a dependent parameter. From "character_set" (as displayed in rds error messages) to "character_set_server" (as defined in a customer's template) 