### PR TITLE
[DBClusterParameterGroup] Add grouping support for DBClusterParameterGroup

### DIFF
--- a/aws-rds-cfn-common/src/main/java/software/amazon/rds/common/test/AbstractTestBase.java
+++ b/aws-rds-cfn-common/src/main/java/software/amazon/rds/common/test/AbstractTestBase.java
@@ -32,7 +32,7 @@ public abstract class AbstractTestBase<ResourceT, ModelT, CallbackT> {
         return UUID.randomUUID().toString();
     }
 
-    protected String randomString(final int length, final String alphabet) {
+    public static String randomString(final int length, final String alphabet) {
         StringBuilder builder = new StringBuilder(length);
         for (int i = 0; i < length; i++) {
             builder.append(alphabet.charAt(random.nextInt(alphabet.length())));

--- a/aws-rds-cfn-common/src/main/java/software/amazon/rds/common/util/ParameterGrouper.java
+++ b/aws-rds-cfn-common/src/main/java/software/amazon/rds/common/util/ParameterGrouper.java
@@ -1,4 +1,4 @@
-package software.amazon.rds.dbparametergroup.util;
+package software.amazon.rds.common.util;
 
 import java.util.ArrayList;
 import java.util.HashMap;

--- a/aws-rds-cfn-common/src/test/java/software/amazon/rds/common/util/ParameterGrouperTest.java
+++ b/aws-rds-cfn-common/src/test/java/software/amazon/rds/common/util/ParameterGrouperTest.java
@@ -1,8 +1,9 @@
-package software.amazon.rds.dbparametergroup.util;
+package software.amazon.rds.common.util;
 
 import com.google.common.collect.ImmutableList;
 import org.junit.jupiter.api.Test;
 import static org.assertj.core.api.Assertions.assertThat;
+import static software.amazon.rds.common.test.AbstractTestBase.ALPHA;
 
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -17,13 +18,9 @@ import java.util.stream.Stream;
 
 import software.amazon.awssdk.services.rds.model.DBParameterGroup;
 import software.amazon.awssdk.services.rds.model.Parameter;
-import software.amazon.cloudformation.proxy.ProgressEvent;
-import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
-import software.amazon.rds.dbparametergroup.CallbackContext;
-import software.amazon.rds.dbparametergroup.ResourceModel;
+import software.amazon.rds.common.test.AbstractTestBase;
 
-
-class ParameterGrouperTest extends software.amazon.rds.common.test.AbstractTestBase<DBParameterGroup, ResourceModel, CallbackContext> {
+class ParameterGrouperTest {
     protected final String NON_PRESENT_DEPENDANT_PARAMETER = "this parameter won't be found";
     protected final int PARAMETER_NAME_LEN = 10;
 
@@ -58,7 +55,7 @@ class ParameterGrouperTest extends software.amazon.rds.common.test.AbstractTestB
     }
 
     private List<String> generateRandomStringList(int listLen, int wordLen, String alphabet) {
-        return Stream.generate(() -> randomString(wordLen, alphabet)).limit(listLen).collect(Collectors.toList());
+        return Stream.generate(() -> AbstractTestBase.randomString(wordLen, alphabet)).limit(listLen).collect(Collectors.toList());
     }
 
     private String[] buildMockExceptionArrayFromExceptionOrder(List<String> randomParameterKeys, List<Integer> expectationOrder) {
@@ -154,20 +151,5 @@ class ParameterGrouperTest extends software.amazon.rds.common.test.AbstractTestB
                         3
                 ), ImmutableList.of(3)
         );
-    }
-
-    @Override
-    protected String getLogicalResourceIdentifier() {
-        return null;
-    }
-
-    @Override
-    protected void expectResourceSupply(Supplier<DBParameterGroup> supplier) {
-
-    }
-
-    @Override
-    protected ProgressEvent<ResourceModel, CallbackContext> invokeHandleRequest(ResourceHandlerRequest<ResourceModel> request, CallbackContext context) {
-        return null;
     }
 }

--- a/aws-rds-dbclusterparametergroup/src/main/java/software/amazon/rds/dbclusterparametergroup/BaseHandlerStd.java
+++ b/aws-rds-dbclusterparametergroup/src/main/java/software/amazon/rds/dbclusterparametergroup/BaseHandlerStd.java
@@ -11,6 +11,8 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import org.apache.commons.lang3.BooleanUtils;
 
 import com.amazonaws.util.StringUtils;
@@ -43,8 +45,16 @@ import software.amazon.rds.common.handler.Tagging;
 import software.amazon.rds.common.logging.LoggingProxyClient;
 import software.amazon.rds.common.logging.RequestLogger;
 import software.amazon.rds.common.printer.FilteredJsonPrinter;
+import software.amazon.rds.common.util.ParameterGrouper;
 
 public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
+    public static final List<Set<String>> DEPENDENCIES = ImmutableList.of(
+            ImmutableSet.of("collation_server", "character_set_server"),
+            ImmutableSet.of("gtid-mode", "enforce_gtid_consistency"),
+            ImmutableSet.of("password_encryption", "rds.accepted_password_auth_method"),
+            ImmutableSet.of("ssl_max_protocol_version", "ssl_min_protocol_version"),
+            ImmutableSet.of("rds.change_data_capture_streaming", "binlog_format")
+    );
     protected static final BiFunction<ResourceModel, ProxyClient<RdsClient>, ResourceModel> EMPTY_CALL = (model, proxyClient) -> model;
     protected static final String AVAILABLE = "available";
     protected static final String RESOURCE_IDENTIFIER = "dbclusterparametergroup";
@@ -289,7 +299,7 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
         final Map<String, Parameter> parametersToModify = getParametersToModify(model.getParameters(), currentDBParameters);
 
         try {
-            for (final List<Parameter> partition : Iterables.partition(parametersToModify.values(), MAX_PARAMETERS_PER_REQUEST)) {
+            for (final List<Parameter> partition : ParameterGrouper.partition(parametersToModify, DEPENDENCIES, MAX_PARAMETERS_PER_REQUEST)) {
                 proxyClient.injectCredentialsAndInvokeV2(
                         Translator.modifyDbClusterParameterGroupRequest(model, partition),
                         proxyClient.client()::modifyDBClusterParameterGroup

--- a/aws-rds-dbparametergroup/src/main/java/software/amazon/rds/dbparametergroup/BaseHandlerStd.java
+++ b/aws-rds-dbparametergroup/src/main/java/software/amazon/rds/dbparametergroup/BaseHandlerStd.java
@@ -34,7 +34,7 @@ import software.amazon.rds.common.handler.Tagging;
 import software.amazon.rds.common.logging.LoggingProxyClient;
 import software.amazon.rds.common.logging.RequestLogger;
 import software.amazon.rds.common.printer.FilteredJsonPrinter;
-import software.amazon.rds.dbparametergroup.util.ParameterGrouper;
+import software.amazon.rds.common.util.ParameterGrouper;
 
 public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
     public static final List<Set<String>> DEPENDENCIES = ImmutableList.of(


### PR DESCRIPTION
This request supersedes #302

This pr duplicate the logic used by DBParameterGroup to group dependent parameters for DBClusterParameterGroup.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
