### PR TITLE
[DBCluster] add dbClusterParameterGroupName to RestoreDbClusterFromSnapshot

### DIFF
--- a/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/Translator.java
+++ b/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/Translator.java
@@ -109,6 +109,7 @@ public class Translator {
                 .databaseName(model.getDatabaseName())
                 .dbClusterIdentifier(model.getDBClusterIdentifier())
                 .dbClusterInstanceClass(model.getDBClusterInstanceClass())
+                .dbClusterParameterGroupName(model.getDBClusterParameterGroupName())
                 .dbSubnetGroupName(model.getDBSubnetGroupName())
                 .deletionProtection(model.getDeletionProtection())
                 .enableCloudwatchLogsExports(model.getEnableCloudwatchLogsExports())


### PR DESCRIPTION
We identified a regression in DBCluster where the dbClusterParameterGroupName was not included as part of the initial RestoreDbClusterFromSnapshot call. This for the most part is fine as the parameter is added in the follow up call to modify the cluster.

This causes a consistency problem that is sometimes enforced by RDS. Like in the case of:  
`lower_case_table_names setting isn't supported for MySQL 8.0 and higher versions`  

Where a customer has taken a snapshot of a cluster with a custom CPG and a custom value for `lower_case_table_names`. Then when they try to restore the cluster with the same custom CPG, the CPG isn't included in the restore call, so the default CPG is used with a different value for `lower_case_table_names`. Throwing the above error.

Adding this code change will ensure consistency across both the restore and follow up modify.