### PR TITLE
[DBCluster] Update documentation for DBSystemId property

### DIFF
--- a/aws-rds-dbcluster/aws-rds-dbcluster.json
+++ b/aws-rds-dbcluster/aws-rds-dbcluster.json
@@ -70,7 +70,7 @@
       "type": "string"
     },
     "DBSystemId": {
-      "description": "The system ID (SID) of an Oracle Database instance (memory and processes) that\nmanages your Oracle RAC database. The name of your CDB is the same as your\nSID. The default SID is RDSCDB. This option is valid only when you specify the\nengine custom-oracle-rac-ee-cdb.",
+      "description": "Reserved for future use.",
       "type": "string"
     },
     "GlobalClusterIdentifier": {

--- a/aws-rds-dbcluster/docs/README.md
+++ b/aws-rds-dbcluster/docs/README.md
@@ -242,10 +242,7 @@ _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormati
 
 #### DBSystemId
 
-The system ID (SID) of an Oracle Database instance (memory and processes) that
-manages your Oracle RAC database. The name of your CDB is the same as your
-SID. The default SID is RDSCDB. This option is valid only when you specify the
-engine custom-oracle-rac-ee-cdb.
+Reserved for future use.
 
 _Required_: No
 


### PR DESCRIPTION
This PR updates the documentation of DBSystemId to be keep parity with the current public documentation https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/services/rds/model/DBCluster.html#dbSystemId()