### PR TITLE
[DBClusterParameterGroup] Do conditional reset/update of DBClusterParameters

### DIFF
--- a/aws-rds-dbclusterparametergroup/src/main/java/software/amazon/rds/dbclusterparametergroup/UpdateHandler.java
+++ b/aws-rds-dbclusterparametergroup/src/main/java/software/amazon/rds/dbclusterparametergroup/UpdateHandler.java
@@ -41,17 +41,17 @@ public class UpdateHandler extends BaseHandlerStd {
                 .resourceTags(Translator.translateTagsToSdk(request.getDesiredResourceState().getTags()))
                 .build();
 
-        final boolean isParametersChange = !DifferenceUtils.diff(request.getPreviousResourceState().getParameters(), request.getDesiredResourceState().getParameters()).isEmpty();
+        final boolean shouldUpdateParameters = !DifferenceUtils.diff(request.getPreviousResourceState().getParameters(), request.getDesiredResourceState().getParameters()).isEmpty();
 
         return ProgressEvent.progress(model, callbackContext)
                 .then(progress -> Commons.execOnce(progress, () -> updateTags(proxy, proxyClient, progress, previousTags, desiredTags), CallbackContext::isAddTagsComplete, CallbackContext::setAddTagsComplete))
                 .then(progress -> {
-                    if (isParametersChange) {
+                    if (shouldUpdateParameters) {
                         return resetAllParameters(progress, proxy, proxyClient);
                     }
                     return progress;
                 }).then(progress -> Commons.execOnce(progress, () -> {
-                    if (isParametersChange) {
+                    if (shouldUpdateParameters) {
                         return applyParameters(proxy, proxyClient, progress.getResourceModel(), progress.getCallbackContext());
                     }
                     return progress;


### PR DESCRIPTION
This PR makes reset/update of DBClusterParameterGroup parameters conditional. In the case when the customer is performing tag-only update, no reset/update of DBClusterParameterGroup parameters is performed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
