### PR TITLE
[DBClusterParameterGroup] apply filters if at least 1 parameter is present

### DIFF
--- a/aws-rds-dbclusterparametergroup/src/main/java/software/amazon/rds/dbclusterparametergroup/Translator.java
+++ b/aws-rds-dbclusterparametergroup/src/main/java/software/amazon/rds/dbclusterparametergroup/Translator.java
@@ -39,14 +39,18 @@ public class Translator {
     }
 
     static DescribeDbClusterParametersRequest describeDbClusterParametersRequest(final ResourceModel model, final String marker) {
-        return DescribeDbClusterParametersRequest.builder()
+        final DescribeDbClusterParametersRequest.Builder builder = DescribeDbClusterParametersRequest.builder()
                 .dbClusterParameterGroupName(model.getDBClusterParameterGroupName())
-                .filters(Filter.builder()
-                        .name(FILTER_PARAMETER_NAME)
-                        .values(model.getParameters().keySet())
-                        .build())
-                .marker(marker)
-                .build();
+                .marker(marker);
+
+        if (model.getParameters() != null && !model.getParameters().isEmpty()) {
+            builder.filters(
+                    Filter.builder()
+                            .name(FILTER_PARAMETER_NAME)
+                            .values(model.getParameters().keySet())
+                            .build());
+        }
+        return builder.build();
     }
 
     static DescribeDbClustersRequest describeDbClustersRequest() {

--- a/aws-rds-dbclusterparametergroup/src/test/java/software/amazon/rds/dbclusterparametergroup/TranslatorTest.java
+++ b/aws-rds-dbclusterparametergroup/src/test/java/software/amazon/rds/dbclusterparametergroup/TranslatorTest.java
@@ -1,0 +1,35 @@
+package software.amazon.rds.dbclusterparametergroup;
+
+import com.google.common.collect.ImmutableMap;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.services.rds.model.DescribeDbClusterParametersRequest;
+import software.amazon.awssdk.services.rds.model.Filter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TranslatorTest {
+
+    @Test
+    public void describeDBClusterParameterGroup_shouldNotHaveFilters_whenParametersAreEmpty() {
+        final DescribeDbClusterParametersRequest request = Translator.describeDbClusterParametersRequest(
+                ResourceModel.builder()
+                        .dBClusterParameterGroupName("DBClusterParameterGroup")
+                        .build(),
+                null);
+        assertThat(request.hasFilters()).isFalse();
+    }
+
+    @Test
+    public void describeDBClusterParameterGroup_shouldHaveFilters_whenParametersArePresent() {
+        final DescribeDbClusterParametersRequest request = Translator.describeDbClusterParametersRequest(
+                ResourceModel.builder()
+                        .dBClusterParameterGroupName("DBClusterParameterGroup")
+                        .parameters(ImmutableMap.of("key1", "value1", "key2", "value2"))
+                        .build(),
+                null);
+        assertThat(request.filters().size()).isEqualTo(1);
+        final Filter filter = request.filters().get(0);
+        assertThat(filter.name()).isEqualTo("parameter-name");
+        assertThat(filter.values()).containsExactlyInAnyOrder("key1", "key2");
+    }
+}


### PR DESCRIPTION
This PR addresses inability to create DBClusterParameterGroup with no parameters. This change is a workaround, and is intended to be reverted when the root cause of this issue is resolved.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
