### PR TITLE
[DBCluster] Unset default port on Update

### DIFF
--- a/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/ModelAdapter.java
+++ b/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/ModelAdapter.java
@@ -34,7 +34,6 @@ public class ModelAdapter {
     );
 
     public static ResourceModel setDefaults(final ResourceModel resourceModel) {
-
         final Integer port = resourceModel.getPort();
         final Integer backupRetentionPeriod = resourceModel.getBackupRetentionPeriod();
         final List<DBClusterRole> associatedRoles = resourceModel.getAssociatedRoles();

--- a/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/UpdateHandler.java
+++ b/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/UpdateHandler.java
@@ -49,7 +49,7 @@ public class UpdateHandler extends BaseHandlerStd {
                 .resourceTags(new HashSet<>(Translator.translateTagsToSdk(request.getDesiredResourceState().getTags())))
                 .build();
 
-        final ResourceModel previousResourceState = request.getPreviousResourceState();
+        final ResourceModel previousResourceState = setDefaults(request.getPreviousResourceState());
         final ResourceModel desiredResourceState = setDefaults(request.getDesiredResourceState());
         final boolean isRollback = BooleanUtils.isTrue(request.getRollback());
 

--- a/aws-rds-dbcluster/src/test/java/software/amazon/rds/dbcluster/CreateHandlerTest.java
+++ b/aws-rds-dbcluster/src/test/java/software/amazon/rds/dbcluster/CreateHandlerTest.java
@@ -1,8 +1,18 @@
 package software.amazon.rds.dbcluster;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Iterables;
-import lombok.Getter;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import java.time.Duration;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.stream.Stream;
+
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -16,6 +26,10 @@ import org.junit.jupiter.params.provider.ArgumentsSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
+import lombok.Getter;
 import software.amazon.awssdk.awscore.exception.AwsErrorDetails;
 import software.amazon.awssdk.services.ec2.Ec2Client;
 import software.amazon.awssdk.services.rds.RdsClient;
@@ -49,19 +63,6 @@ import software.amazon.rds.common.handler.HandlerConfig;
 import software.amazon.rds.common.handler.Tagging;
 import software.amazon.rds.test.common.core.HandlerName;
 import software.amazon.rds.test.common.core.TestUtils;
-
-import java.time.Duration;
-import java.util.Queue;
-import java.util.concurrent.ConcurrentLinkedQueue;
-import java.util.stream.Stream;
-
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.atLeastOnce;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 public class CreateHandlerTest extends AbstractHandlerTest {

--- a/aws-rds-dbcluster/src/test/java/software/amazon/rds/dbcluster/UpdateHandlerTest.java
+++ b/aws-rds-dbcluster/src/test/java/software/amazon/rds/dbcluster/UpdateHandlerTest.java
@@ -653,6 +653,32 @@ public class UpdateHandlerTest extends AbstractHandlerTest {
     }
 
     @Test
+    public void handleRequest_DoNotSetDefaultPortOnUpdate() {
+        when(rdsProxy.client().modifyDBCluster(any(ModifyDbClusterRequest.class)))
+                .thenReturn(ModifyDbClusterResponse.builder().build());
+
+        test_handleRequest_base(
+                new CallbackContext(),
+                () -> DBCLUSTER_ACTIVE,
+                () -> RESOURCE_MODEL.toBuilder()
+                        .engineMode(EngineMode.Serverless.toString())
+                        .engine(ENGINE_AURORA_POSTGRESQL)
+                        .port(null)
+                        .build(),
+                () -> RESOURCE_MODEL.toBuilder()
+                        .engineMode(EngineMode.Serverless.toString())
+                        .engine(ENGINE_AURORA_POSTGRESQL)
+                        .port(null)
+                        .build(),
+                expectSuccess()
+        );
+
+        ArgumentCaptor<ModifyDbClusterRequest> captor = ArgumentCaptor.forClass(ModifyDbClusterRequest.class);
+        verify(rdsProxy.client(), times(1)).modifyDBCluster(captor.capture());
+        Assertions.assertThat(captor.getValue().port()).isNull();
+    }
+
+    @Test
     public void handleRequest_EngineVersionUpdateIfMismatch() {
         final String engineVersion1 = TestUtils.randomString(16, TestUtils.ALPHANUM);
         final String engineVersion2 = TestUtils.randomString(16, TestUtils.ALPHANUM);


### PR DESCRIPTION
This commit ensures the `UpdateHandler` unsets the default port on update. The motivation for this change is to eliminate cases where RDS API would reject a modify request due to a non-null port value. This behavior is engine-specific hence setting port to null upon a no-change seems to be the one-size-fits all approach.

This commit is a follow-up on a change we delivered earlier: https://github.com/aws-cloudformation/aws-cloudformation-resource-providers-rds/pull/343

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Signed-off-by: Oleg Sidorov <sidorovo@amazon.com>