### PR TITLE
[DBCluster] Only update difference in associated roles.

### DIFF
--- a/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/UpdateHandler.java
+++ b/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/UpdateHandler.java
@@ -80,8 +80,12 @@ public class UpdateHandler extends BaseHandlerStd {
                         () -> modifyDBCluster(proxy, rdsProxyClient, progress, previousResourceState, desiredResourceState, isRollback),
                         CallbackContext::isModified,
                         CallbackContext::setModified))
-                .then(progress -> removeAssociatedRoles(proxy, rdsProxyClient, progress, setDefaults(request.getPreviousResourceState()).getAssociatedRoles()))
-                .then(progress -> addAssociatedRoles(proxy, rdsProxyClient, progress, progress.getResourceModel().getAssociatedRoles()))
+                .then(progress -> updateAssociatedRoles(
+                        proxy,
+                        rdsProxyClient,
+                        progress,
+                        request.getPreviousResourceState().getAssociatedRoles(),
+                        progress.getResourceModel().getAssociatedRoles()))
                 .then(progress -> updateTags(proxy, rdsProxyClient, progress, previousTags, desiredTags))
                 .then(progress -> new ReadHandler().handleRequest(proxy, request, callbackContext, rdsProxyClient, ec2ProxyClient, logger));
     }

--- a/aws-rds-dbcluster/src/test/java/software/amazon/rds/dbcluster/AbstractHandlerTest.java
+++ b/aws-rds-dbcluster/src/test/java/software/amazon/rds/dbcluster/AbstractHandlerTest.java
@@ -72,7 +72,11 @@ public abstract class AbstractHandlerTest extends AbstractTestBase<DBCluster, Re
     protected static final String USER_NAME;
     protected static final String USER_PASSWORD;
     protected static final String ROLE_ARN;
+    protected static final String OLD_ROLE_ARN;
+    protected static final String NEW_ROLE_ARN;
     protected static final String ROLE_FEATURE;
+    protected static final DBClusterRole OLD_ROLE;
+    protected static final DBClusterRole NEW_ROLE;
     protected static final DBClusterRole ROLE;
     protected static final DBClusterRole ROLE_WITH_EMPTY_FEATURE;
 
@@ -130,8 +134,12 @@ public abstract class AbstractHandlerTest extends AbstractTestBase<DBCluster, Re
         USER_PASSWORD = "xxx";
 
         ROLE_ARN = "sampleArn";
+        OLD_ROLE_ARN = "oldRoleArn";
+        NEW_ROLE_ARN = "newRoleArn";
         ROLE_FEATURE = "sampleFeature";
         ROLE = DBClusterRole.builder().roleArn(ROLE_ARN).featureName(ROLE_FEATURE).build();
+        OLD_ROLE = DBClusterRole.builder().roleArn(OLD_ROLE_ARN).build();
+        NEW_ROLE = DBClusterRole.builder().roleArn(NEW_ROLE_ARN).featureName(ROLE_FEATURE).build();
         ROLE_WITH_EMPTY_FEATURE = DBClusterRole.builder().roleArn(ROLE_ARN).build();
         VPC_SG_IDS = Arrays.asList("vpc-sg-id-1", "vpc-sg-id-2");
 

--- a/aws-rds-dbcluster/src/test/java/software/amazon/rds/dbcluster/UpdateHandlerTest.java
+++ b/aws-rds-dbcluster/src/test/java/software/amazon/rds/dbcluster/UpdateHandlerTest.java
@@ -141,7 +141,7 @@ public class UpdateHandlerTest extends AbstractHandlerTest {
                 context,
                 () -> DBCLUSTER_ACTIVE,
                 () -> RESOURCE_MODEL.toBuilder()
-                        .associatedRoles(ImmutableList.of(ROLE))
+                        .associatedRoles(ImmutableList.of(OLD_ROLE))
                         .build(),
                 () -> RESOURCE_MODEL.toBuilder()
                         .associatedRoles(ImmutableList.of(ROLE))
@@ -170,7 +170,7 @@ public class UpdateHandlerTest extends AbstractHandlerTest {
                 context,
                 () -> DBCLUSTER_ACTIVE,
                 () -> RESOURCE_MODEL.toBuilder()
-                        .associatedRoles(ImmutableList.of(ROLE))
+                        .associatedRoles(ImmutableList.of(OLD_ROLE))
                         .globalClusterIdentifier("global-cluster-identifier")
                         .build(),
                 () -> RESOURCE_MODEL.toBuilder()
@@ -275,7 +275,7 @@ public class UpdateHandlerTest extends AbstractHandlerTest {
                     return DBCLUSTER_ACTIVE;
                 },
                 () -> RESOURCE_MODEL.toBuilder()
-                        .associatedRoles(ImmutableList.of(ROLE))
+                        .associatedRoles(ImmutableList.of(OLD_ROLE))
                         .build(),
                 () -> RESOURCE_MODEL.toBuilder()
                         .associatedRoles(ImmutableList.of(ROLE))
@@ -377,7 +377,7 @@ public class UpdateHandlerTest extends AbstractHandlerTest {
                     return dbclusterActive;
                 },
                 () -> RESOURCE_MODEL.toBuilder()
-                        .associatedRoles(Lists.newArrayList(ROLE_WITH_EMPTY_FEATURE))
+                        .associatedRoles(Lists.newArrayList(ROLE))
                         .build(),
                 () -> RESOURCE_MODEL.toBuilder()
                         .associatedRoles(Lists.newArrayList(ROLE_WITH_EMPTY_FEATURE))
@@ -390,6 +390,59 @@ public class UpdateHandlerTest extends AbstractHandlerTest {
         verify(rdsProxy.client(), times(1)).addRoleToDBCluster(any(AddRoleToDbClusterRequest.class));
     }
 
+    @Test
+    public void handleRequest_HandleUpdateAssociatedRole() {
+        when(rdsProxy.client().removeRoleFromDBCluster(any(RemoveRoleFromDbClusterRequest.class)))
+                .thenReturn(RemoveRoleFromDbClusterResponse.builder().build());
+        when(rdsProxy.client().addRoleToDBCluster(any(AddRoleToDbClusterRequest.class)))
+                .thenReturn(AddRoleToDbClusterResponse.builder().build());
+
+        Queue<DBCluster> transitions = new ConcurrentLinkedQueue<>();
+
+        final DBCluster dbclusterActive = DBCLUSTER_ACTIVE.toBuilder()
+                .associatedRoles(software.amazon.awssdk.services.rds.model.DBClusterRole.builder()
+                                .roleArn(ROLE.getRoleArn())
+                                .featureName(ROLE.getFeatureName())
+                                .build(),
+                        software.amazon.awssdk.services.rds.model.DBClusterRole.builder()
+                                .roleArn(NEW_ROLE.getRoleArn())
+                                .featureName(NEW_ROLE.getFeatureName())
+                                .build())
+                .build();
+
+        transitions.add(dbclusterActive);
+        transitions.add(DBCLUSTER_INPROGRESS);
+        transitions.add(DBCLUSTER_ACTIVE_NO_ROLE);
+
+        final CallbackContext context = new CallbackContext();
+        context.setModified(true);
+
+        test_handleRequest_base(
+                context,
+                ResourceHandlerRequest.builder(),
+                () -> {
+                    if (transitions.size() > 0) {
+                        return transitions.remove();
+                    }
+                    return dbclusterActive;
+                },
+                () -> RESOURCE_MODEL.toBuilder()
+                        .associatedRoles(Lists.newArrayList(OLD_ROLE, ROLE))
+                        .build(),
+                () -> RESOURCE_MODEL.toBuilder()
+                        .associatedRoles(Lists.newArrayList(ROLE, NEW_ROLE))
+                        .build(),
+                expectSuccess()
+        );
+
+        verify(rdsProxy.client(), times(5)).describeDBClusters(any(DescribeDbClustersRequest.class));
+        ArgumentCaptor<RemoveRoleFromDbClusterRequest> removedRolesArgument = ArgumentCaptor.forClass(RemoveRoleFromDbClusterRequest.class);
+        verify(rdsProxy.client(), times(1)).removeRoleFromDBCluster(removedRolesArgument.capture());
+        Assertions.assertThat(removedRolesArgument.getValue().roleArn()).isEqualTo(OLD_ROLE.getRoleArn());
+        ArgumentCaptor<AddRoleToDbClusterRequest> addedRolesArgument = ArgumentCaptor.forClass(AddRoleToDbClusterRequest.class);
+        verify(rdsProxy.client(), times(1)).addRoleToDBCluster(addedRolesArgument.capture());
+        Assertions.assertThat(addedRolesArgument.getValue().roleArn()).isEqualTo(NEW_ROLE.getRoleArn());
+    }
 
     @Test
     public void handleRequest_ImmutableUpdate_GlobalCluster() {
@@ -511,7 +564,7 @@ public class UpdateHandlerTest extends AbstractHandlerTest {
                     return DBCLUSTER_ACTIVE;
                 },
                 () -> RESOURCE_MODEL.toBuilder()
-                        .associatedRoles(ImmutableList.of(ROLE))
+                        .associatedRoles(ImmutableList.of(OLD_ROLE))
                         .engineVersion(engineVersion)
                         .build(),
                 () -> RESOURCE_MODEL.toBuilder()


### PR DESCRIPTION
Change the unconditional way we update associated roles in DBCluster to only update the difference in roles between previous state and desired resource.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
