### PR TITLE
[DBCluster] Set `enableCloudwatchLogsExports` on `RestoreDbClusterToPointInTimeRequest`

### DIFF
--- a/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/Translator.java
+++ b/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/Translator.java
@@ -99,6 +99,7 @@ public class Translator {
                 .dbSubnetGroupName(model.getDBSubnetGroupName())
                 .domain(model.getDomain())
                 .domainIAMRoleName(model.getDomainIAMRoleName())
+                .enableCloudwatchLogsExports(model.getEnableCloudwatchLogsExports())
                 .iops(model.getIops())
                 .kmsKeyId(model.getKmsKeyId())
                 .networkType(model.getNetworkType())


### PR DESCRIPTION
This commit adds a missing `enableCloudwatchLogsExports` attribute to the `RestoreDbClusterToPointInTimeRequest`.

Refs https://github.com/aws-cloudformation/cloudformation-coverage-roadmap/issues/1426

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Signed-off-by: Oleg Sidorov <sidorovo@amazon.com>