### PR TITLE
[DBCluster] Set port conditionally on modify after create

### DIFF
--- a/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/CreateHandler.java
+++ b/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/CreateHandler.java
@@ -163,7 +163,7 @@ public class CreateHandler extends BaseHandlerStd {
             final ProgressEvent<ResourceModel, CallbackContext> progress
     ) {
         return proxy.initiate("rds::modify-dbcluster", proxyClient, progress.getResourceModel(), progress.getCallbackContext())
-                .translateToServiceRequest(Translator::modifyDbClusterRequest)
+                .translateToServiceRequest(model -> Translator.modifyDbClusterRequest(model, model, false))
                 .backoffDelay(config.getBackoff())
                 .makeServiceCall((dbClusterModifyRequest, proxyInvocation) -> proxyInvocation.injectCredentialsAndInvokeV2(
                         dbClusterModifyRequest,

--- a/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/EngineMode.java
+++ b/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/EngineMode.java
@@ -1,6 +1,6 @@
 package software.amazon.rds.dbcluster;
 
-enum EngineMode {
+public enum EngineMode {
     Serverless("serverless"),
     Provisioned("provisioned"),
     ParallelQuery("parallelquery"),


### PR DESCRIPTION
This commit continues the conditional modify-db-cluster attribute set approach applied in DBInstance. In particular, setting `port` attribute is now conditional as RDS API is quite inconsistent in accepting the same-value parameters: some engines/engine modes would accept it just fine if it is a no-change set, but some would reject agressively.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Signed-off-by: Oleg Sidorov <sidorovo@amazon.com>