### PR TITLE
[DBInstance] Correct CustomIAMInstanceProfile update strategy

### DIFF
--- a/aws-rds-dbinstance/aws-rds-dbinstance.json
+++ b/aws-rds-dbinstance/aws-rds-dbinstance.json
@@ -358,6 +358,7 @@
   },
   "createOnlyProperties": [
     "/properties/CharacterSetName",
+    "/properties/CustomIAMInstanceProfile",
     "/properties/DBClusterIdentifier",
     "/properties/DBInstanceIdentifier",
     "/properties/DBName",

--- a/aws-rds-dbinstance/docs/README.md
+++ b/aws-rds-dbinstance/docs/README.md
@@ -251,7 +251,7 @@ _Required_: No
 
 _Type_: String
 
-_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+_Update requires_: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
 
 #### DBClusterIdentifier
 
@@ -543,7 +543,7 @@ _Required_: No
 
 _Type_: String
 
-_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+_Update requires_: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
 
 #### OptionGroupName
 


### PR DESCRIPTION
Setting CustomIAMInstanceProfile is only supported on creation. This CR addresses oversight in original implementation.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
