### PR TITLE
[DBClusterEndpoint] Fix read handler, relax schema constraints

### DIFF
--- a/aws-rds-dbclusterendpoint/aws-rds-dbclusterendpoint.json
+++ b/aws-rds-dbclusterendpoint/aws-rds-dbclusterendpoint.json
@@ -5,7 +5,6 @@
   "tagging": {
     "taggable": true
   },
-  "replacementStrategy": "delete_then_create",
   "definitions": {
     "Tag": {
       "description": "A key-value pair to associate with a resource.",
@@ -34,25 +33,18 @@
     "DBClusterIdentifier": {
       "description": "The DB cluster identifier of the DB cluster associated with the endpoint. This parameter is stored as a lowercase string.",
       "type": "string",
-      "pattern": "^[a-zA-Z]{1}(?:-?[a-zA-Z0-9]){0,62}$",
       "minLength": 1,
       "maxLength": 63
     },
     "DBClusterEndpointIdentifier": {
       "description": "The identifier to use for the new endpoint. This parameter is stored as a lowercase string.",
       "type": "string",
-      "pattern": "^[a-z]{1}(?:-?[a-z0-9]){0,62}$",
       "minLength": 1,
       "maxLength": 63
     },
     "EndpointType": {
       "description": "The type of the endpoint, one of: READER , WRITER , ANY",
-      "type": "string",
-      "enum": [
-        "READER",
-        "WRITER",
-        "ANY"
-      ]
+      "type": "string"
     },
     "DBClusterEndpointArn": {
       "type": "string",

--- a/aws-rds-dbclusterendpoint/docs/README.md
+++ b/aws-rds-dbclusterendpoint/docs/README.md
@@ -52,8 +52,6 @@ _Minimum_: <code>1</code>
 
 _Maximum_: <code>63</code>
 
-_Pattern_: <code>^[a-zA-Z]{1}(?:-?[a-zA-Z0-9]){0,62}$</code>
-
 _Update requires_: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
 
 #### DBClusterEndpointIdentifier
@@ -68,8 +66,6 @@ _Minimum_: <code>1</code>
 
 _Maximum_: <code>63</code>
 
-_Pattern_: <code>^[a-z]{1}(?:-?[a-z0-9]){0,62}$</code>
-
 _Update requires_: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
 
 #### EndpointType
@@ -79,8 +75,6 @@ The type of the endpoint, one of: READER , WRITER , ANY
 _Required_: Yes
 
 _Type_: String
-
-_Allowed Values_: <code>READER</code> | <code>WRITER</code> | <code>ANY</code>
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 

--- a/aws-rds-dbclusterendpoint/src/main/java/software/amazon/rds/dbclusterendpoint/CallbackContext.java
+++ b/aws-rds-dbclusterendpoint/src/main/java/software/amazon/rds/dbclusterendpoint/CallbackContext.java
@@ -8,7 +8,6 @@ import software.amazon.rds.common.handler.TaggingContext;
 @lombok.ToString
 @lombok.EqualsAndHashCode(callSuper = true)
 public class CallbackContext extends StdCallbackContext implements TaggingContext.Provider {
-    private String dbClusterEndpointArn;
     private TaggingContext taggingContext;
 
     public CallbackContext() {

--- a/aws-rds-dbclusterendpoint/src/main/java/software/amazon/rds/dbclusterendpoint/CreateHandler.java
+++ b/aws-rds-dbclusterendpoint/src/main/java/software/amazon/rds/dbclusterendpoint/CreateHandler.java
@@ -85,10 +85,6 @@ public class CreateHandler extends BaseHandlerStd {
                         ProgressEvent.progress(resourceModel, ctx),
                         exception,
                         DEFAULT_DB_CLUSTER_ENDPOINT_ERROR_RULE_SET))
-                .done((createRequest, createResponse, proxyInvocation, model, context) ->
-                {
-                    context.setDbClusterEndpointArn(createResponse.dbClusterEndpointArn());
-                    return ProgressEvent.progress(model, context);
-                });
+                .progress();
     }
 }

--- a/aws-rds-dbclusterendpoint/src/main/java/software/amazon/rds/dbclusterendpoint/ReadHandler.java
+++ b/aws-rds-dbclusterendpoint/src/main/java/software/amazon/rds/dbclusterendpoint/ReadHandler.java
@@ -54,8 +54,8 @@ public class ReadHandler extends BaseHandlerStd {
                         return ProgressEvent.failed(model, context, HandlerErrorCode.NotFound,
                                 "DBClusterEndpoint " + model.getDBClusterEndpointIdentifier() + " not found");
                     }
-                    context.setDbClusterEndpointArn(dbClusterEndpoint.get().dbClusterEndpointArn());
-                    return ProgressEvent.progress(model, context);
+
+                    return ProgressEvent.progress(Translator.translateDbClusterEndpointFromSdk(dbClusterEndpoint.get()), context);
                 })
                 .then(progress -> readTags(proxyClient, progress));
     }
@@ -66,7 +66,7 @@ public class ReadHandler extends BaseHandlerStd {
         ResourceModel model = progress.getResourceModel();
         CallbackContext context = progress.getCallbackContext();
         try {
-            String arn = progress.getCallbackContext().getDbClusterEndpointArn();
+            String arn = model.getDBClusterEndpointArn();
             Set<software.amazon.rds.dbclusterendpoint.Tag> resourceTags = Translator.translateTagsFromSdk(Tagging.listTagsForResource(proxyClient, arn));
             model.setTags(resourceTags);
         } catch (Exception exception) {

--- a/aws-rds-dbclusterendpoint/src/main/java/software/amazon/rds/dbclusterendpoint/UpdateHandler.java
+++ b/aws-rds-dbclusterendpoint/src/main/java/software/amazon/rds/dbclusterendpoint/UpdateHandler.java
@@ -47,7 +47,7 @@ public class UpdateHandler extends BaseHandlerStd {
 
         return ProgressEvent.progress(desiredModel, callbackContext)
                 .then(progress -> updateEndpoint(proxy, request, callbackContext, proxyClient))
-                .then(progress -> updateTags(proxy, proxyClient, progress, callbackContext.getDbClusterEndpointArn(), previousTags, desiredTags))
+                .then(progress -> updateTags(proxy, proxyClient, progress, progress.getResourceModel().getDBClusterEndpointArn(), previousTags, desiredTags))
                 .then(progress -> new ReadHandler().handleRequest(proxy, request, callbackContext, proxyClient, logger));
     }
 
@@ -70,10 +70,6 @@ public class UpdateHandler extends BaseHandlerStd {
                         ProgressEvent.progress(resourceModel, ctx),
                         exception,
                         DEFAULT_DB_CLUSTER_ENDPOINT_ERROR_RULE_SET))
-                .done((modifyRequest, modifyResponse, proxyInvocation, model, context) ->
-                {
-                    context.setDbClusterEndpointArn(modifyResponse.dbClusterEndpointArn());
-                    return ProgressEvent.progress(model, context);
-                });
+                .progress();
     }
 }

--- a/aws-rds-dbclusterendpoint/src/test/java/software/amazon/rds/dbclusterendpoint/ReadHandlerTest.java
+++ b/aws-rds-dbclusterendpoint/src/test/java/software/amazon/rds/dbclusterendpoint/ReadHandlerTest.java
@@ -21,6 +21,7 @@ import software.amazon.rds.test.common.core.HandlerName;
 import java.time.Duration;
 import java.util.Collections;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
@@ -82,7 +83,8 @@ public class ReadHandlerTest extends AbstractHandlerTest {
                 () -> RESOURCE_MODEL_BUILDER().tags(TAG_LIST).build(),
                 expectSuccess()
         );
-        progress.getResourceModel();
+        final ResourceModel model = progress.getResourceModel();
+        assertThat(model.getDBClusterEndpointIdentifier()).isEqualTo("dbClusterEndpointIdentifier");
         verify(rdsProxy.client(), times(1)).describeDBClusterEndpoints(any(DescribeDbClusterEndpointsRequest.class));
     }
 


### PR DESCRIPTION
This PR fixes Read handler on DBClusterEndpoint and relaxes the schema definition in order to make errors more human-friendly.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
