### PR TITLE
[DBInstance] Set `engineVersion` conditionally

### DIFF
--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/BaseHandlerStd.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/BaseHandlerStd.java
@@ -396,7 +396,7 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
     ) {
         return proxy.initiate("rds::modify-db-instance-v12", rdsProxyClient, progress.getResourceModel(), progress.getCallbackContext())
                 .translateToServiceRequest(resourceModel -> Translator.modifyDbInstanceRequestV12(
-                        Optional.ofNullable(request.getPreviousResourceState()).orElse(ResourceModel.builder().build()),
+                        request.getPreviousResourceState(),
                         request.getDesiredResourceState(),
                         BooleanUtils.isTrue(request.getRollback()))
                 )
@@ -422,7 +422,7 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
     ) {
         return proxy.initiate("rds::modify-db-instance", rdsProxyClient, progress.getResourceModel(), progress.getCallbackContext())
                 .translateToServiceRequest(resourceModel -> Translator.modifyDbInstanceRequest(
-                        Optional.ofNullable(request.getPreviousResourceState()).orElse(ResourceModel.builder().build()),
+                        request.getPreviousResourceState(),
                         request.getDesiredResourceState(),
                         BooleanUtils.isTrue(request.getRollback()))
                 )


### PR DESCRIPTION
This commit changes the way Translator constructs a `ModifyDBInstance` request. In particular, it only sets `engineVersion` attribute if there was any change. The motivation for this change is to avoid a potential immediate engine version upgrade that could be triggered by the API when the request contains a non-null `engineVersion` and marked for an immediate execution (always the case for CFN requests).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Signed-off-by: Oleg Sidorov <sidorovo@amazon.com>