### PR TITLE
[DBCluster][ServerlessV1] Add support for TimeoutAction

### DIFF
--- a/aws-rds-dbcluster/aws-rds-dbcluster.json
+++ b/aws-rds-dbcluster/aws-rds-dbcluster.json
@@ -329,6 +329,10 @@
         "SecondsUntilAutoPause": {
           "description": "The time, in seconds, before an Aurora DB cluster in serverless mode is paused.",
           "type": "integer"
+        },
+        "TimeoutAction": {
+          "description": "The action to take when the timeout is reached, either ForceApplyCapacityChange or RollbackCapacityChange.\nForceApplyCapacityChange sets the capacity to the specified value as soon as possible.\nRollbackCapacityChange, the default, ignores the capacity change if a scaling point isn't found in the timeout period.\n\nFor more information, see Autoscaling for Aurora Serverless v1 in the Amazon Aurora User Guide.",
+          "type": "string"
         }
       }
     },

--- a/aws-rds-dbcluster/docs/scalingconfiguration.md
+++ b/aws-rds-dbcluster/docs/scalingconfiguration.md
@@ -13,7 +13,8 @@ To declare this entity in your AWS CloudFormation template, use the following sy
     "<a href="#autopause" title="AutoPause">AutoPause</a>" : <i>Boolean</i>,
     "<a href="#maxcapacity" title="MaxCapacity">MaxCapacity</a>" : <i>Integer</i>,
     "<a href="#mincapacity" title="MinCapacity">MinCapacity</a>" : <i>Integer</i>,
-    "<a href="#secondsuntilautopause" title="SecondsUntilAutoPause">SecondsUntilAutoPause</a>" : <i>Integer</i>
+    "<a href="#secondsuntilautopause" title="SecondsUntilAutoPause">SecondsUntilAutoPause</a>" : <i>Integer</i>,
+    "<a href="#timeoutaction" title="TimeoutAction">TimeoutAction</a>" : <i>String</i>
 }
 </pre>
 
@@ -24,6 +25,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 <a href="#maxcapacity" title="MaxCapacity">MaxCapacity</a>: <i>Integer</i>
 <a href="#mincapacity" title="MinCapacity">MinCapacity</a>: <i>Integer</i>
 <a href="#secondsuntilautopause" title="SecondsUntilAutoPause">SecondsUntilAutoPause</a>: <i>Integer</i>
+<a href="#timeoutaction" title="TimeoutAction">TimeoutAction</a>: <i>String</i>
 </pre>
 
 ## Properties
@@ -71,5 +73,19 @@ The time, in seconds, before an Aurora DB cluster in serverless mode is paused.
 _Required_: No
 
 _Type_: Integer
+
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+
+#### TimeoutAction
+
+The action to take when the timeout is reached, either ForceApplyCapacityChange or RollbackCapacityChange.
+ForceApplyCapacityChange sets the capacity to the specified value as soon as possible.
+RollbackCapacityChange, the default, ignores the capacity change if a scaling point isn't found in the timeout period.
+
+For more information, see Autoscaling for Aurora Serverless v1 in the Amazon Aurora User Guide.
+
+_Required_: No
+
+_Type_: String
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)

--- a/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/Translator.java
+++ b/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/Translator.java
@@ -358,6 +358,7 @@ public class Translator {
                 .autoPause(scalingConfiguration.getAutoPause())
                 .maxCapacity(scalingConfiguration.getMaxCapacity())
                 .minCapacity(scalingConfiguration.getMinCapacity())
+                .timeoutAction(scalingConfiguration.getTimeoutAction())
                 .secondsUntilAutoPause(scalingConfiguration.getSecondsUntilAutoPause())
                 .build();
     }
@@ -384,6 +385,7 @@ public class Translator {
                 .autoPause(scalingConfiguration.autoPause())
                 .maxCapacity(scalingConfiguration.maxCapacity())
                 .minCapacity(scalingConfiguration.minCapacity())
+                .timeoutAction(scalingConfiguration.timeoutAction())
                 .secondsUntilAutoPause(scalingConfiguration.secondsUntilAutoPause())
                 .build();
     }


### PR DESCRIPTION
This PR adds support for TimeoutAction for ServerlessV1: https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_ScalingConfiguration.html

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
