### PR TITLE
[OptionGroup][DBParameterGroup][DBClusterParameterGroup] Make primary identifers for several resources CreateOnly

### DIFF
--- a/aws-rds-dbclusterparametergroup/aws-rds-dbclusterparametergroup.json
+++ b/aws-rds-dbclusterparametergroup/aws-rds-dbclusterparametergroup.json
@@ -63,14 +63,12 @@
     "Parameters"
   ],
   "createOnlyProperties": [
+    "/properties/DBClusterParameterGroupName",
     "/properties/Description",
     "/properties/Family"
   ],
   "writeOnlyProperties": [
     "/properties/Parameters"
-  ],
-  "readOnlyProperties": [
-    "/properties/DBClusterParameterGroupName"
   ],
   "primaryIdentifier": [
     "/properties/DBClusterParameterGroupName"

--- a/aws-rds-dbclusterparametergroup/docs/README.md
+++ b/aws-rds-dbclusterparametergroup/docs/README.md
@@ -15,6 +15,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
         "<a href="#description" title="Description">Description</a>" : <i>String</i>,
         "<a href="#family" title="Family">Family</a>" : <i>String</i>,
         "<a href="#parameters" title="Parameters">Parameters</a>" : <i>Map</i>,
+        "<a href="#dbclusterparametergroupname" title="DBClusterParameterGroupName">DBClusterParameterGroupName</a>" : <i>String</i>,
         "<a href="#tags" title="Tags">Tags</a>" : <i>[ <a href="tag.md">Tag</a>, ... ]</i>
     }
 }
@@ -28,6 +29,7 @@ Properties:
     <a href="#description" title="Description">Description</a>: <i>String</i>
     <a href="#family" title="Family">Family</a>: <i>String</i>
     <a href="#parameters" title="Parameters">Parameters</a>: <i>Map</i>
+    <a href="#dbclusterparametergroupname" title="DBClusterParameterGroupName">DBClusterParameterGroupName</a>: <i>String</i>
     <a href="#tags" title="Tags">Tags</a>: <i>
       - <a href="tag.md">Tag</a></i>
 </pre>
@@ -64,6 +66,16 @@ _Type_: Map
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 
+#### DBClusterParameterGroupName
+
+_Required_: No
+
+_Type_: String
+
+_Pattern_: <code>^[a-zA-Z]{1}(?:-?[a-zA-Z0-9])*$</code>
+
+_Update requires_: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
+
 #### Tags
 
 The list of tags for the cluster parameter group.
@@ -79,13 +91,3 @@ _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormati
 ### Ref
 
 When you pass the logical ID of this resource to the intrinsic `Ref` function, Ref returns the DBClusterParameterGroupName.
-
-### Fn::GetAtt
-
-The `Fn::GetAtt` intrinsic function returns a value for a specified attribute of this type. The following are the available attributes and sample return values.
-
-For more information about using the `Fn::GetAtt` intrinsic function, see [Fn::GetAtt](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-getatt.html).
-
-#### DBClusterParameterGroupName
-
-Returns the <code>DBClusterParameterGroupName</code> value.

--- a/aws-rds-dbparametergroup/aws-rds-dbparametergroup.json
+++ b/aws-rds-dbparametergroup/aws-rds-dbparametergroup.json
@@ -63,13 +63,11 @@
     "Family",
     "Description"
   ],
-  "readOnlyProperties": [
-    "/properties/DBParameterGroupName"
-  ],
   "primaryIdentifier": [
     "/properties/DBParameterGroupName"
   ],
   "createOnlyProperties": [
+    "/properties/DBParameterGroupName",
     "/properties/Description",
     "/properties/Family"
   ],

--- a/aws-rds-dbparametergroup/docs/README.md
+++ b/aws-rds-dbparametergroup/docs/README.md
@@ -12,6 +12,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 {
     "Type" : "AWS::RDS::DBParameterGroup",
     "Properties" : {
+        "<a href="#dbparametergroupname" title="DBParameterGroupName">DBParameterGroupName</a>" : <i>String</i>,
         "<a href="#description" title="Description">Description</a>" : <i>String</i>,
         "<a href="#family" title="Family">Family</a>" : <i>String</i>,
         "<a href="#parameters" title="Parameters">Parameters</a>" : <i>Map</i>,
@@ -25,6 +26,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 <pre>
 Type: AWS::RDS::DBParameterGroup
 Properties:
+    <a href="#dbparametergroupname" title="DBParameterGroupName">DBParameterGroupName</a>: <i>String</i>
     <a href="#description" title="Description">Description</a>: <i>String</i>
     <a href="#family" title="Family">Family</a>: <i>String</i>
     <a href="#parameters" title="Parameters">Parameters</a>: <i>Map</i>
@@ -33,6 +35,18 @@ Properties:
 </pre>
 
 ## Properties
+
+#### DBParameterGroupName
+
+Specifies the name of the DB parameter group
+
+_Required_: No
+
+_Type_: String
+
+_Pattern_: <code>^[a-zA-Z]{1}(?:-?[a-zA-Z0-9])*$</code>
+
+_Update requires_: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
 
 #### Description
 
@@ -79,13 +93,3 @@ _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormati
 ### Ref
 
 When you pass the logical ID of this resource to the intrinsic `Ref` function, Ref returns the DBParameterGroupName.
-
-### Fn::GetAtt
-
-The `Fn::GetAtt` intrinsic function returns a value for a specified attribute of this type. The following are the available attributes and sample return values.
-
-For more information about using the `Fn::GetAtt` intrinsic function, see [Fn::GetAtt](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-getatt.html).
-
-#### DBParameterGroupName
-
-Specifies the name of the DB parameter group

--- a/aws-rds-optiongroup/aws-rds-optiongroup.json
+++ b/aws-rds-optiongroup/aws-rds-optiongroup.json
@@ -132,13 +132,11 @@
     "MajorEngineVersion",
     "OptionGroupDescription"
   ],
-  "readOnlyProperties": [
-    "/properties/OptionGroupName"
-  ],
   "createOnlyProperties": [
     "/properties/EngineName",
     "/properties/MajorEngineVersion",
-    "/properties/OptionGroupDescription"
+    "/properties/OptionGroupDescription",
+    "/properties/OptionGroupName"
   ],
   "primaryIdentifier": [
     "/properties/OptionGroupName"

--- a/aws-rds-optiongroup/docs/README.md
+++ b/aws-rds-optiongroup/docs/README.md
@@ -12,6 +12,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 {
     "Type" : "AWS::RDS::OptionGroup",
     "Properties" : {
+        "<a href="#optiongroupname" title="OptionGroupName">OptionGroupName</a>" : <i>String</i>,
         "<a href="#optiongroupdescription" title="OptionGroupDescription">OptionGroupDescription</a>" : <i>String</i>,
         "<a href="#enginename" title="EngineName">EngineName</a>" : <i>String</i>,
         "<a href="#majorengineversion" title="MajorEngineVersion">MajorEngineVersion</a>" : <i>String</i>,
@@ -26,6 +27,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 <pre>
 Type: AWS::RDS::OptionGroup
 Properties:
+    <a href="#optiongroupname" title="OptionGroupName">OptionGroupName</a>: <i>String</i>
     <a href="#optiongroupdescription" title="OptionGroupDescription">OptionGroupDescription</a>: <i>String</i>
     <a href="#enginename" title="EngineName">EngineName</a>: <i>String</i>
     <a href="#majorengineversion" title="MajorEngineVersion">MajorEngineVersion</a>: <i>String</i>
@@ -36,6 +38,16 @@ Properties:
 </pre>
 
 ## Properties
+
+#### OptionGroupName
+
+Specifies the name of the option group.
+
+_Required_: No
+
+_Type_: String
+
+_Update requires_: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
 
 #### OptionGroupDescription
 
@@ -92,13 +104,3 @@ _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormati
 ### Ref
 
 When you pass the logical ID of this resource to the intrinsic `Ref` function, Ref returns the OptionGroupName.
-
-### Fn::GetAtt
-
-The `Fn::GetAtt` intrinsic function returns a value for a specified attribute of this type. The following are the available attributes and sample return values.
-
-For more information about using the `Fn::GetAtt` intrinsic function, see [Fn::GetAtt](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-getatt.html).
-
-#### OptionGroupName
-
-Specifies the name of the option group.

--- a/aws-rds-optiongroup/src/main/java/software/amazon/rds/optiongroup/CreateHandler.java
+++ b/aws-rds-optiongroup/src/main/java/software/amazon/rds/optiongroup/CreateHandler.java
@@ -101,9 +101,7 @@ public class CreateHandler extends BaseHandlerStd {
                     .withResourceId(request.getLogicalResourceIdentifier())
                     .withRequestToken(request.getClientRequestToken())
                     .toString());
-            return ProgressEvent.progress(desiredModel, progress.getCallbackContext());
         }
-        return ProgressEvent.failed(desiredModel, progress.getCallbackContext(), HandlerErrorCode.InvalidRequest,
-                "Encountered unsupported property OptionGroupName");
+        return ProgressEvent.progress(desiredModel, progress.getCallbackContext());
     }
 }


### PR DESCRIPTION
This PR makes primary identifiers for OptionGroup, DBParameterGroup and DBClusterParameterGroup resources CreateOnly instead of readonly. This will allow customers to specify those parameters on creation

Fixes https://github.com/aws-cloudformation/cloudformation-coverage-roadmap/issues/212.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
