### PR TITLE
[DBCluster] Set default port for aurora-postgresql on serverless only

### DIFF
--- a/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/EngineMode.java
+++ b/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/EngineMode.java
@@ -1,0 +1,32 @@
+package software.amazon.rds.dbcluster;
+
+enum EngineMode {
+    Serverless("serverless"),
+    Provisioned("provisioned"),
+    ParallelQuery("parallelquery"),
+    MultiMaster("multimaster");
+
+    private final String value;
+
+    EngineMode(final String value) {
+        this.value = value;
+    }
+
+    public boolean equalsString(final String another) {
+        return value.equalsIgnoreCase(another);
+    }
+
+    @Override
+    public String toString() {
+        return value;
+    }
+
+    public static EngineMode fromString(final String value) {
+        for (final EngineMode engineMode : EngineMode.values()) {
+            if (engineMode.value.equalsIgnoreCase(value)) {
+                return engineMode;
+            }
+        }
+        return null;
+    }
+}

--- a/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/ModelAdapter.java
+++ b/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/ModelAdapter.java
@@ -1,5 +1,6 @@
 package software.amazon.rds.dbcluster;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -8,15 +9,28 @@ import com.google.common.collect.Lists;
 
 public class ModelAdapter {
     private static final boolean DEFAULT_PAUSE_DEFAULT = true;
+
     private static final int DEFAULT_BACKUP_RETENTION_PERIOD = 1;
     private static final int DEFAULT_MAX_CAPACITY = 16;
     private static final int DEFAULT_MIN_CAPACITY = 2;
     private static final int DEFAULT_SECONDS_UNTIL_AUTO_PAUSE = 300;
     private static final int DEFAULT_PORT = 3306;
-    private static final String SERVERLESS_ENGINE_MODE = "serverless";
 
-    private static final Map<String, Integer> DEFAULT_ENGINE_PORTS = ImmutableMap.of(
-            "aurora-postgresql", 5432
+    private static final String ENGINE_AURORA = "aurora";
+    private static final String ENGINE_AURORA_MYSQL = "aurora-mysql";
+    private static final String ENGINE_AURORA_POSTGRESQL = "aurora-postgresql";
+
+    private static final Map<EngineMode, Map<String, Integer>> DEFAULT_ENGINE_PORTS = ImmutableMap.of(
+            EngineMode.Provisioned, ImmutableMap.of(
+                    ENGINE_AURORA, 3306,
+                    ENGINE_AURORA_MYSQL, 3306,
+                    ENGINE_AURORA_POSTGRESQL, 3306
+            ),
+            EngineMode.Serverless, ImmutableMap.of(
+                    ENGINE_AURORA, 3306,
+                    ENGINE_AURORA_MYSQL, 3306,
+                    ENGINE_AURORA_POSTGRESQL, 5432
+            )
     );
 
     public static ResourceModel setDefaults(final ResourceModel resourceModel) {
@@ -29,7 +43,7 @@ public class ModelAdapter {
         resourceModel.setBackupRetentionPeriod(backupRetentionPeriod == null ? DEFAULT_BACKUP_RETENTION_PERIOD : backupRetentionPeriod);
         resourceModel.setAssociatedRoles(associatedRoles == null ? Lists.newArrayList() : associatedRoles);
 
-        if (SERVERLESS_ENGINE_MODE.equalsIgnoreCase(resourceModel.getEngineMode())) {
+        if (EngineMode.Serverless.equalsString(resourceModel.getEngineMode())) {
             ScalingConfiguration defaultScalingConfiguration = ScalingConfiguration.builder()
                     .secondsUntilAutoPause(DEFAULT_SECONDS_UNTIL_AUTO_PAUSE)
                     .autoPause(DEFAULT_PAUSE_DEFAULT)
@@ -37,14 +51,21 @@ public class ModelAdapter {
                     .maxCapacity(DEFAULT_MAX_CAPACITY)
                     .build();
             resourceModel.setScalingConfiguration(scalingConfiguration == null ? defaultScalingConfiguration : scalingConfiguration);
-        } else {
-            resourceModel.setPort(port != null ? port : getDefaultPortForEngine(resourceModel.getEngine()));
         }
+
+        final EngineMode engineMode = EngineMode.fromString(resourceModel.getEngineMode());
+
+        resourceModel.setPort(port != null ? port : getDefaultPortForEngine(resourceModel.getEngine(), engineMode));
 
         return resourceModel;
     }
 
-    private static int getDefaultPortForEngine(final String engine) {
-        return DEFAULT_ENGINE_PORTS.getOrDefault(engine, DEFAULT_PORT);
+    private static int getDefaultPortForEngine(final String engine, EngineMode engineMode) {
+        if (engineMode == null) {
+            engineMode = EngineMode.Provisioned;
+        }
+        return DEFAULT_ENGINE_PORTS
+                .getOrDefault(engineMode, Collections.emptyMap())
+                .getOrDefault(engine, DEFAULT_PORT);
     }
 }

--- a/aws-rds-dbcluster/src/test/java/software/amazon/rds/dbcluster/CreateHandlerTest.java
+++ b/aws-rds-dbcluster/src/test/java/software/amazon/rds/dbcluster/CreateHandlerTest.java
@@ -505,7 +505,7 @@ public class CreateHandlerTest extends AbstractHandlerTest {
     }
 
     @Test
-    public void handleRequest_CreateDbCluster_SetDefaultPortForPostgresql() {
+    public void handleRequest_CreateDbCluster_SetDefaultPortForProvisionedPostgresql() {
         when(rdsProxy.client().createDBCluster(any(CreateDbClusterRequest.class)))
                 .thenReturn(CreateDbClusterResponse.builder().build());
 
@@ -514,6 +514,29 @@ public class CreateHandlerTest extends AbstractHandlerTest {
                 () -> DBCLUSTER_ACTIVE,
                 () -> RESOURCE_MODEL.toBuilder()
                         .engine(ENGINE_AURORA_POSTGRESQL)
+                        .port(null)
+                        .build(),
+                expectSuccess()
+        );
+
+        ArgumentCaptor<CreateDbClusterRequest> captor = ArgumentCaptor.forClass(CreateDbClusterRequest.class);
+        verify(rdsProxy.client(), times(1)).createDBCluster(captor.capture());
+        verify(rdsProxy.client(), times(2)).describeDBClusters(any(DescribeDbClustersRequest.class));
+
+        Assertions.assertThat(captor.getValue().port()).isEqualTo(3306);
+    }
+
+    @Test
+    public void handleRequest_CreateDbCluster_SetDefaultPortForServerlessPostgresql() {
+        when(rdsProxy.client().createDBCluster(any(CreateDbClusterRequest.class)))
+                .thenReturn(CreateDbClusterResponse.builder().build());
+
+        test_handleRequest_base(
+                new CallbackContext(),
+                () -> DBCLUSTER_ACTIVE,
+                () -> RESOURCE_MODEL.toBuilder()
+                        .engine(ENGINE_AURORA_POSTGRESQL)
+                        .engineMode(EngineMode.Serverless.toString())
                         .port(null)
                         .build(),
                 expectSuccess()

--- a/aws-rds-dbinstance/resource-role.yaml
+++ b/aws-rds-dbinstance/resource-role.yaml
@@ -54,6 +54,7 @@ Resources:
                 - "rds:DescribeDBParameterGroups"
                 - "rds:DescribeDBSnapshots"
                 - "rds:ModifyDBInstance"
+                - "rds:PromoteReadReplica"
                 - "rds:RebootDBInstance"
                 - "rds:RemoveRoleFromDBInstance"
                 - "rds:RemoveTagsFromResource"


### PR DESCRIPTION
This commit is a follow-up on https://github.com/aws-cloudformation/aws-cloudformation-resource-providers-rds/pull/324.

As per the last change, the default port was set to 5432 on all aurora-postgresql engine versions. According to the documentation, provisioned engine versions should still default to 3306 no matter what engine version was set. This commit introduces a more granular default engine port mapping.

Refs https://github.com/aws-cloudformation/cloudformation-coverage-roadmap/issues/281.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Signed-off-by: Oleg Sidorov <sidorovo@amazon.com>
