### PR TITLE
[DBCluster] Implement ServerlessV2ScalingConfiguration

### DIFF
--- a/aws-rds-dbcluster/aws-rds-dbcluster.json
+++ b/aws-rds-dbcluster/aws-rds-dbcluster.json
@@ -180,6 +180,10 @@
       "type": "string",
       "default": "full-copy"
     },
+    "ServerlessV2ScalingConfiguration": {
+      "description": "Contains the scaling configuration of an Aurora Serverless v2 DB cluster.",
+      "$ref": "#/definitions/ServerlessV2ScalingConfiguration"
+    },
     "ScalingConfiguration": {
       "description": "The ScalingConfiguration property type specifies the scaling configuration of an Aurora Serverless DB cluster.",
       "$ref": "#/definitions/ScalingConfiguration"
@@ -269,6 +273,25 @@
       "required": [
         "RoleArn"
       ]
+    },
+    "ServerlessV2ScalingConfiguration": {
+      "description": "Contains the scaling configuration of an Aurora Serverless v2 DB cluster.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "MinCapacity": {
+          "description": "The minimum number of Aurora capacity units (ACUs) for a DB instance in an Aurora Serverless v2 cluster. You can specify ACU values in half-step increments, such as 8, 8.5, 9, and so on. The smallest value that you can use is 0.5.",
+          "type": "number",
+          "minimum": 0.5,
+          "maximum": 128
+        },
+        "MaxCapacity": {
+          "description": "The maximum number of Aurora capacity units (ACUs) for a DB instance in an Aurora Serverless v2 cluster. You can specify ACU values in half-step increments, such as 40, 40.5, 41, and so on. The largest value that you can use is 128.",
+          "type": "number",
+          "minimum": 0.5,
+          "maximum": 128
+        }
+      }
     },
     "ScalingConfiguration": {
       "description": "The ScalingConfiguration property type specifies the scaling configuration of an Aurora Serverless DB cluster.",

--- a/aws-rds-dbcluster/docs/README.md
+++ b/aws-rds-dbcluster/docs/README.md
@@ -48,6 +48,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
         "<a href="#publiclyaccessible" title="PubliclyAccessible">PubliclyAccessible</a>" : <i>Boolean</i>,
         "<a href="#replicationsourceidentifier" title="ReplicationSourceIdentifier">ReplicationSourceIdentifier</a>" : <i>String</i>,
         "<a href="#restoretype" title="RestoreType">RestoreType</a>" : <i>String</i>,
+        "<a href="#serverlessv2scalingconfiguration" title="ServerlessV2ScalingConfiguration">ServerlessV2ScalingConfiguration</a>" : <i><a href="serverlessv2scalingconfiguration.md">ServerlessV2ScalingConfiguration</a></i>,
         "<a href="#scalingconfiguration" title="ScalingConfiguration">ScalingConfiguration</a>" : <i><a href="scalingconfiguration.md">ScalingConfiguration</a></i>,
         "<a href="#snapshotidentifier" title="SnapshotIdentifier">SnapshotIdentifier</a>" : <i>String</i>,
         "<a href="#sourcedbclusteridentifier" title="SourceDBClusterIdentifier">SourceDBClusterIdentifier</a>" : <i>String</i>,
@@ -105,6 +106,7 @@ Properties:
     <a href="#publiclyaccessible" title="PubliclyAccessible">PubliclyAccessible</a>: <i>Boolean</i>
     <a href="#replicationsourceidentifier" title="ReplicationSourceIdentifier">ReplicationSourceIdentifier</a>: <i>String</i>
     <a href="#restoretype" title="RestoreType">RestoreType</a>: <i>String</i>
+    <a href="#serverlessv2scalingconfiguration" title="ServerlessV2ScalingConfiguration">ServerlessV2ScalingConfiguration</a>: <i><a href="serverlessv2scalingconfiguration.md">ServerlessV2ScalingConfiguration</a></i>
     <a href="#scalingconfiguration" title="ScalingConfiguration">ScalingConfiguration</a>: <i><a href="scalingconfiguration.md">ScalingConfiguration</a></i>
     <a href="#snapshotidentifier" title="SnapshotIdentifier">SnapshotIdentifier</a>: <i>String</i>
     <a href="#sourcedbclusteridentifier" title="SourceDBClusterIdentifier">SourceDBClusterIdentifier</a>: <i>String</i>
@@ -495,6 +497,16 @@ _Required_: No
 _Type_: String
 
 _Update requires_: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
+
+#### ServerlessV2ScalingConfiguration
+
+Contains the scaling configuration of an Aurora Serverless v2 DB cluster.
+
+_Required_: No
+
+_Type_: <a href="serverlessv2scalingconfiguration.md">ServerlessV2ScalingConfiguration</a>
+
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 
 #### ScalingConfiguration
 

--- a/aws-rds-dbcluster/docs/serverlessv2scalingconfiguration.md
+++ b/aws-rds-dbcluster/docs/serverlessv2scalingconfiguration.md
@@ -1,0 +1,45 @@
+# AWS::RDS::DBCluster ServerlessV2ScalingConfiguration
+
+Contains the scaling configuration of an Aurora Serverless v2 DB cluster.
+
+## Syntax
+
+To declare this entity in your AWS CloudFormation template, use the following syntax:
+
+### JSON
+
+<pre>
+{
+    "<a href="#mincapacity" title="MinCapacity">MinCapacity</a>" : <i>Double</i>,
+    "<a href="#maxcapacity" title="MaxCapacity">MaxCapacity</a>" : <i>Double</i>
+}
+</pre>
+
+### YAML
+
+<pre>
+<a href="#mincapacity" title="MinCapacity">MinCapacity</a>: <i>Double</i>
+<a href="#maxcapacity" title="MaxCapacity">MaxCapacity</a>: <i>Double</i>
+</pre>
+
+## Properties
+
+#### MinCapacity
+
+The minimum number of Aurora capacity units (ACUs) for a DB instance in an Aurora Serverless v2 cluster. You can specify ACU values in half-step increments, such as 8, 8.5, 9, and so on. The smallest value that you can use is 0.5.
+
+_Required_: No
+
+_Type_: Double
+
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+
+#### MaxCapacity
+
+The maximum number of Aurora capacity units (ACUs) for a DB instance in an Aurora Serverless v2 cluster. You can specify ACU values in half-step increments, such as 40, 40.5, 41, and so on. The largest value that you can use is 128.
+
+_Required_: No
+
+_Type_: Double
+
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)

--- a/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/Translator.java
+++ b/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/Translator.java
@@ -69,6 +69,7 @@ public class Translator {
                 .preferredMaintenanceWindow(model.getPreferredMaintenanceWindow())
                 .publiclyAccessible(model.getPubliclyAccessible())
                 .replicationSourceIdentifier(model.getReplicationSourceIdentifier())
+                .serverlessV2ScalingConfiguration(translateServerlessV2ScalingConfiguration(model.getServerlessV2ScalingConfiguration()))
                 .scalingConfiguration(translateScalingConfigurationToSdk(model.getScalingConfiguration()))
                 .sourceRegion(model.getSourceRegion())
                 .storageEncrypted(model.getStorageEncrypted())
@@ -91,6 +92,8 @@ public class Translator {
                 .kmsKeyId(model.getKmsKeyId())
                 .publiclyAccessible(model.getPubliclyAccessible())
                 .restoreType(model.getRestoreType())
+                .scalingConfiguration(translateScalingConfigurationToSdk(model.getScalingConfiguration()))
+                .serverlessV2ScalingConfiguration(translateServerlessV2ScalingConfiguration(model.getServerlessV2ScalingConfiguration()))
                 .sourceDBClusterIdentifier(model.getSourceDBClusterIdentifier())
                 .storageType(model.getStorageType())
                 .tags(Tagging.translateTagsToSdk(tagSet))
@@ -122,6 +125,7 @@ public class Translator {
                 .port(model.getPort())
                 .publiclyAccessible(model.getPubliclyAccessible())
                 .scalingConfiguration(translateScalingConfigurationToSdk(model.getScalingConfiguration()))
+                .serverlessV2ScalingConfiguration(translateServerlessV2ScalingConfiguration(model.getServerlessV2ScalingConfiguration()))
                 .snapshotIdentifier(model.getSnapshotIdentifier())
                 .storageType(model.getStorageType())
                 .tags(Tagging.translateTagsToSdk(tagSet))
@@ -193,7 +197,9 @@ public class Translator {
                 .performanceInsightsRetentionPeriod(desiredModel.getPerformanceInsightsRetentionPeriod())
                 .port(desiredModel.getPort())
                 .scalingConfiguration(translateScalingConfigurationToSdk(desiredModel.getScalingConfiguration()))
+                .serverlessV2ScalingConfiguration(translateServerlessV2ScalingConfiguration(desiredModel.getServerlessV2ScalingConfiguration()))
                 .storageType(desiredModel.getStorageType());
+
         if (previousModel != null) {
             if (!Objects.equals(previousModel.getMasterUserPassword(), desiredModel.getMasterUserPassword())) {
                 builder.masterUserPassword(desiredModel.getMasterUserPassword());
@@ -309,6 +315,18 @@ public class Translator {
                 .collect(Collectors.toSet());
     }
 
+    static software.amazon.awssdk.services.rds.model.ServerlessV2ScalingConfiguration translateServerlessV2ScalingConfiguration(
+            final ServerlessV2ScalingConfiguration serverlessV2ScalingConfiguration
+    ) {
+        if (serverlessV2ScalingConfiguration == null) {
+            return null;
+        }
+        return software.amazon.awssdk.services.rds.model.ServerlessV2ScalingConfiguration.builder()
+                .maxCapacity(serverlessV2ScalingConfiguration.getMaxCapacity())
+                .minCapacity(serverlessV2ScalingConfiguration.getMinCapacity())
+                .build();
+    }
+
     static software.amazon.awssdk.services.rds.model.ScalingConfiguration translateScalingConfigurationToSdk(
             final ScalingConfiguration scalingConfiguration
     ) {
@@ -319,7 +337,20 @@ public class Translator {
                 .autoPause(scalingConfiguration.getAutoPause())
                 .maxCapacity(scalingConfiguration.getMaxCapacity())
                 .minCapacity(scalingConfiguration.getMinCapacity())
-                .secondsUntilAutoPause(scalingConfiguration.getSecondsUntilAutoPause()).build();
+                .secondsUntilAutoPause(scalingConfiguration.getSecondsUntilAutoPause())
+                .build();
+    }
+
+    static ServerlessV2ScalingConfiguration translateServerlessV2ScalingConfigurationFromSdk(
+            final software.amazon.awssdk.services.rds.model.ServerlessV2ScalingConfigurationInfo serverlessV2ScalingConfiguration
+    ) {
+        if (serverlessV2ScalingConfiguration == null) {
+            return null;
+        }
+        return ServerlessV2ScalingConfiguration.builder()
+                .maxCapacity(serverlessV2ScalingConfiguration.maxCapacity())
+                .minCapacity(serverlessV2ScalingConfiguration.minCapacity())
+                .build();
     }
 
     static ScalingConfiguration translateScalingConfigurationFromSdk(
@@ -332,7 +363,8 @@ public class Translator {
                 .autoPause(scalingConfiguration.autoPause())
                 .maxCapacity(scalingConfiguration.maxCapacity())
                 .minCapacity(scalingConfiguration.minCapacity())
-                .secondsUntilAutoPause(scalingConfiguration.secondsUntilAutoPause()).build();
+                .secondsUntilAutoPause(scalingConfiguration.secondsUntilAutoPause())
+                .build();
     }
 
     public static DBClusterRole transformDBCusterRoleFromSdk(
@@ -404,10 +436,11 @@ public class Translator {
                                 .build()
                 )
                 .replicationSourceIdentifier(dbCluster.replicationSourceIdentifier())
-                .scalingConfiguration(Translator.translateScalingConfigurationFromSdk(dbCluster.scalingConfigurationInfo()))
+                .serverlessV2ScalingConfiguration(translateServerlessV2ScalingConfigurationFromSdk(dbCluster.serverlessV2ScalingConfiguration()))
+                .scalingConfiguration(translateScalingConfigurationFromSdk(dbCluster.scalingConfigurationInfo()))
                 .storageEncrypted(dbCluster.storageEncrypted())
                 .storageType(dbCluster.storageType())
-                .tags(Translator.translateTagsFromSdk(dbCluster.tagList()))
+                .tags(translateTagsFromSdk(dbCluster.tagList()))
                 .vpcSecurityGroupIds(
                         Optional.ofNullable(dbCluster.vpcSecurityGroups())
                                 .orElse(Collections.emptyList())

--- a/aws-rds-dbcluster/src/test/java/software/amazon/rds/dbcluster/AbstractHandlerTest.java
+++ b/aws-rds-dbcluster/src/test/java/software/amazon/rds/dbcluster/AbstractHandlerTest.java
@@ -16,7 +16,6 @@ import org.mockito.stubbing.OngoingStubbing;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Lists;
 import software.amazon.awssdk.services.ec2.Ec2Client;
 import software.amazon.awssdk.services.rds.RdsClient;
 import software.amazon.awssdk.services.rds.model.CreateDbClusterRequest;
@@ -35,6 +34,7 @@ import software.amazon.awssdk.services.rds.model.RestoreDbClusterFromSnapshotRes
 import software.amazon.awssdk.services.rds.model.RestoreDbClusterToPointInTimeRequest;
 import software.amazon.awssdk.services.rds.model.RestoreDbClusterToPointInTimeResponse;
 import software.amazon.awssdk.services.rds.model.ScalingConfigurationInfo;
+import software.amazon.awssdk.services.rds.model.ServerlessV2ScalingConfigurationInfo;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.Credentials;
 import software.amazon.cloudformation.proxy.LoggerProxy;
@@ -93,6 +93,11 @@ public abstract class AbstractHandlerTest extends AbstractTestBase<DBCluster, Re
 
     protected static final String ERROR_MSG = "error";
 
+    protected static final ServerlessV2ScalingConfigurationInfo SERVERLESS_V2_SCALING_CONFIGURATION_INFO;
+    protected static final ServerlessV2ScalingConfiguration SERVERLESS_V2_SCALING_CONFIGURATION;
+    protected static final ScalingConfigurationInfo SCALING_CONFIGURATION_INFO;
+    protected static final ScalingConfiguration SCALING_CONFIGURATION;
+
     protected static final Set<Tag> TAG_LIST;
     protected static final Set<Tag> TAG_LIST_EMPTY;
     protected static final Set<Tag> TAG_LIST_ALTER;
@@ -125,8 +130,31 @@ public abstract class AbstractHandlerTest extends AbstractTestBase<DBCluster, Re
         ROLE_WITH_EMPTY_FEATURE = DBClusterRole.builder().roleArn(ROLE_ARN).build();
         VPC_SG_IDS = Arrays.asList("vpc-sg-id-1", "vpc-sg-id-2");
 
+        SERVERLESS_V2_SCALING_CONFIGURATION = ServerlessV2ScalingConfiguration.builder()
+                .maxCapacity(10.0)
+                .minCapacity(1.0)
+                .build();
+
+        SERVERLESS_V2_SCALING_CONFIGURATION_INFO = ServerlessV2ScalingConfigurationInfo.builder()
+                .maxCapacity(10.0)
+                .minCapacity(1.0)
+                .build();
+
+        SCALING_CONFIGURATION = ScalingConfiguration.builder()
+                .autoPause(true)
+                .maxCapacity(10)
+                .minCapacity(1)
+                .secondsUntilAutoPause(5)
+                .build();
+
+        SCALING_CONFIGURATION_INFO = ScalingConfigurationInfo.builder()
+                .autoPause(true)
+                .minCapacity(1)
+                .maxCapacity(10)
+                .secondsUntilAutoPause(5)
+                .build();
+
         RESOURCE_MODEL = ResourceModel.builder()
-                .associatedRoles(Lists.newArrayList(ROLE))
                 .backtrackWindow(BACKTRACK_WINDOW)
                 .dBClusterIdentifier(DBCLUSTER_IDENTIFIER)
                 .dBClusterParameterGroupName(DBCLUSTER_PARAMETER_GROUP_NAME)
@@ -139,7 +167,6 @@ public abstract class AbstractHandlerTest extends AbstractTestBase<DBCluster, Re
                 .build();
 
         RESOURCE_MODEL_EMPTY_VPC = ResourceModel.builder()
-                .associatedRoles(Lists.newArrayList(ROLE))
                 .backtrackWindow(BACKTRACK_WINDOW)
                 .dBClusterIdentifier(DBCLUSTER_IDENTIFIER)
                 .dBClusterParameterGroupName(DBCLUSTER_PARAMETER_GROUP_NAME)
@@ -157,14 +184,7 @@ public abstract class AbstractHandlerTest extends AbstractTestBase<DBCluster, Re
                 .engineMode(ENGINE_MODE)
                 .masterUsername(USER_NAME)
                 .masterUserPassword(USER_PASSWORD)
-                .scalingConfiguration(
-                        ScalingConfiguration.builder()
-                                .autoPause(true)
-                                .minCapacity(1)
-                                .maxCapacity(10)
-                                .secondsUntilAutoPause(5)
-                                .build()
-                )
+                .scalingConfiguration(SCALING_CONFIGURATION)
                 .vpcSecurityGroupIds(VPC_SG_IDS)
                 .build();
 
@@ -179,7 +199,6 @@ public abstract class AbstractHandlerTest extends AbstractTestBase<DBCluster, Re
                 .build();
 
         RESOURCE_MODEL_WITH_GLOBAL_CLUSTER = ResourceModel.builder()
-                .associatedRoles(Lists.newArrayList(ROLE))
                 .backtrackWindow(BACKTRACK_WINDOW)
                 .dBClusterIdentifier(DBCLUSTER_IDENTIFIER)
                 .dBClusterParameterGroupName(DBCLUSTER_PARAMETER_GROUP_NAME)
@@ -202,14 +221,7 @@ public abstract class AbstractHandlerTest extends AbstractTestBase<DBCluster, Re
                 .port(RESOURCE_MODEL.getPort())
                 .masterUsername(RESOURCE_MODEL.getMasterUsername())
                 .status(DBClusterStatus.Available.toString())
-                .scalingConfigurationInfo(
-                        ScalingConfigurationInfo.builder()
-                                .autoPause(true)
-                                .maxCapacity(10)
-                                .minCapacity(1)
-                                .secondsUntilAutoPause(5)
-                                .build()
-                )
+                .scalingConfigurationInfo(SCALING_CONFIGURATION_INFO)
                 .build();
 
         DBCLUSTER_ACTIVE_DELETION_ENABLED = DBCluster.builder()
@@ -222,14 +234,7 @@ public abstract class AbstractHandlerTest extends AbstractTestBase<DBCluster, Re
                 .port(RESOURCE_MODEL.getPort())
                 .masterUsername(RESOURCE_MODEL.getMasterUsername())
                 .status(DBClusterStatus.Available.toString())
-                .scalingConfigurationInfo(
-                        ScalingConfigurationInfo.builder()
-                                .autoPause(true)
-                                .maxCapacity(10)
-                                .minCapacity(1)
-                                .secondsUntilAutoPause(5)
-                                .build()
-                )
+                .scalingConfigurationInfo(SCALING_CONFIGURATION_INFO)
                 .build();
 
         DBCLUSTER_SNAPSHOT = DBClusterSnapshot.builder()

--- a/aws-rds-dbcluster/src/test/java/software/amazon/rds/dbcluster/UpdateHandlerTest.java
+++ b/aws-rds-dbcluster/src/test/java/software/amazon/rds/dbcluster/UpdateHandlerTest.java
@@ -13,9 +13,9 @@ import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.stream.Stream;
 
+import org.assertj.core.api.Assertions;
 import org.assertj.core.util.Lists;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -28,6 +28,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import com.google.common.collect.ImmutableList;
 import lombok.Getter;
 import software.amazon.awssdk.awscore.exception.AwsErrorDetails;
 import software.amazon.awssdk.awscore.exception.AwsServiceException;
@@ -139,8 +140,12 @@ public class UpdateHandlerTest extends AbstractHandlerTest {
         test_handleRequest_base(
                 context,
                 () -> DBCLUSTER_ACTIVE,
-                () -> RESOURCE_MODEL,
-                () -> RESOURCE_MODEL,
+                () -> RESOURCE_MODEL.toBuilder()
+                        .associatedRoles(ImmutableList.of(ROLE))
+                        .build(),
+                () -> RESOURCE_MODEL.toBuilder()
+                        .associatedRoles(ImmutableList.of(ROLE))
+                        .build(),
                 expectSuccess()
         );
 
@@ -164,8 +169,14 @@ public class UpdateHandlerTest extends AbstractHandlerTest {
         test_handleRequest_base(
                 context,
                 () -> DBCLUSTER_ACTIVE,
-                () -> RESOURCE_MODEL.toBuilder().globalClusterIdentifier("global-cluster-identifier").build(),
-                () -> RESOURCE_MODEL.toBuilder().globalClusterIdentifier("").build(),
+                () -> RESOURCE_MODEL.toBuilder()
+                        .associatedRoles(ImmutableList.of(ROLE))
+                        .globalClusterIdentifier("global-cluster-identifier")
+                        .build(),
+                () -> RESOURCE_MODEL.toBuilder()
+                        .associatedRoles(ImmutableList.of(ROLE))
+                        .globalClusterIdentifier("")
+                        .build(),
                 expectSuccess()
         );
 
@@ -199,10 +210,6 @@ public class UpdateHandlerTest extends AbstractHandlerTest {
     public void handleRequest_RemoveFromGlobalClusterStabilization() {
         when(rdsProxy.client().removeFromGlobalCluster(any(RemoveFromGlobalClusterRequest.class)))
                 .thenReturn(RemoveFromGlobalClusterResponse.builder().build());
-        when(rdsProxy.client().addRoleToDBCluster(any(AddRoleToDbClusterRequest.class)))
-                .thenReturn(AddRoleToDbClusterResponse.builder().build());
-        when(rdsProxy.client().removeRoleFromDBCluster(any(RemoveRoleFromDbClusterRequest.class)))
-                .thenThrow(DbClusterRoleNotFoundException.builder().message("not found").build());
 
         final Queue<GlobalCluster> transitions = new ConcurrentLinkedQueue<>();
         transitions.add(GlobalCluster.builder().globalClusterMembers(GlobalClusterMember.builder().dbClusterArn(DBCLUSTER_ACTIVE.dbClusterArn()).build()).build());
@@ -221,7 +228,7 @@ public class UpdateHandlerTest extends AbstractHandlerTest {
                 expectSuccess()
         );
 
-        verify(rdsProxy.client(), times(7)).describeDBClusters(any(DescribeDbClustersRequest.class));
+        verify(rdsProxy.client(), times(6)).describeDBClusters(any(DescribeDbClustersRequest.class));
         verify(rdsProxy.client(), times(1)).removeFromGlobalCluster(any(RemoveFromGlobalClusterRequest.class));
         verify(rdsProxy.client(), times(2)).describeGlobalClusters(any(DescribeGlobalClustersRequest.class));
     }
@@ -267,8 +274,12 @@ public class UpdateHandlerTest extends AbstractHandlerTest {
                     }
                     return DBCLUSTER_ACTIVE;
                 },
-                () -> RESOURCE_MODEL,
-                () -> RESOURCE_MODEL,
+                () -> RESOURCE_MODEL.toBuilder()
+                        .associatedRoles(ImmutableList.of(ROLE))
+                        .build(),
+                () -> RESOURCE_MODEL.toBuilder()
+                        .associatedRoles(ImmutableList.of(ROLE))
+                        .build(),
                 expectSuccess()
         );
 
@@ -281,10 +292,6 @@ public class UpdateHandlerTest extends AbstractHandlerTest {
 
     @Test
     public void handleRequest_SuccessWithEmptyVPC() {
-        when(rdsProxy.client().removeRoleFromDBCluster(any(RemoveRoleFromDbClusterRequest.class)))
-                .thenReturn(RemoveRoleFromDbClusterResponse.builder().build());
-        when(rdsProxy.client().addRoleToDBCluster(any(AddRoleToDbClusterRequest.class)))
-                .thenReturn(AddRoleToDbClusterResponse.builder().build());
         when(rdsProxy.client().removeTagsFromResource(any(RemoveTagsFromResourceRequest.class)))
                 .thenReturn(RemoveTagsFromResourceResponse.builder().build());
         when(rdsProxy.client().addTagsToResource(any(AddTagsToResourceRequest.class)))
@@ -318,11 +325,9 @@ public class UpdateHandlerTest extends AbstractHandlerTest {
                 expectSuccess()
         );
 
-        Assertions.assertFalse(resourceModel.getVpcSecurityGroupIds().isEmpty());
+        Assertions.assertThat(resourceModel.getVpcSecurityGroupIds().isEmpty()).isFalse();
 
-        verify(rdsProxy.client(), times(6)).describeDBClusters(any(DescribeDbClustersRequest.class));
-        verify(rdsProxy.client(), times(1)).removeRoleFromDBCluster(any(RemoveRoleFromDbClusterRequest.class));
-        verify(rdsProxy.client(), times(1)).addRoleToDBCluster(any(AddRoleToDbClusterRequest.class));
+        verify(rdsProxy.client(), times(3)).describeDBClusters(any(DescribeDbClustersRequest.class));
         verify(rdsProxy.client(), times(1)).removeTagsFromResource(any(RemoveTagsFromResourceRequest.class));
         verify(rdsProxy.client(), times(1)).addTagsToResource(any(AddTagsToResourceRequest.class));
     }
@@ -358,8 +363,12 @@ public class UpdateHandlerTest extends AbstractHandlerTest {
                     }
                     return dbclusterActive;
                 },
-                () -> RESOURCE_MODEL.toBuilder().associatedRoles(Lists.newArrayList(ROLE_WITH_EMPTY_FEATURE)).build(),
-                () -> RESOURCE_MODEL.toBuilder().associatedRoles(Lists.newArrayList(ROLE_WITH_EMPTY_FEATURE)).build(),
+                () -> RESOURCE_MODEL.toBuilder()
+                        .associatedRoles(Lists.newArrayList(ROLE_WITH_EMPTY_FEATURE))
+                        .build(),
+                () -> RESOURCE_MODEL.toBuilder()
+                        .associatedRoles(Lists.newArrayList(ROLE_WITH_EMPTY_FEATURE))
+                        .build(),
                 expectSuccess()
         );
 
@@ -404,10 +413,6 @@ public class UpdateHandlerTest extends AbstractHandlerTest {
 
         when(rdsProxy.client().modifyDBCluster(any(ModifyDbClusterRequest.class)))
                 .thenReturn(ModifyDbClusterResponse.builder().build());
-        when(rdsProxy.client().removeRoleFromDBCluster(any(RemoveRoleFromDbClusterRequest.class)))
-                .thenReturn(RemoveRoleFromDbClusterResponse.builder().build());
-        when(rdsProxy.client().addRoleToDBCluster(any(AddRoleToDbClusterRequest.class)))
-                .thenReturn(AddRoleToDbClusterResponse.builder().build());
 
         test_handleRequest_base(
                 new CallbackContext(),
@@ -417,14 +422,18 @@ public class UpdateHandlerTest extends AbstractHandlerTest {
                     }
                     return DBCLUSTER_ACTIVE;
                 },
-                () -> RESOURCE_MODEL.toBuilder().masterUserPassword(masterUserPassword).build(),
-                () -> RESOURCE_MODEL.toBuilder().masterUserPassword(masterUserPassword).build(),
+                () -> RESOURCE_MODEL.toBuilder()
+                        .masterUserPassword(masterUserPassword)
+                        .build(),
+                () -> RESOURCE_MODEL.toBuilder()
+                        .masterUserPassword(masterUserPassword)
+                        .build(),
                 expectSuccess()
         );
 
         ArgumentCaptor<ModifyDbClusterRequest> argument = ArgumentCaptor.forClass(ModifyDbClusterRequest.class);
         verify(rdsProxy.client(), times(1)).modifyDBCluster(argument.capture());
-        Assertions.assertNull(argument.getValue().masterUserPassword());
+        Assertions.assertThat(argument.getValue().masterUserPassword()).isNull();
     }
 
     @Test
@@ -432,7 +441,7 @@ public class UpdateHandlerTest extends AbstractHandlerTest {
         final String masterUserPassword1 = TestUtils.randomString(16, TestUtils.ALPHANUM);
         final String masterUserPassword2 = TestUtils.randomString(16, TestUtils.ALPHANUM);
 
-        Assertions.assertNotEquals(masterUserPassword1, masterUserPassword2);
+        Assertions.assertThat(masterUserPassword1).isNotEqualTo(masterUserPassword2);
 
         Queue<DBCluster> transitions = new ConcurrentLinkedQueue<>();
         transitions.add(DBCLUSTER_ACTIVE);
@@ -441,10 +450,6 @@ public class UpdateHandlerTest extends AbstractHandlerTest {
 
         when(rdsProxy.client().modifyDBCluster(any(ModifyDbClusterRequest.class)))
                 .thenReturn(ModifyDbClusterResponse.builder().build());
-        when(rdsProxy.client().removeRoleFromDBCluster(any(RemoveRoleFromDbClusterRequest.class)))
-                .thenReturn(RemoveRoleFromDbClusterResponse.builder().build());
-        when(rdsProxy.client().addRoleToDBCluster(any(AddRoleToDbClusterRequest.class)))
-                .thenReturn(AddRoleToDbClusterResponse.builder().build());
 
         test_handleRequest_base(
                 new CallbackContext(),
@@ -454,14 +459,18 @@ public class UpdateHandlerTest extends AbstractHandlerTest {
                     }
                     return DBCLUSTER_ACTIVE;
                 },
-                () -> RESOURCE_MODEL.toBuilder().masterUserPassword(masterUserPassword1).build(),
-                () -> RESOURCE_MODEL.toBuilder().masterUserPassword(masterUserPassword2).build(),
+                () -> RESOURCE_MODEL.toBuilder()
+                        .masterUserPassword(masterUserPassword1)
+                        .build(),
+                () -> RESOURCE_MODEL.toBuilder()
+                        .masterUserPassword(masterUserPassword2)
+                        .build(),
                 expectSuccess()
         );
 
         ArgumentCaptor<ModifyDbClusterRequest> argument = ArgumentCaptor.forClass(ModifyDbClusterRequest.class);
         verify(rdsProxy.client(), times(1)).modifyDBCluster(argument.capture());
-        Assertions.assertEquals(argument.getValue().masterUserPassword(), masterUserPassword2);
+        Assertions.assertThat(argument.getValue().masterUserPassword()).isEqualTo(masterUserPassword2);
     }
 
     @Test
@@ -488,14 +497,20 @@ public class UpdateHandlerTest extends AbstractHandlerTest {
                     }
                     return DBCLUSTER_ACTIVE;
                 },
-                () -> RESOURCE_MODEL.toBuilder().engineVersion(engineVersion).build(),
-                () -> RESOURCE_MODEL.toBuilder().engineVersion(engineVersion).build(),
+                () -> RESOURCE_MODEL.toBuilder()
+                        .associatedRoles(ImmutableList.of(ROLE))
+                        .engineVersion(engineVersion)
+                        .build(),
+                () -> RESOURCE_MODEL.toBuilder()
+                        .associatedRoles(ImmutableList.of(ROLE))
+                        .engineVersion(engineVersion)
+                        .build(),
                 expectSuccess()
         );
 
         ArgumentCaptor<ModifyDbClusterRequest> argument = ArgumentCaptor.forClass(ModifyDbClusterRequest.class);
         verify(rdsProxy.client(), times(1)).modifyDBCluster(argument.capture());
-        Assertions.assertNull(argument.getValue().engineVersion());
+        Assertions.assertThat(argument.getValue().engineVersion()).isNull();
     }
 
     @Test
@@ -503,7 +518,7 @@ public class UpdateHandlerTest extends AbstractHandlerTest {
         final String engineVersion1 = TestUtils.randomString(16, TestUtils.ALPHANUM);
         final String engineVersion2 = TestUtils.randomString(16, TestUtils.ALPHANUM);
 
-        Assertions.assertNotEquals(engineVersion1, engineVersion2);
+        Assertions.assertThat(engineVersion1).isNotEqualTo(engineVersion2);
 
         Queue<DBCluster> transitions = new ConcurrentLinkedQueue<>();
         transitions.add(DBCLUSTER_ACTIVE);
@@ -512,10 +527,6 @@ public class UpdateHandlerTest extends AbstractHandlerTest {
 
         when(rdsProxy.client().modifyDBCluster(any(ModifyDbClusterRequest.class)))
                 .thenReturn(ModifyDbClusterResponse.builder().build());
-        when(rdsProxy.client().removeRoleFromDBCluster(any(RemoveRoleFromDbClusterRequest.class)))
-                .thenReturn(RemoveRoleFromDbClusterResponse.builder().build());
-        when(rdsProxy.client().addRoleToDBCluster(any(AddRoleToDbClusterRequest.class)))
-                .thenReturn(AddRoleToDbClusterResponse.builder().build());
 
         test_handleRequest_base(
                 new CallbackContext(),
@@ -526,14 +537,18 @@ public class UpdateHandlerTest extends AbstractHandlerTest {
                     }
                     return DBCLUSTER_ACTIVE;
                 },
-                () -> RESOURCE_MODEL.toBuilder().engineVersion(engineVersion1).build(),
-                () -> RESOURCE_MODEL.toBuilder().engineVersion(engineVersion2).build(),
+                () -> RESOURCE_MODEL.toBuilder()
+                        .engineVersion(engineVersion1)
+                        .build(),
+                () -> RESOURCE_MODEL.toBuilder()
+                        .engineVersion(engineVersion2)
+                        .build(),
                 expectSuccess()
         );
 
         ArgumentCaptor<ModifyDbClusterRequest> argument = ArgumentCaptor.forClass(ModifyDbClusterRequest.class);
         verify(rdsProxy.client(), times(1)).modifyDBCluster(argument.capture());
-        Assertions.assertNull(argument.getValue().engineVersion());
+        Assertions.assertThat(argument.getValue().engineVersion()).isNull();
     }
 
     @Test
@@ -541,7 +556,7 @@ public class UpdateHandlerTest extends AbstractHandlerTest {
         final String engineVersion1 = TestUtils.randomString(16, TestUtils.ALPHANUM);
         final String engineVersion2 = TestUtils.randomString(16, TestUtils.ALPHANUM);
 
-        Assertions.assertNotEquals(engineVersion1, engineVersion2);
+        Assertions.assertThat(engineVersion1).isNotEqualTo(engineVersion2);
 
         Queue<DBCluster> transitions = new ConcurrentLinkedQueue<>();
         transitions.add(DBCLUSTER_ACTIVE);
@@ -550,10 +565,6 @@ public class UpdateHandlerTest extends AbstractHandlerTest {
 
         when(rdsProxy.client().modifyDBCluster(any(ModifyDbClusterRequest.class)))
                 .thenReturn(ModifyDbClusterResponse.builder().build());
-        when(rdsProxy.client().removeRoleFromDBCluster(any(RemoveRoleFromDbClusterRequest.class)))
-                .thenReturn(RemoveRoleFromDbClusterResponse.builder().build());
-        when(rdsProxy.client().addRoleToDBCluster(any(AddRoleToDbClusterRequest.class)))
-                .thenReturn(AddRoleToDbClusterResponse.builder().build());
 
         test_handleRequest_base(
                 new CallbackContext(),
@@ -563,16 +574,76 @@ public class UpdateHandlerTest extends AbstractHandlerTest {
                     }
                     return DBCLUSTER_ACTIVE;
                 },
-                () -> RESOURCE_MODEL.toBuilder().engineVersion(engineVersion1).build(),
-                () -> RESOURCE_MODEL.toBuilder().engineVersion(engineVersion2).build(),
+                () -> RESOURCE_MODEL.toBuilder()
+                        .engineVersion(engineVersion1)
+                        .build(),
+                () -> RESOURCE_MODEL.toBuilder()
+                        .engineVersion(engineVersion2)
+                        .build(),
                 expectSuccess()
         );
 
         ArgumentCaptor<ModifyDbClusterRequest> argument = ArgumentCaptor.forClass(ModifyDbClusterRequest.class);
         verify(rdsProxy.client(), times(1)).modifyDBCluster(argument.capture());
-        Assertions.assertEquals(argument.getValue().engineVersion(), engineVersion2);
-        Assertions.assertTrue(argument.getValue().applyImmediately());
-        Assertions.assertTrue(argument.getValue().allowMajorVersionUpgrade());
+        Assertions.assertThat(argument.getValue().engineVersion()).isEqualTo(engineVersion2);
+        Assertions.assertThat(argument.getValue().applyImmediately()).isTrue();
+        Assertions.assertThat(argument.getValue().allowMajorVersionUpgrade()).isTrue();
+    }
+
+    @Test
+    public void handleRequest_ServerlessV2ScalingConfiguration_Success() {
+        when(rdsProxy.client().modifyDBCluster(any(ModifyDbClusterRequest.class)))
+                .thenReturn(ModifyDbClusterResponse.builder().build());
+        when(rdsProxy.client().removeTagsFromResource(any(RemoveTagsFromResourceRequest.class)))
+                .thenReturn(RemoveTagsFromResourceResponse.builder().build());
+        when(rdsProxy.client().addTagsToResource(any(AddTagsToResourceRequest.class)))
+                .thenReturn(AddTagsToResourceResponse.builder().build());
+        Queue<DBCluster> transitions = new ConcurrentLinkedQueue<>();
+        transitions.add(DBCLUSTER_ACTIVE);
+        transitions.add(DBCLUSTER_INPROGRESS);
+        transitions.add(DBCLUSTER_ACTIVE_NO_ROLE);
+
+        final ServerlessV2ScalingConfiguration previousServerlessV2ScalingConfiguration = ServerlessV2ScalingConfiguration.builder()
+                .minCapacity(1.0)
+                .maxCapacity(2.0)
+                .build();
+
+        final ServerlessV2ScalingConfiguration desiredServerlessV2ScalingConfiguration = ServerlessV2ScalingConfiguration.builder()
+                .minCapacity(3.0)
+                .maxCapacity(4.0)
+                .build();
+
+        test_handleRequest_base(
+                new CallbackContext(),
+                ResourceHandlerRequest.<ResourceModel>builder()
+                        .previousResourceTags(Translator.translateTagsToRequest(TAG_LIST))
+                        .desiredResourceTags(Translator.translateTagsToRequest(TAG_LIST_ALTER)),
+                () -> {
+                    if (transitions.size() > 0) {
+                        return transitions.remove();
+                    }
+                    return DBCLUSTER_ACTIVE;
+                },
+                () -> RESOURCE_MODEL.toBuilder()
+                        .serverlessV2ScalingConfiguration(previousServerlessV2ScalingConfiguration)
+                        .build(),
+                () -> RESOURCE_MODEL.toBuilder()
+                        .serverlessV2ScalingConfiguration(desiredServerlessV2ScalingConfiguration)
+                        .build(),
+                expectSuccess()
+        );
+
+        ArgumentCaptor<ModifyDbClusterRequest> captor = ArgumentCaptor.forClass(ModifyDbClusterRequest.class);
+        verify(rdsProxy.client(), times(1)).modifyDBCluster(captor.capture());
+        verify(rdsProxy.client(), times(3)).describeDBClusters(any(DescribeDbClustersRequest.class));
+        verify(rdsProxy.client(), times(1)).removeTagsFromResource(any(RemoveTagsFromResourceRequest.class));
+        verify(rdsProxy.client(), times(1)).addTagsToResource(any(AddTagsToResourceRequest.class));
+
+        Assertions.assertThat(captor.getValue().serverlessV2ScalingConfiguration())
+                .isEqualTo(software.amazon.awssdk.services.rds.model.ServerlessV2ScalingConfiguration.builder()
+                        .maxCapacity(desiredServerlessV2ScalingConfiguration.getMaxCapacity())
+                        .minCapacity(desiredServerlessV2ScalingConfiguration.getMinCapacity())
+                        .build());
     }
 
     static class ModifyDBClusterExceptionArgumentsProvider implements ArgumentsProvider {


### PR DESCRIPTION
This commit adds a new attribute to DBCluter resource definition: `ServerlessV2ScalingConfiguration`. The motivation for this change is to catch up on the existing serverless configuration feature exposed by the SDK and CLI tool.

The teamplate structure is expected in the following format:
```yaml
  ServerlessV2ScalingConfiguration:
    MaxCapacity: <number>
    MinCapacity: <number>
```

The attribute itself is optional.

Documentation:
- https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/aurora-serverless-v2.html
- https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_ServerlessV2ScalingConfiguration.html

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Signed-off-by: Oleg Sidorov <sidorovo@amazon.com>