### PR TITLE
[DBInstance] No retry on `InvalidParameterCombinationException`

### DIFF
--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/BaseHandlerStd.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/BaseHandlerStd.java
@@ -256,12 +256,12 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
     protected static final ErrorRuleSet MODIFY_DB_INSTANCE_ERROR_RULE_SET = ErrorRuleSet
             .extend(DEFAULT_DB_INSTANCE_ERROR_RULE_SET)
             .withErrorCodes(ErrorStatus.failWith(HandlerErrorCode.ResourceConflict),
-                    ErrorCode.InvalidDBInstanceState,
-                    ErrorCode.InvalidParameterCombination)
+                    ErrorCode.InvalidDBInstanceState)
             .withErrorCodes(ErrorStatus.failWith(HandlerErrorCode.NotFound),
                     ErrorCode.DBInstanceNotFound)
             .withErrorCodes(ErrorStatus.failWith(HandlerErrorCode.InvalidRequest),
-                    ErrorCode.InvalidDBSecurityGroupState)
+                    ErrorCode.InvalidDBSecurityGroupState,
+                    ErrorCode.InvalidParameterCombination)
             .withErrorClasses(ErrorStatus.failWith(HandlerErrorCode.ResourceConflict),
                     InvalidDbInstanceStateException.class)
             .withErrorClasses(ErrorStatus.failWith(HandlerErrorCode.NotFound),

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/Translator.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/Translator.java
@@ -300,7 +300,6 @@ public class Translator {
                 .sourceDBInstanceIdentifier(model.getSourceDBInstanceIdentifier())
                 .sourceDbiResourceId(model.getSourceDbiResourceId())
                 .sourceDBInstanceAutomatedBackupsArn(model.getSourceDBInstanceAutomatedBackupsArn())
-                .storageType(model.getStorageType())
                 .tags(Tagging.translateTagsToSdk(tagSet))
                 .targetDBInstanceIdentifier(model.getDBInstanceIdentifier()) // We only work with DBInstanceId not TargetDBInstanceId
                 .tdeCredentialArn(model.getTdeCredentialArn())
@@ -659,6 +658,7 @@ public class Translator {
                 .sourceDBInstanceIdentifier(dbInstance.readReplicaSourceDBInstanceIdentifier())
                 .storageEncrypted(dbInstance.storageEncrypted())
                 .storageThroughput(dbInstance.storageThroughput())
+                .storageType(dbInstance.storageType())
                 .tags(tags)
                 .tdeCredentialArn(dbInstance.tdeCredentialArn())
                 .timezone(dbInstance.timezone())

--- a/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/TranslatorTest.java
+++ b/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/TranslatorTest.java
@@ -4,10 +4,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Collection;
 
-import com.google.common.collect.ImmutableList;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import com.google.common.collect.ImmutableList;
 import software.amazon.awssdk.services.ec2.Ec2Client;
 import software.amazon.awssdk.services.rds.RdsClient;
 import software.amazon.awssdk.services.rds.model.CreateDbInstanceReadReplicaRequest;
@@ -16,6 +16,7 @@ import software.amazon.awssdk.services.rds.model.DBInstance;
 import software.amazon.awssdk.services.rds.model.DomainMembership;
 import software.amazon.awssdk.services.rds.model.ModifyDbInstanceRequest;
 import software.amazon.awssdk.services.rds.model.RestoreDbInstanceFromDbSnapshotRequest;
+import software.amazon.awssdk.services.rds.model.RestoreDbInstanceToPointInTimeRequest;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.rds.common.handler.Tagging;
@@ -322,6 +323,17 @@ class TranslatorTest extends AbstractHandlerTest {
     }
 
     @Test
+    public void test_restoreDbInstanceToPointInTimeRequest_storageTypeIO1() {
+        final ResourceModel model = RESOURCE_MODEL_BLDR()
+                .dBSnapshotIdentifier("snapshot")
+                .storageType("io1")
+                .build();
+
+        final RestoreDbInstanceToPointInTimeRequest request = Translator.restoreDbInstanceToPointInTimeRequest(model, Tagging.TagSet.emptySet());
+        assertThat(request.storageType()).isNull();
+    }
+
+    @Test
     public void test_restoreFromSnapshotRequestV12_storageTypeIO1() {
         final ResourceModel model = RESOURCE_MODEL_BLDR()
                 .dBSnapshotIdentifier("snapshot")
@@ -340,6 +352,17 @@ class TranslatorTest extends AbstractHandlerTest {
                 .build();
 
         final RestoreDbInstanceFromDbSnapshotRequest request = Translator.restoreDbInstanceFromSnapshotRequest(model, Tagging.TagSet.emptySet());
+        assertThat(request.storageType()).isEqualTo("gp2");
+    }
+
+    @Test
+    public void test_restoreDbInstanceToPointInTimeRequest_storageTypeGp2() {
+        final ResourceModel model = RESOURCE_MODEL_BLDR()
+                .dBSnapshotIdentifier("snapshot")
+                .storageType("gp2")
+                .build();
+
+        final RestoreDbInstanceToPointInTimeRequest request = Translator.restoreDbInstanceToPointInTimeRequest(model, Tagging.TagSet.emptySet());
         assertThat(request.storageType()).isEqualTo("gp2");
     }
 

--- a/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/UpdateHandlerTest.java
+++ b/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/UpdateHandlerTest.java
@@ -1104,7 +1104,7 @@ public class UpdateHandlerTest extends AbstractHandlerTest {
                     // Put error codes below
                     Arguments.of(ErrorCode.InvalidDBInstanceState, HandlerErrorCode.ResourceConflict),
                     Arguments.of(ErrorCode.InvalidDBSecurityGroupState, HandlerErrorCode.InvalidRequest),
-                    Arguments.of(ErrorCode.InvalidParameterCombination, HandlerErrorCode.ResourceConflict)
+                    Arguments.of(ErrorCode.InvalidParameterCombination, HandlerErrorCode.InvalidRequest)
                     // Put exception classes below
                     // <empty>
             );


### PR DESCRIPTION
This commit alters the modify-db-instance ruleset. `InvalidParameterCombinationException` is interpreted as a `HandlerErrorCode.ResourceConflict`, which causes retries on modify-db-instance requests that would guarantee to fail no matter the retries. This commit moves the exception to the `HandlerErrorCode.InvalidInput`, so the handler fails fast.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Signed-off-by: Oleg Sidorov <sidorovo@amazon.com>