### PR TITLE
[DBInstance] Modify with a lookback at the current state after create

### DIFF
--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/DeleteHandler.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/DeleteHandler.java
@@ -51,7 +51,8 @@ public class DeleteHandler extends BaseHandlerStd {
         // Final snapshots are not allowed for read replicas and cluster instances.
         if (BooleanUtils.isNotFalse(request.getSnapshotRequested()) &&
                 !ResourceModelHelper.isReadReplica(resourceModel) &&
-                !isDBClusterMember(resourceModel)) {
+                !ResourceModelHelper.isDBClusterMember(resourceModel) &&
+                !ResourceModelHelper.isRdsCustomFamily(resourceModel)) {
             snapshotIdentifier = snapshotIdentifierFactory.newIdentifier()
                     .withStackId(request.getStackId())
                     .withResourceId(StringUtils.prependIfMissing(request.getLogicalResourceIdentifier(), SNAPSHOT_PREFIX))

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/util/ResourceModelHelper.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/util/ResourceModelHelper.java
@@ -1,14 +1,33 @@
 package software.amazon.rds.dbinstance.util;
 
-import com.amazonaws.util.StringUtils;
-import software.amazon.awssdk.utils.CollectionUtils;
-import software.amazon.rds.dbinstance.ResourceModel;
-
+import java.util.Arrays;
+import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
+import com.amazonaws.util.StringUtils;
+import com.google.common.collect.ImmutableList;
+import software.amazon.awssdk.utils.CollectionUtils;
+import software.amazon.rds.dbinstance.ResourceModel;
+
 public final class ResourceModelHelper {
     private final static String STORAGE_TYPE_IO1 = "io1";
+
+    public static final List<String> RDS_CUSTOM_ORACLE_ENGINES = ImmutableList.of(
+            "custom-oracle-ee",
+            "custom-oracle-ee-cdb"
+    );
+
+    public static final List<String> RDS_CUSTOM_SQL_SERVER_ENGINES = ImmutableList.of(
+            "custom-sqlserver-ee",
+            "custom-sqlserver-se",
+            "custom-sqlserver-web"
+    );
+
+    public static final List<String> SQLSERVER_ENGINES_WITH_MIRRORING = Arrays.asList(
+            "sqlserver-ee",
+            "sqlserver-se"
+    );
 
     public static boolean shouldUpdateAfterCreate(final ResourceModel model) {
         return (isReadReplica(model) || isRestoreFromSnapshot(model) || isCertificateAuthorityApplied(model)) &&
@@ -22,7 +41,6 @@ public final class ResourceModelHelper {
                                 StringUtils.hasValue(model.getPreferredBackupWindow()) ||
                                 StringUtils.hasValue(model.getPreferredMaintenanceWindow()) ||
                                 Optional.ofNullable(model.getBackupRetentionPeriod()).orElse(0) > 0 ||
-                                Optional.ofNullable(model.getIops()).orElse(0) > 0 ||
                                 Optional.ofNullable(model.getMaxAllocatedStorage()).orElse(0) > 0
                 );
     }
@@ -41,5 +59,21 @@ public final class ResourceModelHelper {
 
     public static boolean shouldSetStorageTypeOnRestoreFromSnapshot(final ResourceModel model) {
         return !Objects.equals(model.getStorageType(), STORAGE_TYPE_IO1) && shouldUpdateAfterCreate(model);
+    }
+
+    public static boolean isDBClusterMember(final ResourceModel model) {
+        return StringUtils.hasValue(model.getDBClusterIdentifier());
+    }
+
+    public static boolean isRdsCustomFamily(final ResourceModel model) {
+        return isRdsCustomOracleInstance(model) || isRdsCustomSQLServer(model);
+    }
+
+    public static boolean isRdsCustomSQLServer(final ResourceModel model) {
+        return RDS_CUSTOM_SQL_SERVER_ENGINES.contains(model.getEngine());
+    }
+
+    public static boolean isRdsCustomOracleInstance(final ResourceModel model) {
+        return RDS_CUSTOM_ORACLE_ENGINES.contains(model.getEngine());
     }
 }

--- a/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/AbstractHandlerTest.java
+++ b/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/AbstractHandlerTest.java
@@ -130,6 +130,9 @@ public abstract class AbstractHandlerTest extends AbstractTestBase<DBInstance, R
     protected static final String ENGINE_SQLSERVER_SE = "sqlserver-se";
     protected static final String ENGINE_SQLSERVER_EX = "sqlserver-ex";
     protected static final String ENGINE_SQLSERVER_WEB = "sqlserver-web";
+    protected static final String ENGINE_SQLSERVER_EE_CUSTOM = "custom-sqlserver-ee";
+    protected static final String ENGINE_SQLSERVER_SE_CUSTOM = "custom-sqlserver-se";
+    protected static final String ENGINE_SQLSERVER_WEB_CUSTOM = "custom-sqlserver-web";
     protected static final String ENGINE_VERSION_MYSQL_56 = "5.6";
     protected static final String ENGINE_VERSION_MYSQL_80 = "8.0";
     protected static final Integer IOPS_DEFAULT = 10_000;

--- a/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/TranslatorTest.java
+++ b/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/TranslatorTest.java
@@ -315,6 +315,118 @@ class TranslatorTest extends AbstractHandlerTest {
         assertThat(model.getDomainIAMRoleName()).isEqualTo(DOMAIN_IAM_ROLE_NAME_NON_EMPTY);
     }
 
+    @Test
+    public void test_modifyDbInstanceRequestV12_keepPreviousAllocatedStorageOnRollbackIfNotUpdatable() {
+        final boolean isRollback = true;
+        final String allocatedStoragePrev = "100";
+        final String allocatedStorageDesired = "50";
+        final ModifyDbInstanceRequest request = Translator.modifyDbInstanceRequestV12(
+                ResourceModel.builder()
+                        .allocatedStorage(allocatedStoragePrev)
+                        .build(),
+                ResourceModel.builder()
+                        .allocatedStorage(allocatedStorageDesired)
+                        .build(),
+                isRollback
+        );
+        // Given that the desired storage size is smaller than previous,
+        // the largest of 2 should be set
+        assertThat(request.allocatedStorage()).isEqualTo(Integer.parseInt(allocatedStoragePrev, 10));
+    }
+
+    @Test
+    public void test_modifyDbInstanceRequestV12_setDesiredAllocatedStorageOnRollbackIfUpdatable() {
+        final boolean isRollback = true;
+        final String allocatedStoragePrev = "50";
+        final String allocatedStorageDesired = "100";
+        final ModifyDbInstanceRequest request = Translator.modifyDbInstanceRequestV12(
+                ResourceModel.builder()
+                        .allocatedStorage(allocatedStoragePrev)
+                        .build(),
+                ResourceModel.builder()
+                        .allocatedStorage(allocatedStorageDesired)
+                        .build(),
+                isRollback
+        );
+        // Given that the desired storage size is smaller than previous,
+        // the largest of 2 should be set
+        assertThat(request.allocatedStorage()).isEqualTo(Integer.parseInt(allocatedStorageDesired, 10));
+    }
+
+    @Test
+    public void test_translateDBParameterGroupFromSdk_returnNull() {
+        assertThat(Translator.translateDBParameterGroupFromSdk(null)).isNull();
+    }
+
+    @Test
+    public void test_translateDBParameterGroupFromSdk_returnNonNull() {
+        final String dbParameterGroupName = "db-parameter-group-name";
+        assertThat(Translator.translateDBParameterGroupFromSdk(
+                software.amazon.awssdk.services.rds.model.DBParameterGroupStatus.builder()
+                        .dbParameterGroupName(dbParameterGroupName)
+                        .build()
+        )).isEqualTo(dbParameterGroupName);
+    }
+
+    @Test
+    public void test_translateEnableCloudwatchLogsExport_returnNull() {
+        assertThat(Translator.translateEnableCloudwatchLogsExport(null)).isNull();
+    }
+
+    @Test
+    public void test_translateEnableCloudwatchLogsExport_returnNonNull() {
+        assertThat(Translator.translateEnableCloudwatchLogsExport(
+                ImmutableList.of("cloudwatch-log")
+        )).isNotEmpty();
+    }
+
+    @Test
+    public void test_translateVpcSecurityGroupsFromSdk_returnNull() {
+        assertThat(Translator.translateVpcSecurityGroupsFromSdk(null)).isNull();
+    }
+
+    @Test
+    public void test_translateVpcSecurityGroupsFromSdk_returnNonNull() {
+        final String vpcSecurityGroupId = "vpc-security-group-id";
+        assertThat(Translator.translateVpcSecurityGroupsFromSdk(ImmutableList.of(
+                software.amazon.awssdk.services.rds.model.VpcSecurityGroupMembership.builder()
+                        .vpcSecurityGroupId(vpcSecurityGroupId)
+                        .build()
+        ))).containsExactly(vpcSecurityGroupId);
+    }
+
+    @Test
+    public void test_translateProcessorFeaturesFromSdk_returnNull() {
+        assertThat(Translator.translateProcessorFeaturesFromSdk(null)).isNull();
+    }
+
+    @Test
+    public void test_translateProcessorFeaturesFromSdk_returnNonNull() {
+        final String featureName = "feature-name";
+        final String featureValue = "feature-value";
+        assertThat(Translator.translateProcessorFeaturesFromSdk(ImmutableList.of(
+                software.amazon.awssdk.services.rds.model.ProcessorFeature.builder()
+                        .name(featureName)
+                        .value(featureValue)
+                        .build()
+        ))).containsExactly(ProcessorFeature.builder().name(featureName).value(featureValue).build());
+    }
+
+    @Test
+    public void test_translateDbSecurityGroupsFromSdk_returnNull() {
+        assertThat(Translator.translateDbSecurityGroupsFromSdk(null)).isNull();
+    }
+
+    @Test
+    public void test_translateDbSecurityGroupsFromSdk_returnNonNull() {
+        final String dbSecurityGroupName = "db-security-group-name";
+        assertThat(Translator.translateDbSecurityGroupsFromSdk(ImmutableList.of(
+                software.amazon.awssdk.services.rds.model.DBSecurityGroupMembership.builder()
+                        .dbSecurityGroupName(dbSecurityGroupName)
+                        .build()
+        ))).containsExactly(dbSecurityGroupName);
+    }
+
     // Stub methods to satisfy the interface. This is a 1-time thing.
 
     @Override


### PR DESCRIPTION
This commit changes the way `CreateHandler` performs an update after create. Historically, not every attribute of DBInstance could be set with a `CreateDBInstance`/`RestoreDBInstanceFromDBSnapshot`/`CreateDBInstanceReadReplica` request. For this reason the handler would emit a follow-up `ModifyDBInstance` request that would ensure the right attribute set. Since `DifferenceUtils` was introduced, `Translator` started assembling minimalistic modify requests, only including the attributes that are about to be changed. Given that a `CreateHandler` request contains no previous resource state, we were using a barebone model builder and feed it to diff. This gives an all-changed modify request. This commit alters this approach and describes a DBInstance right before modifying it. Using this technique allows us to use `diff` effectively and emit minimalistic modify requests.

This commit embeds a series of smaller changes:
- Apart from oracle-custom, we're adding a set of sqlserver-custom engines and gather them under a custom engine family umbrella.
- `DeletionPolicy: Snapshot` is rejected upon a create for custom engine family.
- Final snapshot is skipped for custom engine family.
- Translator avoids creating empty collections on from-sdk and to-sdk conversions if a null input is provided. This allows us to skip sending meaningless empty collections in modifies.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Signed-off-by: Oleg Sidorov <sidorovo@amazon.com>