### PR TITLE
[TestCommon] Implement access permission verifier

### DIFF
--- a/aws-rds-cfn-test-common/src/main/java/software/amazon/rds/test/common/annotations/ExcludeFromJacocoGeneratedReport.java
+++ b/aws-rds-cfn-test-common/src/main/java/software/amazon/rds/test/common/annotations/ExcludeFromJacocoGeneratedReport.java
@@ -6,5 +6,5 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 @Retention(RetentionPolicy.RUNTIME)
-@Target(ElementType.METHOD)
+@Target({ElementType.METHOD, ElementType.TYPE})
 public @interface ExcludeFromJacocoGeneratedReport {}

--- a/aws-rds-cfn-test-common/src/main/java/software/amazon/rds/test/common/core/HandlerName.java
+++ b/aws-rds-cfn-test-common/src/main/java/software/amazon/rds/test/common/core/HandlerName.java
@@ -1,0 +1,23 @@
+package software.amazon.rds.test.common.core;
+
+import software.amazon.rds.test.common.annotations.ExcludeFromJacocoGeneratedReport;
+
+@ExcludeFromJacocoGeneratedReport
+public enum HandlerName {
+    LIST("list"),
+    READ("read"),
+    CREATE("create"),
+    UPDATE("update"),
+    DELETE("delete");
+
+    private final String name;
+
+    private HandlerName(final String name) {
+        this.name = name;
+    }
+
+    @Override
+    public String toString() {
+        return this.name;
+    }
+}

--- a/aws-rds-cfn-test-common/src/main/java/software/amazon/rds/test/common/core/ServiceProvider.java
+++ b/aws-rds-cfn-test-common/src/main/java/software/amazon/rds/test/common/core/ServiceProvider.java
@@ -1,0 +1,49 @@
+package software.amazon.rds.test.common.core;
+
+import java.util.Map;
+
+import com.google.common.collect.ImmutableMap;
+
+public enum ServiceProvider {
+    EC2("ec2"),
+    IAM("iam"),
+    KMS("kms"),
+    RDS("rds"),
+    SDK("sdk");
+
+    private final String name;
+
+    private ServiceProvider(final String name) {
+        this.name = name;
+    }
+
+    @Override
+    public String toString() {
+        return this.name;
+    }
+
+    private static final Map<String, ServiceProvider> SERVICE_CLIENT_CLASSES = ImmutableMap.of(
+            "Ec2Client", EC2,
+            "IamClient", IAM,
+            "KmsClient", KMS,
+            "RdsClient", RDS,
+            "SdkClient", SDK
+    );
+
+    public static ServiceProvider fromString(final String s) {
+        for (final ServiceProvider provider : ServiceProvider.values()) {
+            if (provider.name.equals(s)) {
+                return provider;
+            }
+        }
+        throw new RuntimeException(String.format("Unknown service provider: \"%s\"", s));
+    }
+
+    public static ServiceProvider fromClientClass(final Class<?> clientClass) {
+        final String className = clientClass.getSimpleName();
+        if (!SERVICE_CLIENT_CLASSES.containsKey(className)) {
+            throw new RuntimeException(String.format("Service provider mapping is missing for class \"%s\"", className));
+        }
+        return SERVICE_CLIENT_CLASSES.get(className);
+    }
+}

--- a/aws-rds-cfn-test-common/src/main/java/software/amazon/rds/test/common/core/TestUtils.java
+++ b/aws-rds-cfn-test-common/src/main/java/software/amazon/rds/test/common/core/TestUtils.java
@@ -2,6 +2,10 @@ package software.amazon.rds.test.common.core;
 
 import java.security.SecureRandom;
 
+import org.mockito.internal.util.MockUtil;
+import org.mockito.internal.verification.VerificationDataImpl;
+import org.mockito.internal.verification.api.VerificationData;
+
 public final class TestUtils {
     final private static SecureRandom random = new SecureRandom();
 
@@ -16,5 +20,9 @@ public final class TestUtils {
             builder.append(alphabet.charAt(random.nextInt(alphabet.length())));
         }
         return builder.toString();
+    }
+
+    public static VerificationData getVerificationData(final Object mock) {
+        return new VerificationDataImpl(MockUtil.getInvocationContainer(mock), null);
     }
 }

--- a/aws-rds-cfn-test-common/src/main/java/software/amazon/rds/test/common/verification/AccessPermission.java
+++ b/aws-rds-cfn-test-common/src/main/java/software/amazon/rds/test/common/verification/AccessPermission.java
@@ -1,0 +1,17 @@
+package software.amazon.rds.test.common.verification;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import software.amazon.rds.test.common.core.ServiceProvider;
+
+@Data
+@AllArgsConstructor
+public class AccessPermission {
+    private ServiceProvider serviceProvider;
+    private String methodName;
+
+    @Override
+    public String toString() {
+        return String.format("%s:%s", serviceProvider.toString(), methodName);
+    }
+}

--- a/aws-rds-cfn-test-common/src/main/java/software/amazon/rds/test/common/verification/AccessPermissionFactory.java
+++ b/aws-rds-cfn-test-common/src/main/java/software/amazon/rds/test/common/verification/AccessPermissionFactory.java
@@ -1,0 +1,28 @@
+package software.amazon.rds.test.common.verification;
+
+import java.lang.reflect.Method;
+
+import org.mockito.invocation.Invocation;
+
+import lombok.NonNull;
+import software.amazon.rds.test.common.core.ServiceProvider;
+
+public class AccessPermissionFactory {
+
+    public static AccessPermission fromString(final String s) {
+        final String[] chunks = s.split(":", 2);
+        return new AccessPermission(ServiceProvider.fromString(chunks[0]), chunks[1]);
+    }
+
+    public static AccessPermission fromInvocation(final Invocation invocation) {
+        final Method method = invocation.getMethod();
+        return new AccessPermission(
+                ServiceProvider.fromClientClass(method.getDeclaringClass()),
+                conformMethodName(method.getName())
+        );
+    }
+
+    private static String conformMethodName(@NonNull final String methodName) {
+        return methodName.substring(0, 1).toUpperCase() + methodName.substring(1);
+    }
+}

--- a/aws-rds-cfn-test-common/src/main/java/software/amazon/rds/test/common/verification/AccessPermissionVerificationMode.java
+++ b/aws-rds-cfn-test-common/src/main/java/software/amazon/rds/test/common/verification/AccessPermissionVerificationMode.java
@@ -1,0 +1,69 @@
+package software.amazon.rds.test.common.verification;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.mockito.exceptions.base.MockitoAssertionError;
+import org.mockito.internal.verification.api.VerificationData;
+import org.mockito.invocation.Invocation;
+import org.mockito.verification.VerificationMode;
+
+import software.amazon.rds.test.common.annotations.ExcludeFromJacocoGeneratedReport;
+import software.amazon.rds.test.common.core.HandlerName;
+import software.amazon.rds.test.common.core.ServiceProvider;
+
+public class AccessPermissionVerificationMode implements VerificationMode {
+
+    private final Set<AccessPermission> permissions;
+
+    public AccessPermissionVerificationMode() {
+        this.permissions = new HashSet<>();
+    }
+
+    public AccessPermissionVerificationMode enablePermission(final AccessPermission permission) {
+        this.permissions.add(permission);
+        return this;
+    }
+
+    @ExcludeFromJacocoGeneratedReport
+    public AccessPermissionVerificationMode withDefaultPermissions() {
+        this.permissions.add(new AccessPermission(ServiceProvider.SDK, "ServiceName"));
+        return this;
+    }
+
+    @ExcludeFromJacocoGeneratedReport
+    public AccessPermissionVerificationMode withSchemaPermissions(final JSONObject schema, final HandlerName handlerName) {
+        final JSONArray schemaPermissions = schema.getJSONObject("handlers")
+                .getJSONObject(handlerName.toString())
+                .getJSONArray("permissions");
+
+        for (final Object permissionHandle : schemaPermissions) {
+            final AccessPermission permission = AccessPermissionFactory.fromString((String) permissionHandle);
+            this.enablePermission(permission);
+        }
+
+        return this;
+    }
+
+    private MockitoAssertionError missingRequiredPermission(final AccessPermission permission) {
+        return new MockitoAssertionError(String.format("Missing a required access permission: %s", permission));
+    }
+
+    private void verifyInvocationPermissions(final Invocation invocation) {
+        final AccessPermission requiredPermission = AccessPermissionFactory.fromInvocation(invocation);
+        if (!permissions.contains(requiredPermission)) {
+            throw missingRequiredPermission(requiredPermission);
+        }
+    }
+
+    @Override
+    public void verify(final VerificationData data) {
+        final List<Invocation> invocations = data.getAllInvocations();
+        for (final Invocation invocation : invocations) {
+            verifyInvocationPermissions(invocation);
+        }
+    }
+}

--- a/aws-rds-cfn-test-common/src/test/java/software/amazon/rds/test/common/core/ServiceProviderTest.java
+++ b/aws-rds-cfn-test-common/src/test/java/software/amazon/rds/test/common/core/ServiceProviderTest.java
@@ -1,0 +1,35 @@
+package software.amazon.rds.test.common.core;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class ServiceProviderTest {
+
+    @Test
+    public void test_fromString_Success() {
+        for (final ServiceProvider serviceProvider: ServiceProvider.values()) {
+            Assertions.assertThat(ServiceProvider.fromString(serviceProvider.toString())).isEqualTo(serviceProvider);
+        }
+    }
+
+    @Test
+    public void test_fromString_NonExistingThrowsRuntimeError() {
+        Assertions.assertThatThrownBy(() -> {
+            ServiceProvider.fromString("non-existing-provider");
+        }).isInstanceOf(RuntimeException.class);
+    }
+
+    @Test
+    public void test_fromClientClass_Success() {
+        class RdsClient {}
+        Assertions.assertThat(ServiceProvider.fromClientClass(RdsClient.class)).isEqualTo(ServiceProvider.RDS);
+    }
+
+    @Test
+    public void test_fromClientClass_NonExistingThrowsRuntimeException() {
+        class NonExistingClient {}
+        Assertions.assertThatThrownBy(() -> {
+            ServiceProvider.fromClientClass(NonExistingClient.class);
+        }).isInstanceOf(RuntimeException.class);
+    }
+}

--- a/aws-rds-cfn-test-common/src/test/java/software/amazon/rds/test/common/verification/AccessPermissionVerificationModeTest.java
+++ b/aws-rds-cfn-test-common/src/test/java/software/amazon/rds/test/common/verification/AccessPermissionVerificationModeTest.java
@@ -1,0 +1,44 @@
+package software.amazon.rds.test.common.verification;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.mockito.exceptions.base.MockitoAssertionError;
+import org.mockito.internal.util.MockUtil;
+import org.mockito.internal.verification.VerificationDataImpl;
+
+import software.amazon.rds.test.common.core.ServiceProvider;
+
+class AccessPermissionVerificationModeTest {
+
+    // A hack to pretend we're passing a known ServiceProvider to the FASPermission constructor.
+    static class RdsClient {
+        public void testMethod() {
+        }
+    }
+
+    @Test
+    public void test_unknownPermissionThrowsMockitoAssertionError() {
+        final AccessPermissionVerificationMode verificationMode = new AccessPermissionVerificationMode();
+        RdsClient mock = Mockito.mock(RdsClient.class);
+
+        mock.testMethod();
+
+        Assertions.assertThatThrownBy(() -> {
+            verificationMode.verify(new VerificationDataImpl(MockUtil.getInvocationContainer(mock), null));
+        }).isInstanceOf(MockitoAssertionError.class);
+    }
+
+    @Test
+    public void test_enabledPermissionVerifiedSuccessfully() {
+        final AccessPermissionVerificationMode verificationMode = new AccessPermissionVerificationMode();
+        RdsClient mock = Mockito.mock(RdsClient.class);
+        verificationMode.enablePermission(new AccessPermission(ServiceProvider.RDS, "TestMethod"));
+
+        mock.testMethod();
+
+        Assertions.assertThatCode(() -> {
+            verificationMode.verify(new VerificationDataImpl(MockUtil.getInvocationContainer(mock), null));
+        }).doesNotThrowAnyException();
+    }
+}

--- a/aws-rds-dbcluster/src/test/java/software/amazon/rds/dbcluster/AbstractHandlerTest.java
+++ b/aws-rds-dbcluster/src/test/java/software/amazon/rds/dbcluster/AbstractHandlerTest.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.function.Supplier;
 
+import org.json.JSONObject;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.mockito.stubbing.OngoingStubbing;
@@ -42,7 +43,10 @@ import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 import software.amazon.rds.common.handler.Tagging;
 import software.amazon.rds.test.common.core.AbstractTestBase;
+import software.amazon.rds.test.common.core.HandlerName;
 import software.amazon.rds.test.common.core.MethodCallExpectation;
+import software.amazon.rds.test.common.core.TestUtils;
+import software.amazon.rds.test.common.verification.AccessPermissionVerificationMode;
 
 public abstract class AbstractHandlerTest extends AbstractTestBase<DBCluster, ResourceModel, CallbackContext> {
 
@@ -310,6 +314,17 @@ public abstract class AbstractHandlerTest extends AbstractTestBase<DBCluster, Re
     protected abstract ProxyClient<RdsClient> getRdsProxy();
 
     protected abstract ProxyClient<Ec2Client> getEc2Proxy();
+
+    public abstract HandlerName getHandlerName();
+
+    private static final JSONObject resourceSchema = new Configuration().resourceSchemaJsonObject();
+
+    public void verifyAccessPermissions(final Object mock) {
+        new AccessPermissionVerificationMode()
+                .withDefaultPermissions()
+                .withSchemaPermissions(resourceSchema, getHandlerName())
+                .verify(TestUtils.getVerificationData(mock));
+    }
 
     @Override
     protected ProgressEvent<ResourceModel, CallbackContext> invokeHandleRequest(

--- a/aws-rds-dbcluster/src/test/java/software/amazon/rds/dbcluster/CreateHandlerTest.java
+++ b/aws-rds-dbcluster/src/test/java/software/amazon/rds/dbcluster/CreateHandlerTest.java
@@ -58,6 +58,7 @@ import software.amazon.cloudformation.proxy.delay.Constant;
 import software.amazon.rds.common.error.ErrorCode;
 import software.amazon.rds.common.handler.HandlerConfig;
 import software.amazon.rds.common.handler.Tagging;
+import software.amazon.rds.test.common.core.HandlerName;
 import software.amazon.rds.test.common.core.TestUtils;
 
 @ExtendWith(MockitoExtension.class)
@@ -82,6 +83,11 @@ public class CreateHandlerTest extends AbstractHandlerTest {
     @Getter
     private CreateHandler handler;
 
+    @Override
+    public HandlerName getHandlerName() {
+        return HandlerName.CREATE;
+    }
+
     @BeforeEach
     public void setup() {
         handler = new CreateHandler(
@@ -101,6 +107,7 @@ public class CreateHandlerTest extends AbstractHandlerTest {
     public void tear_down() {
         verify(rdsClient, atLeastOnce()).serviceName();
         verifyNoMoreInteractions(rdsClient);
+        verifyAccessPermissions(rdsClient);
     }
 
     @Test

--- a/aws-rds-dbcluster/src/test/java/software/amazon/rds/dbcluster/DeleteHandlerTest.java
+++ b/aws-rds-dbcluster/src/test/java/software/amazon/rds/dbcluster/DeleteHandlerTest.java
@@ -48,6 +48,7 @@ import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 import software.amazon.cloudformation.proxy.delay.Constant;
 import software.amazon.rds.common.handler.HandlerConfig;
+import software.amazon.rds.test.common.core.HandlerName;
 
 @ExtendWith(MockitoExtension.class)
 public class DeleteHandlerTest extends AbstractHandlerTest {
@@ -72,6 +73,11 @@ public class DeleteHandlerTest extends AbstractHandlerTest {
 
     @Getter
     private DeleteHandler handler;
+
+    @Override
+    public HandlerName getHandlerName() {
+        return HandlerName.DELETE;
+    }
 
     private boolean expectServiceInvocation;
 
@@ -98,6 +104,7 @@ public class DeleteHandlerTest extends AbstractHandlerTest {
             verify(rdsClient, atLeastOnce()).serviceName();
         }
         verifyNoMoreInteractions(rdsClient);
+        verifyAccessPermissions(rdsClient);
     }
 
     @Test

--- a/aws-rds-dbcluster/src/test/java/software/amazon/rds/dbcluster/ListHandlerTest.java
+++ b/aws-rds-dbcluster/src/test/java/software/amazon/rds/dbcluster/ListHandlerTest.java
@@ -26,6 +26,7 @@ import software.amazon.awssdk.services.rds.model.DescribeDbClustersResponse;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ProxyClient;
+import software.amazon.rds.test.common.core.HandlerName;
 
 @ExtendWith(MockitoExtension.class)
 public class ListHandlerTest extends AbstractHandlerTest {
@@ -48,6 +49,11 @@ public class ListHandlerTest extends AbstractHandlerTest {
     @Getter
     private ListHandler handler;
 
+    @Override
+    public HandlerName getHandlerName() {
+        return HandlerName.LIST;
+    }
+
     private boolean expectServiceInvocation;
 
     @BeforeEach
@@ -65,6 +71,7 @@ public class ListHandlerTest extends AbstractHandlerTest {
             verify(rdsClient, atLeastOnce()).serviceName();
         }
         verifyNoMoreInteractions(rdsClient);
+        verifyAccessPermissions(rdsClient);
     }
 
     @Test

--- a/aws-rds-dbcluster/src/test/java/software/amazon/rds/dbcluster/ReadHandlerTest.java
+++ b/aws-rds-dbcluster/src/test/java/software/amazon/rds/dbcluster/ReadHandlerTest.java
@@ -22,6 +22,7 @@ import software.amazon.awssdk.services.rds.RdsClient;
 import software.amazon.awssdk.services.rds.model.DescribeDbClustersRequest;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.ProxyClient;
+import software.amazon.rds.test.common.core.HandlerName;
 
 @ExtendWith(MockitoExtension.class)
 public class ReadHandlerTest extends AbstractHandlerTest {
@@ -44,6 +45,11 @@ public class ReadHandlerTest extends AbstractHandlerTest {
     @Getter
     private ReadHandler handler;
 
+    @Override
+    public HandlerName getHandlerName() {
+        return HandlerName.READ;
+    }
+
     @BeforeEach
     public void setup() {
         handler = new ReadHandler();
@@ -56,6 +62,7 @@ public class ReadHandlerTest extends AbstractHandlerTest {
     public void tear_down() {
         verify(rdsClient, atLeastOnce()).serviceName();
         verifyNoMoreInteractions(rdsClient);
+        verifyAccessPermissions(rdsClient);
     }
 
     @Test

--- a/aws-rds-dbcluster/src/test/java/software/amazon/rds/dbcluster/TranslatorTest.java
+++ b/aws-rds-dbcluster/src/test/java/software/amazon/rds/dbcluster/TranslatorTest.java
@@ -6,6 +6,7 @@ import software.amazon.awssdk.services.rds.RdsClient;
 import software.amazon.awssdk.services.rds.model.ModifyDbClusterRequest;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.ProxyClient;
+import software.amazon.rds.test.common.core.HandlerName;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -81,4 +82,8 @@ public class TranslatorTest extends AbstractHandlerTest {
     @Override
     protected ProxyClient<Ec2Client> getEc2Proxy() { return null; }
 
+    @Override
+    public HandlerName getHandlerName() {
+        return null;
+    }
 }

--- a/aws-rds-dbcluster/src/test/java/software/amazon/rds/dbcluster/UpdateHandlerTest.java
+++ b/aws-rds-dbcluster/src/test/java/software/amazon/rds/dbcluster/UpdateHandlerTest.java
@@ -66,6 +66,7 @@ import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 import software.amazon.cloudformation.proxy.delay.Constant;
 import software.amazon.rds.common.handler.HandlerConfig;
+import software.amazon.rds.test.common.core.HandlerName;
 import software.amazon.rds.test.common.core.TestUtils;
 
 @ExtendWith(MockitoExtension.class)
@@ -92,6 +93,11 @@ public class UpdateHandlerTest extends AbstractHandlerTest {
 
     private boolean expectServiceInvocation;
 
+    @Override
+    public HandlerName getHandlerName() {
+        return HandlerName.UPDATE;
+    }
+
     @BeforeEach
     public void setup() {
         handler = new UpdateHandler(
@@ -117,6 +123,7 @@ public class UpdateHandlerTest extends AbstractHandlerTest {
             verify(rdsClient, atLeastOnce()).serviceName();
         }
         verifyNoMoreInteractions(rdsClient);
+        verifyAccessPermissions(rdsClient);
     }
 
     @Test

--- a/aws-rds-dbclusterendpoint/src/test/java/software/amazon/rds/dbclusterendpoint/AbstractHandlerTest.java
+++ b/aws-rds-dbclusterendpoint/src/test/java/software/amazon/rds/dbclusterendpoint/AbstractHandlerTest.java
@@ -11,6 +11,8 @@ import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
+import org.json.JSONObject;
+
 import com.google.common.collect.ImmutableSet;
 import software.amazon.awssdk.awscore.AwsRequest;
 import software.amazon.awssdk.awscore.AwsResponse;
@@ -30,6 +32,9 @@ import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 import software.amazon.cloudformation.proxy.delay.Constant;
 import software.amazon.rds.common.handler.Tagging;
 import software.amazon.rds.test.common.core.AbstractTestBase;
+import software.amazon.rds.test.common.core.HandlerName;
+import software.amazon.rds.test.common.core.TestUtils;
+import software.amazon.rds.test.common.verification.AccessPermissionVerificationMode;
 
 public abstract class AbstractHandlerTest extends AbstractTestBase<DBClusterEndpoint, ResourceModel, CallbackContext> {
     protected static final LoggerProxy logger;
@@ -94,6 +99,17 @@ public abstract class AbstractHandlerTest extends AbstractTestBase<DBClusterEndp
     protected abstract AmazonWebServicesClientProxy getProxy();
 
     protected abstract ProxyClient<RdsClient> getRdsProxy();
+
+    public abstract HandlerName getHandlerName();
+
+    private static final JSONObject resourceSchema = new Configuration().resourceSchemaJSONObject();
+
+    public void verifyAccessPermissions(final Object mock) {
+        new AccessPermissionVerificationMode()
+                .withDefaultPermissions()
+                .withSchemaPermissions(resourceSchema, getHandlerName())
+                .verify(TestUtils.getVerificationData(mock));
+    }
 
     static {
         RESOURCE_MODEL = RESOURCE_MODEL_BUILDER()

--- a/aws-rds-dbclusterendpoint/src/test/java/software/amazon/rds/dbclusterendpoint/CreateHandlerTest.java
+++ b/aws-rds-dbclusterendpoint/src/test/java/software/amazon/rds/dbclusterendpoint/CreateHandlerTest.java
@@ -17,7 +17,6 @@ import software.amazon.awssdk.services.rds.model.AddTagsToResourceRequest;
 import software.amazon.awssdk.services.rds.model.AddTagsToResourceResponse;
 import software.amazon.awssdk.services.rds.model.CreateDbClusterEndpointRequest;
 import software.amazon.awssdk.services.rds.model.CreateDbClusterEndpointResponse;
-import software.amazon.awssdk.services.rds.model.DBClusterEndpoint;
 import software.amazon.awssdk.services.rds.model.DescribeDbClusterEndpointsRequest;
 import software.amazon.awssdk.services.rds.model.InvalidDbClusterStateException;
 import software.amazon.awssdk.services.rds.model.ListTagsForResourceRequest;
@@ -31,6 +30,7 @@ import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 import software.amazon.rds.common.error.ErrorCode;
 import software.amazon.rds.common.handler.HandlerConfig;
 import software.amazon.rds.common.handler.Tagging;
+import software.amazon.rds.test.common.core.HandlerName;
 
 import java.time.Duration;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -61,6 +61,11 @@ public class CreateHandlerTest extends AbstractHandlerTest {
     @Getter
     private CreateHandler handler;
 
+    @Override
+    public HandlerName getHandlerName() {
+        return HandlerName.CREATE;
+    }
+
     @BeforeEach
     public void setup() {
         handler = new CreateHandler(HandlerConfig.builder().backoff(TEST_BACKOFF_DELAY).build());
@@ -73,6 +78,7 @@ public class CreateHandlerTest extends AbstractHandlerTest {
     public void tear_down() {
         verify(rdsClient, atLeastOnce()).serviceName();
         verifyNoMoreInteractions(rdsClient);
+        verifyAccessPermissions(rdsClient);
     }
 
     @Test

--- a/aws-rds-dbclusterendpoint/src/test/java/software/amazon/rds/dbclusterendpoint/DeleteHandlerTest.java
+++ b/aws-rds-dbclusterendpoint/src/test/java/software/amazon/rds/dbclusterendpoint/DeleteHandlerTest.java
@@ -19,6 +19,7 @@ import software.amazon.cloudformation.proxy.HandlerErrorCode;
 import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.rds.common.handler.HandlerConfig;
+import software.amazon.rds.test.common.core.HandlerName;
 
 import java.time.Duration;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -49,6 +50,11 @@ public class DeleteHandlerTest extends AbstractHandlerTest {
     @Getter
     private DeleteHandler handler;
 
+    @Override
+    public HandlerName getHandlerName() {
+        return HandlerName.DELETE;
+    }
+
     @BeforeEach
     public void setup() {
         handler = new DeleteHandler(HandlerConfig.builder().backoff(TEST_BACKOFF_DELAY).build());
@@ -61,6 +67,7 @@ public class DeleteHandlerTest extends AbstractHandlerTest {
     public void tear_down() {
         verify(rdsClient, atLeastOnce()).serviceName();
         verifyNoMoreInteractions(rdsClient);
+        verifyAccessPermissions(rdsClient);
     }
 
     @Test

--- a/aws-rds-dbclusterendpoint/src/test/java/software/amazon/rds/dbclusterendpoint/ListHandlerTest.java
+++ b/aws-rds-dbclusterendpoint/src/test/java/software/amazon/rds/dbclusterendpoint/ListHandlerTest.java
@@ -15,6 +15,7 @@ import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.rds.common.handler.HandlerConfig;
+import software.amazon.rds.test.common.core.HandlerName;
 
 import java.time.Duration;
 import java.util.Collections;
@@ -46,6 +47,11 @@ public class ListHandlerTest extends AbstractHandlerTest {
     @Getter
     private ListHandler handler;
 
+    @Override
+    public HandlerName getHandlerName() {
+        return HandlerName.LIST;
+    }
+
     @BeforeEach
     public void setup() {
         handler = new ListHandler(HandlerConfig.builder().backoff(TEST_BACKOFF_DELAY).build());
@@ -58,6 +64,7 @@ public class ListHandlerTest extends AbstractHandlerTest {
     public void tear_down() {
         verify(rdsClient, atLeastOnce()).serviceName();
         verifyNoMoreInteractions(rdsClient);
+        verifyAccessPermissions(rdsClient);
     }
 
     @Test

--- a/aws-rds-dbclusterendpoint/src/test/java/software/amazon/rds/dbclusterendpoint/ReadHandlerTest.java
+++ b/aws-rds-dbclusterendpoint/src/test/java/software/amazon/rds/dbclusterendpoint/ReadHandlerTest.java
@@ -16,6 +16,7 @@ import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.HandlerErrorCode;
 import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.rds.common.handler.HandlerConfig;
+import software.amazon.rds.test.common.core.HandlerName;
 
 import java.time.Duration;
 import java.util.Collections;
@@ -44,6 +45,11 @@ public class ReadHandlerTest extends AbstractHandlerTest {
     @Getter
     private ReadHandler handler;
 
+    @Override
+    public HandlerName getHandlerName() {
+        return HandlerName.READ;
+    }
+
     @BeforeEach
     public void setup() {
         handler = new ReadHandler(HandlerConfig.builder().backoff(TEST_BACKOFF_DELAY).build());
@@ -56,6 +62,7 @@ public class ReadHandlerTest extends AbstractHandlerTest {
     public void tear_down() {
         verify(rdsClient, atLeastOnce()).serviceName();
         verifyNoMoreInteractions(rdsClient);
+        verifyAccessPermissions(rdsClient);
     }
 
     @Test

--- a/aws-rds-dbclusterendpoint/src/test/java/software/amazon/rds/dbclusterendpoint/UpdateHandlerTest.java
+++ b/aws-rds-dbclusterendpoint/src/test/java/software/amazon/rds/dbclusterendpoint/UpdateHandlerTest.java
@@ -27,6 +27,7 @@ import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 import software.amazon.rds.common.error.ErrorCode;
 import software.amazon.rds.common.handler.HandlerConfig;
+import software.amazon.rds.test.common.core.HandlerName;
 
 import java.time.Duration;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -56,6 +57,11 @@ public class UpdateHandlerTest extends AbstractHandlerTest {
     @Getter
     private UpdateHandler handler;
 
+    @Override
+    public HandlerName getHandlerName() {
+        return HandlerName.UPDATE;
+    }
+
     @BeforeEach
     public void setup() {
         handler = new UpdateHandler(HandlerConfig.builder().backoff(TEST_BACKOFF_DELAY).build());
@@ -69,6 +75,7 @@ public class UpdateHandlerTest extends AbstractHandlerTest {
     public void tear_down() {
         verify(rdsProxy.client(), atLeastOnce()).serviceName();
         verifyNoMoreInteractions(rdsClient);
+        verifyAccessPermissions(rdsClient);
     }
 
     @Test

--- a/aws-rds-dbclusterparametergroup/aws-rds-dbclusterparametergroup.json
+++ b/aws-rds-dbclusterparametergroup/aws-rds-dbclusterparametergroup.json
@@ -78,9 +78,12 @@
   "handlers": {
     "create": {
       "permissions": [
+        "rds:AddTagsToResource",
         "rds:CreateDBClusterParameterGroup",
+        "rds:DescribeDBClusterParameterGroups",
         "rds:DescribeDBClusterParameters",
         "rds:DescribeEngineDefaultClusterParameters",
+        "rds:ListTagsForResource",
         "rds:ModifyDBClusterParameterGroup"
       ],
       "timeoutInMinutes": 180
@@ -93,14 +96,15 @@
     },
     "update": {
       "permissions": [
-        "rds:DescribeDBClusters",
+        "rds:AddTagsToResource",
+        "rds:DescribeDBClusterParameterGroups",
         "rds:DescribeDBClusterParameters",
+        "rds:DescribeDBClusters",
         "rds:DescribeEngineDefaultClusterParameters",
         "rds:ListTagsForResource",
-        "rds:AddTagsToResource",
+        "rds:ModifyDBClusterParameterGroup",
         "rds:RemoveTagsFromResource",
-        "rds:ResetDBClusterParameterGroup",
-        "rds:ModifyDBClusterParameterGroup"
+        "rds:ResetDBClusterParameterGroup"
       ],
       "timeoutInMinutes": 180
     },

--- a/aws-rds-dbclusterparametergroup/src/test/java/software/amazon/rds/dbclusterparametergroup/CreateHandlerTest.java
+++ b/aws-rds-dbclusterparametergroup/src/test/java/software/amazon/rds/dbclusterparametergroup/CreateHandlerTest.java
@@ -59,6 +59,7 @@ import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 import software.amazon.rds.common.error.ErrorCode;
 import software.amazon.rds.common.handler.HandlerConfig;
 import software.amazon.rds.common.handler.Tagging;
+import software.amazon.rds.test.common.core.HandlerName;
 
 @ExtendWith(MockitoExtension.class)
 public class CreateHandlerTest extends AbstractTestBase {
@@ -78,6 +79,11 @@ public class CreateHandlerTest extends AbstractTestBase {
 
     private Map<String, Object> PARAMS;
     private final String StackId = "arn:aws:cloudformation:us-east-1:123456789:stack/MyStack/aaf549a0-a413-11df-adb3-5081b3858e83";
+
+    @Override
+    public HandlerName getHandlerName() {
+        return HandlerName.CREATE;
+    }
 
     @BeforeEach
     public void setup() {
@@ -109,6 +115,7 @@ public class CreateHandlerTest extends AbstractTestBase {
     public void post_execute() {
         verify(rds, atLeastOnce()).serviceName();
         verifyNoMoreInteractions(proxyRdsClient.client());
+        verifyAccessPermissions(proxyRdsClient.client());
     }
 
     @Test

--- a/aws-rds-dbclusterparametergroup/src/test/java/software/amazon/rds/dbclusterparametergroup/DeleteHandlerTest.java
+++ b/aws-rds-dbclusterparametergroup/src/test/java/software/amazon/rds/dbclusterparametergroup/DeleteHandlerTest.java
@@ -32,6 +32,7 @@ import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 import software.amazon.rds.common.handler.HandlerConfig;
+import software.amazon.rds.test.common.core.HandlerName;
 
 @ExtendWith(MockitoExtension.class)
 public class DeleteHandlerTest extends AbstractTestBase {
@@ -50,6 +51,11 @@ public class DeleteHandlerTest extends AbstractTestBase {
     private ResourceModel RESOURCE_MODEL;
 
     private Map<String, Object> PARAMS;
+
+    @Override
+    public HandlerName getHandlerName() {
+        return HandlerName.DELETE;
+    }
 
     @BeforeEach
     public void setup() {
@@ -80,6 +86,7 @@ public class DeleteHandlerTest extends AbstractTestBase {
     public void post_execute() {
         verify(rds, atLeastOnce()).serviceName();
         verifyNoMoreInteractions(proxyRdsClient.client());
+        verifyAccessPermissions(proxyRdsClient.client());
     }
 
     @Test

--- a/aws-rds-dbclusterparametergroup/src/test/java/software/amazon/rds/dbclusterparametergroup/ListHandlerTest.java
+++ b/aws-rds-dbclusterparametergroup/src/test/java/software/amazon/rds/dbclusterparametergroup/ListHandlerTest.java
@@ -25,6 +25,7 @@ import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 import software.amazon.rds.common.handler.HandlerConfig;
+import software.amazon.rds.test.common.core.HandlerName;
 
 @ExtendWith(MockitoExtension.class)
 public class ListHandlerTest extends AbstractTestBase {
@@ -39,6 +40,11 @@ public class ListHandlerTest extends AbstractTestBase {
     RdsClient rds;
 
     private ListHandler handler;
+
+    @Override
+    public HandlerName getHandlerName() {
+        return HandlerName.LIST;
+    }
 
     @BeforeEach
     public void setup() {
@@ -55,6 +61,7 @@ public class ListHandlerTest extends AbstractTestBase {
     @AfterEach
     public void post_execute() {
         verifyNoMoreInteractions(proxyRdsClient.client());
+        verifyAccessPermissions(proxyRdsClient.client());
     }
 
     @Test

--- a/aws-rds-dbclusterparametergroup/src/test/java/software/amazon/rds/dbclusterparametergroup/ReadHandlerTest.java
+++ b/aws-rds-dbclusterparametergroup/src/test/java/software/amazon/rds/dbclusterparametergroup/ReadHandlerTest.java
@@ -30,6 +30,7 @@ import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 import software.amazon.rds.common.handler.HandlerConfig;
+import software.amazon.rds.test.common.core.HandlerName;
 
 @ExtendWith(MockitoExtension.class)
 public class ReadHandlerTest extends AbstractTestBase {
@@ -44,6 +45,11 @@ public class ReadHandlerTest extends AbstractTestBase {
     RdsClient rds;
 
     private ReadHandler handler;
+
+    @Override
+    public HandlerName getHandlerName() {
+        return HandlerName.READ;
+    }
 
     @BeforeEach
     public void setup() {
@@ -61,6 +67,7 @@ public class ReadHandlerTest extends AbstractTestBase {
     public void post_execute() {
         verify(rds, atLeastOnce()).serviceName();
         verifyNoMoreInteractions(proxyRdsClient.client());
+        verifyAccessPermissions(proxyRdsClient.client());
     }
 
     @Test

--- a/aws-rds-dbclusterparametergroup/src/test/java/software/amazon/rds/dbclusterparametergroup/UpdateHandlerTest.java
+++ b/aws-rds-dbclusterparametergroup/src/test/java/software/amazon/rds/dbclusterparametergroup/UpdateHandlerTest.java
@@ -47,6 +47,7 @@ import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 import software.amazon.rds.common.handler.HandlerConfig;
+import software.amazon.rds.test.common.core.HandlerName;
 
 @ExtendWith(MockitoExtension.class)
 public class UpdateHandlerTest extends AbstractTestBase {
@@ -70,6 +71,11 @@ public class UpdateHandlerTest extends AbstractTestBase {
 
     private ResourceHandlerRequest<ResourceModel> requestSameParams;
     private ResourceHandlerRequest<ResourceModel> requestUpdParams;
+
+    @Override
+    public HandlerName getHandlerName() {
+        return HandlerName.UPDATE;
+    }
 
     @BeforeEach
     public void setup() {
@@ -128,6 +134,7 @@ public class UpdateHandlerTest extends AbstractTestBase {
     public void post_execute() {
         verify(rds, atLeastOnce()).serviceName();
         verifyNoMoreInteractions(proxyRdsClient.client());
+        verifyAccessPermissions(proxyRdsClient.client());
     }
 
     @Test

--- a/aws-rds-dbinstance/aws-rds-dbinstance.json
+++ b/aws-rds-dbinstance/aws-rds-dbinstance.json
@@ -468,6 +468,7 @@
         "rds:DescribeDBInstances",
         "rds:DescribeDBParameterGroups",
         "rds:ModifyDBInstance",
+        "rds:RebootDBInstance",
         "rds:RemoveRoleFromDBInstance",
         "rds:RemoveTagsFromResource"
       ],

--- a/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/AbstractHandlerTest.java
+++ b/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/AbstractHandlerTest.java
@@ -10,6 +10,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.function.Supplier;
 
+import org.json.JSONObject;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.mockito.stubbing.OngoingStubbing;
@@ -44,7 +45,10 @@ import software.amazon.rds.common.handler.Tagging;
 import software.amazon.rds.dbinstance.client.ApiVersion;
 import software.amazon.rds.dbinstance.client.VersionedProxyClient;
 import software.amazon.rds.test.common.core.AbstractTestBase;
+import software.amazon.rds.test.common.core.HandlerName;
 import software.amazon.rds.test.common.core.MethodCallExpectation;
+import software.amazon.rds.test.common.core.TestUtils;
+import software.amazon.rds.test.common.verification.AccessPermissionVerificationMode;
 
 public abstract class AbstractHandlerTest extends AbstractTestBase<DBInstance, ResourceModel, CallbackContext> {
 
@@ -581,6 +585,16 @@ public abstract class AbstractHandlerTest extends AbstractTestBase<DBInstance, R
 
     protected abstract ProxyClient<Ec2Client> getEc2Proxy();
 
+    public abstract HandlerName getHandlerName();
+
+    private static final JSONObject resourceSchema = new Configuration().resourceSchemaJsonObject();
+
+    public void verifyAccessPermissions(final Object mock) {
+        new AccessPermissionVerificationMode()
+                .withDefaultPermissions()
+                .withSchemaPermissions(resourceSchema, getHandlerName())
+                .verify(TestUtils.getVerificationData(mock));
+    }
 
     @Override
     protected ProgressEvent<ResourceModel, CallbackContext> invokeHandleRequest(

--- a/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/CreateHandlerTest.java
+++ b/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/CreateHandlerTest.java
@@ -71,6 +71,7 @@ import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 import software.amazon.rds.common.error.ErrorCode;
 import software.amazon.rds.common.handler.HandlerConfig;
 import software.amazon.rds.common.handler.Tagging;
+import software.amazon.rds.test.common.core.HandlerName;
 
 @ExtendWith(MockitoExtension.class)
 public class CreateHandlerTest extends AbstractHandlerTest {
@@ -103,6 +104,11 @@ public class CreateHandlerTest extends AbstractHandlerTest {
     private CreateHandler handler;
 
     private boolean expectServiceInvocation;
+
+    @Override
+    public HandlerName getHandlerName() {
+        return HandlerName.CREATE;
+    }
 
     @Override
     public ProxyClient<RdsClient> getRdsProxy(final String version) {
@@ -138,6 +144,9 @@ public class CreateHandlerTest extends AbstractHandlerTest {
         }
         verifyNoMoreInteractions(rdsClient);
         verifyNoMoreInteractions(ec2Client);
+        verifyAccessPermissions(rdsClient);
+        verifyAccessPermissions(rdsClientV12);
+        verifyAccessPermissions(ec2Client);
     }
 
     @Test

--- a/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/DeleteHandlerTest.java
+++ b/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/DeleteHandlerTest.java
@@ -42,6 +42,7 @@ import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 import software.amazon.rds.common.error.ErrorCode;
 import software.amazon.rds.common.handler.HandlerConfig;
+import software.amazon.rds.test.common.core.HandlerName;
 import software.amazon.rds.test.common.core.TestUtils;
 
 @ExtendWith(MockitoExtension.class)
@@ -68,6 +69,11 @@ public class DeleteHandlerTest extends AbstractHandlerTest {
     @Getter
     private DeleteHandler handler;
 
+    @Override
+    public HandlerName getHandlerName() {
+        return HandlerName.DELETE;
+    }
+
     @BeforeEach
     public void setup() {
         handler = new DeleteHandler(
@@ -88,6 +94,8 @@ public class DeleteHandlerTest extends AbstractHandlerTest {
         verify(rdsClient, atLeastOnce()).serviceName();
         verifyNoMoreInteractions(rdsClient);
         verifyNoMoreInteractions(ec2Client);
+        verifyAccessPermissions(rdsClient);
+        verifyAccessPermissions(ec2Client);
     }
 
     @Test

--- a/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/ListHandlerTest.java
+++ b/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/ListHandlerTest.java
@@ -27,6 +27,7 @@ import software.amazon.awssdk.services.rds.model.DescribeDbInstancesResponse;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ProxyClient;
+import software.amazon.rds.test.common.core.HandlerName;
 
 @ExtendWith(MockitoExtension.class)
 public class ListHandlerTest extends AbstractHandlerTest {
@@ -49,6 +50,11 @@ public class ListHandlerTest extends AbstractHandlerTest {
     @Getter
     private ListHandler handler;
 
+    @Override
+    public HandlerName getHandlerName() {
+        return HandlerName.LIST;
+    }
+
     @BeforeEach
     public void setup() {
         handler = new ListHandler();
@@ -64,6 +70,8 @@ public class ListHandlerTest extends AbstractHandlerTest {
         verify(rdsClient, atLeastOnce()).serviceName();
         verifyNoMoreInteractions(rdsClient);
         verifyNoMoreInteractions(ec2Client);
+        verifyAccessPermissions(rdsClient);
+        verifyAccessPermissions(ec2Client);
     }
 
     @Test

--- a/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/ReadHandlerTest.java
+++ b/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/ReadHandlerTest.java
@@ -8,9 +8,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 import java.time.Duration;
-import java.util.Locale;
 
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -23,8 +21,8 @@ import software.amazon.awssdk.services.ec2.Ec2Client;
 import software.amazon.awssdk.services.rds.RdsClient;
 import software.amazon.awssdk.services.rds.model.DescribeDbInstancesRequest;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
-import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ProxyClient;
+import software.amazon.rds.test.common.core.HandlerName;
 
 @ExtendWith(MockitoExtension.class)
 public class ReadHandlerTest extends AbstractHandlerTest {
@@ -50,6 +48,11 @@ public class ReadHandlerTest extends AbstractHandlerTest {
     @Getter
     private ReadHandler handler;
 
+    @Override
+    public HandlerName getHandlerName() {
+        return HandlerName.READ;
+    }
+
     @BeforeEach
     public void setup() {
         handler = new ReadHandler();
@@ -65,6 +68,8 @@ public class ReadHandlerTest extends AbstractHandlerTest {
         verify(rdsClient, atLeastOnce()).serviceName();
         verifyNoMoreInteractions(rdsClient);
         verifyNoMoreInteractions(ec2Client);
+        verifyAccessPermissions(rdsClient);
+        verifyAccessPermissions(ec2Client);
     }
 
     @Test

--- a/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/TranslatorTest.java
+++ b/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/TranslatorTest.java
@@ -14,6 +14,7 @@ import software.amazon.awssdk.services.rds.model.RestoreDbInstanceFromDbSnapshot
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.rds.common.handler.Tagging;
+import software.amazon.rds.test.common.core.HandlerName;
 
 class TranslatorTest extends AbstractHandlerTest {
 
@@ -263,6 +264,11 @@ class TranslatorTest extends AbstractHandlerTest {
 
     @Override
     protected ProxyClient<Ec2Client> getEc2Proxy() {
+        return null;
+    }
+
+    @Override
+    public HandlerName getHandlerName() {
         return null;
     }
 }

--- a/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/UpdateHandlerTest.java
+++ b/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/UpdateHandlerTest.java
@@ -75,6 +75,7 @@ import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 import software.amazon.rds.common.error.ErrorCode;
 import software.amazon.rds.common.handler.HandlerConfig;
+import software.amazon.rds.test.common.core.HandlerName;
 
 @ExtendWith(MockitoExtension.class)
 public class UpdateHandlerTest extends AbstractHandlerTest {
@@ -107,6 +108,11 @@ public class UpdateHandlerTest extends AbstractHandlerTest {
     private UpdateHandler handler;
 
     private Boolean expectServiceInvocation;
+
+    @Override
+    public HandlerName getHandlerName() {
+        return HandlerName.UPDATE;
+    }
 
     @Override
     public ProxyClient<RdsClient> getRdsProxy(final String version) {
@@ -143,6 +149,9 @@ public class UpdateHandlerTest extends AbstractHandlerTest {
         }
         verifyNoMoreInteractions(rdsClient);
         verifyNoMoreInteractions(ec2Client);
+        verifyAccessPermissions(rdsClient);
+        verifyAccessPermissions(rdsClientV12);
+        verifyAccessPermissions(ec2Client);
     }
 
     @Test
@@ -1160,7 +1169,9 @@ public class UpdateHandlerTest extends AbstractHandlerTest {
 
         test_handleRequest_base(
                 context,
-                () -> { throw DbInstanceNotFoundException.builder().message(MSG_NOT_FOUND_ERR).build(); },
+                () -> {
+                    throw DbInstanceNotFoundException.builder().message(MSG_NOT_FOUND_ERR).build();
+                },
                 () -> RESOURCE_MODEL_BLDR().build(),
                 () -> RESOURCE_MODEL_BLDR().build(),
                 expectFailed(HandlerErrorCode.NotFound)

--- a/aws-rds-dbparametergroup/src/test/java/software/amazon/rds/dbparametergroup/AbstractTestBase.java
+++ b/aws-rds-dbparametergroup/src/test/java/software/amazon/rds/dbparametergroup/AbstractTestBase.java
@@ -1,7 +1,6 @@
 package software.amazon.rds.dbparametergroup;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.util.Collections;
@@ -12,8 +11,8 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
+import org.json.JSONObject;
 import org.mockito.internal.util.collections.Sets;
 
 import software.amazon.awssdk.awscore.AwsRequest;
@@ -35,8 +34,11 @@ import software.amazon.cloudformation.proxy.LoggerProxy;
 import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 import software.amazon.rds.common.logging.RequestLogger;
+import software.amazon.rds.test.common.core.HandlerName;
+import software.amazon.rds.test.common.core.TestUtils;
+import software.amazon.rds.test.common.verification.AccessPermissionVerificationMode;
 
-public class AbstractTestBase {
+public abstract class AbstractTestBase {
     protected static final Credentials MOCK_CREDENTIALS;
     protected static final LoggerProxy logger;
 
@@ -49,8 +51,6 @@ public class AbstractTestBase {
     protected static final Map<String, Object> PARAMS;
     protected static final Map<String, Object> RESET_PARAMS;
     protected static final RequestLogger EMPTY_REQUEST_LOGGER;
-
-
 
     static {
         MOCK_CREDENTIALS = new Credentials("accessKey", "secretKey", "token");
@@ -97,6 +97,17 @@ public class AbstractTestBase {
                 .build();
 
         TAG_SET = Sets.newSet(Tag.builder().key("key").value("value").build());
+    }
+
+    public abstract HandlerName getHandlerName();
+
+    private static final JSONObject resourceSchema = new Configuration().resourceSchemaJsonObject();
+
+    public void verifyAccessPermissions(final Object mock) {
+        new AccessPermissionVerificationMode()
+                .withDefaultPermissions()
+                .withSchemaPermissions(resourceSchema, getHandlerName())
+                .verify(TestUtils.getVerificationData(mock));
     }
 
     static Map<String, String> translateTagsToMap(final Set<Tag> tags) {

--- a/aws-rds-dbparametergroup/src/test/java/software/amazon/rds/dbparametergroup/CreateHandlerTest.java
+++ b/aws-rds-dbparametergroup/src/test/java/software/amazon/rds/dbparametergroup/CreateHandlerTest.java
@@ -43,6 +43,7 @@ import software.amazon.cloudformation.proxy.OperationStatus;
 import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
+import software.amazon.rds.test.common.core.HandlerName;
 
 @ExtendWith(MockitoExtension.class)
 public class CreateHandlerTest extends AbstractTestBase {
@@ -59,6 +60,11 @@ public class CreateHandlerTest extends AbstractTestBase {
     private CreateHandler handler;
     private CreateDbParameterGroupResponse createDbParameterGroupResponse;
 
+    @Override
+    public HandlerName getHandlerName() {
+        return HandlerName.CREATE;
+    }
+
     @BeforeEach
     public void setup() {
         handler = new CreateHandler();
@@ -71,6 +77,7 @@ public class CreateHandlerTest extends AbstractTestBase {
     public void tear_down() {
         verify(rdsClient, atLeastOnce()).serviceName();
         verifyNoMoreInteractions(rdsClient);
+        verifyAccessPermissions(rdsClient);
     }
 
     @Test

--- a/aws-rds-dbparametergroup/src/test/java/software/amazon/rds/dbparametergroup/DeleteHandlerTest.java
+++ b/aws-rds-dbparametergroup/src/test/java/software/amazon/rds/dbparametergroup/DeleteHandlerTest.java
@@ -29,6 +29,7 @@ import software.amazon.cloudformation.proxy.OperationStatus;
 import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
+import software.amazon.rds.test.common.core.HandlerName;
 
 @ExtendWith(MockitoExtension.class)
 public class DeleteHandlerTest extends AbstractTestBase {
@@ -44,6 +45,11 @@ public class DeleteHandlerTest extends AbstractTestBase {
 
     private DeleteHandler handler;
 
+    @Override
+    public HandlerName getHandlerName() {
+        return HandlerName.DELETE;
+    }
+
     @BeforeEach
     public void setup() {
         handler = new DeleteHandler();
@@ -56,6 +62,7 @@ public class DeleteHandlerTest extends AbstractTestBase {
     public void tear_down() {
         verify(rdsClient, atLeastOnce()).serviceName();
         verifyNoMoreInteractions(rdsClient);
+        verifyAccessPermissions(rdsClient);
     }
 
     @Test

--- a/aws-rds-dbparametergroup/src/test/java/software/amazon/rds/dbparametergroup/ListHandlerTest.java
+++ b/aws-rds-dbparametergroup/src/test/java/software/amazon/rds/dbparametergroup/ListHandlerTest.java
@@ -24,6 +24,7 @@ import software.amazon.cloudformation.proxy.OperationStatus;
 import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
+import software.amazon.rds.test.common.core.HandlerName;
 
 @ExtendWith(MockitoExtension.class)
 public class ListHandlerTest extends AbstractTestBase {
@@ -39,9 +40,15 @@ public class ListHandlerTest extends AbstractTestBase {
 
     private ListHandler handler;
 
+    @Override
+    public HandlerName getHandlerName() {
+        return HandlerName.LIST;
+    }
+
     @AfterEach
     public void post_execute() {
         verifyNoMoreInteractions(proxyRdsClient.client());
+        verifyAccessPermissions(proxyRdsClient.client());
     }
 
     @BeforeEach

--- a/aws-rds-dbparametergroup/src/test/java/software/amazon/rds/dbparametergroup/ReadHandlerTest.java
+++ b/aws-rds-dbparametergroup/src/test/java/software/amazon/rds/dbparametergroup/ReadHandlerTest.java
@@ -32,6 +32,7 @@ import software.amazon.cloudformation.proxy.OperationStatus;
 import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
+import software.amazon.rds.test.common.core.HandlerName;
 
 @ExtendWith(MockitoExtension.class)
 public class ReadHandlerTest extends AbstractTestBase {
@@ -47,6 +48,11 @@ public class ReadHandlerTest extends AbstractTestBase {
 
     private ReadHandler handler;
 
+    @Override
+    public HandlerName getHandlerName() {
+        return HandlerName.READ;
+    }
+
     @BeforeEach
     public void setup() {
         handler = new ReadHandler();
@@ -59,6 +65,7 @@ public class ReadHandlerTest extends AbstractTestBase {
     public void tear_down() {
         verify(rdsClient, atLeastOnce()).serviceName();
         verifyNoMoreInteractions(rdsClient);
+        verifyAccessPermissions(rdsClient);
     }
 
     @Test

--- a/aws-rds-dbparametergroup/src/test/java/software/amazon/rds/dbparametergroup/UpdateHandlerTest.java
+++ b/aws-rds-dbparametergroup/src/test/java/software/amazon/rds/dbparametergroup/UpdateHandlerTest.java
@@ -23,7 +23,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import software.amazon.awssdk.services.rds.RdsClient;
 import software.amazon.awssdk.services.rds.model.AddTagsToResourceRequest;
 import software.amazon.awssdk.services.rds.model.AddTagsToResourceResponse;
-import software.amazon.awssdk.services.rds.model.CreateDbParameterGroupRequest;
 import software.amazon.awssdk.services.rds.model.DBParameterGroup;
 import software.amazon.awssdk.services.rds.model.DescribeDbParameterGroupsRequest;
 import software.amazon.awssdk.services.rds.model.DescribeDbParameterGroupsResponse;
@@ -39,23 +38,33 @@ import software.amazon.cloudformation.proxy.OperationStatus;
 import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
+import software.amazon.rds.test.common.core.HandlerName;
 
 @ExtendWith(MockitoExtension.class)
 public class UpdateHandlerTest extends AbstractTestBase {
 
     @Mock
     RdsClient rdsClient;
+
     @Captor
     ArgumentCaptor<ResetDbParameterGroupRequest> captor;
+
     @Mock
     private AmazonWebServicesClientProxy proxy;
+
     @Mock
     private ProxyClient<RdsClient> proxyRdsClient;
+
     private DBParameterGroup simpleDbParameterGroup;
     private ResourceModel previousResourceModel;
 
     private ResourceHandlerRequest<ResourceModel> sameParamsRequest;
     private ResourceHandlerRequest<ResourceModel> updateParamsRequest;
+
+    @Override
+    public HandlerName getHandlerName() {
+        return HandlerName.UPDATE;
+    }
 
     @BeforeEach
     public void setup() {
@@ -91,6 +100,7 @@ public class UpdateHandlerTest extends AbstractTestBase {
     public void tear_down() {
         verify(rdsClient, atLeastOnce()).serviceName();
         verifyNoMoreInteractions(rdsClient);
+        verifyAccessPermissions(rdsClient);
     }
 
     @Test

--- a/aws-rds-dbsubnetgroup/src/test/java/software/amazon/rds/dbsubnetgroup/AbstractTestBase.java
+++ b/aws-rds-dbsubnetgroup/src/test/java/software/amazon/rds/dbsubnetgroup/AbstractTestBase.java
@@ -8,6 +8,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import org.json.JSONObject;
 import org.mockito.internal.util.collections.Sets;
 import org.slf4j.LoggerFactory;
 
@@ -24,8 +25,11 @@ import software.amazon.cloudformation.proxy.Credentials;
 import software.amazon.cloudformation.proxy.LoggerProxy;
 import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.delay.Constant;
+import software.amazon.rds.test.common.core.HandlerName;
+import software.amazon.rds.test.common.core.TestUtils;
+import software.amazon.rds.test.common.verification.AccessPermissionVerificationMode;
 
-public class AbstractTestBase {
+public abstract class AbstractTestBase {
     protected static final Credentials MOCK_CREDENTIALS;
     protected static final org.slf4j.Logger delegate;
     protected static final LoggerProxy logger;
@@ -67,6 +71,17 @@ public class AbstractTestBase {
         DB_SUBNET_GROUP_ACTIVE = DBSubnetGroup.builder()
                 .subnetGroupStatus("Complete").build();
         TAG_SET = Sets.newSet(Tag.builder().key("key").value("value").build());
+    }
+
+    public abstract HandlerName getHandlerName();
+
+    private static final JSONObject resourceSchema = new Configuration().resourceSchemaJSONObject();
+
+    public void verifyAccessPermissions(final Object mock) {
+        new AccessPermissionVerificationMode()
+                .withDefaultPermissions()
+                .withSchemaPermissions(resourceSchema, getHandlerName())
+                .verify(TestUtils.getVerificationData(mock));
     }
 
     static Map<String, String> translateTagsToMap(final Set<Tag> tags) {

--- a/aws-rds-dbsubnetgroup/src/test/java/software/amazon/rds/dbsubnetgroup/CreateHandlerTest.java
+++ b/aws-rds-dbsubnetgroup/src/test/java/software/amazon/rds/dbsubnetgroup/CreateHandlerTest.java
@@ -15,7 +15,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -24,10 +23,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import software.amazon.awssdk.awscore.exception.AwsErrorDetails;
 import software.amazon.awssdk.awscore.exception.AwsServiceException;
 import software.amazon.awssdk.services.rds.RdsClient;
-import software.amazon.awssdk.services.rds.model.AddTagsToResourceRequest;
-import software.amazon.awssdk.services.rds.model.AddTagsToResourceResponse;
-import software.amazon.awssdk.services.rds.model.CreateDbParameterGroupRequest;
-import software.amazon.awssdk.services.rds.model.CreateDbParameterGroupResponse;
 import software.amazon.awssdk.services.rds.model.CreateDbSubnetGroupRequest;
 import software.amazon.awssdk.services.rds.model.CreateDbSubnetGroupResponse;
 import software.amazon.awssdk.services.rds.model.DBSubnetGroup;
@@ -44,17 +39,26 @@ import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 import software.amazon.rds.common.handler.HandlerConfig;
+import software.amazon.rds.test.common.core.HandlerName;
 
 @ExtendWith(MockitoExtension.class)
 public class CreateHandlerTest extends AbstractTestBase {
 
     @Mock
     RdsClient rds;
+
     @Mock
     private AmazonWebServicesClientProxy proxy;
+
     @Mock
     private ProxyClient<RdsClient> proxyRdsClient;
+
     private CreateHandler handler;
+
+    @Override
+    public HandlerName getHandlerName() {
+        return HandlerName.CREATE;
+    }
 
     @BeforeEach
     public void setup() {
@@ -72,6 +76,7 @@ public class CreateHandlerTest extends AbstractTestBase {
     public void post_execute() {
         verify(rds, atLeastOnce()).serviceName();
         verifyNoMoreInteractions(proxyRdsClient.client());
+        verifyAccessPermissions(proxyRdsClient.client());
     }
 
     @Test

--- a/aws-rds-dbsubnetgroup/src/test/java/software/amazon/rds/dbsubnetgroup/DeleteHandlerTest.java
+++ b/aws-rds-dbsubnetgroup/src/test/java/software/amazon/rds/dbsubnetgroup/DeleteHandlerTest.java
@@ -30,17 +30,26 @@ import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 import software.amazon.rds.common.handler.HandlerConfig;
+import software.amazon.rds.test.common.core.HandlerName;
 
 @ExtendWith(MockitoExtension.class)
 public class DeleteHandlerTest extends AbstractTestBase {
 
     @Mock
     RdsClient rds;
+
     @Mock
     private AmazonWebServicesClientProxy proxy;
+
     @Mock
     private ProxyClient<RdsClient> proxyRdsClient;
+
     private DeleteHandler handler;
+
+    @Override
+    public HandlerName getHandlerName() {
+        return HandlerName.DELETE;
+    }
 
     @BeforeEach
     public void setup() {
@@ -57,6 +66,7 @@ public class DeleteHandlerTest extends AbstractTestBase {
     public void post_execute() {
         verify(rds, atLeastOnce()).serviceName();
         verifyNoMoreInteractions(proxyRdsClient.client());
+        verifyAccessPermissions(proxyRdsClient.client());
     }
 
     @Test

--- a/aws-rds-dbsubnetgroup/src/test/java/software/amazon/rds/dbsubnetgroup/ListHandlerTest.java
+++ b/aws-rds-dbsubnetgroup/src/test/java/software/amazon/rds/dbsubnetgroup/ListHandlerTest.java
@@ -25,6 +25,7 @@ import software.amazon.cloudformation.proxy.OperationStatus;
 import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
+import software.amazon.rds.test.common.core.HandlerName;
 
 @ExtendWith(MockitoExtension.class)
 public class ListHandlerTest extends AbstractTestBase {
@@ -40,9 +41,15 @@ public class ListHandlerTest extends AbstractTestBase {
 
     private ListHandler handler;
 
+    @Override
+    public HandlerName getHandlerName() {
+        return HandlerName.LIST;
+    }
+
     @AfterEach
     public void post_execute() {
         verifyNoMoreInteractions(proxyRdsClient.client());
+        verifyAccessPermissions(proxyRdsClient.client());
     }
 
     @BeforeEach

--- a/aws-rds-dbsubnetgroup/src/test/java/software/amazon/rds/dbsubnetgroup/ReadHandlerTest.java
+++ b/aws-rds-dbsubnetgroup/src/test/java/software/amazon/rds/dbsubnetgroup/ReadHandlerTest.java
@@ -31,6 +31,7 @@ import software.amazon.cloudformation.proxy.OperationStatus;
 import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
+import software.amazon.rds.test.common.core.HandlerName;
 
 @ExtendWith(MockitoExtension.class)
 public class ReadHandlerTest extends AbstractTestBase {
@@ -46,6 +47,11 @@ public class ReadHandlerTest extends AbstractTestBase {
 
     private ReadHandler handler;
 
+    @Override
+    public HandlerName getHandlerName() {
+        return HandlerName.READ;
+    }
+
     @BeforeEach
     public void setup() {
         handler = new ReadHandler();
@@ -58,6 +64,7 @@ public class ReadHandlerTest extends AbstractTestBase {
     public void post_execute() {
         verify(rds, atLeastOnce()).serviceName();
         verifyNoMoreInteractions(proxyRdsClient.client());
+        verifyAccessPermissions(proxyRdsClient.client());
     }
 
     @Test

--- a/aws-rds-dbsubnetgroup/src/test/java/software/amazon/rds/dbsubnetgroup/UpdateHandlerTest.java
+++ b/aws-rds-dbsubnetgroup/src/test/java/software/amazon/rds/dbsubnetgroup/UpdateHandlerTest.java
@@ -37,17 +37,26 @@ import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 import software.amazon.rds.common.handler.HandlerConfig;
+import software.amazon.rds.test.common.core.HandlerName;
 
 @ExtendWith(MockitoExtension.class)
 public class UpdateHandlerTest extends AbstractTestBase {
 
     @Mock
     RdsClient rds;
+
     @Mock
     private AmazonWebServicesClientProxy proxy;
+
     @Mock
     private ProxyClient<RdsClient> proxyRdsClient;
+
     private UpdateHandler handler;
+
+    @Override
+    public HandlerName getHandlerName() {
+        return HandlerName.UPDATE;
+    }
 
     @BeforeEach
     public void setup() {
@@ -64,6 +73,7 @@ public class UpdateHandlerTest extends AbstractTestBase {
     public void post_execute() {
         verify(rds, atLeastOnce()).serviceName();
         verifyNoMoreInteractions(proxyRdsClient.client());
+        verifyAccessPermissions(proxyRdsClient.client());
     }
 
     @Test

--- a/aws-rds-eventsubscription/src/test/java/software/amazon/rds/eventsubscription/AbstractTestBase.java
+++ b/aws-rds-eventsubscription/src/test/java/software/amazon/rds/eventsubscription/AbstractTestBase.java
@@ -3,6 +3,8 @@ package software.amazon.rds.eventsubscription;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 
+import org.json.JSONObject;
+
 import software.amazon.awssdk.awscore.AwsRequest;
 import software.amazon.awssdk.awscore.AwsResponse;
 import software.amazon.awssdk.core.ResponseBytes;
@@ -13,14 +15,28 @@ import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.Credentials;
 import software.amazon.cloudformation.proxy.LoggerProxy;
 import software.amazon.cloudformation.proxy.ProxyClient;
+import software.amazon.rds.test.common.core.HandlerName;
+import software.amazon.rds.test.common.core.TestUtils;
+import software.amazon.rds.test.common.verification.AccessPermissionVerificationMode;
 
-public class AbstractTestBase {
+public abstract class AbstractTestBase {
     protected static final Credentials MOCK_CREDENTIALS;
     protected static final LoggerProxy logger;
 
     static {
         MOCK_CREDENTIALS = new Credentials("accessKey", "secretKey", "token");
         logger = new LoggerProxy();
+    }
+
+    public abstract HandlerName getHandlerName();
+
+    private static final JSONObject resourceSchema = new Configuration().resourceSchemaJSONObject();
+
+    public void verifyAccessPermissions(final Object mock) {
+        new AccessPermissionVerificationMode()
+                .withDefaultPermissions()
+                .withSchemaPermissions(resourceSchema, getHandlerName())
+                .verify(TestUtils.getVerificationData(mock));
     }
 
     static ProxyClient<RdsClient> MOCK_PROXY(

--- a/aws-rds-eventsubscription/src/test/java/software/amazon/rds/eventsubscription/CreateHandlerTest.java
+++ b/aws-rds-eventsubscription/src/test/java/software/amazon/rds/eventsubscription/CreateHandlerTest.java
@@ -39,6 +39,7 @@ import software.amazon.cloudformation.proxy.OperationStatus;
 import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
+import software.amazon.rds.test.common.core.HandlerName;
 
 @ExtendWith(MockitoExtension.class)
 public class CreateHandlerTest extends AbstractTestBase {
@@ -48,10 +49,17 @@ public class CreateHandlerTest extends AbstractTestBase {
 
     @Mock
     RdsClient rds;
+
     @Mock
     private AmazonWebServicesClientProxy proxy;
+
     @Mock
     private ProxyClient<RdsClient> proxyRdsClient;
+
+    @Override
+    public HandlerName getHandlerName() {
+        return HandlerName.CREATE;
+    }
 
     @BeforeEach
     public void setup() {
@@ -64,6 +72,7 @@ public class CreateHandlerTest extends AbstractTestBase {
     public void post_execute() {
         verify(rds, atLeastOnce()).serviceName();
         verifyNoMoreInteractions(rds);
+        verifyAccessPermissions(rds);
     }
 
     @Test

--- a/aws-rds-eventsubscription/src/test/java/software/amazon/rds/eventsubscription/DeleteHandlerTest.java
+++ b/aws-rds-eventsubscription/src/test/java/software/amazon/rds/eventsubscription/DeleteHandlerTest.java
@@ -27,16 +27,24 @@ import software.amazon.cloudformation.proxy.OperationStatus;
 import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
+import software.amazon.rds.test.common.core.HandlerName;
 
 @ExtendWith(MockitoExtension.class)
 public class DeleteHandlerTest extends AbstractTestBase {
 
     @Mock
     RdsClient rds;
+
     @Mock
     private AmazonWebServicesClientProxy proxy;
+
     @Mock
     private ProxyClient<RdsClient> proxyRdsClient;
+
+    @Override
+    public HandlerName getHandlerName() {
+        return HandlerName.DELETE;
+    }
 
     @BeforeEach
     public void setup() {
@@ -49,6 +57,7 @@ public class DeleteHandlerTest extends AbstractTestBase {
     public void post_execute() {
         verify(rds, atLeastOnce()).serviceName();
         verifyNoMoreInteractions(rds);
+        verifyAccessPermissions(rds);
     }
 
     @Test

--- a/aws-rds-eventsubscription/src/test/java/software/amazon/rds/eventsubscription/ListHandlerTest.java
+++ b/aws-rds-eventsubscription/src/test/java/software/amazon/rds/eventsubscription/ListHandlerTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.when;
 
 import java.time.Duration;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -23,6 +24,7 @@ import software.amazon.cloudformation.proxy.OperationStatus;
 import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
+import software.amazon.rds.test.common.core.HandlerName;
 
 @ExtendWith(MockitoExtension.class)
 public class ListHandlerTest extends AbstractTestBase {
@@ -33,10 +35,20 @@ public class ListHandlerTest extends AbstractTestBase {
     @Mock
     private ProxyClient<RdsClient> proxyRdsClient;
 
+    @Override
+    public HandlerName getHandlerName() {
+        return HandlerName.LIST;
+    }
+
     @BeforeEach
     public void setup() {
         proxy = new AmazonWebServicesClientProxy(logger, MOCK_CREDENTIALS, () -> Duration.ofSeconds(600).toMillis());
         proxyRdsClient = MOCK_PROXY(proxy, mock(RdsClient.class));
+    }
+
+    @AfterEach
+    public void post_execute() {
+        verifyAccessPermissions(proxyRdsClient.client());
     }
 
     @Test

--- a/aws-rds-eventsubscription/src/test/java/software/amazon/rds/eventsubscription/ReadHandlerTest.java
+++ b/aws-rds-eventsubscription/src/test/java/software/amazon/rds/eventsubscription/ReadHandlerTest.java
@@ -29,6 +29,7 @@ import software.amazon.cloudformation.proxy.OperationStatus;
 import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
+import software.amazon.rds.test.common.core.HandlerName;
 
 @ExtendWith(MockitoExtension.class)
 public class ReadHandlerTest extends AbstractTestBase {
@@ -42,6 +43,11 @@ public class ReadHandlerTest extends AbstractTestBase {
     @Mock
     RdsClient rds;
 
+    @Override
+    public HandlerName getHandlerName() {
+        return HandlerName.READ;
+    }
+
     @BeforeEach
     public void setup() {
         proxy = new AmazonWebServicesClientProxy(logger, MOCK_CREDENTIALS, () -> Duration.ofSeconds(600).toMillis());
@@ -53,6 +59,7 @@ public class ReadHandlerTest extends AbstractTestBase {
     public void post_execute() {
         verify(rds, atLeastOnce()).serviceName();
         verifyNoMoreInteractions(rds);
+        verifyAccessPermissions(rds);
     }
 
     @Test

--- a/aws-rds-eventsubscription/src/test/java/software/amazon/rds/eventsubscription/UpdateHandlerTest.java
+++ b/aws-rds-eventsubscription/src/test/java/software/amazon/rds/eventsubscription/UpdateHandlerTest.java
@@ -25,7 +25,6 @@ import software.amazon.awssdk.services.rds.model.AddSourceIdentifierToSubscripti
 import software.amazon.awssdk.services.rds.model.AddSourceIdentifierToSubscriptionResponse;
 import software.amazon.awssdk.services.rds.model.AddTagsToResourceRequest;
 import software.amazon.awssdk.services.rds.model.AddTagsToResourceResponse;
-import software.amazon.awssdk.services.rds.model.CreateEventSubscriptionRequest;
 import software.amazon.awssdk.services.rds.model.DescribeEventSubscriptionsRequest;
 import software.amazon.awssdk.services.rds.model.DescribeEventSubscriptionsResponse;
 import software.amazon.awssdk.services.rds.model.EventSubscription;
@@ -36,14 +35,13 @@ import software.amazon.awssdk.services.rds.model.ModifyEventSubscriptionResponse
 import software.amazon.awssdk.services.rds.model.RemoveSourceIdentifierFromSubscriptionRequest;
 import software.amazon.awssdk.services.rds.model.RemoveSourceIdentifierFromSubscriptionResponse;
 import software.amazon.awssdk.services.rds.model.RemoveTagsFromResourceRequest;
-import software.amazon.awssdk.services.rds.model.ResourceNotFoundException;
 import software.amazon.awssdk.services.rds.model.SourceNotFoundException;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
-import software.amazon.cloudformation.proxy.HandlerErrorCode;
 import software.amazon.cloudformation.proxy.OperationStatus;
 import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
+import software.amazon.rds.test.common.core.HandlerName;
 
 @ExtendWith(MockitoExtension.class)
 public class UpdateHandlerTest extends AbstractTestBase {
@@ -57,6 +55,11 @@ public class UpdateHandlerTest extends AbstractTestBase {
     @Mock
     RdsClient rds;
 
+    @Override
+    public HandlerName getHandlerName() {
+        return HandlerName.UPDATE;
+    }
+
     @BeforeEach
     public void setup() {
         proxy = new AmazonWebServicesClientProxy(logger, MOCK_CREDENTIALS, () -> Duration.ofSeconds(600).toMillis());
@@ -68,6 +71,7 @@ public class UpdateHandlerTest extends AbstractTestBase {
     public void post_execute() {
         verify(rds, atLeastOnce()).serviceName();
         verifyNoMoreInteractions(rds);
+        verifyAccessPermissions(rds);
     }
 
     @Test

--- a/aws-rds-optiongroup/aws-rds-optiongroup.json
+++ b/aws-rds-optiongroup/aws-rds-optiongroup.json
@@ -149,7 +149,8 @@
         "rds:AddTagsToResource",
         "rds:CreateOptionGroup",
         "rds:DescribeOptionGroups",
-        "rds:ListTagsForResource"
+        "rds:ListTagsForResource",
+        "rds:ModifyOptionGroup"
       ]
     },
     "read": {

--- a/aws-rds-optiongroup/src/test/java/software/amazon/rds/optiongroup/AbstractTestBase.java
+++ b/aws-rds-optiongroup/src/test/java/software/amazon/rds/optiongroup/AbstractTestBase.java
@@ -8,6 +8,8 @@ import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
+import org.json.JSONObject;
+
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 
@@ -28,6 +30,9 @@ import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 import software.amazon.cloudformation.proxy.delay.Constant;
 import software.amazon.rds.common.handler.Tagging;
+import software.amazon.rds.test.common.core.HandlerName;
+import software.amazon.rds.test.common.core.TestUtils;
+import software.amazon.rds.test.common.verification.AccessPermissionVerificationMode;
 
 public abstract class AbstractTestBase extends software.amazon.rds.test.common.core.AbstractTestBase<OptionGroup, ResourceModel, CallbackContext> {
 
@@ -145,6 +150,17 @@ public abstract class AbstractTestBase extends software.amazon.rds.test.common.c
     protected abstract AmazonWebServicesClientProxy getProxy();
 
     protected abstract ProxyClient<RdsClient> getProxyClient();
+
+    public abstract HandlerName getHandlerName();
+
+    private static final JSONObject resourceSchema = new Configuration().resourceSchemaJsonObject();
+
+    public void verifyAccessPermissions(final Object mock) {
+        new AccessPermissionVerificationMode()
+                .withDefaultPermissions()
+                .withSchemaPermissions(resourceSchema, getHandlerName())
+                .verify(TestUtils.getVerificationData(mock));
+    }
 
     @Override
     protected String getLogicalResourceIdentifier() {

--- a/aws-rds-optiongroup/src/test/java/software/amazon/rds/optiongroup/CreateHandlerTest.java
+++ b/aws-rds-optiongroup/src/test/java/software/amazon/rds/optiongroup/CreateHandlerTest.java
@@ -46,6 +46,7 @@ import software.amazon.cloudformation.proxy.OperationStatus;
 import software.amazon.rds.common.error.ErrorCode;
 import software.amazon.rds.common.handler.HandlerConfig;
 import software.amazon.rds.common.handler.Tagging;
+import software.amazon.rds.test.common.core.HandlerName;
 import software.amazon.rds.test.common.core.TestUtils;
 
 @ExtendWith(MockitoExtension.class)
@@ -64,6 +65,11 @@ public class CreateHandlerTest extends AbstractTestBase {
 
     @Getter
     private CreateHandler handler;
+
+    @Override
+    public HandlerName getHandlerName() {
+        return HandlerName.CREATE;
+    }
 
     @BeforeEach
     public void setup() {
@@ -85,6 +91,7 @@ public class CreateHandlerTest extends AbstractTestBase {
 
         verify(rdsClient, atLeastOnce()).serviceName();
         verifyNoMoreInteractions(rdsClient);
+        verifyAccessPermissions(rdsClient);
     }
 
     @Test

--- a/aws-rds-optiongroup/src/test/java/software/amazon/rds/optiongroup/DeleteHandlerTest.java
+++ b/aws-rds-optiongroup/src/test/java/software/amazon/rds/optiongroup/DeleteHandlerTest.java
@@ -28,6 +28,7 @@ import software.amazon.cloudformation.proxy.HandlerErrorCode;
 import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.rds.common.handler.HandlerConfig;
+import software.amazon.rds.test.common.core.HandlerName;
 
 @ExtendWith(MockitoExtension.class)
 public class DeleteHandlerTest extends AbstractTestBase {
@@ -46,6 +47,11 @@ public class DeleteHandlerTest extends AbstractTestBase {
     @Getter
     private DeleteHandler handler;
 
+    @Override
+    public HandlerName getHandlerName() {
+        return HandlerName.DELETE;
+    }
+
     @BeforeEach
     public void setup() {
         handler = new DeleteHandler(HandlerConfig.builder()
@@ -60,6 +66,7 @@ public class DeleteHandlerTest extends AbstractTestBase {
     public void tear_down() {
         verify(rdsClient, atLeastOnce()).serviceName();
         verifyNoMoreInteractions(rdsClient);
+        verifyAccessPermissions(rdsClient);
     }
 
     @Test

--- a/aws-rds-optiongroup/src/test/java/software/amazon/rds/optiongroup/ListHandlerTest.java
+++ b/aws-rds-optiongroup/src/test/java/software/amazon/rds/optiongroup/ListHandlerTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.when;
 import java.time.Duration;
 import java.util.Collections;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -26,6 +27,7 @@ import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 import software.amazon.rds.common.handler.HandlerConfig;
+import software.amazon.rds.test.common.core.HandlerName;
 
 @ExtendWith(MockitoExtension.class)
 public class ListHandlerTest extends AbstractTestBase {
@@ -44,6 +46,11 @@ public class ListHandlerTest extends AbstractTestBase {
     @Getter
     private ListHandler handler;
 
+    @Override
+    public HandlerName getHandlerName() {
+        return HandlerName.LIST;
+    }
+
     @BeforeEach
     public void setup() {
         handler = new ListHandler(HandlerConfig.builder()
@@ -52,6 +59,11 @@ public class ListHandlerTest extends AbstractTestBase {
         rdsClient = mock(RdsClient.class);
         proxy = new AmazonWebServicesClientProxy(logger, MOCK_CREDENTIALS, () -> Duration.ofSeconds(600).toMillis());
         proxyClient = MOCK_PROXY(proxy, rdsClient);
+    }
+
+    @AfterEach
+    public void tear_down() {
+        verifyAccessPermissions(rdsClient);
     }
 
     @Test

--- a/aws-rds-optiongroup/src/test/java/software/amazon/rds/optiongroup/ReadHandlerTest.java
+++ b/aws-rds-optiongroup/src/test/java/software/amazon/rds/optiongroup/ReadHandlerTest.java
@@ -27,6 +27,7 @@ import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.HandlerErrorCode;
 import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.rds.common.handler.HandlerConfig;
+import software.amazon.rds.test.common.core.HandlerName;
 
 @ExtendWith(MockitoExtension.class)
 public class ReadHandlerTest extends AbstractTestBase {
@@ -45,6 +46,11 @@ public class ReadHandlerTest extends AbstractTestBase {
     @Getter
     private ReadHandler handler;
 
+    @Override
+    public HandlerName getHandlerName() {
+        return HandlerName.READ;
+    }
+
     @BeforeEach
     public void setup() {
         handler = new ReadHandler(HandlerConfig.builder()
@@ -59,6 +65,7 @@ public class ReadHandlerTest extends AbstractTestBase {
     public void tear_down() {
         verify(rdsClient, atLeastOnce()).serviceName();
         verifyNoMoreInteractions(rdsClient);
+        verifyAccessPermissions(rdsClient);
     }
 
     @Test

--- a/aws-rds-optiongroup/src/test/java/software/amazon/rds/optiongroup/UpdateHandlerTest.java
+++ b/aws-rds-optiongroup/src/test/java/software/amazon/rds/optiongroup/UpdateHandlerTest.java
@@ -31,6 +31,7 @@ import software.amazon.awssdk.services.rds.model.Tag;
 import software.amazon.cloudformation.proxy.*;
 import software.amazon.rds.common.error.ErrorCode;
 import software.amazon.rds.common.handler.HandlerConfig;
+import software.amazon.rds.test.common.core.HandlerName;
 import software.amazon.rds.test.common.core.TestUtils;
 
 @ExtendWith(MockitoExtension.class)
@@ -50,6 +51,11 @@ public class UpdateHandlerTest extends AbstractTestBase {
     @Getter
     private UpdateHandler handler;
 
+    @Override
+    public HandlerName getHandlerName() {
+        return HandlerName.UPDATE;
+    }
+
     @BeforeEach
     public void setup() {
         handler = new UpdateHandler(HandlerConfig.builder()
@@ -64,6 +70,7 @@ public class UpdateHandlerTest extends AbstractTestBase {
     public void tear_down() {
         verify(rdsClient, atLeastOnce()).serviceName();
         verifyNoMoreInteractions(rdsClient);
+        verifyAccessPermissions(rdsClient);
     }
 
     @Test


### PR DESCRIPTION
This commit adds a mechanism to programmatically verify the schema permission integrity. The motivation for this change is to close the gap between the schema definition and the actual implementation. As practice indicates, one of the most common problems occurs when a new API call is being added and no corresponding access permission is requested by the schema.

The approach in a nutshell is to inspect the corresponding client object after every unit test execution and verify that all invocations were declared in the corresponding schema access permissions.

The public API for access permission verification is:

    verifyFASPermissions(clientMock);

It is supposed to be called upon every unit test completion, e.g:

    @AfterEach
    public void tearDown() {
        verifyFASPermissions(clientMock);
    }

The verifier will throw a MockitoAssertionError if the permission is missing.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Signed-off-by: Oleg Sidorov <sidorovo@amazon.com>