### PR TITLE
[Common] Rework runtime config system

### DIFF
--- a/aws-rds-cfn-common/src/main/java/software/amazon/rds/common/config/RuntimeConfig.java
+++ b/aws-rds-cfn-common/src/main/java/software/amazon/rds/common/config/RuntimeConfig.java
@@ -1,0 +1,88 @@
+package software.amazon.rds.common.config;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
+
+import com.amazonaws.util.StringUtils;
+import software.amazon.rds.common.annotations.ExcludeFromJacocoGeneratedReport;
+
+public class RuntimeConfig {
+
+    public static final String RUNTIME_PROPERTIES = "config/runtime.properties";
+    public static final String TEST_PROPERTIES = "config/test.properties";
+
+    protected RuntimeConfig() {
+        this.rawProperties = new Properties();
+    }
+
+    private final Properties rawProperties;
+
+    @ExcludeFromJacocoGeneratedReport
+    public static RuntimeConfig loadFrom(final InputStream input) {
+        final RuntimeConfig config = new RuntimeConfig();
+        try {
+            config.rawProperties.load(input);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+
+        return config;
+    }
+
+    public Integer getInteger(final String key) {
+        return getInteger(key, null);
+    }
+
+    public Integer getInteger(final String key, final Integer defaultValue) {
+        final String stringVal = rawProperties.getProperty(key);
+        if (StringUtils.isNullOrEmpty(stringVal)) {
+            return defaultValue;
+        }
+        try {
+            return Integer.parseInt(stringVal, 10);
+        } catch (NumberFormatException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public Long getLong(final String key) {
+        return getLong(key, null);
+    }
+
+    public Long getLong(final String key, final Long defaultValue) {
+        final String stringVal = rawProperties.getProperty(key);
+        if (StringUtils.isNullOrEmpty(stringVal)) {
+            return defaultValue;
+        }
+        try {
+            return Long.parseLong(stringVal, 10);
+        } catch (NumberFormatException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public String getString(final String key) {
+        return getString(key, null);
+    }
+
+    public String getString(final String key, final String defaultValue) {
+        return rawProperties.getProperty(key, defaultValue);
+    }
+
+    public Boolean getBoolean(final String key) {
+        return getBoolean(key, null);
+    }
+
+    public Boolean getBoolean(final String key, final Boolean defaultValue) {
+        final String stringVal = rawProperties.getProperty(key);
+        if (StringUtils.isNullOrEmpty(stringVal)) {
+            return defaultValue;
+        }
+        return Boolean.parseBoolean(stringVal);
+    }
+
+    public boolean isSet(final String key) {
+        return rawProperties.containsKey(key);
+    }
+}

--- a/aws-rds-cfn-common/src/main/java/software/amazon/rds/common/util/ConfigHelper.java
+++ b/aws-rds-cfn-common/src/main/java/software/amazon/rds/common/util/ConfigHelper.java
@@ -1,0 +1,23 @@
+package software.amazon.rds.common.util;
+
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+
+import software.amazon.cloudformation.proxy.Delay;
+import software.amazon.cloudformation.proxy.delay.Constant;
+import software.amazon.rds.common.annotations.ExcludeFromJacocoGeneratedReport;
+import software.amazon.rds.common.config.RuntimeConfig;
+
+public class ConfigHelper {
+
+    public static final String HANDLER_BACKOFF_DELAY = "handler.backoff.delay";
+    public static final String HANDLER_BACKOFF_TIMEOUT = "handler.backoff.timeout";
+
+    @ExcludeFromJacocoGeneratedReport
+    public static Delay getBackoff(final RuntimeConfig config) {
+        return Constant.of()
+                .delay(Duration.ofMillis(config.getLong(HANDLER_BACKOFF_DELAY, TimeUnit.SECONDS.toMillis(30))))
+                .timeout(Duration.ofMillis(config.getLong(HANDLER_BACKOFF_TIMEOUT, TimeUnit.MINUTES.toMillis(180))))
+                .build();
+    }
+}

--- a/aws-rds-cfn-common/src/test/java/software/amazon/rds/common/config/RuntimeConfigTest.java
+++ b/aws-rds-cfn-common/src/test/java/software/amazon/rds/common/config/RuntimeConfigTest.java
@@ -1,0 +1,80 @@
+package software.amazon.rds.common.config;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class RuntimeConfigTest {
+
+    private final static String propertiesFile = "string.key=TestString\n" +
+            "integer.key=42\n" +
+            "long.key=1234567890\n" +
+            "boolean.key=true";
+
+    @Test
+    public void test_getString() {
+        final InputStream input = new ByteArrayInputStream(propertiesFile.getBytes(StandardCharsets.UTF_8));
+        final RuntimeConfig config = RuntimeConfig.loadFrom(input);
+        Assertions.assertThat(config.isSet("string.key")).isTrue();
+        Assertions.assertThat(config.getString("string.key")).isEqualTo("TestString");
+    }
+
+    @Test
+    public void test_getStringDefault() {
+        final InputStream input = new ByteArrayInputStream(propertiesFile.getBytes(StandardCharsets.UTF_8));
+        final RuntimeConfig config = RuntimeConfig.loadFrom(input);
+        Assertions.assertThat(config.isSet("string.key.non.existing")).isFalse();
+        Assertions.assertThat(config.getString("string.key.non.existing", "TestString")).isEqualTo("TestString");
+    }
+
+    @Test
+    public void test_getInteger() {
+        final InputStream input = new ByteArrayInputStream(propertiesFile.getBytes(StandardCharsets.UTF_8));
+        final RuntimeConfig config = RuntimeConfig.loadFrom(input);
+        Assertions.assertThat(config.isSet("integer.key")).isTrue();
+        Assertions.assertThat(config.getInteger("integer.key")).isEqualTo(42);
+    }
+
+    @Test
+    public void test_getIntegerDefault() {
+        final InputStream input = new ByteArrayInputStream(propertiesFile.getBytes(StandardCharsets.UTF_8));
+        final RuntimeConfig config = RuntimeConfig.loadFrom(input);
+        Assertions.assertThat(config.isSet("integer.key.non.existing")).isFalse();
+        Assertions.assertThat(config.getInteger("integer.key.non.existing", 42)).isEqualTo(42);
+    }
+
+    @Test
+    public void test_getLong() {
+        final InputStream input = new ByteArrayInputStream(propertiesFile.getBytes(StandardCharsets.UTF_8));
+        final RuntimeConfig config = RuntimeConfig.loadFrom(input);
+        Assertions.assertThat(config.isSet("long.key")).isTrue();
+        Assertions.assertThat(config.getLong("long.key")).isEqualTo(1234567890L);
+    }
+
+    @Test
+    public void test_getLongDefault() {
+        final InputStream input = new ByteArrayInputStream(propertiesFile.getBytes(StandardCharsets.UTF_8));
+        final RuntimeConfig config = RuntimeConfig.loadFrom(input);
+        Assertions.assertThat(config.isSet("long.key.non.existing")).isFalse();
+        Assertions.assertThat(config.getLong("long.key.non.existing", 1234567890L)).isEqualTo(1234567890L);
+    }
+
+    @Test
+    public void test_getBoolean() {
+        final InputStream input = new ByteArrayInputStream(propertiesFile.getBytes(StandardCharsets.UTF_8));
+        final RuntimeConfig config = RuntimeConfig.loadFrom(input);
+        Assertions.assertThat(config.isSet("boolean.key")).isTrue();
+        Assertions.assertThat(config.getBoolean("boolean.key")).isEqualTo(true);
+    }
+
+    @Test
+    public void test_getBooleanDefault() {
+        final InputStream input = new ByteArrayInputStream(propertiesFile.getBytes(StandardCharsets.UTF_8));
+        final RuntimeConfig config = RuntimeConfig.loadFrom(input);
+        Assertions.assertThat(config.isSet("boolean.key.non.existing")).isFalse();
+        Assertions.assertThat(config.getBoolean("boolean.key.non.existing", true)).isEqualTo(true);
+    }
+}

--- a/aws-rds-dbinstance/config/runtime.properties
+++ b/aws-rds-dbinstance/config/runtime.properties
@@ -1,0 +1,2 @@
+handler.backoff.delay=30000
+handler.backoff.timeout=129600000

--- a/aws-rds-dbinstance/config/test.properties
+++ b/aws-rds-dbinstance/config/test.properties
@@ -1,0 +1,2 @@
+handler.backoff.delay=1
+handler.backoff.timeout=1000

--- a/aws-rds-dbinstance/pom.xml
+++ b/aws-rds-dbinstance/pom.xml
@@ -224,6 +224,7 @@
                 <directory>${project.basedir}</directory>
                 <includes>
                     <include>aws-rds-dbinstance.json</include>
+                    <include>config/*.properties</include>
                 </includes>
             </resource>
         </resources>

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/Configuration.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/Configuration.java
@@ -1,15 +1,7 @@
 package software.amazon.rds.dbinstance;
 
-import org.json.JSONObject;
-import org.json.JSONTokener;
-
 class Configuration extends BaseConfiguration {
-
     public Configuration() {
         super("aws-rds-dbinstance.json");
-    }
-
-    public JSONObject resourceSchemaJsonObject() {
-        return new JSONObject(new JSONTokener(this.getClass().getClassLoader().getResourceAsStream(schemaFilename)));
     }
 }

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/ListHandler.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/ListHandler.java
@@ -8,17 +8,17 @@ import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.Logger;
 import software.amazon.cloudformation.proxy.OperationStatus;
 import software.amazon.cloudformation.proxy.ProgressEvent;
-import software.amazon.rds.common.handler.HandlerConfig;
+import software.amazon.rds.common.config.RuntimeConfig;
 import software.amazon.rds.dbinstance.client.VersionedProxyClient;
 import software.amazon.rds.dbinstance.request.ValidatedRequest;
 
 public class ListHandler extends BaseHandlerStd {
 
     public ListHandler() {
-        this(DEFAULT_DB_INSTANCE_HANDLER_CONFIG);
+        this(RuntimeConfig.loadFrom(resource(RuntimeConfig.RUNTIME_PROPERTIES)));
     }
 
-    public ListHandler(final HandlerConfig config) {
+    public ListHandler(final RuntimeConfig config) {
         super(config);
     }
 

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/ReadHandler.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/ReadHandler.java
@@ -6,18 +6,18 @@ import software.amazon.awssdk.services.rds.model.DBInstance;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.Logger;
 import software.amazon.cloudformation.proxy.ProgressEvent;
+import software.amazon.rds.common.config.RuntimeConfig;
 import software.amazon.rds.common.handler.Commons;
-import software.amazon.rds.common.handler.HandlerConfig;
 import software.amazon.rds.dbinstance.client.VersionedProxyClient;
 import software.amazon.rds.dbinstance.request.ValidatedRequest;
 
 public class ReadHandler extends BaseHandlerStd {
 
     public ReadHandler() {
-        this(DEFAULT_DB_INSTANCE_HANDLER_CONFIG);
+        this(RuntimeConfig.loadFrom(resource(RuntimeConfig.RUNTIME_PROPERTIES)));
     }
 
-    public ReadHandler(final HandlerConfig config) {
+    public ReadHandler(final RuntimeConfig config) {
         super(config);
     }
 

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/UpdateHandler.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/UpdateHandler.java
@@ -2,7 +2,6 @@ package software.amazon.rds.dbinstance;
 
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Function;
 
@@ -28,8 +27,9 @@ import software.amazon.cloudformation.proxy.Logger;
 import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
+import software.amazon.rds.common.util.ConfigHelper;
+import software.amazon.rds.common.config.RuntimeConfig;
 import software.amazon.rds.common.handler.Commons;
-import software.amazon.rds.common.handler.HandlerConfig;
 import software.amazon.rds.common.handler.Tagging;
 import software.amazon.rds.dbinstance.client.ApiVersion;
 import software.amazon.rds.dbinstance.client.VersionedProxyClient;
@@ -41,10 +41,10 @@ import software.amazon.rds.dbinstance.util.ImmutabilityHelper;
 public class UpdateHandler extends BaseHandlerStd {
 
     public UpdateHandler() {
-        this(DB_INSTANCE_HANDLER_CONFIG_36H);
+        this(RuntimeConfig.loadFrom(resource(RuntimeConfig.RUNTIME_PROPERTIES)));
     }
 
-    public UpdateHandler(final HandlerConfig config) {
+    public UpdateHandler(final RuntimeConfig config) {
         super(config);
     }
 
@@ -140,7 +140,7 @@ public class UpdateHandler extends BaseHandlerStd {
                         CallbackContext::isUpdatedRoles, CallbackContext::setUpdatedRoles)
                 )
                 .then(progress -> updateTags(proxy, rdsClient, progress, previousTags, desiredTags))
-                .then(progress -> new ReadHandler().handleRequest(proxy, request, callbackContext, rdsProxyClient, ec2ProxyClient, logger));
+                .then(progress -> new ReadHandler(config).handleRequest(proxy, request, callbackContext, rdsProxyClient, ec2ProxyClient, logger));
     }
 
     private ProgressEvent<ResourceModel, CallbackContext> handleResourceDrift(
@@ -167,7 +167,7 @@ public class UpdateHandler extends BaseHandlerStd {
                     }
                     return progress;
                 })
-                .then(progress -> new ReadHandler().handleRequest(proxy, request, callbackContext, rdsProxyClient, ec2ProxyClient, logger));
+                .then(progress -> new ReadHandler(config).handleRequest(proxy, request, callbackContext, rdsProxyClient, ec2ProxyClient, logger));
     }
 
     private boolean shouldReboot(
@@ -235,10 +235,10 @@ public class UpdateHandler extends BaseHandlerStd {
         progress.getCallbackContext().setAllocatingStorage(true);
         return proxy.initiate("rds::increase-allocated-storage", rdsProxyClient, progress.getResourceModel(), progress.getCallbackContext())
                 .translateToServiceRequest(Translator::updateAllocatedStorageRequest)
-                .backoffDelay(config.getBackoff())
+                .backoffDelay(ConfigHelper.getBackoff(config))
                 .makeServiceCall((modifyRequest, proxyInvocation) -> proxyInvocation.injectCredentialsAndInvokeV2(
-                                modifyRequest,
-                                proxyInvocation.client()::modifyDBInstance))
+                        modifyRequest,
+                        proxyInvocation.client()::modifyDBInstance))
                 .stabilize((request, response, proxyInvocation, model, context) -> isDBInstanceStabilizedAfterMutate(proxyInvocation, model))
                 .handleError((request, exception, proxyInvocation, model, context) -> Commons.handleException(
                         ProgressEvent.progress(model, context),
@@ -355,7 +355,7 @@ public class UpdateHandler extends BaseHandlerStd {
     ) {
         return proxy.initiate("rds::stabilize-db-parameter-group-drift", rdsProxyClient, progress.getResourceModel(), progress.getCallbackContext())
                 .translateToServiceRequest(Function.identity())
-                .backoffDelay(config.getBackoff())
+                .backoffDelay(ConfigHelper.getBackoff(config))
                 .makeServiceCall(NOOP_CALL)
                 .stabilize((request, response, proxyInvocation, model, context) -> isDBParameterGroupStabilized(proxyInvocation, model))
                 .handleError((request, exception, proxyInvocation, model, context) -> Commons.handleException(
@@ -373,7 +373,7 @@ public class UpdateHandler extends BaseHandlerStd {
     ) {
         return proxy.initiate("rds::stabilize-option-group-drift", rdsProxyClient, progress.getResourceModel(), progress.getCallbackContext())
                 .translateToServiceRequest(Function.identity())
-                .backoffDelay(config.getBackoff())
+                .backoffDelay(ConfigHelper.getBackoff(config))
                 .makeServiceCall(NOOP_CALL)
                 .stabilize((request, response, proxyInvocation, model, context) -> isOptionGroupStabilized(proxyInvocation, model))
                 .handleError((request, exception, proxyInvocation, model, context) -> Commons.handleException(
@@ -391,7 +391,7 @@ public class UpdateHandler extends BaseHandlerStd {
     ) {
         return proxy.initiate("rds::stabilize-db-cluster-parameter-group-drift", rdsProxyClient, progress.getResourceModel(), progress.getCallbackContext())
                 .translateToServiceRequest(Function.identity())
-                .backoffDelay(config.getBackoff())
+                .backoffDelay(ConfigHelper.getBackoff(config))
                 .makeServiceCall(NOOP_CALL)
                 .stabilize((request, response, proxyInvocation, model, context) -> isDBClusterParameterGroupStabilized(proxyInvocation, model))
                 .handleError((request, exception, proxyInvocation, model, context) -> Commons.handleException(

--- a/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/AbstractHandlerTest.java
+++ b/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/AbstractHandlerTest.java
@@ -5,7 +5,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.when;
 import static software.amazon.rds.dbinstance.BaseHandlerStd.API_VERSION_V12;
 
-import java.time.Duration;
+import java.io.InputStream;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.function.Supplier;
@@ -40,7 +40,6 @@ import software.amazon.cloudformation.proxy.LoggerProxy;
 import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
-import software.amazon.cloudformation.proxy.delay.Constant;
 import software.amazon.rds.common.handler.Tagging;
 import software.amazon.rds.dbinstance.client.ApiVersion;
 import software.amazon.rds.dbinstance.client.VersionedProxyClient;
@@ -190,11 +189,6 @@ public abstract class AbstractHandlerTest extends AbstractTestBase<DBInstance, R
     protected static final DBInstance DB_INSTANCE_MODIFYING;
     protected static final DBInstance DB_INSTANCE_EMPTY_PORT;
     protected static final DBInstance DB_INSTANCE_STORAGE_FULL;
-
-    protected static Constant TEST_BACKOFF_DELAY = Constant.of()
-            .delay(Duration.ofMillis(1L))
-            .timeout(Duration.ofSeconds(10L))
-            .build();
 
     static {
         MOCK_CREDENTIALS = new Credentials("accessKey", "secretKey", "token");
@@ -593,7 +587,7 @@ public abstract class AbstractHandlerTest extends AbstractTestBase<DBInstance, R
 
     public abstract HandlerName getHandlerName();
 
-    private static final JSONObject resourceSchema = new Configuration().resourceSchemaJsonObject();
+    private static final JSONObject resourceSchema = new Configuration().resourceSchemaJSONObject();
 
     public void verifyAccessPermissions(final Object mock) {
         new AccessPermissionVerificationMode()

--- a/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/BaseHandlerStdTest.java
+++ b/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/BaseHandlerStdTest.java
@@ -21,7 +21,7 @@ import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.Logger;
 import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
-import software.amazon.rds.common.handler.HandlerConfig;
+import software.amazon.rds.common.config.RuntimeConfig;
 import software.amazon.rds.dbinstance.client.VersionedProxyClient;
 import software.amazon.rds.dbinstance.request.RequestValidationException;
 import software.amazon.rds.dbinstance.request.ValidatedRequest;
@@ -30,7 +30,7 @@ class BaseHandlerStdTest {
 
     class TestBaseHandlerStd extends BaseHandlerStd {
 
-        public TestBaseHandlerStd(HandlerConfig config) {
+        public TestBaseHandlerStd(RuntimeConfig config) {
             super(config);
         }
 

--- a/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/CreateHandlerTest.java
+++ b/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/CreateHandlerTest.java
@@ -70,8 +70,8 @@ import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.HandlerErrorCode;
 import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
+import software.amazon.rds.common.config.RuntimeConfig;
 import software.amazon.rds.common.error.ErrorCode;
-import software.amazon.rds.common.handler.HandlerConfig;
 import software.amazon.rds.common.handler.Tagging;
 import software.amazon.rds.dbinstance.status.OptionGroupStatus;
 import software.amazon.rds.test.common.core.HandlerName;
@@ -125,10 +125,7 @@ public class CreateHandlerTest extends AbstractHandlerTest {
 
     @BeforeEach
     public void setup() {
-        handler = new CreateHandler(HandlerConfig.builder()
-                .probingEnabled(false)
-                .backoff(TEST_BACKOFF_DELAY)
-                .build());
+        handler = new CreateHandler(RuntimeConfig.loadFrom(CreateHandler.resource(RuntimeConfig.TEST_PROPERTIES)));
         proxy = new AmazonWebServicesClientProxy(logger, MOCK_CREDENTIALS, () -> Duration.ofSeconds(600).toMillis());
         rdsClient = mock(RdsClient.class);
         rdsClientV12 = mock(RdsClient.class);

--- a/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/DeleteHandlerTest.java
+++ b/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/DeleteHandlerTest.java
@@ -40,8 +40,8 @@ import software.amazon.cloudformation.proxy.HandlerErrorCode;
 import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
+import software.amazon.rds.common.config.RuntimeConfig;
 import software.amazon.rds.common.error.ErrorCode;
-import software.amazon.rds.common.handler.HandlerConfig;
 import software.amazon.rds.test.common.core.HandlerName;
 import software.amazon.rds.test.common.core.TestUtils;
 
@@ -76,12 +76,7 @@ public class DeleteHandlerTest extends AbstractHandlerTest {
 
     @BeforeEach
     public void setup() {
-        handler = new DeleteHandler(
-                HandlerConfig.builder()
-                        .probingEnabled(false)
-                        .backoff(TEST_BACKOFF_DELAY)
-                        .build()
-        );
+        handler = new DeleteHandler(RuntimeConfig.loadFrom(DeleteHandler.resource(RuntimeConfig.TEST_PROPERTIES)));
         proxy = new AmazonWebServicesClientProxy(logger, MOCK_CREDENTIALS, () -> Duration.ofSeconds(600).toMillis());
         rdsClient = mock(RdsClient.class);
         ec2Client = mock(Ec2Client.class);

--- a/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/ListHandlerTest.java
+++ b/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/ListHandlerTest.java
@@ -27,6 +27,7 @@ import software.amazon.awssdk.services.rds.model.DescribeDbInstancesResponse;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ProxyClient;
+import software.amazon.rds.common.config.RuntimeConfig;
 import software.amazon.rds.test.common.core.HandlerName;
 
 @ExtendWith(MockitoExtension.class)
@@ -57,7 +58,7 @@ public class ListHandlerTest extends AbstractHandlerTest {
 
     @BeforeEach
     public void setup() {
-        handler = new ListHandler();
+        handler = new ListHandler(RuntimeConfig.loadFrom(ListHandler.resource(RuntimeConfig.TEST_PROPERTIES)));
         proxy = new AmazonWebServicesClientProxy(logger, MOCK_CREDENTIALS, () -> Duration.ofSeconds(600).toMillis());
         rdsClient = mock(RdsClient.class);
         ec2Client = mock(Ec2Client.class);

--- a/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/ReadHandlerTest.java
+++ b/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/ReadHandlerTest.java
@@ -22,6 +22,7 @@ import software.amazon.awssdk.services.rds.RdsClient;
 import software.amazon.awssdk.services.rds.model.DescribeDbInstancesRequest;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.ProxyClient;
+import software.amazon.rds.common.config.RuntimeConfig;
 import software.amazon.rds.test.common.core.HandlerName;
 
 @ExtendWith(MockitoExtension.class)
@@ -55,7 +56,7 @@ public class ReadHandlerTest extends AbstractHandlerTest {
 
     @BeforeEach
     public void setup() {
-        handler = new ReadHandler();
+        handler = new ReadHandler(RuntimeConfig.loadFrom(ReadHandler.resource(RuntimeConfig.TEST_PROPERTIES)));
         proxy = new AmazonWebServicesClientProxy(logger, MOCK_CREDENTIALS, () -> Duration.ofSeconds(600).toMillis());
         rdsClient = mock(RdsClient.class);
         ec2Client = mock(Ec2Client.class);

--- a/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/UpdateHandlerTest.java
+++ b/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/UpdateHandlerTest.java
@@ -73,8 +73,8 @@ import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.HandlerErrorCode;
 import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
+import software.amazon.rds.common.config.RuntimeConfig;
 import software.amazon.rds.common.error.ErrorCode;
-import software.amazon.rds.common.handler.HandlerConfig;
 import software.amazon.rds.test.common.core.HandlerName;
 
 @ExtendWith(MockitoExtension.class)
@@ -126,10 +126,7 @@ public class UpdateHandlerTest extends AbstractHandlerTest {
 
     @BeforeEach
     public void setup() {
-        handler = new UpdateHandler(HandlerConfig.builder()
-                .probingEnabled(false)
-                .backoff(TEST_BACKOFF_DELAY)
-                .build());
+        handler = new UpdateHandler(RuntimeConfig.loadFrom(UpdateHandler.resource(RuntimeConfig.TEST_PROPERTIES)));
         proxy = new AmazonWebServicesClientProxy(logger, MOCK_CREDENTIALS, () -> Duration.ofSeconds(600).toMillis());
         rdsClient = mock(RdsClient.class);
         rdsClientV12 = mock(RdsClient.class);


### PR DESCRIPTION
This commit introduces a new config system called `RuntimeConfig` as a replacement of `HandlerConfig`.

The motivation for the change is to move away from the hardcoded config to a local file-backed extendable system.

As the primary config data medium we chose plain old properties files. It is not the best way to store structured data, but works well enough for flat primitive-only configs.

A resource using RuntimeConfig is expected to expose a new config properties folder and add it to the compiled classpath.

The default config sets are:
- `config/runtime.properties`
- `config/test.properties`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.