### PR TITLE
[DBInstance] Move modify-after-create to a standalone method

### DIFF
--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/BaseHandlerStd.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/BaseHandlerStd.java
@@ -114,11 +114,6 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
 
     protected static final int RESOURCE_ID_MAX_LENGTH = 63;
 
-    protected static final List<String> SQLSERVER_ENGINES_WITH_MIRRORING = Arrays.asList(
-            "sqlserver-ee",
-            "sqlserver-se"
-    );
-
     protected final static HandlerConfig DEFAULT_DB_INSTANCE_HANDLER_CONFIG = HandlerConfig.builder()
             .backoff(Constant.of().delay(Duration.ofSeconds(30)).timeout(Duration.ofMinutes(180)).build())
             .build();

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/CreateHandler.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/CreateHandler.java
@@ -90,7 +90,7 @@ public class CreateHandler extends BaseHandlerStd {
                             try {
                                 final DBSnapshot snapshot = fetchDBSnapshot(rdsProxyClient.defaultClient(), model);
                                 final String engine = snapshot.engine();
-                                progress.getResourceModel().setMultiAZ(getDefaultMultiAzForEngine(engine));
+                                progress.getResourceModel().setMultiAZ(ResourceModelHelper.getDefaultMultiAzForEngine(engine));
                             } catch (Exception e) {
                                 return Commons.handleException(progress, e, RESTORE_DB_INSTANCE_ERROR_RULE_SET);
                             }
@@ -117,12 +117,12 @@ public class CreateHandler extends BaseHandlerStd {
                     if (ResourceModelHelper.shouldUpdateAfterCreate(progress.getResourceModel())) {
                         return Commons.execOnce(progress, () ->
                                                 versioned(proxy, rdsProxyClient, progress, null, ImmutableMap.of(
-                                                        ApiVersion.V12, (pxy, pcl, prg, tgs) -> updateDbInstanceV12(pxy, request, pcl, prg),
-                                                        ApiVersion.DEFAULT, (pxy, pcl, prg, tgs) -> updateDbInstance(pxy, request, pcl, prg)
+                                                        ApiVersion.V12, (pxy, pcl, prg, tgs) -> updateDbInstanceAfterCreateV12(pxy, request, pcl, prg),
+                                                        ApiVersion.DEFAULT, (pxy, pcl, prg, tgs) -> updateDbInstanceAfterCreate(pxy, request, pcl, prg)
                                                 )),
                                         CallbackContext::isUpdated, CallbackContext::setUpdated)
                                 .then(p -> Commons.execOnce(p, () -> {
-                                    if (shouldReboot(p.getResourceModel())) {
+                                    if (ResourceModelHelper.shouldReboot(p.getResourceModel())) {
                                         return rebootAwait(proxy, rdsProxyClient.defaultClient(), p);
                                     }
                                     return p;
@@ -275,14 +275,47 @@ public class CreateHandler extends BaseHandlerStd {
                 .progress();
     }
 
-    private boolean shouldReboot(final ResourceModel model) {
-        return StringUtils.hasValue(model.getDBParameterGroupName());
+    protected ProgressEvent<ResourceModel, CallbackContext> updateDbInstanceAfterCreateV12(
+            final AmazonWebServicesClientProxy proxy,
+            final ResourceHandlerRequest<ResourceModel> request,
+            final ProxyClient<RdsClient> rdsProxyClient,
+            final ProgressEvent<ResourceModel, CallbackContext> progress
+    ) {
+        return proxy.initiate("rds::modify-db-instance-v12", rdsProxyClient, progress.getResourceModel(), progress.getCallbackContext())
+                .translateToServiceRequest(resourceModel -> Translator.modifyDbInstanceAfterCreateRequestV12(request.getDesiredResourceState()))
+                .backoffDelay(config.getBackoff())
+                .makeServiceCall((modifyRequest, proxyInvocation) -> proxyInvocation.injectCredentialsAndInvokeV2(
+                        modifyRequest,
+                        proxyInvocation.client()::modifyDBInstance
+                ))
+                .stabilize((modifyRequest, response, proxyInvocation, model, context) -> isDBInstanceStabilizedAfterMutate(proxyInvocation, model))
+                .handleError((modifyRequest, exception, client, model, context) -> Commons.handleException(
+                        ProgressEvent.progress(model, context),
+                        exception,
+                        MODIFY_DB_INSTANCE_ERROR_RULE_SET
+                ))
+                .progress();
     }
 
-    private Boolean getDefaultMultiAzForEngine(final String engine) {
-        if (SQLSERVER_ENGINES_WITH_MIRRORING.contains(engine)) {
-            return null;
-        }
-        return false;
+    protected ProgressEvent<ResourceModel, CallbackContext> updateDbInstanceAfterCreate(
+            final AmazonWebServicesClientProxy proxy,
+            final ResourceHandlerRequest<ResourceModel> request,
+            final ProxyClient<RdsClient> rdsProxyClient,
+            final ProgressEvent<ResourceModel, CallbackContext> progress
+    ) {
+        return proxy.initiate("rds::modify-db-instance", rdsProxyClient, progress.getResourceModel(), progress.getCallbackContext())
+                .translateToServiceRequest(resourceModel -> Translator.modifyDbInstanceAfterCreateRequest(request.getDesiredResourceState()))
+                .backoffDelay(config.getBackoff())
+                .makeServiceCall((modifyRequest, proxyInvocation) -> proxyInvocation.injectCredentialsAndInvokeV2(
+                        modifyRequest,
+                        proxyInvocation.client()::modifyDBInstance
+                ))
+                .stabilize((modifyRequest, response, proxyInvocation, model, context) -> isDBInstanceStabilizedAfterMutate(proxyInvocation, model))
+                .handleError((modifyRequest, exception, client, model, context) -> Commons.handleException(
+                        ProgressEvent.progress(model, context),
+                        exception,
+                        MODIFY_DB_INSTANCE_ERROR_RULE_SET
+                ))
+                .progress();
     }
 }

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/Translator.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/Translator.java
@@ -18,6 +18,7 @@ import java.util.stream.Stream;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.BooleanUtils;
 
+import com.google.common.annotations.VisibleForTesting;
 import software.amazon.awssdk.services.ec2.model.DescribeSecurityGroupsRequest;
 import software.amazon.awssdk.services.ec2.model.Filter;
 import software.amazon.awssdk.services.rds.model.AddRoleToDbInstanceRequest;
@@ -262,14 +263,10 @@ public class Translator {
     }
 
     public static ModifyDbInstanceRequest modifyDbInstanceRequestV12(
-            ResourceModel previousModel,
+            final ResourceModel previousModel,
             final ResourceModel desiredModel,
             final Boolean isRollback
     ) {
-        // previousModel might be null if called from CreateHandler.
-        // In this case diff will ensure to set all attributes provided by desiredModel.
-        previousModel = (previousModel != null) ? previousModel : ResourceModel.builder().build();
-
         final ModifyDbInstanceRequest.Builder builder = ModifyDbInstanceRequest.builder()
                 .allowMajorVersionUpgrade(desiredModel.getAllowMajorVersionUpgrade())
                 .applyImmediately(Boolean.TRUE)
@@ -304,23 +301,11 @@ public class Translator {
         return builder.build();
     }
 
-    public static ModifyDbInstanceRequest updateAllocatedStorageRequest(final ResourceModel desiredModel) {
-        return ModifyDbInstanceRequest.builder()
-                .dbInstanceIdentifier(desiredModel.getDBInstanceIdentifier())
-                .allocatedStorage(getAllocatedStorage(desiredModel))
-                .applyImmediately(Boolean.TRUE)
-                .build();
-    }
-
     public static ModifyDbInstanceRequest modifyDbInstanceRequest(
-            ResourceModel previousModel,
+            final ResourceModel previousModel,
             final ResourceModel desiredModel,
             final Boolean isRollback
     ) {
-        // previousModel might be null if called from CreateHandler.
-        // In this case diff will ensure to set all attributes provided by desiredModel.
-        previousModel = (previousModel != null) ? previousModel : ResourceModel.builder().build();
-
         final ModifyDbInstanceRequest.Builder builder = ModifyDbInstanceRequest.builder()
                 .allowMajorVersionUpgrade(desiredModel.getAllowMajorVersionUpgrade())
                 .applyImmediately(Boolean.TRUE)
@@ -387,6 +372,47 @@ public class Translator {
         return builder.build();
     }
 
+    public static ModifyDbInstanceRequest modifyDbInstanceAfterCreateRequestV12(final ResourceModel model) {
+        return ModifyDbInstanceRequest.builder()
+                .applyImmediately(Boolean.TRUE)
+                .dbInstanceIdentifier(model.getDBInstanceIdentifier())
+                .allocatedStorage(getAllocatedStorage(model))
+                .backupRetentionPeriod(model.getBackupRetentionPeriod())
+                .dbParameterGroupName(model.getDBParameterGroupName())
+                .dbSecurityGroups(model.getDBSecurityGroups())
+                .engineVersion(model.getEngineVersion())
+                .iops(model.getIops())
+                .masterUserPassword(model.getMasterUserPassword())
+                .preferredBackupWindow(model.getPreferredBackupWindow())
+                .preferredMaintenanceWindow(model.getPreferredMaintenanceWindow())
+                .build();
+    }
+
+    public static ModifyDbInstanceRequest modifyDbInstanceAfterCreateRequest(final ResourceModel model) {
+        return ModifyDbInstanceRequest.builder()
+                .applyImmediately(Boolean.TRUE)
+                .dbInstanceIdentifier(model.getDBInstanceIdentifier())
+                .allocatedStorage(getAllocatedStorage(model))
+                .backupRetentionPeriod(model.getBackupRetentionPeriod())
+                .caCertificateIdentifier(model.getCACertificateIdentifier())
+                .dbParameterGroupName(model.getDBParameterGroupName())
+                .engineVersion(model.getEngineVersion())
+                .iops(model.getIops())
+                .masterUserPassword(model.getMasterUserPassword())
+                .maxAllocatedStorage(model.getMaxAllocatedStorage())
+                .preferredBackupWindow(model.getPreferredBackupWindow())
+                .preferredMaintenanceWindow(model.getPreferredMaintenanceWindow())
+                .build();
+    }
+
+    public static ModifyDbInstanceRequest updateAllocatedStorageRequest(final ResourceModel desiredModel) {
+        return ModifyDbInstanceRequest.builder()
+                .dbInstanceIdentifier(desiredModel.getDBInstanceIdentifier())
+                .allocatedStorage(getAllocatedStorage(desiredModel))
+                .applyImmediately(Boolean.TRUE)
+                .build();
+    }
+
     public static RemoveRoleFromDbInstanceRequest removeRoleFromDbInstanceRequest(
             final ResourceModel model,
             final DBInstanceRole role
@@ -432,6 +458,11 @@ public class Translator {
 
         logTypesToEnable.removeAll(Optional.ofNullable(previousLogExports).orElse(Collections.emptyList()));
         logTypesToDisable.removeAll(Optional.ofNullable(desiredLogExports).orElse(Collections.emptyList()));
+
+        if (CollectionUtils.isEmpty(logTypesToEnable) && CollectionUtils.isEmpty(logTypesToDisable)) {
+            // This is a no-op
+            return null;
+        }
 
         return CloudwatchLogsExportConfiguration.builder()
                 .enableLogTypes(logTypesToEnable)
@@ -595,18 +626,17 @@ public class Translator {
     }
 
     public static String translateDBParameterGroupFromSdk(final software.amazon.awssdk.services.rds.model.DBParameterGroupStatus parameterGroup) {
-        return Optional.ofNullable(parameterGroup).map(DBParameterGroupStatus::dbParameterGroupName).orElse(null);
+        return parameterGroup == null ? null : parameterGroup.dbParameterGroupName();
     }
 
     public static List<String> translateEnableCloudwatchLogsExport(final Collection<String> enabledCloudwatchLogsExports) {
-        return new ArrayList<>(Optional.ofNullable(enabledCloudwatchLogsExports)
-                .orElse(Collections.emptyList()));
+        return enabledCloudwatchLogsExports == null ? null : new ArrayList<>(enabledCloudwatchLogsExports);
     }
 
     public static List<String> translateVpcSecurityGroupsFromSdk(
             final Collection<software.amazon.awssdk.services.rds.model.VpcSecurityGroupMembership> vpcSecurityGroups
     ) {
-        return streamOfOrEmpty(vpcSecurityGroups)
+        return vpcSecurityGroups == null ? null : vpcSecurityGroups.stream()
                 .map(software.amazon.awssdk.services.rds.model.VpcSecurityGroupMembership::vpcSecurityGroupId)
                 .collect(Collectors.toList());
     }
@@ -640,7 +670,7 @@ public class Translator {
     public static List<ProcessorFeature> translateProcessorFeaturesFromSdk(
             final Collection<software.amazon.awssdk.services.rds.model.ProcessorFeature> sdkProcessorFeatures
     ) {
-        return streamOfOrEmpty(sdkProcessorFeatures)
+        return sdkProcessorFeatures == null ? null : sdkProcessorFeatures.stream()
                 .map(processorFeature -> ProcessorFeature
                         .builder()
                         .name(processorFeature.name())
@@ -652,7 +682,7 @@ public class Translator {
     public static Set<software.amazon.awssdk.services.rds.model.ProcessorFeature> translateProcessorFeaturesToSdk(
             final Collection<ProcessorFeature> processorFeatures
     ) {
-        return streamOfOrEmpty(processorFeatures)
+        return processorFeatures == null ? null : processorFeatures.stream()
                 .map(processorFeature -> software.amazon.awssdk.services.rds.model.ProcessorFeature
                         .builder()
                         .name(processorFeature.getName())
@@ -664,7 +694,7 @@ public class Translator {
     public static List<String> translateDbSecurityGroupsFromSdk(
             final List<software.amazon.awssdk.services.rds.model.DBSecurityGroupMembership> dbSecurityGroupMemberships
     ) {
-        return streamOfOrEmpty(dbSecurityGroupMemberships)
+        return dbSecurityGroupMemberships == null ? null : dbSecurityGroupMemberships.stream()
                 .map(software.amazon.awssdk.services.rds.model.DBSecurityGroupMembership::dbSecurityGroupName)
                 .collect(Collectors.toList());
     }
@@ -672,7 +702,7 @@ public class Translator {
     public static String translateDbSubnetGroupFromSdk(
             final software.amazon.awssdk.services.rds.model.DBSubnetGroup dbSubnetGroup
     ) {
-        return Optional.ofNullable(dbSubnetGroup).map(DBSubnetGroup::dbSubnetGroupName).orElse(null);
+        return dbSubnetGroup == null ? null : dbSubnetGroup.dbSubnetGroupName();
     }
 
     public static List<DBInstanceRole> translateAssociatedRolesFromSdk(
@@ -712,7 +742,8 @@ public class Translator {
                 .orElseGet(Stream::empty);
     }
 
-    private static boolean canUpdateAllocatedStorage(final String fromAllocatedStorage, final String toAllocatedStorage) {
+    @VisibleForTesting
+    static boolean canUpdateAllocatedStorage(final String fromAllocatedStorage, final String toAllocatedStorage) {
         if (fromAllocatedStorage == null || toAllocatedStorage == null) {
             return true;
         }
@@ -726,11 +757,13 @@ public class Translator {
         return to >= from;
     }
 
-    private static boolean canUpdateIops(final Integer fromIops, final Integer toIops) {
+    @VisibleForTesting
+    static boolean canUpdateIops(final Integer fromIops, final Integer toIops) {
         return fromIops == null || toIops == null || toIops >= fromIops;
     }
 
-    private static boolean shouldSetProcessorFeatures(final ResourceModel previousModel, final ResourceModel desiredModel) {
+    @VisibleForTesting
+    static boolean shouldSetProcessorFeatures(final ResourceModel previousModel, final ResourceModel desiredModel) {
         return previousModel != null && desiredModel != null &&
                 (!Objects.deepEquals(previousModel.getProcessorFeatures(), desiredModel.getProcessorFeatures()) ||
                         !Objects.equals(previousModel.getUseDefaultProcessorFeatures(), desiredModel.getUseDefaultProcessorFeatures()));

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/util/ResourceModelHelper.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/util/ResourceModelHelper.java
@@ -4,11 +4,18 @@ import com.amazonaws.util.StringUtils;
 import software.amazon.awssdk.utils.CollectionUtils;
 import software.amazon.rds.dbinstance.ResourceModel;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
 public final class ResourceModelHelper {
     private final static String STORAGE_TYPE_IO1 = "io1";
+
+    protected static final List<String> SQLSERVER_ENGINES_WITH_MIRRORING = Arrays.asList(
+            "sqlserver-ee",
+            "sqlserver-se"
+    );
 
     public static boolean shouldUpdateAfterCreate(final ResourceModel model) {
         return (isReadReplica(model) || isRestoreFromSnapshot(model) || isCertificateAuthorityApplied(model)) &&
@@ -41,5 +48,16 @@ public final class ResourceModelHelper {
 
     public static boolean shouldSetStorageTypeOnRestoreFromSnapshot(final ResourceModel model) {
         return !Objects.equals(model.getStorageType(), STORAGE_TYPE_IO1) && shouldUpdateAfterCreate(model);
+    }
+
+    public static boolean shouldReboot(final ResourceModel model) {
+        return StringUtils.hasValue(model.getDBParameterGroupName());
+    }
+
+    public static Boolean getDefaultMultiAzForEngine(final String engine) {
+        if (SQLSERVER_ENGINES_WITH_MIRRORING.contains(engine)) {
+            return null;
+        }
+        return false;
     }
 }

--- a/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/TranslatorTest.java
+++ b/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/TranslatorTest.java
@@ -37,6 +37,19 @@ class TranslatorTest extends AbstractHandlerTest {
     }
 
     @Test
+    public void test_modifyDbInstanceRequestV12_IncreaseAllocatedStorage() {
+        final ResourceModel previousModel = RESOURCE_MODEL_BLDR()
+                .allocatedStorage(ALLOCATED_STORAGE.toString())
+                .build();
+        final ResourceModel desiredModel = RESOURCE_MODEL_BLDR()
+                .allocatedStorage(ALLOCATED_STORAGE_INCR.toString())
+                .build();
+        final Boolean isRollback = false;
+        final ModifyDbInstanceRequest request = Translator.modifyDbInstanceRequestV12(previousModel, desiredModel, isRollback);
+        assertThat(request.allocatedStorage()).isEqualTo(ALLOCATED_STORAGE_INCR);
+    }
+
+    @Test
     public void test_modifyDbInstanceRequest_DecreaseAllocatedStorage() {
         final ResourceModel previousModel = RESOURCE_MODEL_BLDR()
                 .allocatedStorage(ALLOCATED_STORAGE.toString())
@@ -46,6 +59,19 @@ class TranslatorTest extends AbstractHandlerTest {
                 .build();
         final Boolean isRollback = false;
         final ModifyDbInstanceRequest request = Translator.modifyDbInstanceRequest(previousModel, desiredModel, isRollback);
+        assertThat(request.allocatedStorage()).isEqualTo(ALLOCATED_STORAGE_DECR);
+    }
+
+    @Test
+    public void test_modifyDbInstanceRequestV12_DecreaseAllocatedStorage() {
+        final ResourceModel previousModel = RESOURCE_MODEL_BLDR()
+                .allocatedStorage(ALLOCATED_STORAGE.toString())
+                .build();
+        final ResourceModel desiredModel = RESOURCE_MODEL_BLDR()
+                .allocatedStorage(ALLOCATED_STORAGE_DECR.toString())
+                .build();
+        final Boolean isRollback = false;
+        final ModifyDbInstanceRequest request = Translator.modifyDbInstanceRequestV12(previousModel, desiredModel, isRollback);
         assertThat(request.allocatedStorage()).isEqualTo(ALLOCATED_STORAGE_DECR);
     }
 
@@ -63,6 +89,19 @@ class TranslatorTest extends AbstractHandlerTest {
     }
 
     @Test
+    public void test_modifyDbInstanceRequestV12_isRollback_IncreaseAllocatedStorage() {
+        final ResourceModel previousModel = RESOURCE_MODEL_BLDR()
+                .allocatedStorage(ALLOCATED_STORAGE.toString())
+                .build();
+        final ResourceModel desiredModel = RESOURCE_MODEL_BLDR()
+                .allocatedStorage(ALLOCATED_STORAGE_INCR.toString())
+                .build();
+        final Boolean isRollback = true;
+        final ModifyDbInstanceRequest request = Translator.modifyDbInstanceRequestV12(previousModel, desiredModel, isRollback);
+        assertThat(request.allocatedStorage()).isEqualTo(ALLOCATED_STORAGE_INCR);
+    }
+
+    @Test
     public void test_modifyDbInstanceRequest_isRollback_DecreaseAllocatedStorage() {
         final ResourceModel previousModel = RESOURCE_MODEL_BLDR()
                 .allocatedStorage(ALLOCATED_STORAGE.toString())
@@ -72,6 +111,19 @@ class TranslatorTest extends AbstractHandlerTest {
                 .build();
         final Boolean isRollback = true;
         final ModifyDbInstanceRequest request = Translator.modifyDbInstanceRequest(previousModel, desiredModel, isRollback);
+        assertThat(request.allocatedStorage()).isEqualTo(ALLOCATED_STORAGE); // should stay unchanged
+    }
+
+    @Test
+    public void test_modifyDbInstanceRequestV12_isRollback_DecreaseAllocatedStorage() {
+        final ResourceModel previousModel = RESOURCE_MODEL_BLDR()
+                .allocatedStorage(ALLOCATED_STORAGE.toString())
+                .build();
+        final ResourceModel desiredModel = RESOURCE_MODEL_BLDR()
+                .allocatedStorage(ALLOCATED_STORAGE_DECR.toString())
+                .build();
+        final Boolean isRollback = true;
+        final ModifyDbInstanceRequest request = Translator.modifyDbInstanceRequestV12(previousModel, desiredModel, isRollback);
         assertThat(request.allocatedStorage()).isEqualTo(ALLOCATED_STORAGE); // should stay unchanged
     }
 
@@ -89,6 +141,19 @@ class TranslatorTest extends AbstractHandlerTest {
     }
 
     @Test
+    public void test_modifyDbInstanceRequestV12_IncreaseIops() {
+        final ResourceModel previousModel = RESOURCE_MODEL_BLDR()
+                .iops(IOPS_DEFAULT)
+                .build();
+        final ResourceModel desiredModel = RESOURCE_MODEL_BLDR()
+                .iops(IOPS_INCR)
+                .build();
+        final Boolean isRollback = false;
+        final ModifyDbInstanceRequest request = Translator.modifyDbInstanceRequestV12(previousModel, desiredModel, isRollback);
+        assertThat(request.iops()).isEqualTo(IOPS_INCR);
+    }
+
+    @Test
     public void test_modifyDbInstanceRequest_DecreaseIops() {
         final ResourceModel previousModel = RESOURCE_MODEL_BLDR()
                 .iops(IOPS_DEFAULT)
@@ -98,6 +163,19 @@ class TranslatorTest extends AbstractHandlerTest {
                 .build();
         final Boolean isRollback = false;
         final ModifyDbInstanceRequest request = Translator.modifyDbInstanceRequest(previousModel, desiredModel, isRollback);
+        assertThat(request.iops()).isEqualTo(IOPS_DECR);
+    }
+
+    @Test
+    public void test_modifyDbInstanceRequestV12_DecreaseIops() {
+        final ResourceModel previousModel = RESOURCE_MODEL_BLDR()
+                .iops(IOPS_DEFAULT)
+                .build();
+        final ResourceModel desiredModel = RESOURCE_MODEL_BLDR()
+                .iops(IOPS_DECR)
+                .build();
+        final Boolean isRollback = false;
+        final ModifyDbInstanceRequest request = Translator.modifyDbInstanceRequestV12(previousModel, desiredModel, isRollback);
         assertThat(request.iops()).isEqualTo(IOPS_DECR);
     }
 
@@ -115,6 +193,19 @@ class TranslatorTest extends AbstractHandlerTest {
     }
 
     @Test
+    public void test_modifyDbInstanceRequestV12_isRollback_IncreaseIops() {
+        final ResourceModel previousModel = RESOURCE_MODEL_BLDR()
+                .iops(IOPS_DEFAULT)
+                .build();
+        final ResourceModel desiredModel = RESOURCE_MODEL_BLDR()
+                .iops(IOPS_INCR)
+                .build();
+        final Boolean isRollback = true;
+        final ModifyDbInstanceRequest request = Translator.modifyDbInstanceRequestV12(previousModel, desiredModel, isRollback);
+        assertThat(request.iops()).isEqualTo(IOPS_INCR);
+    }
+
+    @Test
     public void test_modifyDbInstanceRequest_isRollback_DecreaseIops() {
         final ResourceModel previousModel = RESOURCE_MODEL_BLDR()
                 .iops(IOPS_DEFAULT)
@@ -124,6 +215,19 @@ class TranslatorTest extends AbstractHandlerTest {
                 .build();
         final Boolean isRollback = true;
         final ModifyDbInstanceRequest request = Translator.modifyDbInstanceRequest(previousModel, desiredModel, isRollback);
+        assertThat(request.iops()).isEqualTo(IOPS_DEFAULT);
+    }
+
+    @Test
+    public void test_modifyDbInstanceRequestV12_isRollback_DecreaseIops() {
+        final ResourceModel previousModel = RESOURCE_MODEL_BLDR()
+                .iops(IOPS_DEFAULT)
+                .build();
+        final ResourceModel desiredModel = RESOURCE_MODEL_BLDR()
+                .iops(IOPS_DECR)
+                .build();
+        final Boolean isRollback = true;
+        final ModifyDbInstanceRequest request = Translator.modifyDbInstanceRequestV12(previousModel, desiredModel, isRollback);
         assertThat(request.iops()).isEqualTo(IOPS_DEFAULT);
     }
 
@@ -313,6 +417,17 @@ class TranslatorTest extends AbstractHandlerTest {
         final ResourceModel model = Translator.translateDbInstanceFromSdk(instance);
         assertThat(model.getDomain()).isEqualTo(DOMAIN_NON_EMPTY);
         assertThat(model.getDomainIAMRoleName()).isEqualTo(DOMAIN_IAM_ROLE_NAME_NON_EMPTY);
+    }
+
+    @Test
+    public void test_canUpdateAllocatedStorage_nullArg() {
+        assertThat(Translator.canUpdateAllocatedStorage(null, "42")).isTrue();
+        assertThat(Translator.canUpdateAllocatedStorage("42", null)).isTrue();
+    }
+
+    @Test
+    public void test_canUpdateAllocatedStorage_NumberFormatException() {
+        assertThat(Translator.canUpdateAllocatedStorage("123", "invalid")).isTrue();
     }
 
     // Stub methods to satisfy the interface. This is a 1-time thing.


### PR DESCRIPTION
This commit moves modify-after-create Translator to a separate method. The motivation for this change is to get rid of an overly-complicated logic in the current implementation of `Translator.modifyDbInstanceRequest`. There is a significant difference between a regular update and an update after create that is only supposed to concern a limited set of attributes. An example of this logic is handling iops or allocatedStorage parameters.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Signed-off-by: Oleg Sidorov <sidorovo@amazon.com>

