### PR TITLE
[DBCluster] Stabilize on pending actions

### DIFF
--- a/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/BaseHandlerStd.java
+++ b/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/BaseHandlerStd.java
@@ -16,6 +16,7 @@ import software.amazon.awssdk.services.ec2.Ec2Client;
 import software.amazon.awssdk.services.ec2.model.DescribeSecurityGroupsResponse;
 import software.amazon.awssdk.services.ec2.model.SecurityGroup;
 import software.amazon.awssdk.services.rds.RdsClient;
+import software.amazon.awssdk.services.rds.model.ClusterPendingModifiedValues;
 import software.amazon.awssdk.services.rds.model.DBCluster;
 import software.amazon.awssdk.services.rds.model.DBSubnetGroup;
 import software.amazon.awssdk.services.rds.model.DbClusterAlreadyExistsException;
@@ -221,12 +222,25 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
         return StringUtils.isNotBlank(model.getGlobalClusterIdentifier());
     }
 
+    protected boolean isDBClusterAvailable(final DBCluster dbCluster) {
+        return DBClusterStatus.Available.equalsString(dbCluster.status());
+    }
+
+    protected boolean isNoPendingChanges(final DBCluster dbCluster) {
+        final ClusterPendingModifiedValues modifiedValues = dbCluster.pendingModifiedValues();
+        return modifiedValues == null || (
+                modifiedValues.masterUserPassword() == null &&
+                        modifiedValues.iamDatabaseAuthenticationEnabled() == null &&
+                        modifiedValues.engineVersion() == null);
+    }
+
     protected boolean isDBClusterStabilized(
             final ProxyClient<RdsClient> proxyClient,
             final ResourceModel model
     ) {
         final DBCluster dbCluster = fetchDBCluster(proxyClient, model);
-        return DBClusterStatus.Available.equalsString(dbCluster.status());
+        return isDBClusterAvailable(dbCluster) &&
+                isNoPendingChanges(dbCluster);
     }
 
     protected boolean isClusterRemovedFromGlobalCluster(


### PR DESCRIPTION
This commit adds an additional condition to the DBCluster stabilization logic: apart from checking that the cluster has achieved an Available state, it also checks there are no pending actions scheduled for an immediate execution.

The motivation for this change is the RDS API specifics: whereas some attributes are being applied immediately, the rest could be scheduled up for a delayed execution and picked up as soon as possible. This is the case for the following attributes:
  - `masterUserPassword`
  - `iamDatabaseAuthenticationEnabled`
  - `engineVersion`

This commit ensures the handler will inspect `pendingActions` before moving on.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Fixes #56.

Signed-off-by: Oleg Sidorov <sidorovo@amazon.com>