### PR TITLE
[DBCluster] Pass `VPCSecirutyGroups` to `RestoreDBClsuterToPointInTime`

### DIFF
--- a/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/Translator.java
+++ b/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/Translator.java
@@ -108,6 +108,7 @@ public class Translator {
                 .storageType(model.getStorageType())
                 .tags(Tagging.translateTagsToSdk(tagSet))
                 .useLatestRestorableTime(model.getUseLatestRestorableTime())
+                .vpcSecurityGroupIds(model.getVpcSecurityGroupIds())
                 .build();
     }
 

--- a/aws-rds-dbcluster/src/test/java/software/amazon/rds/dbcluster/CreateHandlerTest.java
+++ b/aws-rds-dbcluster/src/test/java/software/amazon/rds/dbcluster/CreateHandlerTest.java
@@ -405,6 +405,27 @@ public class CreateHandlerTest extends AbstractHandlerTest {
     }
 
     @Test
+    public void handleRequest_RestoreDbClusterToPointInTime_UpdateVpcSecurityGroups() {
+        when(rdsProxy.client().restoreDBClusterToPointInTime(any(RestoreDbClusterToPointInTimeRequest.class)))
+                .thenReturn(RestoreDbClusterToPointInTimeResponse.builder().build());
+
+        test_handleRequest_base(
+                new CallbackContext(),
+                () -> DBCLUSTER_ACTIVE,
+                () -> RESOURCE_MODEL_ON_RESTORE_IN_TIME.toBuilder()
+                        .vpcSecurityGroupIds(VPC_SG_IDS)
+                        .build(),
+                expectSuccess()
+        );
+
+        final ArgumentCaptor<RestoreDbClusterToPointInTimeRequest> argumentCaptor = ArgumentCaptor.forClass(RestoreDbClusterToPointInTimeRequest.class);
+        verify(rdsProxy.client(), times(1)).restoreDBClusterToPointInTime(argumentCaptor.capture());
+        Assertions.assertThat(argumentCaptor.getValue().vpcSecurityGroupIds()).isEqualTo(VPC_SG_IDS);
+
+        verify(rdsProxy.client(), times(2)).describeDBClusters(any(DescribeDbClustersRequest.class));
+    }
+
+    @Test
     public void handleRequest_RestoreDbClusterToPointInTime_ServerlessV2ScalingConfiguration() {
         when(rdsProxy.client().restoreDBClusterToPointInTime(any(RestoreDbClusterToPointInTimeRequest.class)))
                 .thenReturn(RestoreDbClusterToPointInTimeResponse.builder().build());


### PR DESCRIPTION
This commit modifies `RestoreDBClusterToPointInTime` request construction. In particular, `VPCSecurityGroupIds` parameter is being passed from the desired resource state. In this case one can restore a customer with a reference to the same security group set as the original cluster.

Fixes #15.
Fixes https://github.com/aws-cloudformation/cloudformation-coverage-roadmap/issues/336.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Signed-off-by: Oleg Sidorov <sidorovo@amazon.com>