### PR TITLE
[DbCluster] Pass enableCloudwatchLogsExports to RestoreDbClusterToPointInTimeRequest

### DIFF
--- a/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/Translator.java
+++ b/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/Translator.java
@@ -99,6 +99,7 @@ public class Translator {
                 .dbSubnetGroupName(model.getDBSubnetGroupName())
                 .domain(model.getDomain())
                 .domainIAMRoleName(model.getDomainIAMRoleName())
+                .enableCloudwatchLogsExports(model.getEnableCloudwatchLogsExports())
                 .iops(model.getIops())
                 .kmsKeyId(model.getKmsKeyId())
                 .networkType(model.getNetworkType())

--- a/aws-rds-dbcluster/src/test/java/software/amazon/rds/dbcluster/CreateHandlerTest.java
+++ b/aws-rds-dbcluster/src/test/java/software/amazon/rds/dbcluster/CreateHandlerTest.java
@@ -536,6 +536,27 @@ public class CreateHandlerTest extends AbstractHandlerTest {
     }
 
     @Test
+    public void handleRequest_RestoreDbClusterToPointInTime_CloudWatchLogsExports() {
+        when(rdsProxy.client().restoreDBClusterToPointInTime(any(RestoreDbClusterToPointInTimeRequest.class)))
+                .thenReturn(RestoreDbClusterToPointInTimeResponse.builder().build());
+
+        test_handleRequest_base(
+                new CallbackContext(),
+                () -> DBCLUSTER_ACTIVE,
+                () -> RESOURCE_MODEL_ON_RESTORE_IN_TIME.toBuilder()
+                        .enableCloudwatchLogsExports(ImmutableList.of("config-1", "config-2"))
+                        .build(),
+                expectSuccess()
+        );
+
+        final ArgumentCaptor<RestoreDbClusterToPointInTimeRequest> argumentCaptor = ArgumentCaptor.forClass(RestoreDbClusterToPointInTimeRequest.class);
+        verify(rdsProxy.client(), times(1)).restoreDBClusterToPointInTime(argumentCaptor.capture());
+        Assertions.assertThat(argumentCaptor.getValue().enableCloudwatchLogsExports()).isEqualTo(ImmutableList.of("config-1", "config-2"));
+
+        verify(rdsProxy.client(), times(2)).describeDBClusters(any(DescribeDbClustersRequest.class));
+    }
+
+    @Test
     public void handleRequest_CreateDbCluster_SetDefaultPortForProvisionedPostgresql() {
         when(rdsProxy.client().createDBCluster(any(CreateDbClusterRequest.class)))
                 .thenReturn(CreateDbClusterResponse.builder().build());


### PR DESCRIPTION
Restoring a DbCluster to a point in time now includes the CloudWatch log export configuration.

Fixes https://github.com/aws-cloudformation/aws-cloudformation-resource-providers-rds/issues/365
Fixes https://github.com/aws-cloudformation/cloudformation-coverage-roadmap/issues/1426

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
