### PR TITLE
[DBCluster] Set default port for aurora-postgresql to `5432`

### DIFF
--- a/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/CreateHandler.java
+++ b/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/CreateHandler.java
@@ -36,8 +36,10 @@ public class CreateHandler extends BaseHandlerStd {
             final ResourceHandlerRequest<ResourceModel> request,
             final CallbackContext callbackContext,
             final ProxyClient<RdsClient> rdsProxyClient,
-            final ProxyClient<Ec2Client> ec2ProxyClient, final Logger logger) {
-        ResourceModel model = ModelAdapter.setDefaults(request.getDesiredResourceState());
+            final ProxyClient<Ec2Client> ec2ProxyClient, final Logger logger
+    ) {
+        final ResourceModel model = ModelAdapter.setDefaults(request.getDesiredResourceState());
+
         if (StringUtils.isNullOrEmpty(model.getDBClusterIdentifier())) {
             model.setDBClusterIdentifier(dbClusterIdentifierFactory.newIdentifier()
                     .withStackId(request.getStackId())

--- a/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/ModelAdapter.java
+++ b/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/ModelAdapter.java
@@ -1,7 +1,9 @@
 package software.amazon.rds.dbcluster;
 
 import java.util.List;
+import java.util.Map;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 
 public class ModelAdapter {
@@ -9,9 +11,13 @@ public class ModelAdapter {
     private static final int DEFAULT_BACKUP_RETENTION_PERIOD = 1;
     private static final int DEFAULT_MAX_CAPACITY = 16;
     private static final int DEFAULT_MIN_CAPACITY = 2;
-    private static final int DEFAULT_PORT = 3306;
     private static final int DEFAULT_SECONDS_UNTIL_AUTO_PAUSE = 300;
+    private static final int DEFAULT_PORT = 3306;
     private static final String SERVERLESS_ENGINE_MODE = "serverless";
+
+    private static final Map<String, Integer> DEFAULT_ENGINE_PORTS = ImmutableMap.of(
+            "aurora-postgresql", 5432
+    );
 
     public static ResourceModel setDefaults(final ResourceModel resourceModel) {
 
@@ -32,9 +38,13 @@ public class ModelAdapter {
                     .build();
             resourceModel.setScalingConfiguration(scalingConfiguration == null ? defaultScalingConfiguration : scalingConfiguration);
         } else {
-            resourceModel.setPort(port == null ? DEFAULT_PORT : port);
+            resourceModel.setPort(port != null ? port : getDefaultPortForEngine(resourceModel.getEngine()));
         }
 
         return resourceModel;
+    }
+
+    private static int getDefaultPortForEngine(final String engine) {
+        return DEFAULT_ENGINE_PORTS.getOrDefault(engine, DEFAULT_PORT);
     }
 }

--- a/aws-rds-dbcluster/src/test/java/software/amazon/rds/dbcluster/AbstractHandlerTest.java
+++ b/aws-rds-dbcluster/src/test/java/software/amazon/rds/dbcluster/AbstractHandlerTest.java
@@ -56,7 +56,6 @@ public abstract class AbstractHandlerTest extends AbstractTestBase<DBCluster, Re
     protected static final org.slf4j.Logger delegate;
     protected static final LoggerProxy logger;
 
-
     protected static final Integer BACKUP_RETENTION_PERIOD;
     protected static final Integer BACKTRACK_WINDOW;
     protected static final String DBCLUSTER_IDENTIFIER;
@@ -65,6 +64,7 @@ public abstract class AbstractHandlerTest extends AbstractTestBase<DBCluster, Re
     protected static final String SNAPSHOT_IDENTIFIER;
     protected static final String SOURCE_IDENTIFIER;
     protected static final String ENGINE;
+    protected static final String ENGINE_AURORA_POSTGRESQL;
     protected static final String ENGINE_MODE;
     protected static final Integer PORT;
     protected static final String USER_NAME;
@@ -119,6 +119,7 @@ public abstract class AbstractHandlerTest extends AbstractTestBase<DBCluster, Re
         SNAPSHOT_IDENTIFIER = "my-sample-dbcluster-snapshot";
         SOURCE_IDENTIFIER = "my-source-dbcluster-identifier";
         ENGINE = "aurora";
+        ENGINE_AURORA_POSTGRESQL = "aurora-postgresql";
         ENGINE_MODE = "serverless";
         PORT = 3306;
         USER_NAME = "username";


### PR DESCRIPTION
This commits fixes the create handler behavior in case a port value was not provided. The default value for this port is `3306` for Aurora and `5432` for Aurora Postgres.

Fixes #48.
Fixes https://github.com/aws-cloudformation/cloudformation-coverage-roadmap/issues/281.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Signed-off-by: Oleg Sidorov <sidorovo@amazon.com>