### PR TITLE
[DBInstance] Fix DBInstance Empty vpcSecurityGroupIds create-with-update scenario

### DIFF
--- a/aws-rds-cfn-common/src/main/java/software/amazon/rds/common/util/DifferenceUtils.java
+++ b/aws-rds-cfn-common/src/main/java/software/amazon/rds/common/util/DifferenceUtils.java
@@ -1,5 +1,7 @@
 package software.amazon.rds.common.util;
 
+import com.amazonaws.util.CollectionUtils;
+import org.apache.commons.collections.MapUtils;
 import software.amazon.awssdk.core.util.DefaultSdkAutoConstructList;
 import software.amazon.awssdk.core.util.DefaultSdkAutoConstructMap;
 
@@ -10,14 +12,14 @@ import java.util.Objects;
 public class DifferenceUtils {
 
     public static <E, T extends List<E>> List<E> diff(final T prev, final T upd) {
-        if ((prev == null && upd == null) || (Objects.deepEquals(prev, upd))) {
+        if ((CollectionUtils.isNullOrEmpty(prev) && CollectionUtils.isNullOrEmpty(upd)) || (Objects.deepEquals(prev, upd))) {
             return DefaultSdkAutoConstructList.getInstance();
         }
         return upd;
     }
 
     public static <K, V, T extends Map<K, V>> Map<K, V> diff(final T prev, final T upd) {
-        if ((prev == null && upd == null) || (Objects.deepEquals(prev, upd))) {
+        if ((MapUtils.isEmpty(prev) && MapUtils.isEmpty(upd)) || (Objects.deepEquals(prev, upd))) {
             return DefaultSdkAutoConstructMap.getInstance();
         }
         return upd;

--- a/aws-rds-cfn-common/src/test/java/software/amazon/rds/common/util/DifferenceUtilsTest.java
+++ b/aws-rds-cfn-common/src/test/java/software/amazon/rds/common/util/DifferenceUtilsTest.java
@@ -4,11 +4,18 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+import org.junit.jupiter.params.provider.ArgumentsSource;
 import software.amazon.awssdk.core.util.DefaultSdkAutoConstructList;
 import software.amazon.awssdk.core.util.DefaultSdkAutoConstructMap;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Stream;
 
 public class DifferenceUtilsTest {
 
@@ -40,6 +47,27 @@ public class DifferenceUtilsTest {
         Assertions.assertThat(diff.getClass()).isEqualTo(DefaultSdkAutoConstructList.class);
     }
 
+    @ParameterizedTest
+    @ArgumentsSource(EmptyListArgumentsProvider.class)
+    public void listDifference_empty(final List<String> prev, final List<String> upd) {
+        final List<String> diff = DifferenceUtils.diff(prev, upd);
+
+        Assertions.assertThat(diff).isEmpty();
+        Assertions.assertThat(diff.getClass()).isEqualTo(DefaultSdkAutoConstructList.class);
+    }
+
+    static class EmptyListArgumentsProvider implements ArgumentsProvider {
+        @Override
+        public Stream<? extends Arguments> provideArguments(ExtensionContext extensionContext) {
+            return Stream.of(
+                    Arguments.of(null, null),
+                    Arguments.of(null, Collections.emptyList()),
+                    Arguments.of(Collections.emptyList(), Collections.emptyList()),
+                    Arguments.of(Collections.emptyList(), null)
+            );
+        }
+    }
+
     @Test void mapDifference_equals() {
         final Map<String, String> previous = ImmutableMap.of("key1", "value1", "key2", "value2");
         final Map<String, String> desired = ImmutableMap.of("key1", "value1", "key2", "value2");
@@ -57,11 +85,25 @@ public class DifferenceUtilsTest {
         Assertions.assertThat(diff).isEqualTo(ImmutableMap.of("key1", "value3", "key3", "value2"));
     }
 
-    @Test void mapDifference_prevNull() {
-        final Map<String, String> desired = ImmutableMap.of("key1", "value3", "key3", "value2");
+    @ParameterizedTest
+    @ArgumentsSource(EmptyMapArgumentsProvider.class)
+    void mapDifference_empty(final Map<String,String> prev, final Map<String, String> upd) {
+        final Map<String, String> diff = DifferenceUtils.diff(prev, upd);
 
-        final Map<String, String> diff = DifferenceUtils.diff(null, desired);
-        Assertions.assertThat(diff).isEqualTo(ImmutableMap.of("key1", "value3", "key3", "value2"));
+        Assertions.assertThat(diff).isEmpty();
+        Assertions.assertThat(diff.getClass()).isEqualTo(DefaultSdkAutoConstructMap.class);
+    }
+
+    static class EmptyMapArgumentsProvider implements ArgumentsProvider {
+        @Override
+        public Stream<? extends Arguments> provideArguments(ExtensionContext extensionContext) {
+            return Stream.of(
+                    Arguments.of(null, null),
+                    Arguments.of(null, Collections.emptyMap()),
+                    Arguments.of(Collections.emptyMap(), Collections.emptyMap()),
+                    Arguments.of(Collections.emptyMap(), null)
+            );
+        }
     }
 
     @Test void stringDifference_differs() {


### PR DESCRIPTION
This PR fixes a regression introduced by #323 for some DBInstance Create scenarios. When DBInstance requires update after create - read replica creation, restore from snapshot, or CACertificate is applied, and an empty vpcSecurityGroupIds list is provided and the instance is a member of DBCluster, ModifyDBInstance call will no longer fail.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
