### PR TITLE
[GlobalCluster] Added major version upgrade support to globalCluster …

### DIFF
--- a/aws-rds-globalcluster/aws-rds-globalcluster.json
+++ b/aws-rds-globalcluster/aws-rds-globalcluster.json
@@ -59,8 +59,7 @@
     "/properties/GlobalClusterIdentifier",
     "/properties/SourceDBClusterIdentifier",
     "/properties/StorageEncrypted",
-    "/properties/Engine",
-    "/properties/EngineVersion"
+    "/properties/Engine"
   ],
   "primaryIdentifier": [
     "/properties/GlobalClusterIdentifier"

--- a/aws-rds-globalcluster/docs/README.md
+++ b/aws-rds-globalcluster/docs/README.md
@@ -58,7 +58,7 @@ _Required_: No
 
 _Type_: String
 
-_Update requires_: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 
 #### DeletionProtection
 

--- a/aws-rds-globalcluster/src/main/java/software/amazon/rds/globalcluster/Translator.java
+++ b/aws-rds-globalcluster/src/main/java/software/amazon/rds/globalcluster/Translator.java
@@ -35,13 +35,17 @@ public class Translator {
             .build();
   }
 
-  static ModifyGlobalClusterRequest modifyGlobalClusterRequest(final ResourceModel previousModel, final ResourceModel desiredModel) {
+  static ModifyGlobalClusterRequest modifyGlobalClusterRequest(
+          final ResourceModel previousModel,
+          final ResourceModel desiredModel,
+          final boolean isRollback
+  ) {
     ModifyGlobalClusterRequest.Builder builder = ModifyGlobalClusterRequest.builder()
             .globalClusterIdentifier(desiredModel.getGlobalClusterIdentifier())
             .deletionProtection(desiredModel.getDeletionProtection());
 
     if (previousModel != null) {
-      if (!Objects.equals(previousModel.getEngineVersion(), desiredModel.getEngineVersion())) {
+      if (!(isRollback || Objects.equals(previousModel.getEngineVersion(), desiredModel.getEngineVersion()))) {
         builder.engineVersion(desiredModel.getEngineVersion());
         builder.allowMajorVersionUpgrade(true);
       }

--- a/aws-rds-globalcluster/src/main/java/software/amazon/rds/globalcluster/Translator.java
+++ b/aws-rds-globalcluster/src/main/java/software/amazon/rds/globalcluster/Translator.java
@@ -1,5 +1,7 @@
 package software.amazon.rds.globalcluster;
 
+import java.util.Objects;
+
 import software.amazon.awssdk.services.rds.model.CreateGlobalClusterRequest;
 import software.amazon.awssdk.services.rds.model.ModifyGlobalClusterRequest;
 import software.amazon.awssdk.services.rds.model.DescribeGlobalClustersRequest;
@@ -33,11 +35,19 @@ public class Translator {
             .build();
   }
 
-  static ModifyGlobalClusterRequest modifyGlobalClusterRequest(final ResourceModel model) {
-    return ModifyGlobalClusterRequest.builder()
-            .globalClusterIdentifier(model.getGlobalClusterIdentifier())
-            .deletionProtection(model.getDeletionProtection())
-            .build();
+  static ModifyGlobalClusterRequest modifyGlobalClusterRequest(final ResourceModel previousModel, final ResourceModel desiredModel) {
+    ModifyGlobalClusterRequest.Builder builder = ModifyGlobalClusterRequest.builder()
+            .globalClusterIdentifier(desiredModel.getGlobalClusterIdentifier())
+            .deletionProtection(desiredModel.getDeletionProtection());
+
+    if (previousModel != null) {
+      if (!Objects.equals(previousModel.getEngineVersion(), desiredModel.getEngineVersion())) {
+        builder.engineVersion(desiredModel.getEngineVersion());
+        builder.allowMajorVersionUpgrade(true);
+      }
+    }
+
+    return builder.build();
   }
 
   static DeleteGlobalClusterRequest deleteGlobalClusterRequest(final ResourceModel model) {

--- a/aws-rds-globalcluster/src/main/java/software/amazon/rds/globalcluster/UpdateHandler.java
+++ b/aws-rds-globalcluster/src/main/java/software/amazon/rds/globalcluster/UpdateHandler.java
@@ -1,5 +1,7 @@
 package software.amazon.rds.globalcluster;
 
+import org.apache.commons.lang3.BooleanUtils;
+
 import software.amazon.awssdk.services.rds.RdsClient;
 import software.amazon.cloudformation.proxy.Logger;
 import software.amazon.cloudformation.proxy.ProgressEvent;
@@ -19,7 +21,7 @@ public class UpdateHandler extends BaseHandlerStd {
 
         return proxy.initiate("rds::update-global-cluster", proxyClient, request.getDesiredResourceState(), callbackContext)
                 // request to update global cluster
-                .translateToServiceRequest(model -> Translator.modifyGlobalClusterRequest(previousModel, desiredModel))
+                .translateToServiceRequest(model -> Translator.modifyGlobalClusterRequest(previousModel, desiredModel, BooleanUtils.isTrue(request.getRollback())))
                 .backoffDelay(BACKOFF_STRATEGY)
                 .makeServiceCall((modifyGlobalClusterRequest, proxyClient1) -> proxyClient1.injectCredentialsAndInvokeV2(modifyGlobalClusterRequest, proxyClient1.client()::modifyGlobalCluster))
                 .stabilize(((modifyGlobalClusterRequest, modifyGlobalClusterResponse, proxyClient1, resourceModel, callbackContext1) ->

--- a/aws-rds-globalcluster/src/test/java/software/amazon/rds/globalcluster/AbstractTestBase.java
+++ b/aws-rds-globalcluster/src/test/java/software/amazon/rds/globalcluster/AbstractTestBase.java
@@ -31,11 +31,13 @@ public class AbstractTestBase {
   protected static final String SOURCECLUSTER_IDENTIFIER;
   protected static final String SOURCECLUSTER_ARN;
   protected static final String ENGINE_VERSION;
+  protected static final String ENGINE_VERSION_MVU;
   protected static final String ENGINE;
   protected static final boolean DELETION_PROTECTION;
 
   protected static final ResourceModel RESOURCE_MODEL;
   protected static final ResourceModel RESOURCE_MODEL_UPDATE;
+  protected static final ResourceModel RESOURCE_MODEL_UPDATE_MVU;
   protected static final ResourceModel RESOURCE_MODEL_ALTERNATIVE;
   protected static final ResourceModel RESOURCE_MODEL_WITH_MASTER;
   protected static final ResourceModel RESOURCE_MODEL_WITH_MASTER_ARN;
@@ -59,6 +61,7 @@ public class AbstractTestBase {
     SOURCECLUSTER_ARN = "arn:aws:rds:us-east-1:340834135580:cluster:sample-globalcluster";
     ENGINE = "aurora";
     ENGINE_VERSION = "5.6.mysql_aurora.1.22.2";
+    ENGINE_VERSION_MVU = "5.7.mysql_aurora.2.10.2";
     DELETION_PROTECTION = false;
 
 
@@ -109,6 +112,13 @@ public class AbstractTestBase {
     RESOURCE_MODEL_UPDATE = ResourceModel.builder()
             .globalClusterIdentifier(GLOBALCLUSTER_IDENTIFIER)
             .deletionProtection(DELETION_PROTECTION)
+            .engineVersion(ENGINE_VERSION)
+            .build();
+
+    RESOURCE_MODEL_UPDATE_MVU = ResourceModel.builder()
+            .globalClusterIdentifier(GLOBALCLUSTER_IDENTIFIER)
+            .deletionProtection(DELETION_PROTECTION)
+            .engineVersion(ENGINE_VERSION_MVU)
             .build();
   }
 


### PR DESCRIPTION
[GlobalCluster]

[1179](https://github.com/aws-cloudformation/cloudformation-coverage-roadmap/issues/1179)

Added major version upgrade support to globalCluster 

Please note: this change doesn't support minor version upgrade, the usual method of manually upgrading all member clusters before patching primary still applies.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
