### PR TITLE
[Common] Split cfn-common and cfn-test-common

### DIFF
--- a/.github/workflows/maven-verify.yml
+++ b/.github/workflows/maven-verify.yml
@@ -26,6 +26,14 @@ jobs:
       run: pip install pre-commit cloudformation-cli cloudformation-cli-java-plugin
     - name: Run pre-commit
       run: pre-commit run --all-files
+    - name: Verify AWS::RDS::Test::Common
+      run: |
+        cd "${GITHUB_WORKSPACE}/aws-rds-cfn-test-common"
+        mvn clean verify --no-transfer-progress
+    - name: Install AWS::RDS::Test::Common
+      run: |
+        cd "${GITHUB_WORKSPACE}/aws-rds-cfn-test-common"
+        mvn clean install --no-transfer-progress
     - name: Verify AWS::RDS::Common
       run: |
         cd "${GITHUB_WORKSPACE}/aws-rds-cfn-common"

--- a/aws-rds-cfn-common/pom.xml
+++ b/aws-rds-cfn-common/pom.xml
@@ -66,18 +66,24 @@
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
             <version>3.22.0</version>
-            <scope>compile</scope>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <version>4.3.1</version>
-            <scope>compile</scope>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-junit-jupiter</artifactId>
             <version>4.3.1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.rds.common</groupId>
+            <artifactId>aws-rds-cfn-test-common</artifactId>
+            <version>1.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/aws-rds-cfn-common/src/main/java/software/amazon/rds/common/annotations/ExcludeFromJacocoGeneratedReport.java
+++ b/aws-rds-cfn-common/src/main/java/software/amazon/rds/common/annotations/ExcludeFromJacocoGeneratedReport.java
@@ -1,4 +1,4 @@
-package software.amazon.rds.common.test;
+package software.amazon.rds.common.annotations;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;

--- a/aws-rds-cfn-common/src/main/java/software/amazon/rds/common/client/RdsUserAgentProvider.java
+++ b/aws-rds-cfn-common/src/main/java/software/amazon/rds/common/client/RdsUserAgentProvider.java
@@ -5,7 +5,7 @@ import java.io.InputStream;
 import java.util.Properties;
 
 import com.amazonaws.util.StringUtils;
-import software.amazon.rds.common.test.ExcludeFromJacocoGeneratedReport;
+import software.amazon.rds.common.annotations.ExcludeFromJacocoGeneratedReport;
 
 public final class RdsUserAgentProvider {
 

--- a/aws-rds-cfn-common/src/main/java/software/amazon/rds/common/util/ParameterGrouper.java
+++ b/aws-rds-cfn-common/src/main/java/software/amazon/rds/common/util/ParameterGrouper.java
@@ -43,10 +43,10 @@ public class ParameterGrouper {
     }
 
     private static void addAsIndependentParam(
-                                               final Map<String, Parameter> params,
-                                               final List<List<Parameter>> paramGroups,
-                                               final Set<String> added,
-                                               final String paramName
+            final Map<String, Parameter> params,
+            final List<List<Parameter>> paramGroups,
+            final Set<String> added,
+            final String paramName
     ) {
         paramGroups.get(0).add(params.get(paramName));
         added.add(paramName);

--- a/aws-rds-cfn-common/src/test/java/software/amazon/rds/common/util/ParameterGrouperTest.java
+++ b/aws-rds-cfn-common/src/test/java/software/amazon/rds/common/util/ParameterGrouperTest.java
@@ -1,9 +1,6 @@
 package software.amazon.rds.common.util;
 
-import com.google.common.collect.ImmutableList;
-import org.junit.jupiter.api.Test;
 import static org.assertj.core.api.Assertions.assertThat;
-import static software.amazon.rds.common.test.AbstractTestBase.ALPHA;
 
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -12,13 +9,14 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import software.amazon.awssdk.services.rds.model.DBParameterGroup;
+import org.junit.jupiter.api.Test;
+
+import com.google.common.collect.ImmutableList;
 import software.amazon.awssdk.services.rds.model.Parameter;
-import software.amazon.rds.common.test.AbstractTestBase;
+import software.amazon.rds.test.common.core.TestUtils;
 
 class ParameterGrouperTest {
     protected final String NON_PRESENT_DEPENDANT_PARAMETER = "this parameter won't be found";
@@ -40,12 +38,12 @@ class ParameterGrouperTest {
         return parametersToUpdate;
     }
 
-    private List<List<Parameter>> setUpExpectedPartition(String [] parameterNames, List<Integer> partitionBreak) {
+    private List<List<Parameter>> setUpExpectedPartition(String[] parameterNames, List<Integer> partitionBreak) {
         List<List<Parameter>> partitions = new ArrayList<>();
         List<Parameter> partition = new ArrayList<>();
-        for (int i = 0; i < parameterNames.length ; i++) {
+        for (int i = 0; i < parameterNames.length; i++) {
             partition.add(constructSimpleParameter(parameterNames[i]));
-            if (partitionBreak.contains(i+1)) {
+            if (partitionBreak.contains(i + 1)) {
                 partitions.add(partition);
                 partition = new ArrayList<>();
             }
@@ -55,7 +53,7 @@ class ParameterGrouperTest {
     }
 
     private List<String> generateRandomStringList(int listLen, int wordLen, String alphabet) {
-        return Stream.generate(() -> AbstractTestBase.randomString(wordLen, alphabet)).limit(listLen).collect(Collectors.toList());
+        return Stream.generate(() -> TestUtils.randomString(wordLen, alphabet)).limit(listLen).collect(Collectors.toList());
     }
 
     private String[] buildMockExceptionArrayFromExceptionOrder(List<String> randomParameterKeys, List<Integer> expectationOrder) {
@@ -84,7 +82,7 @@ class ParameterGrouperTest {
 
     public void test_helper(int partitionSize, List<List<Integer>> dependenciesAsIndexesOfParameters, List<Integer> expectationOrder, List<Integer> expectationPartitions) {
         int listLen = expectationOrder.size();
-        List<String>  randomParameterKeys = generateRandomStringList(listLen, PARAMETER_NAME_LEN, ALPHA);
+        List<String> randomParameterKeys = generateRandomStringList(listLen, PARAMETER_NAME_LEN, TestUtils.ALPHA);
         Map<String, Parameter> parametersToUpdate = setUpParametersToUpdate(randomParameterKeys);
         final List<Set<String>> dependencies = buildMockDependencies(randomParameterKeys,
                 dependenciesAsIndexesOfParameters
@@ -94,7 +92,7 @@ class ParameterGrouperTest {
         List<List<Parameter>> expectedPartitions = setUpExpectedPartition(buildMockExceptionArrayFromExceptionOrder(randomParameterKeys,
                 expectationOrder
         ), expectationPartitions);
-        assertThat(partitions.size()).isEqualTo(expectationPartitions.size()+1);
+        assertThat(partitions.size()).isEqualTo(expectationPartitions.size() + 1);
         assertThat(partitions).isEqualTo(expectedPartitions);
     }
 
@@ -109,11 +107,11 @@ class ParameterGrouperTest {
                         ImmutableList.of(-1)
                 ),
                 ImmutableList.of(
-                        0,2,1,
-                        4,5,8,
-                        3,6,7,
+                        0, 2, 1,
+                        4, 5, 8,
+                        3, 6, 7,
                         9
-                ), ImmutableList.of(3,6,9)
+                ), ImmutableList.of(3, 6, 9)
         );
     }
 
@@ -129,10 +127,10 @@ class ParameterGrouperTest {
                 ),
                 ImmutableList.of(
                         0,
-                        1,2,6,
-                        3,4,
-                        5,7
-                ), ImmutableList.of(1,4,6)
+                        1, 2, 6,
+                        3, 4,
+                        5, 7
+                ), ImmutableList.of(1, 4, 6)
         );
     }
 
@@ -147,7 +145,7 @@ class ParameterGrouperTest {
                         ImmutableList.of(-1)
                 ),
                 ImmutableList.of(
-                        0,1,2,
+                        0, 1, 2,
                         3
                 ), ImmutableList.of(3)
         );

--- a/aws-rds-cfn-test-common/.gitignore
+++ b/aws-rds-cfn-test-common/.gitignore
@@ -1,0 +1,20 @@
+# macOS
+.DS_Store
+._*
+
+# Maven outputs
+.classpath
+
+# IntelliJ
+*.iml
+.idea
+out.java
+out/
+.settings
+.project
+
+# auto-generated files
+target/
+
+# our logs
+rpdk.log

--- a/aws-rds-cfn-test-common/lombok.config
+++ b/aws-rds-cfn-test-common/lombok.config
@@ -1,0 +1,1 @@
+lombok.addLombokGeneratedAnnotation = true

--- a/aws-rds-cfn-test-common/pom.xml
+++ b/aws-rds-cfn-test-common/pom.xml
@@ -1,14 +1,14 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0"?>
 <project
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd"
         xmlns="http://maven.apache.org/POM/4.0.0"
-        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>software.amazon.rds.dbparametergroup</groupId>
-    <artifactId>aws-rds-dbparametergroup-handler</artifactId>
-    <name>aws-rds-dbparametergroup-handler</name>
-    <version>1.0-SNAPSHOT</version>
+    <groupId>software.amazon.rds.common</groupId>
+    <artifactId>aws-rds-cfn-test-common</artifactId>
+    <name>aws-rds-cfn-test-common</name>
+    <version>1.0</version>
     <packaging>jar</packaging>
 
     <properties>
@@ -20,62 +20,49 @@
 
     <dependencies>
         <dependency>
-            <groupId>software.amazon.awssdk</groupId>
-            <artifactId>rds</artifactId>
-            <version>2.17.267</version>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.12.0</version>
         </dependency>
-        <!-- https://mvnrepository.com/artifact/software.amazon.cloudformation/aws-cloudformation-rpdk-java-plugin -->
         <dependency>
             <groupId>software.amazon.cloudformation</groupId>
             <artifactId>aws-cloudformation-rpdk-java-plugin</artifactId>
             <version>[2.0.0,3.0.0)</version>
         </dependency>
-        <!-- https://mvnrepository.com/artifact/org.projectlombok/lombok -->
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <version>1.18.22</version>
             <scope>provided</scope>
         </dependency>
-
-        <!-- https://mvnrepository.com/artifact/org.assertj/assertj-core -->
-        <dependency>
-            <groupId>org.assertj</groupId>
-            <artifactId>assertj-core</artifactId>
-            <version>3.22.0</version>
-            <scope>test</scope>
-        </dependency>
-        <!-- https://mvnrepository.com/artifact/org.junit.jupiter/junit-jupiter -->
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
             <version>5.8.2</version>
             <scope>test</scope>
         </dependency>
-        <!-- https://mvnrepository.com/artifact/org.mockito/mockito-core -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>5.8.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>3.22.0</version>
+            <scope>compile</scope>
+        </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <version>4.3.1</version>
-            <scope>test</scope>
+            <scope>compile</scope>
         </dependency>
-        <!-- https://mvnrepository.com/artifact/org.mockito/mockito-junit-jupiter -->
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-junit-jupiter</artifactId>
             <version>4.3.1</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>software.amazon.rds.common</groupId>
-            <artifactId>aws-rds-cfn-common</artifactId>
-            <version>1.0</version>
-            <scope>compile</scope>
-        </dependency>
-        <dependency>
-            <groupId>software.amazon.rds.common</groupId>
-            <artifactId>aws-rds-cfn-test-common</artifactId>
-            <version>1.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -106,24 +93,17 @@
                         <goals>
                             <goal>shade</goal>
                         </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>exec-maven-plugin</artifactId>
-                <version>1.6.0</version>
-                <executions>
-                    <execution>
-                        <id>generate</id>
-                        <phase>generate-sources</phase>
-                        <goals>
-                            <goal>exec</goal>
-                        </goals>
                         <configuration>
-                            <executable>cfn</executable>
-                            <commandlineArgs>generate</commandlineArgs>
-                            <workingDirectory>${project.basedir}</workingDirectory>
+                            <filters>
+                                <filter>
+                                    <artifact>*:*</artifact>
+                                    <excludes>
+                                        <exclude>META-INF/*.SF</exclude>
+                                        <exclude>META-INF/*.DSA</exclude>
+                                        <exclude>META-INF/*.RSA</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
                         </configuration>
                     </execution>
                 </executions>
@@ -153,6 +133,7 @@
                 <version>2.4</version>
             </plugin>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>3.0.0-M3</version>
             </plugin>
@@ -162,10 +143,6 @@
                 <version>0.8.4</version>
                 <configuration>
                     <excludes>
-                        <exclude>**/BaseConfiguration*</exclude>
-                        <exclude>**/BaseHandler*</exclude>
-                        <exclude>**/HandlerWrapper*</exclude>
-                        <exclude>**/ResourceModel*</exclude>
                     </excludes>
                 </configuration>
                 <executions>
@@ -209,13 +186,5 @@
                 </executions>
             </plugin>
         </plugins>
-        <resources>
-            <resource>
-                <directory>${project.basedir}</directory>
-                <includes>
-                    <include>aws-rds-dbparametergroup.json</include>
-                </includes>
-            </resource>
-        </resources>
     </build>
 </project>

--- a/aws-rds-cfn-test-common/src/main/java/software/amazon/rds/test/common/annotations/ExcludeFromJacocoGeneratedReport.java
+++ b/aws-rds-cfn-test-common/src/main/java/software/amazon/rds/test/common/annotations/ExcludeFromJacocoGeneratedReport.java
@@ -1,0 +1,10 @@
+package software.amazon.rds.test.common.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface ExcludeFromJacocoGeneratedReport {}

--- a/aws-rds-cfn-test-common/src/main/java/software/amazon/rds/test/common/core/AbstractTestBase.java
+++ b/aws-rds-cfn-test-common/src/main/java/software/amazon/rds/test/common/core/AbstractTestBase.java
@@ -1,6 +1,5 @@
-package software.amazon.rds.common.test;
+package software.amazon.rds.test.common.core;
 
-import java.security.SecureRandom;
 import java.util.UUID;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
@@ -15,13 +14,9 @@ import software.amazon.cloudformation.proxy.HandlerErrorCode;
 import software.amazon.cloudformation.proxy.OperationStatus;
 import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
-import software.amazon.rds.common.error.ErrorCode;
+import software.amazon.rds.test.common.annotations.ExcludeFromJacocoGeneratedReport;
 
 public abstract class AbstractTestBase<ResourceT, ModelT, ContextT> {
-
-    final private static SecureRandom random = new SecureRandom();
-    final public static String ALPHA = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
-    final public static String ALPHANUM = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
 
     protected abstract String getLogicalResourceIdentifier();
 
@@ -35,14 +30,6 @@ public abstract class AbstractTestBase<ResourceT, ModelT, ContextT> {
 
     protected String newStackId() {
         return UUID.randomUUID().toString();
-    }
-
-    public static String randomString(final int length, final String alphabet) {
-        StringBuilder builder = new StringBuilder(length);
-        for (int i = 0; i < length; i++) {
-            builder.append(alphabet.charAt(random.nextInt(alphabet.length())));
-        }
-        return builder.toString();
     }
 
     protected Consumer<ProgressEvent<ModelT, ContextT>> expectInProgress(int pause) {
@@ -129,7 +116,7 @@ public abstract class AbstractTestBase<ResourceT, ModelT, ContextT> {
         return response;
     }
 
-    protected static AwsServiceException newAwsServiceException(final ErrorCode errorCode) {
+    protected static AwsServiceException newAwsServiceException(final Object errorCode) {
         return AwsServiceException.builder()
                 .awsErrorDetails(AwsErrorDetails.builder()
                         .errorCode(errorCode.toString())
@@ -164,7 +151,7 @@ public abstract class AbstractTestBase<ResourceT, ModelT, ContextT> {
             final Object requestException,
             final HandlerErrorCode expectErrorCode
     ) {
-        final Exception exception = requestException instanceof ErrorCode ? newAwsServiceException((ErrorCode) requestException) : (Exception) requestException;
+        final Exception exception = requestException instanceof Exception ? (Exception) requestException : newAwsServiceException(requestException);
 
         expectation.setup()
                 .thenThrow(exception);

--- a/aws-rds-cfn-test-common/src/main/java/software/amazon/rds/test/common/core/MethodCallExpectation.java
+++ b/aws-rds-cfn-test-common/src/main/java/software/amazon/rds/test/common/core/MethodCallExpectation.java
@@ -1,4 +1,4 @@
-package software.amazon.rds.common.test;
+package software.amazon.rds.test.common.core;
 
 import org.mockito.ArgumentCaptor;
 import org.mockito.stubbing.OngoingStubbing;

--- a/aws-rds-cfn-test-common/src/main/java/software/amazon/rds/test/common/core/TestUtils.java
+++ b/aws-rds-cfn-test-common/src/main/java/software/amazon/rds/test/common/core/TestUtils.java
@@ -1,0 +1,20 @@
+package software.amazon.rds.test.common.core;
+
+import java.security.SecureRandom;
+
+public final class TestUtils {
+    final private static SecureRandom random = new SecureRandom();
+
+    private TestUtils() {}
+
+    final public static String ALPHA = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+    final public static String ALPHANUM = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+
+    public static String randomString(final int length, final String alphabet) {
+        StringBuilder builder = new StringBuilder(length);
+        for (int i = 0; i < length; i++) {
+            builder.append(alphabet.charAt(random.nextInt(alphabet.length())));
+        }
+        return builder.toString();
+    }
+}

--- a/aws-rds-cfn-test-common/src/test/java/software/amazon/rds/test/common/core/AbstractTestBaseTest.java
+++ b/aws-rds-cfn-test-common/src/test/java/software/amazon/rds/test/common/core/AbstractTestBaseTest.java
@@ -1,18 +1,16 @@
-package software.amazon.rds.common.test;
+package software.amazon.rds.test.common.core;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import software.amazon.cloudformation.proxy.HandlerErrorCode;
@@ -66,7 +64,7 @@ class AbstractTestBaseTest {
         final int pause = 10;
         final Consumer<ProgressEvent<Void, Void>> expectInProgress = testBase.expectInProgress(pause);
         final ProgressEvent<Void, Void> response = ProgressEvent.defaultSuccessHandler(null);
-        assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> expectInProgress.accept(response));
+        Assertions.assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> expectInProgress.accept(response));
     }
 
     @Test
@@ -82,7 +80,7 @@ class AbstractTestBaseTest {
         final TestAbstractTestBase testBase = new TestAbstractTestBase();
         final Consumer<ProgressEvent<Void, Void>> expectSuccess = testBase.expectSuccess();
         final ProgressEvent<Void, Void> response = ProgressEvent.defaultInProgressHandler(null, 0, null);
-        assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> expectSuccess.accept(response));
+        Assertions.assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> expectSuccess.accept(response));
     }
 
     @Test
@@ -98,7 +96,7 @@ class AbstractTestBaseTest {
         final TestAbstractTestBase testBase = new TestAbstractTestBase();
         final Consumer<ProgressEvent<Void, Void>> expectFailed = testBase.expectFailed(HandlerErrorCode.InvalidRequest);
         final ProgressEvent<Void, Void> response = ProgressEvent.defaultSuccessHandler(null);
-        assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> expectFailed.accept(response));
+        Assertions.assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> expectFailed.accept(response));
     }
 
     @Mock
@@ -107,8 +105,8 @@ class AbstractTestBaseTest {
     @Test
     void test_handleRequest_base_ExpectResourceStateInvocation() {
         final TestAbstractTestBase testBase = new TestAbstractTestBase();
-        when(builder.desiredResourceState(any())).thenReturn(null);
-        when(builder.previousResourceState(any())).thenReturn(null);
+        Mockito.when(builder.desiredResourceState(ArgumentMatchers.any())).thenReturn(null);
+        Mockito.when(builder.previousResourceState(ArgumentMatchers.any())).thenReturn(null);
 
         testBase.test_handleRequest_base(
                 null,
@@ -120,14 +118,14 @@ class AbstractTestBaseTest {
                 }
         );
 
-        verify(builder, times(1)).desiredResourceState(any());
-        verify(builder, times(1)).previousResourceState(any());
+        Mockito.verify(builder, Mockito.times(1)).desiredResourceState(ArgumentMatchers.any());
+        Mockito.verify(builder, Mockito.times(1)).previousResourceState(ArgumentMatchers.any());
     }
 
     @Test
     void test_handleRequest_base_ExpectNoPreviousStateInvocation() {
         final TestAbstractTestBase testBase = new TestAbstractTestBase();
-        when(builder.desiredResourceState(any())).thenReturn(null);
+        Mockito.when(builder.desiredResourceState(ArgumentMatchers.any())).thenReturn(null);
 
         testBase.test_handleRequest_base(
                 null,
@@ -139,13 +137,13 @@ class AbstractTestBaseTest {
                 }
         );
 
-        verify(builder, times(1)).desiredResourceState(any());
+        Mockito.verify(builder, Mockito.times(1)).desiredResourceState(ArgumentMatchers.any());
     }
 
     @Test
     void test_handleRequest_base_NoSupplyExpect() {
         final TestAbstractTestBase testBase = new TestAbstractTestBase();
-        when(builder.desiredResourceState(any())).thenReturn(null);
+        Mockito.when(builder.desiredResourceState(ArgumentMatchers.any())).thenReturn(null);
 
         testBase.test_handleRequest_base(
                 null,
@@ -157,23 +155,6 @@ class AbstractTestBaseTest {
                 }
         );
 
-        verify(builder, times(1)).desiredResourceState(any());
-    }
-
-    @Test
-    public void test_randomString() {
-        final TestAbstractTestBase testBase = new TestAbstractTestBase();
-        final int length = 16;
-        final String alphabet = "abc";
-
-        final String randStr = testBase.randomString(length, alphabet);
-        assertThat(randStr.length()).isEqualTo(length);
-
-        final String resultAlphabet = randStr.chars()
-                .distinct()
-                .sorted()
-                .collect(StringBuilder::new, StringBuilder::appendCodePoint, StringBuilder::append)
-                .toString();
-        assertThat(alphabet.contains(resultAlphabet)).isTrue();
+        Mockito.verify(builder, Mockito.times(1)).desiredResourceState(ArgumentMatchers.any());
     }
 }

--- a/aws-rds-cfn-test-common/src/test/java/software/amazon/rds/test/common/core/TestUtilsTest.java
+++ b/aws-rds-cfn-test-common/src/test/java/software/amazon/rds/test/common/core/TestUtilsTest.java
@@ -1,0 +1,23 @@
+package software.amazon.rds.test.common.core;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class TestUtilsTest {
+
+    @Test
+    public void test_randomString() {
+        final int length = 16;
+        final String alphabet = "abc";
+
+        final String randStr = TestUtils.randomString(length, alphabet);
+        Assertions.assertThat(randStr.length()).isEqualTo(length);
+
+        final String resultAlphabet = randStr.chars()
+                .distinct()
+                .sorted()
+                .collect(StringBuilder::new, StringBuilder::appendCodePoint, StringBuilder::append)
+                .toString();
+        Assertions.assertThat(alphabet.contains(resultAlphabet)).isTrue();
+    }
+}

--- a/aws-rds-dbcluster/pom.xml
+++ b/aws-rds-dbcluster/pom.xml
@@ -84,6 +84,12 @@
             <version>1.0</version>
             <scope>compile</scope>
         </dependency>
+        <dependency>
+            <groupId>software.amazon.rds.common</groupId>
+            <artifactId>aws-rds-cfn-test-common</artifactId>
+            <version>1.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/Ec2ClientProvider.java
+++ b/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/Ec2ClientProvider.java
@@ -3,7 +3,7 @@ package software.amazon.rds.dbcluster;
 import software.amazon.awssdk.services.ec2.Ec2Client;
 import software.amazon.awssdk.services.ec2.Ec2ClientBuilder;
 import software.amazon.rds.common.client.BaseSdkClientProvider;
-import software.amazon.rds.common.test.ExcludeFromJacocoGeneratedReport;
+import software.amazon.rds.common.annotations.ExcludeFromJacocoGeneratedReport;
 
 public class Ec2ClientProvider extends BaseSdkClientProvider<Ec2ClientBuilder, Ec2Client> {
 

--- a/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/RdsClientProvider.java
+++ b/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/RdsClientProvider.java
@@ -2,8 +2,8 @@ package software.amazon.rds.dbcluster;
 
 import software.amazon.awssdk.services.rds.RdsClient;
 import software.amazon.awssdk.services.rds.RdsClientBuilder;
+import software.amazon.rds.common.annotations.ExcludeFromJacocoGeneratedReport;
 import software.amazon.rds.common.client.BaseSdkClientProvider;
-import software.amazon.rds.common.test.ExcludeFromJacocoGeneratedReport;
 
 public class RdsClientProvider extends BaseSdkClientProvider<RdsClientBuilder, RdsClient> {
 

--- a/aws-rds-dbcluster/src/test/java/software/amazon/rds/dbcluster/AbstractHandlerTest.java
+++ b/aws-rds-dbcluster/src/test/java/software/amazon/rds/dbcluster/AbstractHandlerTest.java
@@ -41,8 +41,8 @@ import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 import software.amazon.rds.common.handler.Tagging;
-import software.amazon.rds.common.test.AbstractTestBase;
-import software.amazon.rds.common.test.MethodCallExpectation;
+import software.amazon.rds.test.common.core.AbstractTestBase;
+import software.amazon.rds.test.common.core.MethodCallExpectation;
 
 public abstract class AbstractHandlerTest extends AbstractTestBase<DBCluster, ResourceModel, CallbackContext> {
 

--- a/aws-rds-dbcluster/src/test/java/software/amazon/rds/dbcluster/CreateHandlerTest.java
+++ b/aws-rds-dbcluster/src/test/java/software/amazon/rds/dbcluster/CreateHandlerTest.java
@@ -58,6 +58,7 @@ import software.amazon.cloudformation.proxy.delay.Constant;
 import software.amazon.rds.common.error.ErrorCode;
 import software.amazon.rds.common.handler.HandlerConfig;
 import software.amazon.rds.common.handler.Tagging;
+import software.amazon.rds.test.common.core.TestUtils;
 
 @ExtendWith(MockitoExtension.class)
 public class CreateHandlerTest extends AbstractHandlerTest {
@@ -297,7 +298,7 @@ public class CreateHandlerTest extends AbstractHandlerTest {
         final CallbackContext context = new CallbackContext();
         context.setModified(true);
 
-        final String kmsKeyId = randomString(32, ALPHA);
+        final String kmsKeyId = TestUtils.randomString(32, TestUtils.ALPHA);
 
         test_handleRequest_base(
                 context,

--- a/aws-rds-dbcluster/src/test/java/software/amazon/rds/dbcluster/UpdateHandlerTest.java
+++ b/aws-rds-dbcluster/src/test/java/software/amazon/rds/dbcluster/UpdateHandlerTest.java
@@ -66,6 +66,7 @@ import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 import software.amazon.cloudformation.proxy.delay.Constant;
 import software.amazon.rds.common.handler.HandlerConfig;
+import software.amazon.rds.test.common.core.TestUtils;
 
 @ExtendWith(MockitoExtension.class)
 public class UpdateHandlerTest extends AbstractHandlerTest {
@@ -387,7 +388,7 @@ public class UpdateHandlerTest extends AbstractHandlerTest {
 
     @Test
     public void handleRequest_NoMasterUserUpdateIfMatch() {
-        final String masterUserPassword = randomString(16, ALPHANUM);
+        final String masterUserPassword = TestUtils.randomString(16, TestUtils.ALPHANUM);
 
         Queue<DBCluster> transitions = new ConcurrentLinkedQueue<>();
         transitions.add(DBCLUSTER_ACTIVE);
@@ -421,8 +422,8 @@ public class UpdateHandlerTest extends AbstractHandlerTest {
 
     @Test
     public void handleRequest_UpdateMasterUserPasswordIfMismatch() {
-        final String masterUserPassword1 = randomString(16, ALPHANUM);
-        final String masterUserPassword2 = randomString(16, ALPHANUM);
+        final String masterUserPassword1 = TestUtils.randomString(16, TestUtils.ALPHANUM);
+        final String masterUserPassword2 = TestUtils.randomString(16, TestUtils.ALPHANUM);
 
         Assertions.assertNotEquals(masterUserPassword1, masterUserPassword2);
 
@@ -458,7 +459,7 @@ public class UpdateHandlerTest extends AbstractHandlerTest {
 
     @Test
     public void handleRequest_NoEngineVersionUpdateIfMatch() {
-        final String engineVersion = randomString(16, ALPHANUM);
+        final String engineVersion = TestUtils.randomString(16, TestUtils.ALPHANUM);
 
         Queue<DBCluster> transitions = new ConcurrentLinkedQueue<>();
         transitions.add(DBCLUSTER_ACTIVE);
@@ -492,8 +493,8 @@ public class UpdateHandlerTest extends AbstractHandlerTest {
 
     @Test
     public void handleRequest_NoEngineVersionUpdateIfRollback() {
-        final String engineVersion1 = randomString(16, ALPHANUM);
-        final String engineVersion2 = randomString(16, ALPHANUM);
+        final String engineVersion1 = TestUtils.randomString(16, TestUtils.ALPHANUM);
+        final String engineVersion2 = TestUtils.randomString(16, TestUtils.ALPHANUM);
 
         Assertions.assertNotEquals(engineVersion1, engineVersion2);
 
@@ -530,8 +531,8 @@ public class UpdateHandlerTest extends AbstractHandlerTest {
 
     @Test
     public void handleRequest_EngineVersionUpdateIfMismatch() {
-        final String engineVersion1 = randomString(16, ALPHANUM);
-        final String engineVersion2 = randomString(16, ALPHANUM);
+        final String engineVersion1 = TestUtils.randomString(16, TestUtils.ALPHANUM);
+        final String engineVersion2 = TestUtils.randomString(16, TestUtils.ALPHANUM);
 
         Assertions.assertNotEquals(engineVersion1, engineVersion2);
 

--- a/aws-rds-dbclusterendpoint/pom.xml
+++ b/aws-rds-dbclusterendpoint/pom.xml
@@ -79,6 +79,12 @@
             <version>1.0</version>
             <scope>compile</scope>
         </dependency>
+        <dependency>
+            <groupId>software.amazon.rds.common</groupId>
+            <artifactId>aws-rds-cfn-test-common</artifactId>
+            <version>1.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/aws-rds-dbclusterendpoint/src/test/java/software/amazon/rds/dbclusterendpoint/AbstractHandlerTest.java
+++ b/aws-rds-dbclusterendpoint/src/test/java/software/amazon/rds/dbclusterendpoint/AbstractHandlerTest.java
@@ -1,5 +1,16 @@
 package software.amazon.rds.dbclusterendpoint;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import java.time.Duration;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
 import com.google.common.collect.ImmutableSet;
 import software.amazon.awssdk.awscore.AwsRequest;
 import software.amazon.awssdk.awscore.AwsResponse;
@@ -18,18 +29,7 @@ import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 import software.amazon.cloudformation.proxy.delay.Constant;
 import software.amazon.rds.common.handler.Tagging;
-import software.amazon.rds.common.test.AbstractTestBase;
-
-import java.time.Duration;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Set;
-import java.util.concurrent.CompletableFuture;
-import java.util.function.Function;
-import java.util.function.Supplier;
-
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.when;
+import software.amazon.rds.test.common.core.AbstractTestBase;
 
 public abstract class AbstractHandlerTest extends AbstractTestBase<DBClusterEndpoint, ResourceModel, CallbackContext> {
     protected static final LoggerProxy logger;
@@ -81,6 +81,7 @@ public abstract class AbstractHandlerTest extends AbstractTestBase<DBClusterEndp
                         software.amazon.awssdk.services.rds.model.Tag.builder().key("resource-tag-3").value("resource-tag-value3").build()
                 )).build();
     }
+
     protected static final ResourceModel RESOURCE_MODEL;
     protected static final DBClusterEndpoint DB_CLUSTER_ENDPOINT_AVAILABLE;
     protected static final DBClusterEndpoint DB_CLUSTER_ENDPOINT_CREATING;

--- a/aws-rds-dbclusterparametergroup/pom.xml
+++ b/aws-rds-dbclusterparametergroup/pom.xml
@@ -79,6 +79,12 @@
             <version>1.0</version>
             <scope>compile</scope>
         </dependency>
+        <dependency>
+            <groupId>software.amazon.rds.common</groupId>
+            <artifactId>aws-rds-cfn-test-common</artifactId>
+            <version>1.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/aws-rds-dbinstance/pom.xml
+++ b/aws-rds-dbinstance/pom.xml
@@ -81,6 +81,12 @@
             <version>4.3.1</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>software.amazon.rds.common</groupId>
+            <artifactId>aws-rds-cfn-test-common</artifactId>
+            <version>1.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/AbstractHandlerTest.java
+++ b/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/AbstractHandlerTest.java
@@ -41,10 +41,10 @@ import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 import software.amazon.cloudformation.proxy.delay.Constant;
 import software.amazon.rds.common.handler.Tagging;
-import software.amazon.rds.common.test.AbstractTestBase;
-import software.amazon.rds.common.test.MethodCallExpectation;
 import software.amazon.rds.dbinstance.client.ApiVersion;
 import software.amazon.rds.dbinstance.client.VersionedProxyClient;
+import software.amazon.rds.test.common.core.AbstractTestBase;
+import software.amazon.rds.test.common.core.MethodCallExpectation;
 
 public abstract class AbstractHandlerTest extends AbstractTestBase<DBInstance, ResourceModel, CallbackContext> {
 

--- a/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/DeleteHandlerTest.java
+++ b/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/DeleteHandlerTest.java
@@ -42,6 +42,7 @@ import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 import software.amazon.rds.common.error.ErrorCode;
 import software.amazon.rds.common.handler.HandlerConfig;
+import software.amazon.rds.test.common.core.TestUtils;
 
 @ExtendWith(MockitoExtension.class)
 public class DeleteHandlerTest extends AbstractHandlerTest {
@@ -225,7 +226,7 @@ public class DeleteHandlerTest extends AbstractHandlerTest {
         final DeleteDbInstanceResponse deleteDbInstanceResponse = DeleteDbInstanceResponse.builder().build();
         when(rdsProxy.client().deleteDBInstance(any(DeleteDbInstanceRequest.class))).thenReturn(deleteDbInstanceResponse);
 
-        final String dbClusterIdentifier = randomString(64, ALPHA);
+        final String dbClusterIdentifier = TestUtils.randomString(64, TestUtils.ALPHA);
 
         final ProgressEvent<ResourceModel, CallbackContext> response = test_handleRequest_base(
                 new CallbackContext(),
@@ -251,7 +252,7 @@ public class DeleteHandlerTest extends AbstractHandlerTest {
         final DeleteDbInstanceResponse deleteDbInstanceResponse = DeleteDbInstanceResponse.builder().build();
         when(rdsProxy.client().deleteDBInstance(any(DeleteDbInstanceRequest.class))).thenReturn(deleteDbInstanceResponse);
 
-        final String sourceDBInstanceIdentifier = randomString(64, ALPHA);
+        final String sourceDBInstanceIdentifier = TestUtils.randomString(64, TestUtils.ALPHA);
 
         final ProgressEvent<ResourceModel, CallbackContext> response = test_handleRequest_base(
                 new CallbackContext(),

--- a/aws-rds-dbsubnetgroup/pom.xml
+++ b/aws-rds-dbsubnetgroup/pom.xml
@@ -72,6 +72,12 @@
             <version>1.0</version>
             <scope>compile</scope>
         </dependency>
+        <dependency>
+            <groupId>software.amazon.rds.common</groupId>
+            <artifactId>aws-rds-cfn-test-common</artifactId>
+            <version>1.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/aws-rds-eventsubscription/pom.xml
+++ b/aws-rds-eventsubscription/pom.xml
@@ -72,6 +72,12 @@
             <version>4.3.1</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>software.amazon.rds.common</groupId>
+            <artifactId>aws-rds-cfn-test-common</artifactId>
+            <version>1.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/aws-rds-optiongroup/pom.xml
+++ b/aws-rds-optiongroup/pom.xml
@@ -72,6 +72,12 @@
             <version>1.0</version>
             <scope>compile</scope>
         </dependency>
+        <dependency>
+            <groupId>software.amazon.rds.common</groupId>
+            <artifactId>aws-rds-cfn-test-common</artifactId>
+            <version>1.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/aws-rds-optiongroup/src/test/java/software/amazon/rds/optiongroup/AbstractTestBase.java
+++ b/aws-rds-optiongroup/src/test/java/software/amazon/rds/optiongroup/AbstractTestBase.java
@@ -29,7 +29,7 @@ import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 import software.amazon.cloudformation.proxy.delay.Constant;
 import software.amazon.rds.common.handler.Tagging;
 
-public abstract class AbstractTestBase extends software.amazon.rds.common.test.AbstractTestBase<OptionGroup, ResourceModel, CallbackContext> {
+public abstract class AbstractTestBase extends software.amazon.rds.test.common.core.AbstractTestBase<OptionGroup, ResourceModel, CallbackContext> {
 
     protected final String IGNORE_TEST_VERIFICATION= "IgnoreTestVerification";
 

--- a/aws-rds-optiongroup/src/test/java/software/amazon/rds/optiongroup/CreateHandlerTest.java
+++ b/aws-rds-optiongroup/src/test/java/software/amazon/rds/optiongroup/CreateHandlerTest.java
@@ -46,6 +46,7 @@ import software.amazon.cloudformation.proxy.OperationStatus;
 import software.amazon.rds.common.error.ErrorCode;
 import software.amazon.rds.common.handler.HandlerConfig;
 import software.amazon.rds.common.handler.Tagging;
+import software.amazon.rds.test.common.core.TestUtils;
 
 @ExtendWith(MockitoExtension.class)
 public class CreateHandlerTest extends AbstractTestBase {
@@ -101,10 +102,10 @@ public class CreateHandlerTest extends AbstractTestBase {
                 .thenReturn(ListTagsForResourceResponse.builder().build());
 
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
-                .clientRequestToken(randomString(32, ALPHA))
+                .clientRequestToken(TestUtils.randomString(32, TestUtils.ALPHA))
                 .desiredResourceState(RESOURCE_MODEL)
-                .stackId(randomString(32, ALPHA))
-                .logicalResourceIdentifier(randomString(32, ALPHA))
+                .stackId(TestUtils.randomString(32, TestUtils.ALPHA))
+                .logicalResourceIdentifier(TestUtils.randomString(32, TestUtils.ALPHA))
                 .build();
         final ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);
 
@@ -127,10 +128,10 @@ public class CreateHandlerTest extends AbstractTestBase {
         ResourceModel RESOURCE_MODEL_WITH_NAME = RESOURCE_MODEL_WITH_NAME_BUILDER().build();
 
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
-                .clientRequestToken(randomString(32, ALPHA))
+                .clientRequestToken(TestUtils.randomString(32, TestUtils.ALPHA))
                 .desiredResourceState(RESOURCE_MODEL_WITH_NAME)
-                .stackId(randomString(32, ALPHA))
-                .logicalResourceIdentifier(randomString(32, ALPHA))
+                .stackId(TestUtils.randomString(32, TestUtils.ALPHA))
+                .logicalResourceIdentifier(TestUtils.randomString(32, TestUtils.ALPHA))
                 .build();
         final ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);
 
@@ -163,10 +164,10 @@ public class CreateHandlerTest extends AbstractTestBase {
                 .thenReturn(ListTagsForResourceResponse.builder().build());
 
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
-                .clientRequestToken(randomString(32, ALPHA))
+                .clientRequestToken(TestUtils.randomString(32, TestUtils.ALPHA))
                 .desiredResourceState(RESOURCE_MODEL_WITH_CONFIGURATIONS)
-                .stackId(randomString(32, ALPHA))
-                .logicalResourceIdentifier(randomString(32, ALPHA))
+                .stackId(TestUtils.randomString(32, TestUtils.ALPHA))
+                .logicalResourceIdentifier(TestUtils.randomString(32, TestUtils.ALPHA))
                 .build();
         final ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);
 
@@ -217,12 +218,12 @@ public class CreateHandlerTest extends AbstractTestBase {
                 .thenReturn(ListTagsForResourceResponse.builder().build());
 
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
-                .clientRequestToken(randomString(32, ALPHA))
+                .clientRequestToken(TestUtils.randomString(32, TestUtils.ALPHA))
                 .systemTags(Translator.translateTagsToRequest(Translator.translateTagsFromSdk(desiredTags.getSystemTags())))
                 .desiredResourceTags(Translator.translateTagsToRequest(Translator.translateTagsFromSdk(desiredTags.getStackTags())))
                 .desiredResourceState(RESOURCE_MODEL)
-                .stackId(randomString(32, ALPHA))
-                .logicalResourceIdentifier(randomString(32, ALPHA))
+                .stackId(TestUtils.randomString(32, TestUtils.ALPHA))
+                .logicalResourceIdentifier(TestUtils.randomString(32, TestUtils.ALPHA))
                 .build();
         final ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);
 
@@ -288,11 +289,11 @@ public class CreateHandlerTest extends AbstractTestBase {
                                 ).build());
 
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
-                .clientRequestToken(randomString(32, ALPHA))
+                .clientRequestToken(TestUtils.randomString(32, TestUtils.ALPHA))
                 .systemTags(Translator.translateTagsToRequest(Translator.translateTagsFromSdk(TAG_SET.getSystemTags())))
                 .desiredResourceState(RESOURCE_MODEL_WITH_RESOURCE_TAGS)
-                .stackId(randomString(32, ALPHA))
-                .logicalResourceIdentifier(randomString(32, ALPHA))
+                .stackId(TestUtils.randomString(32, TestUtils.ALPHA))
+                .logicalResourceIdentifier(TestUtils.randomString(32, TestUtils.ALPHA))
                 .build();
         final ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);
 
@@ -340,11 +341,11 @@ public class CreateHandlerTest extends AbstractTestBase {
                 .thenReturn(ListTagsForResourceResponse.builder().build());
 
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
-                .clientRequestToken(randomString(32, ALPHA))
+                .clientRequestToken(TestUtils.randomString(32, TestUtils.ALPHA))
                 .systemTags(Translator.translateTagsToRequest(Translator.translateTagsFromSdk(TAG_SET.getSystemTags())))
                 .desiredResourceState(RESOURCE_MODEL)
-                .stackId(randomString(32, ALPHA))
-                .logicalResourceIdentifier(randomString(32, ALPHA))
+                .stackId(TestUtils.randomString(32, TestUtils.ALPHA))
+                .logicalResourceIdentifier(TestUtils.randomString(32, TestUtils.ALPHA))
                 .build();
         final ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);
 
@@ -368,11 +369,11 @@ public class CreateHandlerTest extends AbstractTestBase {
                 .thenThrow(new RuntimeException("test exception"));
 
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
-                .clientRequestToken(randomString(32, ALPHA))
+                .clientRequestToken(TestUtils.randomString(32, TestUtils.ALPHA))
                 .systemTags(Translator.translateTagsToRequest(Translator.translateTagsFromSdk(TAG_SET.getSystemTags())))
                 .desiredResourceState(RESOURCE_MODEL)
-                .stackId(randomString(32, ALPHA))
-                .logicalResourceIdentifier(randomString(32, ALPHA))
+                .stackId(TestUtils.randomString(32, TestUtils.ALPHA))
+                .logicalResourceIdentifier(TestUtils.randomString(32, TestUtils.ALPHA))
                 .build();
         final ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);
 

--- a/aws-rds-optiongroup/src/test/java/software/amazon/rds/optiongroup/UpdateHandlerTest.java
+++ b/aws-rds-optiongroup/src/test/java/software/amazon/rds/optiongroup/UpdateHandlerTest.java
@@ -31,6 +31,7 @@ import software.amazon.awssdk.services.rds.model.Tag;
 import software.amazon.cloudformation.proxy.*;
 import software.amazon.rds.common.error.ErrorCode;
 import software.amazon.rds.common.handler.HandlerConfig;
+import software.amazon.rds.test.common.core.TestUtils;
 
 @ExtendWith(MockitoExtension.class)
 public class UpdateHandlerTest extends AbstractTestBase {
@@ -85,11 +86,11 @@ public class UpdateHandlerTest extends AbstractTestBase {
         when(proxyClient.client().describeOptionGroups(any(DescribeOptionGroupsRequest.class))).thenReturn(describeDbClusterParameterGroupsResponse);
 
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
-                .clientRequestToken(randomString(32, ALPHA))
+                .clientRequestToken(TestUtils.randomString(32, TestUtils.ALPHA))
                 .previousResourceState(RESOURCE_MODEL_WITH_CONFIGURATIONS)
                 .desiredResourceState(RESOURCE_MODEL_WITH_UPDATED_CONFIGURATIONS)
-                .stackId(randomString(32, ALPHA))
-                .logicalResourceIdentifier(randomString(32, ALPHA))
+                .stackId(TestUtils.randomString(32, TestUtils.ALPHA))
+                .logicalResourceIdentifier(TestUtils.randomString(32, TestUtils.ALPHA))
                 .build();
         final ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);
 
@@ -131,11 +132,11 @@ public class UpdateHandlerTest extends AbstractTestBase {
         when(proxyClient.client().describeOptionGroups(any(DescribeOptionGroupsRequest.class))).thenReturn(describeDbClusterParameterGroupsResponse);
 
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
-                .clientRequestToken(randomString(32, ALPHA))
+                .clientRequestToken(TestUtils.randomString(32, TestUtils.ALPHA))
                 .previousResourceState(RESOURCE_MODEL_WITH_CONFIGURATIONS)
                 .desiredResourceState(RESOURCE_MODEL_WITH_UPDATED_CONFIGURATIONS)
-                .stackId(randomString(32, ALPHA))
-                .logicalResourceIdentifier(randomString(32, ALPHA))
+                .stackId(TestUtils.randomString(32, TestUtils.ALPHA))
+                .logicalResourceIdentifier(TestUtils.randomString(32, TestUtils.ALPHA))
                 .build();
         final ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);
 
@@ -174,11 +175,11 @@ public class UpdateHandlerTest extends AbstractTestBase {
                 .thenReturn(AddTagsToResourceResponse.builder().build());
 
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
-                .clientRequestToken(randomString(32, ALPHA))
+                .clientRequestToken(TestUtils.randomString(32, TestUtils.ALPHA))
                 .previousResourceState(RESOURCE_MODEL_WITH_RESOURCE_TAGS)
                 .desiredResourceState(RESOURCE_MODEL_WITH_UPDATED_RESOURCE_TAGS)
-                .stackId(randomString(32, ALPHA))
-                .logicalResourceIdentifier(randomString(32, ALPHA))
+                .stackId(TestUtils.randomString(32, TestUtils.ALPHA))
+                .logicalResourceIdentifier(TestUtils.randomString(32, TestUtils.ALPHA))
                 .build();
         final ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);
 
@@ -234,13 +235,13 @@ public class UpdateHandlerTest extends AbstractTestBase {
                                 ).build());
 
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
-                .clientRequestToken(randomString(32, ALPHA))
+                .clientRequestToken(TestUtils.randomString(32, TestUtils.ALPHA))
                 .previousResourceTags(previousResourceTags)
                 .desiredResourceTags(desiredResourceTags)
                 .previousResourceState(RESOURCE_MODEL_WITH_NAME)
                 .desiredResourceState(RESOURCE_MODEL_WITH_NAME)
-                .stackId(randomString(32, ALPHA))
-                .logicalResourceIdentifier(randomString(32, ALPHA))
+                .stackId(TestUtils.randomString(32, TestUtils.ALPHA))
+                .logicalResourceIdentifier(TestUtils.randomString(32, TestUtils.ALPHA))
                 .build();
         final ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);
 
@@ -293,11 +294,11 @@ public class UpdateHandlerTest extends AbstractTestBase {
                                 ).build());
 
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
-                .clientRequestToken(randomString(32, ALPHA))
+                .clientRequestToken(TestUtils.randomString(32, TestUtils.ALPHA))
                 .previousResourceState(RESOURCE_MODEL_WITH_NAME)
                 .desiredResourceState(RESOURCE_MODEL_WITH_RESOURCE_TAGS)
-                .stackId(randomString(32, ALPHA))
-                .logicalResourceIdentifier(randomString(32, ALPHA))
+                .stackId(TestUtils.randomString(32, TestUtils.ALPHA))
+                .logicalResourceIdentifier(TestUtils.randomString(32, TestUtils.ALPHA))
                 .build();
         final ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);
 
@@ -338,11 +339,11 @@ public class UpdateHandlerTest extends AbstractTestBase {
                 .thenReturn(describeDbClusterParameterGroupsResponse);
 
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
-                .clientRequestToken(randomString(32, ALPHA))
+                .clientRequestToken(TestUtils.randomString(32, TestUtils.ALPHA))
                 .previousResourceState(previousModel)
                 .desiredResourceState(desiredModel)
-                .stackId(randomString(32, ALPHA))
-                .logicalResourceIdentifier(randomString(32, ALPHA))
+                .stackId(TestUtils.randomString(32, TestUtils.ALPHA))
+                .logicalResourceIdentifier(TestUtils.randomString(32, TestUtils.ALPHA))
                 .build();
         final ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);
 
@@ -384,11 +385,11 @@ public class UpdateHandlerTest extends AbstractTestBase {
                 .thenReturn(describeDbClusterParameterGroupsResponse);
 
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
-                .clientRequestToken(randomString(32, ALPHA))
+                .clientRequestToken(TestUtils.randomString(32, TestUtils.ALPHA))
                 .previousResourceState(previousModel)
                 .desiredResourceState(desiredModel)
-                .stackId(randomString(32, ALPHA))
-                .logicalResourceIdentifier(randomString(32, ALPHA))
+                .stackId(TestUtils.randomString(32, TestUtils.ALPHA))
+                .logicalResourceIdentifier(TestUtils.randomString(32, TestUtils.ALPHA))
                 .build();
         final ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);
 
@@ -432,11 +433,11 @@ public class UpdateHandlerTest extends AbstractTestBase {
                 .thenReturn(describeDbClusterParameterGroupsResponse);
 
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
-                .clientRequestToken(randomString(32, ALPHA))
+                .clientRequestToken(TestUtils.randomString(32, TestUtils.ALPHA))
                 .previousResourceState(previousModel)
                 .desiredResourceState(desiredModel)
-                .stackId(randomString(32, ALPHA))
-                .logicalResourceIdentifier(randomString(32, ALPHA))
+                .stackId(TestUtils.randomString(32, TestUtils.ALPHA))
+                .logicalResourceIdentifier(TestUtils.randomString(32, TestUtils.ALPHA))
                 .build();
         final ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);
 
@@ -463,11 +464,11 @@ public class UpdateHandlerTest extends AbstractTestBase {
                 .thenThrow(OptionGroupNotFoundException.builder().message(MSG_NOT_FOUND_ERR).build());
 
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
-                .clientRequestToken(randomString(32, ALPHA))
+                .clientRequestToken(TestUtils.randomString(32, TestUtils.ALPHA))
                 .previousResourceState(previousModel)
                 .desiredResourceState(RESOURCE_MODEL_WITH_CONFIGURATIONS)
-                .stackId(randomString(32, ALPHA))
-                .logicalResourceIdentifier(randomString(32, ALPHA))
+                .stackId(TestUtils.randomString(32, TestUtils.ALPHA))
+                .logicalResourceIdentifier(TestUtils.randomString(32, TestUtils.ALPHA))
                 .build();
         final ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);
 
@@ -493,11 +494,11 @@ public class UpdateHandlerTest extends AbstractTestBase {
                 .thenThrow(new RuntimeException("test exception"));
 
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
-                .clientRequestToken(randomString(32, ALPHA))
+                .clientRequestToken(TestUtils.randomString(32, TestUtils.ALPHA))
                 .previousResourceState(previousModel)
                 .desiredResourceState(RESOURCE_MODEL_WITH_CONFIGURATIONS)
-                .stackId(randomString(32, ALPHA))
-                .logicalResourceIdentifier(randomString(32, ALPHA))
+                .stackId(TestUtils.randomString(32, TestUtils.ALPHA))
+                .logicalResourceIdentifier(TestUtils.randomString(32, TestUtils.ALPHA))
                 .build();
         final ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);
 

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
-                             http://maven.apache.org/maven-v4_0_0.xsd">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0                              http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>software.amazon.rds</groupId>
@@ -11,6 +9,7 @@
     <name>The CloudFormation Resource Provider Package For Amazon Relational Database Service</name>
 
     <modules>
+        <module>aws-rds-cfn-test-common</module>
         <module>aws-rds-cfn-common</module>
         <module>aws-rds-dbcluster</module>
         <module>aws-rds-dbclusterparametergroup</module>


### PR DESCRIPTION
This commit splits up `aws-rds-cfn-common` package in 2.

The test helper suite is moved to a new package called `aws-rds-cfn-test-common`. The motivation for this change is to break down the common dependencies into compile and test scopes. The old approach forced us to include test dependencies into the compile scope, it is eliminated with this commit.

This PR superseeds https://github.com/aws-cloudformation/aws-cloudformation-resource-providers-rds/pull/308.

Signed-off-by: Oleg Sidorov <sidorovo@amazon.com>