### PR TITLE
[DBInstance] Move status definitions to enums

### DIFF
--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/BaseHandlerStd.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/BaseHandlerStd.java
@@ -54,6 +54,7 @@ import software.amazon.awssdk.services.rds.model.InvalidRestoreException;
 import software.amazon.awssdk.services.rds.model.InvalidSubnetException;
 import software.amazon.awssdk.services.rds.model.InvalidVpcNetworkStateException;
 import software.amazon.awssdk.services.rds.model.KmsKeyNotAccessibleException;
+import software.amazon.awssdk.services.rds.model.OptionGroupMembership;
 import software.amazon.awssdk.services.rds.model.OptionGroupNotFoundException;
 import software.amazon.awssdk.services.rds.model.PendingModifiedValues;
 import software.amazon.awssdk.services.rds.model.ProvisionedIopsNotAvailableInAzException;
@@ -87,6 +88,12 @@ import software.amazon.rds.dbinstance.client.RdsClientProvider;
 import software.amazon.rds.dbinstance.client.VersionedProxyClient;
 import software.amazon.rds.dbinstance.request.RequestValidationException;
 import software.amazon.rds.dbinstance.request.ValidatedRequest;
+import software.amazon.rds.dbinstance.status.DBInstanceStatus;
+import software.amazon.rds.dbinstance.status.DBParameterGroupStatus;
+import software.amazon.rds.dbinstance.status.DomainMembershipStatus;
+import software.amazon.rds.dbinstance.status.OptionGroupStatus;
+import software.amazon.rds.dbinstance.status.ReadReplicaStatus;
+import software.amazon.rds.dbinstance.status.VPCSecurityGroupStatus;
 import software.amazon.rds.dbinstance.util.ResourceModelHelper;
 
 public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
@@ -96,15 +103,7 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
 
     public static final String API_VERSION_V12 = "2012-09-17";
 
-    static final String DB_PARAMETER_GROUP_STATUS_APPLYING = "applying";
-    static final String IN_SYNC_STATUS = "in-sync";
-    static final String PENDING_REBOOT_STATUS = "pending-reboot";
-    static final String READ_REPLICA_STATUS = "read replication";
-    static final String STORAGE_FULL_STATUS = "storage-full";
-    static final String READ_REPLICA_STATUS_REPLICATING = "replicating";
-    static final String VPC_SECURITY_GROUP_STATUS_ACTIVE = "active";
-    static final String DOMAIN_MEMBERSHIP_JOINED = "joined";
-    static final String DOMAIN_MEMBERSHIP_KERBEROS_ENABLED = "kerberos-enabled";
+    static final String READ_REPLICA_STATUS_TYPE = "read replication";
 
     protected static final int RESOURCE_ID_MAX_LENGTH = 63;
 
@@ -503,11 +502,32 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
         return false;
     }
 
-    private void assertNoTerminalStatus(final DBInstance dbInstance) throws CfnNotStabilizedException {
+    private void assertNoDBInstanceTerminalStatus(final DBInstance dbInstance) throws CfnNotStabilizedException {
         final DBInstanceStatus status = DBInstanceStatus.fromString(dbInstance.dbInstanceStatus());
         if (status != null && status.isTerminal()) {
             throw new CfnNotStabilizedException(new Exception("DB Instance is in state: " + status.toString()));
         }
+    }
+
+    private void assertNoOptionGroupTerminalStatus(final DBInstance dbInstance) throws CfnNotStabilizedException {
+        final List<OptionGroupMembership> termOptionGroups = Optional.ofNullable(dbInstance.optionGroupMemberships()).orElse(Collections.emptyList())
+                .stream()
+                .filter(optionGroup -> {
+                    final OptionGroupStatus status = OptionGroupStatus.fromString(optionGroup.status());
+                    return status != null && status.isTerminal();
+                })
+                .collect(Collectors.toList());
+
+        if (!termOptionGroups.isEmpty()) {
+            throw new CfnNotStabilizedException(new Exception(
+                    String.format("OptionGroup %s is in a terminal state",
+                            termOptionGroups.get(0).optionGroupName())));
+        }
+    }
+
+    private void assertNoTerminalStatus(final DBInstance dbInstance) throws CfnNotStabilizedException {
+        assertNoDBInstanceTerminalStatus(dbInstance);
+        assertNoOptionGroupTerminalStatus(dbInstance);
     }
 
     protected boolean isDBInstanceStabilizedAfterMutate(
@@ -552,14 +572,14 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
     boolean isDomainMembershipsJoined(final DBInstance dbInstance) {
         return Optional.ofNullable(dbInstance.domainMemberships()).orElse(Collections.emptyList())
                 .stream()
-                .allMatch(membership -> DOMAIN_MEMBERSHIP_JOINED.equals(membership.status()) ||
-                        DOMAIN_MEMBERSHIP_KERBEROS_ENABLED.equals(membership.status()));
+                .allMatch(membership -> DomainMembershipStatus.Joined.equalsString(membership.status()) ||
+                        DomainMembershipStatus.KerberosEnabled.equalsString(membership.status()));
     }
 
     boolean isVpcSecurityGroupsActive(final DBInstance dbInstance) {
         return Optional.ofNullable(dbInstance.vpcSecurityGroups()).orElse(Collections.emptyList())
                 .stream()
-                .allMatch(group -> VPC_SECURITY_GROUP_STATUS_ACTIVE.equals(group.status()));
+                .allMatch(group -> VPCSecurityGroupStatus.Active.equalsString(group.status()));
     }
 
     boolean isNoPendingChanges(final DBInstance dbInstance) {
@@ -588,14 +608,14 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
     boolean isDBParameterGroupNotApplying(final DBInstance dbInstance) {
         return Optional.ofNullable(dbInstance.dbParameterGroups()).orElse(Collections.emptyList())
                 .stream()
-                .noneMatch(group -> DB_PARAMETER_GROUP_STATUS_APPLYING.equals(group.parameterApplyStatus()));
+                .noneMatch(group -> DBParameterGroupStatus.Applying.equalsString(group.parameterApplyStatus()));
     }
 
     boolean isReplicationComplete(final DBInstance dbInstance) {
         return Optional.ofNullable(dbInstance.statusInfos()).orElse(Collections.emptyList())
                 .stream()
-                .filter(statusInfo -> READ_REPLICA_STATUS.equals(statusInfo.statusType()))
-                .allMatch(statusInfo -> READ_REPLICA_STATUS_REPLICATING.equals(statusInfo.status()));
+                .filter(statusInfo -> READ_REPLICA_STATUS_TYPE.equals(statusInfo.statusType()))
+                .allMatch(statusInfo -> ReadReplicaStatus.Replicating.equalsString(statusInfo.status()));
     }
 
     protected boolean isOptionGroupStabilized(
@@ -608,7 +628,7 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
     protected boolean isOptionGroupInSync(final DBInstance dbInstance) {
         return Optional.ofNullable(dbInstance.optionGroupMemberships()).orElse(Collections.emptyList())
                 .stream()
-                .allMatch(optionGroup -> IN_SYNC_STATUS.equals(optionGroup.status()));
+                .allMatch(optionGroup -> OptionGroupStatus.InSync.equalsString(optionGroup.status()));
     }
 
     protected boolean isDBParameterGroupStabilized(
@@ -621,7 +641,7 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
     protected boolean isDBParameterGroupInSync(final DBInstance dbInstance) {
         return Optional.ofNullable(dbInstance.dbParameterGroups()).orElse(Collections.emptyList())
                 .stream()
-                .allMatch(parameterGroup -> IN_SYNC_STATUS.equals(parameterGroup.parameterApplyStatus()));
+                .allMatch(parameterGroup -> DBParameterGroupStatus.InSync.equalsString(parameterGroup.parameterApplyStatus()));
     }
 
     protected boolean isDBClusterParameterGroupStabilized(
@@ -635,7 +655,7 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
         return Optional.ofNullable(dbCluster.dbClusterMembers()).orElse(Collections.emptyList())
                 .stream()
                 .filter(member -> model.getDBInstanceIdentifier().equalsIgnoreCase(member.dbInstanceIdentifier()))
-                .anyMatch(member -> IN_SYNC_STATUS.equals(member.dbClusterParameterGroupStatus()));
+                .anyMatch(member -> DBParameterGroupStatus.InSync.equalsString(member.dbClusterParameterGroupStatus()));
     }
 
     protected boolean isDBInstanceRoleStabilized(

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/UpdateHandler.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/UpdateHandler.java
@@ -34,6 +34,8 @@ import software.amazon.rds.common.handler.Tagging;
 import software.amazon.rds.dbinstance.client.ApiVersion;
 import software.amazon.rds.dbinstance.client.VersionedProxyClient;
 import software.amazon.rds.dbinstance.request.ValidatedRequest;
+import software.amazon.rds.dbinstance.status.DBInstanceStatus;
+import software.amazon.rds.dbinstance.status.DBParameterGroupStatus;
 import software.amazon.rds.dbinstance.util.ImmutabilityHelper;
 
 public class UpdateHandler extends BaseHandlerStd {
@@ -175,7 +177,7 @@ public class UpdateHandler extends BaseHandlerStd {
         try {
             final DBInstance dbInstance = fetchDBInstance(proxyClient, progress.getResourceModel());
             if (!CollectionUtils.isNullOrEmpty(dbInstance.dbParameterGroups())) {
-                return PENDING_REBOOT_STATUS.equals(dbInstance.dbParameterGroups().get(0).parameterApplyStatus());
+                return DBParameterGroupStatus.PendingReboot.equalsString(dbInstance.dbParameterGroups().get(0).parameterApplyStatus());
             }
         } catch (DbInstanceNotFoundException e) {
             return false;
@@ -192,7 +194,7 @@ public class UpdateHandler extends BaseHandlerStd {
         if (!CollectionUtils.isNullOrEmpty(dbCluster.dbClusterMembers())) {
             for (final DBClusterMember member : dbCluster.dbClusterMembers()) {
                 if (dbInstanceIdentifier.equalsIgnoreCase(member.dbInstanceIdentifier())) {
-                    return PENDING_REBOOT_STATUS.equals(member.dbClusterParameterGroupStatus());
+                    return DBParameterGroupStatus.PendingReboot.equalsString(member.dbClusterParameterGroupStatus());
                 }
             }
         }
@@ -316,7 +318,7 @@ public class UpdateHandler extends BaseHandlerStd {
             return true;
         }
         final DBInstance instance = fetchDBInstance(rdsProxyClient, request.getDesiredResourceState());
-        return Objects.equals(instance.dbInstanceStatus(), STORAGE_FULL_STATUS);
+        return DBInstanceStatus.StorageFull.equalsString(instance.dbInstanceStatus());
     }
 
     private ProgressEvent<ResourceModel, CallbackContext> setDefaultVpcId(

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/status/DBInstanceStatus.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/status/DBInstanceStatus.java
@@ -7,11 +7,11 @@ public enum DBInstanceStatus implements TerminableStatus {
     Creating("creating"),
     Deleting("deleting"),
     Failed("failed", true),
-    IncompatibleRestore("incompatible-restore", true),
+    InaccessibleEncryptionCredentials("inaccessible-encryption-credentials", true),
     IncompatibleNetwork("incompatible-network", true),
     IncompatibleParameters("incompatible-parameters", true),
-    InaccessibleEncryptionCredentials("inaccessible-encryption-credentials", true),
-    StorageFull("storage-full", true);
+    IncompatibleRestore("incompatible-restore", true),
+    StorageFull("storage-full");
 
     private final String value;
     private final boolean terminal;

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/status/DBInstanceStatus.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/status/DBInstanceStatus.java
@@ -1,8 +1,8 @@
-package software.amazon.rds.dbinstance;
+package software.amazon.rds.dbinstance.status;
 
 import software.amazon.awssdk.utils.StringUtils;
 
-public enum DBInstanceStatus {
+public enum DBInstanceStatus implements TerminableStatus {
     Available("available"),
     Creating("creating"),
     Deleting("deleting"),
@@ -10,7 +10,8 @@ public enum DBInstanceStatus {
     IncompatibleRestore("incompatible-restore", true),
     IncompatibleNetwork("incompatible-network", true),
     IncompatibleParameters("incompatible-parameters", true),
-    InaccessibleEncryptionCredentials("inaccessible-encryption-credentials", true);
+    InaccessibleEncryptionCredentials("inaccessible-encryption-credentials", true),
+    StorageFull("storage-full", true);
 
     private final String value;
     private final boolean terminal;
@@ -24,23 +25,26 @@ public enum DBInstanceStatus {
         this.terminal = terminal;
     }
 
+    public static DBInstanceStatus fromString(final String status) {
+        for (final DBInstanceStatus dbInstanceStatus : DBInstanceStatus.values()) {
+            if (dbInstanceStatus.equalsString(status)) {
+                return dbInstanceStatus;
+            }
+        }
+        return null;
+    }
+
     @Override
     public String toString() {
         return value;
     }
 
-    public static DBInstanceStatus fromString(final String status) {
-        try {
-            return DBInstanceStatus.valueOf(status);
-        } catch (IllegalArgumentException e) {
-            return null;
-        }
-    }
-
+    @Override
     public boolean equalsString(final String other) {
         return StringUtils.equals(value, other);
     }
 
+    @Override
     public boolean isTerminal() {
         return this.terminal;
     }

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/status/DBParameterGroupStatus.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/status/DBParameterGroupStatus.java
@@ -1,0 +1,34 @@
+package software.amazon.rds.dbinstance.status;
+
+import software.amazon.awssdk.utils.StringUtils;
+
+public enum DBParameterGroupStatus implements Status {
+    Applying("applying"),
+    InSync("in-sync"),
+    PendingReboot("pending-reboot");
+
+    private final String value;
+
+    DBParameterGroupStatus(final String value) {
+        this.value = value;
+    }
+
+    public static DBParameterGroupStatus fromString(final String status) {
+        for (DBParameterGroupStatus dbParameterGroupStatus : DBParameterGroupStatus.values()) {
+            if (dbParameterGroupStatus.equalsString(status)) {
+                return dbParameterGroupStatus;
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public String toString() {
+        return this.value;
+    }
+
+    @Override
+    public boolean equalsString(final String other) {
+        return StringUtils.equals(this.value, other);
+    }
+}

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/status/DomainMembershipStatus.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/status/DomainMembershipStatus.java
@@ -1,0 +1,33 @@
+package software.amazon.rds.dbinstance.status;
+
+import software.amazon.awssdk.utils.StringUtils;
+
+public enum DomainMembershipStatus implements Status {
+    Joined("joined"),
+    KerberosEnabled("kerberos-enabled");
+
+    private final String value;
+
+    DomainMembershipStatus(final String value) {
+        this.value = value;
+    }
+
+    public static DomainMembershipStatus fromString(final String status) {
+        for (final DomainMembershipStatus domainMembershipStatus : DomainMembershipStatus.values()) {
+            if (domainMembershipStatus.equalsString(status)) {
+                return domainMembershipStatus;
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public String toString() {
+        return this.value;
+    }
+
+    @Override
+    public boolean equalsString(final String other) {
+        return StringUtils.equals(this.value, other);
+    }
+}

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/status/OptionGroupStatus.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/status/OptionGroupStatus.java
@@ -1,0 +1,44 @@
+package software.amazon.rds.dbinstance.status;
+
+import software.amazon.awssdk.utils.StringUtils;
+
+public enum OptionGroupStatus implements TerminableStatus {
+    InSync("in-sync"),
+    Failed("failed", true);
+
+    private final String value;
+    private final boolean terminal;
+
+    OptionGroupStatus(final String value) {
+        this(value, false);
+    }
+
+    OptionGroupStatus(final String value, final boolean terminal) {
+        this.value = value;
+        this.terminal = terminal;
+    }
+
+    public static OptionGroupStatus fromString(final String status) {
+        for (final OptionGroupStatus optionGroupStatus : OptionGroupStatus.values()) {
+            if (optionGroupStatus.equalsString(status)) {
+                return optionGroupStatus;
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public String toString() {
+        return this.value;
+    }
+
+    @Override
+    public boolean equalsString(final String other) {
+        return StringUtils.equals(this.value, other);
+    }
+
+    @Override
+    public boolean isTerminal() {
+        return this.terminal;
+    }
+}

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/status/ReadReplicaStatus.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/status/ReadReplicaStatus.java
@@ -1,0 +1,32 @@
+package software.amazon.rds.dbinstance.status;
+
+import software.amazon.awssdk.utils.StringUtils;
+
+public enum ReadReplicaStatus implements Status {
+    Replicating("replicating");
+
+    private final String value;
+
+    ReadReplicaStatus(final String value) {
+        this.value = value;
+    }
+
+    public static ReadReplicaStatus fromString(final String status) {
+        for (final ReadReplicaStatus readReplicaStatus : ReadReplicaStatus.values()) {
+            if (readReplicaStatus.equalsString(status)) {
+                return readReplicaStatus;
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public String toString() {
+        return this.value;
+    }
+
+    @Override
+    public boolean equalsString(final String other) {
+        return StringUtils.equals(this.value, other);
+    }
+}

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/status/Status.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/status/Status.java
@@ -1,0 +1,5 @@
+package software.amazon.rds.dbinstance.status;
+
+public interface Status {
+    boolean equalsString(String other);
+}

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/status/TerminableStatus.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/status/TerminableStatus.java
@@ -1,0 +1,5 @@
+package software.amazon.rds.dbinstance.status;
+
+public interface TerminableStatus extends Status {
+    boolean isTerminal();
+}

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/status/VPCSecurityGroupStatus.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/status/VPCSecurityGroupStatus.java
@@ -1,0 +1,32 @@
+package software.amazon.rds.dbinstance.status;
+
+import software.amazon.awssdk.utils.StringUtils;
+
+public enum VPCSecurityGroupStatus implements Status {
+    Active("active");
+
+    private final String value;
+
+    VPCSecurityGroupStatus(final String value) {
+        this.value = value;
+    }
+
+    public static VPCSecurityGroupStatus fromString(final String status) {
+        for (VPCSecurityGroupStatus vpcSecurityGroupStatus : VPCSecurityGroupStatus.values()) {
+            if (vpcSecurityGroupStatus.equalsString(status)) {
+                return vpcSecurityGroupStatus;
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public String toString() {
+        return this.value;
+    }
+
+    @Override
+    public boolean equalsString(final String other) {
+        return StringUtils.equals(this.value, other);
+    }
+}

--- a/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/UpdateHandlerTest.java
+++ b/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/UpdateHandlerTest.java
@@ -522,14 +522,14 @@ public class UpdateHandlerTest extends AbstractHandlerTest {
         transitions.add(DB_INSTANCE_ACTIVE.toBuilder().dbParameterGroups(
                 ImmutableList.of(DBParameterGroupStatus.builder()
                         .dbParameterGroupName(DB_PARAMETER_GROUP_NAME_DEFAULT)
-                        .parameterApplyStatus(UpdateHandler.PENDING_REBOOT_STATUS)
+                        .parameterApplyStatus(software.amazon.rds.dbinstance.status.DBParameterGroupStatus.PendingReboot.toString())
                         .build())
         ).build());
 
         transitions.add(DB_INSTANCE_ACTIVE.toBuilder().dbParameterGroups(
                 ImmutableList.of(DBParameterGroupStatus.builder()
                         .dbParameterGroupName(DB_PARAMETER_GROUP_NAME_DEFAULT)
-                        .parameterApplyStatus(UpdateHandler.IN_SYNC_STATUS)
+                        .parameterApplyStatus(software.amazon.rds.dbinstance.status.DBParameterGroupStatus.InSync.toString())
                         .build())
         ).build());
 

--- a/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/status/DBInstanceStatusTest.java
+++ b/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/status/DBInstanceStatusTest.java
@@ -1,0 +1,19 @@
+package software.amazon.rds.dbinstance.status;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class DBInstanceStatusTest {
+
+    @Test
+    public void test_fromString() {
+        for (final DBInstanceStatus status : DBInstanceStatus.values()) {
+            Assertions.assertThat(DBInstanceStatus.fromString(status.toString())).isEqualTo(status);
+        }
+    }
+
+    @Test
+    public void test_fromString_Unknown() {
+        Assertions.assertThat(DBInstanceStatus.fromString("unknown-status")).isNull();
+    }
+}

--- a/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/status/DBParameterGroupStatusTest.java
+++ b/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/status/DBParameterGroupStatusTest.java
@@ -1,0 +1,19 @@
+package software.amazon.rds.dbinstance.status;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class DBParameterGroupStatusTest {
+
+    @Test
+    public void test_fromString() {
+        for (final DBParameterGroupStatus status : DBParameterGroupStatus.values()) {
+            Assertions.assertThat(DBParameterGroupStatus.fromString(status.toString())).isEqualTo(status);
+        }
+    }
+
+    @Test
+    public void test_fromString_Unknown() {
+        Assertions.assertThat(DBParameterGroupStatus.fromString("unknown-status")).isNull();
+    }
+}

--- a/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/status/DomainMembershipStatusTest.java
+++ b/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/status/DomainMembershipStatusTest.java
@@ -1,0 +1,19 @@
+package software.amazon.rds.dbinstance.status;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class DomainMembershipStatusTest {
+
+    @Test
+    public void test_fromString() {
+        for (final DomainMembershipStatus status : DomainMembershipStatus.values()) {
+            Assertions.assertThat(DomainMembershipStatus.fromString(status.toString())).isEqualTo(status);
+        }
+    }
+
+    @Test
+    public void test_fromString_Unknown() {
+        Assertions.assertThat(DomainMembershipStatus.fromString("unknown-status")).isNull();
+    }
+}

--- a/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/status/OptionGroupStatusTest.java
+++ b/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/status/OptionGroupStatusTest.java
@@ -1,0 +1,19 @@
+package software.amazon.rds.dbinstance.status;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class OptionGroupStatusTest {
+
+    @Test
+    public void test_fromString() {
+        for (final OptionGroupStatus status : OptionGroupStatus.values()) {
+            Assertions.assertThat(OptionGroupStatus.fromString(status.toString())).isEqualTo(status);
+        }
+    }
+
+    @Test
+    public void test_fromString_Unknown() {
+        Assertions.assertThat(OptionGroupStatus.fromString("unknown-status")).isNull();
+    }
+}

--- a/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/status/ReadReplicaStatusTest.java
+++ b/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/status/ReadReplicaStatusTest.java
@@ -1,0 +1,19 @@
+package software.amazon.rds.dbinstance.status;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class ReadReplicaStatusTest {
+
+    @Test
+    public void test_fromString() {
+        for (final ReadReplicaStatus status : ReadReplicaStatus.values()) {
+            Assertions.assertThat(ReadReplicaStatus.fromString(status.toString())).isEqualTo(status);
+        }
+    }
+
+    @Test
+    public void test_fromString_Unknown() {
+        Assertions.assertThat(ReadReplicaStatus.fromString("unknown-status")).isNull();
+    }
+}

--- a/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/status/VPCSecurityGroupStatusTest.java
+++ b/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/status/VPCSecurityGroupStatusTest.java
@@ -1,0 +1,19 @@
+package software.amazon.rds.dbinstance.status;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class VPCSecurityGroupStatusTest {
+
+    @Test
+    public void test_fromString() {
+        for (final VPCSecurityGroupStatus status : VPCSecurityGroupStatus.values()) {
+            Assertions.assertThat(VPCSecurityGroupStatus.fromString(status.toString())).isEqualTo(status);
+        }
+    }
+
+    @Test
+    public void test_fromString_Unknown() {
+        Assertions.assertThat(VPCSecurityGroupStatus.fromString("unknown-status")).isNull();
+    }
+}


### PR DESCRIPTION
This commits performs a shallow refactoring of the status tracking layer which was implemented as a trivial set of string constants. `DBInstanceStatus` was the first case where we had to attach some additional meta-information to the status (terminal status flag).

Given our ultimate aim to let the stack expose unrecoverable problems as soon as possible, we are adding the same bit of information (terminal status flag) to `OptionGroupStatus`. This move motivates an introduction of a new inheritance chain.

Firstly, we introduce a `Status` interface which defines a minimalistic API for status-like enums. Whereas enums is a great way of handling discrete values, java adds some limitations on using the actual inheritance on these classes, hence we favor interfaces.

The second family grid or status-like objects is `TerminableStatus`. This interface declares a basic API to check whether this state is transient or terminal.

Other constant-defined statuses were moved to the same package and gained the same implementation of the base methods. Using this enum package is encouraged instead of const-based status handling.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Signed-off-by: Oleg Sidorov <sidorovo@amazon.com>