### PR TITLE
[DBInstance] Correcting warning while running tests

### DIFF
--- a/aws-rds-cfn-common/src/test/java/software/amazon/rds/common/test/AbstractTestBaseTest.java
+++ b/aws-rds-cfn-common/src/test/java/software/amazon/rds/common/test/AbstractTestBaseTest.java
@@ -166,7 +166,7 @@ class AbstractTestBaseTest {
         final int length = 16;
         final String alphabet = "abc";
 
-        final String randStr = testBase.randomString(length, alphabet);
+        final String randStr = software.amazon.rds.common.test.AbstractTestBase.randomString(length, alphabet);
         assertThat(randStr.length()).isEqualTo(length);
 
         final String resultAlphabet = randStr.chars()


### PR DESCRIPTION
Attempting to address `static method should be qualified by type name, software.amazon.rds.common.test.AbstractTestBase, instead of by an expression`