### PR TITLE
[OptionGroup] Fix contract tests for option group

### DIFF
--- a/aws-rds-optiongroup/inputs/inputs_1_create.json
+++ b/aws-rds-optiongroup/inputs/inputs_1_create.json
@@ -2,6 +2,7 @@
   "OptionGroupDescription": "A test option group",
   "EngineName": "mysql",
   "MajorEngineVersion": "5.6",
+  "OptionGroupName": "contract-test-optiongroup",
   "OptionConfigurations": [
     {
       "OptionName": "MEMCACHED",

--- a/aws-rds-optiongroup/inputs/inputs_1_update.json
+++ b/aws-rds-optiongroup/inputs/inputs_1_update.json
@@ -2,6 +2,7 @@
   "EngineName": "mysql",
   "MajorEngineVersion": "5.6",
   "OptionGroupDescription": "A test option group",
+  "OptionGroupName": "contract-test-optiongroup",
   "OptionConfigurations": [
     {
       "OptionName": "MEMCACHED",

--- a/aws-rds-optiongroup/src/main/java/software/amazon/rds/optiongroup/BaseHandlerStd.java
+++ b/aws-rds-optiongroup/src/main/java/software/amazon/rds/optiongroup/BaseHandlerStd.java
@@ -50,7 +50,7 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
             .extend(Commons.DEFAULT_ERROR_RULE_SET)
             .withErrorCodes(ErrorStatus.failWith(HandlerErrorCode.ResourceConflict),
                     ErrorCode.InvalidOptionGroupStateFault)
-            .withErrorClasses(ErrorStatus.ignore(OperationStatus.IN_PROGRESS),
+            .withErrorClasses(ErrorStatus.failWith(HandlerErrorCode.AlreadyExists),
                     OptionGroupAlreadyExistsException.class)
             .withErrorClasses(ErrorStatus.failWith(HandlerErrorCode.NotFound),
                     OptionGroupNotFoundException.class)

--- a/aws-rds-optiongroup/src/test/java/software/amazon/rds/optiongroup/CreateHandlerTest.java
+++ b/aws-rds-optiongroup/src/test/java/software/amazon/rds/optiongroup/CreateHandlerTest.java
@@ -353,13 +353,6 @@ public class CreateHandlerTest extends AbstractTestBase {
         when(proxyClient.client().createOptionGroup(any(CreateOptionGroupRequest.class)))
                 .thenThrow(OptionGroupAlreadyExistsException.class);
 
-        final DescribeOptionGroupsResponse describeDbClusterParameterGroupsResponse = DescribeOptionGroupsResponse.builder()
-                .optionGroupsList(OPTION_GROUP_ACTIVE).build();
-        when(proxyClient.client().describeOptionGroups(any(DescribeOptionGroupsRequest.class))).thenReturn(describeDbClusterParameterGroupsResponse);
-
-        when(proxyClient.client().listTagsForResource(any(ListTagsForResourceRequest.class)))
-                .thenReturn(ListTagsForResourceResponse.builder().build());
-
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
                 .clientRequestToken(TestUtils.randomString(32, TestUtils.ALPHA))
                 .systemTags(Translator.translateTagsToRequest(Translator.translateTagsFromSdk(TAG_SET.getSystemTags())))
@@ -370,15 +363,13 @@ public class CreateHandlerTest extends AbstractTestBase {
         final ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);
 
         assertThat(response).isNotNull();
-        assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.FAILED);
         assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
         assertThat(response.getResourceModels()).isNull();
         assertThat(response.getMessage()).isNull();
-        assertThat(response.getErrorCode()).isNull();
+        assertThat(response.getErrorCode()).isEqualTo(HandlerErrorCode.AlreadyExists);
 
         verify(proxyClient.client(), times(1)).createOptionGroup(any(CreateOptionGroupRequest.class));
-        verify(proxyClient.client(), times(1)).describeOptionGroups(any(DescribeOptionGroupsRequest.class));
-        verify(proxyClient.client(), times(1)).listTagsForResource(any(ListTagsForResourceRequest.class));
     }
 
     @Test


### PR DESCRIPTION
This PR fixes Contract tests for OptionGroup. In addition, this PR also prevents OptionGroup resource created outside of CFN being overriden by custom-named option group.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
