### PR TITLE
[DBCluster] Add rds:DescribeGlobalClusters permission

### DIFF
--- a/aws-rds-dbcluster/aws-rds-dbcluster.json
+++ b/aws-rds-dbcluster/aws-rds-dbcluster.json
@@ -391,6 +391,7 @@
         "rds:AddTagsToResource",
         "rds:DescribeDBClusters",
         "rds:DescribeDBSubnetGroups",
+        "rds:DescribeGlobalClusters",
         "rds:ModifyDBCluster",
         "rds:ModifyDBInstance",
         "rds:RemoveFromGlobalCluster",
@@ -404,6 +405,7 @@
         "rds:DeleteDBCluster",
         "rds:DeleteDBInstance",
         "rds:DescribeDBClusters",
+        "rds:DescribeGlobalClusters",
         "rds:RemoveFromGlobalCluster"
       ]
     },

--- a/aws-rds-dbcluster/resource-role.yaml
+++ b/aws-rds-dbcluster/resource-role.yaml
@@ -33,6 +33,7 @@ Resources:
                 - "rds:DeleteDBInstance"
                 - "rds:DescribeDBClusters"
                 - "rds:DescribeDBSubnetGroups"
+                - "rds:DescribeGlobalClusters"
                 - "rds:ModifyDBCluster"
                 - "rds:ModifyDBInstance"
                 - "rds:RemoveFromGlobalCluster"


### PR DESCRIPTION
*Description of changes:*
Add rds:DescribeGlobalClusters permission as we are using this call while stabilzation after removing cluster from GlobalCluster

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
