### PR TITLE
[DBCluster] Fail early when encountering a terminal DBCluster status

### DIFF
--- a/aws-rds-cfn-common/src/main/java/software/amazon/rds/common/printer/FilteredJsonPrinter.java
+++ b/aws-rds-cfn-common/src/main/java/software/amazon/rds/common/printer/FilteredJsonPrinter.java
@@ -35,7 +35,7 @@ public class FilteredJsonPrinter implements JsonPrinter {
     public FilteredJsonPrinter(String... filterFields) {
         this.filterFields = filterFields;
         mapper = new ObjectMapper()
-                //.setPropertyNamingStrategy(PropertyNamingStrategy.UPPER_CAMEL_CASE)
+                .setPropertyNamingStrategy(PropertyNamingStrategy.UPPER_CAMEL_CASE)
                 .enable(SerializationFeature.INDENT_OUTPUT)
                 .disable(SerializationFeature.FAIL_ON_EMPTY_BEANS);
         mapper.registerModule(new JavaTimeModule());

--- a/aws-rds-cfn-common/src/main/java/software/amazon/rds/common/printer/FilteredJsonPrinter.java
+++ b/aws-rds-cfn-common/src/main/java/software/amazon/rds/common/printer/FilteredJsonPrinter.java
@@ -35,7 +35,7 @@ public class FilteredJsonPrinter implements JsonPrinter {
     public FilteredJsonPrinter(String... filterFields) {
         this.filterFields = filterFields;
         mapper = new ObjectMapper()
-                .setPropertyNamingStrategy(PropertyNamingStrategy.UPPER_CAMEL_CASE)
+                //.setPropertyNamingStrategy(PropertyNamingStrategy.UPPER_CAMEL_CASE)
                 .enable(SerializationFeature.INDENT_OUTPUT)
                 .disable(SerializationFeature.FAIL_ON_EMPTY_BEANS);
         mapper.registerModule(new JavaTimeModule());

--- a/aws-rds-cfn-common/src/main/java/software/amazon/rds/common/status/Status.java
+++ b/aws-rds-cfn-common/src/main/java/software/amazon/rds/common/status/Status.java
@@ -1,4 +1,4 @@
-package software.amazon.rds.dbinstance.status;
+package software.amazon.rds.common.status;
 
 public interface Status {
     boolean equalsString(String other);

--- a/aws-rds-cfn-common/src/main/java/software/amazon/rds/common/status/TerminableStatus.java
+++ b/aws-rds-cfn-common/src/main/java/software/amazon/rds/common/status/TerminableStatus.java
@@ -1,4 +1,4 @@
-package software.amazon.rds.dbinstance.status;
+package software.amazon.rds.common.status;
 
 public interface TerminableStatus extends Status {
     boolean isTerminal();

--- a/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/BaseHandlerStd.java
+++ b/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/BaseHandlerStd.java
@@ -514,7 +514,7 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
     private void assertNoDBClusterTerminalStatus(final DBCluster dbCluster) throws CfnNotStabilizedException {
         final DBClusterStatus status = DBClusterStatus.fromString(dbCluster.status());
         if (status != null && status.isTerminal()) {
-            throw new CfnNotStabilizedException(new Exception("DBDluster is in state: " + status));
+            throw new CfnNotStabilizedException(new Exception("DBCluster is in state: " + status));
         }
     }
 }

--- a/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/DBClusterStatus.java
+++ b/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/DBClusterStatus.java
@@ -1,14 +1,34 @@
 package software.amazon.rds.dbcluster;
 
-public enum DBClusterStatus {
+import software.amazon.rds.common.status.TerminableStatus;
+
+public enum DBClusterStatus implements TerminableStatus {
     Available("available"),
     Creating("creating"),
-    Deleted("deleted");
+    Deleted("deleted"),
+    InaccessibleEncryptionCredentials("inaccessible-encryption-credentials", true),
+    IncompatibleNetwork("incompatible-network", true),
+    IncompatibleParameters("incompatible-parameters", true),
+    IncompatibleRestore("incompatible-restore", true);
 
     private final String value;
+    private final boolean isTerminal;
 
-    DBClusterStatus(String value) {
+    DBClusterStatus(final String value) {
+        this(value, false);
+    }
+    DBClusterStatus(final String value,final  boolean isTerminal) {
         this.value = value;
+        this.isTerminal = isTerminal;
+    }
+
+    public static DBClusterStatus fromString(final String source) {
+        for (final DBClusterStatus status: DBClusterStatus.values()) {
+            if (status.equalsString(source)) {
+                return status;
+            }
+        }
+        return null;
     }
 
     @Override
@@ -18,5 +38,10 @@ public enum DBClusterStatus {
 
     public boolean equalsString(final String status) {
         return this.value.equals(status);
+    }
+
+    @Override
+    public boolean isTerminal() {
+        return this.isTerminal;
     }
 }

--- a/aws-rds-dbcluster/src/test/java/software/amazon/rds/dbcluster/DBClusterStatusTest.java
+++ b/aws-rds-dbcluster/src/test/java/software/amazon/rds/dbcluster/DBClusterStatusTest.java
@@ -1,0 +1,22 @@
+package software.amazon.rds.dbcluster;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class DBClusterStatusTest {
+
+    @Test
+    public void fromString_unknown() {
+        final String source = "unknown";
+        assertThat(DBClusterStatus.fromString(source)).isNull();
+    }
+
+    @Test
+    public void test_fromString() {
+        for (final DBClusterStatus status : DBClusterStatus.values()) {
+            Assertions.assertThat(DBClusterStatus.fromString(status.toString())).isEqualTo(status);
+        }
+    }
+}

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/status/DBInstanceStatus.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/status/DBInstanceStatus.java
@@ -1,6 +1,7 @@
 package software.amazon.rds.dbinstance.status;
 
 import software.amazon.awssdk.utils.StringUtils;
+import software.amazon.rds.common.status.TerminableStatus;
 
 public enum DBInstanceStatus implements TerminableStatus {
     Available("available"),

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/status/DBParameterGroupStatus.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/status/DBParameterGroupStatus.java
@@ -1,6 +1,7 @@
 package software.amazon.rds.dbinstance.status;
 
 import software.amazon.awssdk.utils.StringUtils;
+import software.amazon.rds.common.status.Status;
 
 public enum DBParameterGroupStatus implements Status {
     Applying("applying"),

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/status/DomainMembershipStatus.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/status/DomainMembershipStatus.java
@@ -1,6 +1,7 @@
 package software.amazon.rds.dbinstance.status;
 
 import software.amazon.awssdk.utils.StringUtils;
+import software.amazon.rds.common.status.Status;
 
 public enum DomainMembershipStatus implements Status {
     Joined("joined"),

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/status/OptionGroupStatus.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/status/OptionGroupStatus.java
@@ -1,6 +1,7 @@
 package software.amazon.rds.dbinstance.status;
 
 import software.amazon.awssdk.utils.StringUtils;
+import software.amazon.rds.common.status.TerminableStatus;
 
 public enum OptionGroupStatus implements TerminableStatus {
     InSync("in-sync"),

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/status/ReadReplicaStatus.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/status/ReadReplicaStatus.java
@@ -1,6 +1,7 @@
 package software.amazon.rds.dbinstance.status;
 
 import software.amazon.awssdk.utils.StringUtils;
+import software.amazon.rds.common.status.Status;
 
 public enum ReadReplicaStatus implements Status {
     Replicating("replicating");

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/status/VPCSecurityGroupStatus.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/status/VPCSecurityGroupStatus.java
@@ -1,6 +1,7 @@
 package software.amazon.rds.dbinstance.status;
 
 import software.amazon.awssdk.utils.StringUtils;
+import software.amazon.rds.common.status.Status;
 
 public enum VPCSecurityGroupStatus implements Status {
     Active("active");


### PR DESCRIPTION
This PR allows for DBCluster to fail early when encountering a terminal status during stabilization

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
