### PR TITLE
[DBClusterParameterGroup] Do not describe parameters if empty

### DIFF
--- a/aws-rds-dbclusterparametergroup/src/main/java/software/amazon/rds/dbclusterparametergroup/BaseHandlerStd.java
+++ b/aws-rds-dbclusterparametergroup/src/main/java/software/amazon/rds/dbclusterparametergroup/BaseHandlerStd.java
@@ -8,15 +8,15 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.BiFunction;
 import java.util.function.Function;
-import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+
+import org.apache.commons.collections.MapUtils;
 import org.apache.commons.lang3.BooleanUtils;
 
 import com.amazonaws.util.StringUtils;
-import com.google.common.collect.Iterables;
 import com.google.common.collect.Maps;
 import software.amazon.awssdk.services.rds.RdsClient;
 import software.amazon.awssdk.services.rds.model.DbClusterParameterGroupNotFoundException;
@@ -230,8 +230,11 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
                                                                                              final AmazonWebServicesClientProxy proxy,
                                                                                              final ProxyClient<RdsClient> proxyClient,
                                                                                              final String marker) {
+        if (MapUtils.isEmpty(progress.getResourceModel().getParameters())) {
+            return progress;
+        }
         return proxy.initiate("rds::describe-db-parameters", proxyClient, progress.getResourceModel(), progress.getCallbackContext())
-                .translateToServiceRequest(model -> Translator.describeDbClusterParametersRequest(model, marker))
+                .translateToServiceRequest(model -> Translator.describeDbClusterParametersFilteredRequest(model, marker))
                 .makeServiceCall((request, proxyInvocation) -> proxyInvocation.injectCredentialsAndInvokeV2(request,
                         proxyInvocation.client()::describeDBClusterParameters))
                 .handleError((describeDBParametersRequest, exception, client, resourceModel, ctx) ->

--- a/aws-rds-dbclusterparametergroup/src/test/java/software/amazon/rds/dbclusterparametergroup/TranslatorTest.java
+++ b/aws-rds-dbclusterparametergroup/src/test/java/software/amazon/rds/dbclusterparametergroup/TranslatorTest.java
@@ -1,27 +1,36 @@
 package software.amazon.rds.dbclusterparametergroup;
 
 import com.google.common.collect.ImmutableMap;
+
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.services.rds.model.DescribeDbClusterParametersRequest;
+import software.amazon.awssdk.services.rds.model.DescribeDbClustersRequest;
+import software.amazon.awssdk.services.rds.model.DescribeDbClustersResponse;
 import software.amazon.awssdk.services.rds.model.Filter;
+import software.amazon.cloudformation.exceptions.CfnInternalFailureException;
 
 import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Collections;
 
 public class TranslatorTest {
 
     @Test
-    public void describeDBClusterParameterGroup_shouldNotHaveFilters_whenParametersAreEmpty() {
-        final DescribeDbClusterParametersRequest request = Translator.describeDbClusterParametersRequest(
-                ResourceModel.builder()
-                        .dBClusterParameterGroupName("DBClusterParameterGroup")
-                        .build(),
-                null);
-        assertThat(request.hasFilters()).isFalse();
+    public void describeDbClusterParametersFilteredRequest_throwIfParametersEmpty() {
+        Assertions.assertThatThrownBy(() -> {
+            Translator.describeDbClusterParametersFilteredRequest(
+                    ResourceModel.builder()
+                            .parameters(Collections.emptyMap())
+                            .build(),
+                    null
+            );
+        }).isInstanceOf(CfnInternalFailureException.class);
     }
 
     @Test
-    public void describeDBClusterParameterGroup_shouldHaveFilters_whenParametersArePresent() {
-        final DescribeDbClusterParametersRequest request = Translator.describeDbClusterParametersRequest(
+    public void describeDbClusterParametersFilteredRequest_shouldSetParameterNameFilters() {
+        final DescribeDbClusterParametersRequest request = Translator.describeDbClusterParametersFilteredRequest(
                 ResourceModel.builder()
                         .dBClusterParameterGroupName("DBClusterParameterGroup")
                         .parameters(ImmutableMap.of("key1", "value1", "key2", "value2"))


### PR DESCRIPTION
This commit is a follow-up on https://github.com/aws-cloudformation/aws-cloudformation-resource-providers-rds/pull/337.

The motivation for the change is to eliminate a describe parameters call completely if the model parameter set is empty. Under the hood, this change is dictated by the fact that an empty parameter set is an invalid request from RDS API's perspective. In this case we should choose between these 2 options:
* set no filters of the param set is empty
* do not describe current parameters at all (as the upcoming validation would cross-match an empty parameter set against a presumably empty default parameter set, hence it is a no-op).

This commit is a move from point 1 to point 2.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Signed-off-by: Oleg Sidorov <sidorovo@amazon.com>