### PR TITLE
[DBInstance] Add support for read replica promotion

### DIFF
--- a/aws-rds-dbinstance/aws-rds-dbinstance.json
+++ b/aws-rds-dbinstance/aws-rds-dbinstance.json
@@ -381,7 +381,6 @@
     "/properties/NcharCharacterSetName",
     "/properties/Port",
     "/properties/PubliclyAccessible",
-    "/properties/SourceDBInstanceIdentifier",
     "/properties/SourceRegion",
     "/properties/StorageEncrypted",
     "/properties/Timezone"
@@ -396,6 +395,7 @@
     "/properties/MultiAZ",
     "/properties/PerformanceInsightsKMSKeyId",
     "/properties/PreferredMaintenanceWindow",
+    "/properties/SourceDBInstanceIdentifier",
     "/properties/StorageType"
   ],
   "deprecatedProperties": [
@@ -482,6 +482,7 @@
         "rds:DescribeDBInstances",
         "rds:DescribeDBParameterGroups",
         "rds:ModifyDBInstance",
+        "rds:PromoteReadReplica",
         "rds:RebootDBInstance",
         "rds:RemoveRoleFromDBInstance",
         "rds:RemoveTagsFromResource"

--- a/aws-rds-dbinstance/docs/README.md
+++ b/aws-rds-dbinstance/docs/README.md
@@ -657,7 +657,7 @@ _Required_: No
 
 _Type_: String
 
-_Update requires_: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 
 #### SourceRegion
 

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/CallbackContext.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/CallbackContext.java
@@ -15,6 +15,7 @@ public class CallbackContext extends StdCallbackContext implements TaggingContex
     private boolean rebooted;
     private boolean storageAllocated;
     private boolean allocatingStorage;
+    private boolean readReplicaPromoted;
 
     private TaggingContext taggingContext;
 

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/Translator.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/Translator.java
@@ -446,7 +446,7 @@ public class Translator {
         return builder.build();
     }
 
-    public static PromoteReadReplicaRequest promoteReadReplica(final ResourceModel model) {
+    public static PromoteReadReplicaRequest promoteReadReplicaRequest(final ResourceModel model) {
         return PromoteReadReplicaRequest.builder()
                 .dbInstanceIdentifier(model.getDBInstanceIdentifier())
                 .backupRetentionPeriod(model.getBackupRetentionPeriod())

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/Translator.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/Translator.java
@@ -33,6 +33,7 @@ import software.amazon.awssdk.services.rds.model.DescribeDbInstancesRequest;
 import software.amazon.awssdk.services.rds.model.DescribeDbParameterGroupsRequest;
 import software.amazon.awssdk.services.rds.model.DescribeDbSnapshotsRequest;
 import software.amazon.awssdk.services.rds.model.ModifyDbInstanceRequest;
+import software.amazon.awssdk.services.rds.model.PromoteReadReplicaRequest;
 import software.amazon.awssdk.services.rds.model.RebootDbInstanceRequest;
 import software.amazon.awssdk.services.rds.model.RemoveRoleFromDbInstanceRequest;
 import software.amazon.awssdk.services.rds.model.RestoreDbInstanceFromDbSnapshotRequest;
@@ -443,6 +444,14 @@ public class Translator {
                     .finalDBSnapshotIdentifier(finalDBSnapshotIdentifier);
         }
         return builder.build();
+    }
+
+    public static PromoteReadReplicaRequest promoteReadReplica(final ResourceModel model) {
+        return PromoteReadReplicaRequest.builder()
+                .dbInstanceIdentifier(model.getDBInstanceIdentifier())
+                .backupRetentionPeriod(model.getBackupRetentionPeriod())
+                .preferredBackupWindow(model.getPreferredBackupWindow())
+                .build();
     }
 
     public static DescribeDbParameterGroupsRequest describeDbParameterGroupsRequest(final String dbParameterGroupName) {

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/UpdateHandler.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/UpdateHandler.java
@@ -418,7 +418,7 @@ public class UpdateHandler extends BaseHandlerStd {
             final ProgressEvent<ResourceModel, CallbackContext> progress
     ) {
         return proxy.initiate("rds::promote-read-replica", rdsProxyClient, progress.getResourceModel(), progress.getCallbackContext())
-                .translateToServiceRequest(Translator::promoteReadReplica)
+                .translateToServiceRequest(Translator::promoteReadReplicaRequest)
                 .backoffDelay(config.getBackoff())
                 .makeServiceCall((modifyRequest, proxyInvocation) -> proxyInvocation.injectCredentialsAndInvokeV2(
                         modifyRequest,

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/UpdateHandler.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/UpdateHandler.java
@@ -2,7 +2,6 @@ package software.amazon.rds.dbinstance;
 
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Function;
 
@@ -117,6 +116,12 @@ public class UpdateHandler extends BaseHandlerStd {
                         return Commons.handleException(progress, ex, MODIFY_DB_INSTANCE_ERROR_RULE_SET);
                     }
                 }, CallbackContext::isStorageAllocated, CallbackContext::setStorageAllocated))
+                .then(progress -> Commons.execOnce(progress, () -> {
+                    if (shouldPromoteReadReplica(request.getPreviousResourceState(), request.getDesiredResourceState())) {
+                        return promoteReadReplica(proxy, rdsClient, progress);
+                    }
+                    return progress;
+                }, CallbackContext::isReadReplicaPromoted, CallbackContext::setReadReplicaPromoted))
                 .then(progress -> Commons.execOnce(progress, () ->
                                 versioned(proxy, rdsProxyClient, progress, null, ImmutableMap.of(
                                         /*
@@ -300,6 +305,11 @@ public class UpdateHandler extends BaseHandlerStd {
                 request.getDesiredResourceState().getMaxAllocatedStorage() == null;
     }
 
+    private boolean shouldPromoteReadReplica(final ResourceModel previous, final ResourceModel desired) {
+        return !StringUtils.isNullOrEmpty(previous.getSourceDBInstanceIdentifier()) &&
+                StringUtils.isNullOrEmpty(desired.getSourceDBInstanceIdentifier());
+    }
+
 
     private boolean isAllocatedStorageIncrease(
             final ResourceHandlerRequest<ResourceModel> request
@@ -394,6 +404,26 @@ public class UpdateHandler extends BaseHandlerStd {
                 .backoffDelay(config.getBackoff())
                 .makeServiceCall(NOOP_CALL)
                 .stabilize((request, response, proxyInvocation, model, context) -> isDBClusterParameterGroupStabilized(proxyInvocation, model))
+                .handleError((request, exception, proxyInvocation, model, context) -> Commons.handleException(
+                        ProgressEvent.progress(model, context),
+                        exception,
+                        DEFAULT_DB_INSTANCE_ERROR_RULE_SET
+                ))
+                .progress();
+    }
+
+    private ProgressEvent<ResourceModel, CallbackContext> promoteReadReplica(
+            final AmazonWebServicesClientProxy proxy,
+            final ProxyClient<RdsClient> rdsProxyClient,
+            final ProgressEvent<ResourceModel, CallbackContext> progress
+    ) {
+        return proxy.initiate("rds::promote-read-replica", rdsProxyClient, progress.getResourceModel(), progress.getCallbackContext())
+                .translateToServiceRequest(Translator::promoteReadReplica)
+                .backoffDelay(config.getBackoff())
+                .makeServiceCall((modifyRequest, proxyInvocation) -> proxyInvocation.injectCredentialsAndInvokeV2(
+                        modifyRequest,
+                        proxyInvocation.client()::promoteReadReplica))
+                .stabilize((request, response, proxyInvocation, model, context) -> isDBInstanceStabilizedAfterMutate(proxyInvocation, model))
                 .handleError((request, exception, proxyInvocation, model, context) -> Commons.handleException(
                         ProgressEvent.progress(model, context),
                         exception,

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/util/ImmutabilityHelper.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/util/ImmutabilityHelper.java
@@ -51,9 +51,20 @@ public final class ImmutabilityHelper {
                 (StringUtils.isNullOrEmpty(desired.getAvailabilityZone()) && desired.getMultiAZ());
     }
 
+    private static boolean isReadReplicaPromotion(final ResourceModel previous, final ResourceModel desired) {
+        return !StringUtils.isNullOrEmpty(previous.getSourceDBInstanceIdentifier()) &&
+                StringUtils.isNullOrEmpty(desired.getSourceDBInstanceIdentifier());
+    }
+
+    public static boolean isSourceDBInstanceIdentifierMutable(final ResourceModel previous, final ResourceModel desired) {
+        return Objects.equal(previous.getSourceDBInstanceIdentifier(), desired.getSourceDBInstanceIdentifier()) ||
+                isReadReplicaPromotion(previous, desired);
+    }
+
     public static boolean isChangeMutable(final ResourceModel previous, final ResourceModel desired) {
         return isEngineMutable(previous, desired) &&
                 isPerformanceInsightsKMSKeyIdMutable(previous, desired) &&
-                isAvailabilityZoneChangeMutable(previous, desired);
+                isAvailabilityZoneChangeMutable(previous, desired) &&
+                isSourceDBInstanceIdentifierMutable(previous, desired);
     }
 }

--- a/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/UpdateHandlerTest.java
+++ b/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/UpdateHandlerTest.java
@@ -63,6 +63,8 @@ import software.amazon.awssdk.services.rds.model.DescribeDbParameterGroupsRespon
 import software.amazon.awssdk.services.rds.model.ModifyDbInstanceRequest;
 import software.amazon.awssdk.services.rds.model.ModifyDbInstanceResponse;
 import software.amazon.awssdk.services.rds.model.OptionGroupMembership;
+import software.amazon.awssdk.services.rds.model.PromoteReadReplicaRequest;
+import software.amazon.awssdk.services.rds.model.PromoteReadReplicaResponse;
 import software.amazon.awssdk.services.rds.model.RebootDbInstanceRequest;
 import software.amazon.awssdk.services.rds.model.RebootDbInstanceResponse;
 import software.amazon.awssdk.services.rds.model.RemoveRoleFromDbInstanceRequest;
@@ -1256,5 +1258,27 @@ public class UpdateHandlerTest extends AbstractHandlerTest {
         final ArgumentCaptor<ModifyDbInstanceRequest> argumentCaptor = ArgumentCaptor.forClass(ModifyDbInstanceRequest.class);
         verify(rdsProxy.client(), times(1)).modifyDBInstance(argumentCaptor.capture());
         Assertions.assertThat(argumentCaptor.getValue().engineVersion()).isNull();
+    }
+
+    @Test
+    public void handleRequest_PromoteReadReplica() {
+        when(rdsProxy.client().promoteReadReplica(any(PromoteReadReplicaRequest.class)))
+                .thenReturn(PromoteReadReplicaResponse.builder().build());
+
+        final CallbackContext context = new CallbackContext();
+        context.setRebooted(true);
+        context.setUpdatedRoles(true);
+        context.setUpdated(true);
+
+        test_handleRequest_base(
+                context,
+                () -> DB_INSTANCE_ACTIVE,
+                () -> RESOURCE_MODEL_BLDR().sourceDBInstanceIdentifier("previous").build(),
+                () -> RESOURCE_MODEL_BLDR().sourceDBInstanceIdentifier(null).build(),
+                expectSuccess()
+        );
+
+        verify(rdsProxy.client(), times(3)).describeDBInstances(any(DescribeDbInstancesRequest.class));
+        verify(rdsProxy.client()).promoteReadReplica(any(PromoteReadReplicaRequest.class));
     }
 }

--- a/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/util/ImmutabilityHelperTest.java
+++ b/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/util/ImmutabilityHelperTest.java
@@ -153,4 +153,32 @@ class ImmutabilityHelperTest {
             assertThat(ImmutabilityHelper.isChangeMutable(test.previous, test.desired)).isEqualTo(test.expect);
         }
     }
+
+    @Test
+    public void test_isSourceDBIdentifierMutable() {
+        final List<ResourceModelTestCase> tests = Arrays.asList(
+                ResourceModelTestCase.builder()
+                        .previous(ResourceModel.builder().sourceDBInstanceIdentifier("old").build())
+                        .desired(ResourceModel.builder().sourceDBInstanceIdentifier("old").build())
+                        .expect(true)
+                        .build(),
+                ResourceModelTestCase.builder()
+                        .previous(ResourceModel.builder().sourceDBInstanceIdentifier("old").build())
+                        .desired(ResourceModel.builder().sourceDBInstanceIdentifier("").build())
+                        .expect(true)
+                        .build(),
+                ResourceModelTestCase.builder()
+                        .previous(ResourceModel.builder().sourceDBInstanceIdentifier("old").build())
+                        .desired(ResourceModel.builder().availabilityZone(null).build())
+                        .expect(true)
+                        .build(),
+                ResourceModelTestCase.builder()
+                        .previous(ResourceModel.builder().sourceDBInstanceIdentifier("old").build())
+                        .desired(ResourceModel.builder().sourceDBInstanceIdentifier("new").build())
+                        .expect(false)
+                        .build());
+        for (final ResourceModelTestCase test : tests) {
+            assertThat(ImmutabilityHelper.isChangeMutable(test.previous, test.desired)).isEqualTo(test.expect);
+        }
+    }
 }


### PR DESCRIPTION
This PR adds support for ReadReplica promotion. When customer updates DBInstance read replica which previously had SourceDBInstanceIdentifier set to no longer having one, promoteReadReplica API will be used rather than re-creation of a DBInstance will be triggered.

Fixes https://github.com/aws-cloudformation/cloudformation-coverage-roadmap/issues/67.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
