### PR TITLE
[DBInstance] Update PubliclyAccessible property

### DIFF
--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/Translator.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/Translator.java
@@ -388,7 +388,7 @@ public class Translator {
                 .preferredBackupWindow(diff(previousModel.getPreferredBackupWindow(), desiredModel.getPreferredBackupWindow()))
                 .preferredMaintenanceWindow(diff(previousModel.getPreferredMaintenanceWindow(), desiredModel.getPreferredMaintenanceWindow()))
                 .promotionTier(diff(previousModel.getPromotionTier(), desiredModel.getPromotionTier()))
-                .publiclyAccessible(diff(previousModel.getPubliclyAccessible(), previousModel.getPubliclyAccessible()))
+                .publiclyAccessible(diff(previousModel.getPubliclyAccessible(), desiredModel.getPubliclyAccessible()))
                 .replicaMode(diff(previousModel.getReplicaMode(), desiredModel.getReplicaMode()))
                 .storageThroughput(diff(previousModel.getStorageThroughput(), desiredModel.getStorageThroughput()))
                 .storageType(diff(previousModel.getStorageType(), desiredModel.getStorageType()))


### PR DESCRIPTION
This PR fixes the previous [PR](https://github.com/aws-cloudformation/aws-cloudformation-resource-providers-rds/pull/349) which was supposed to fix the update behaviour of the PubliclyAccessible property from Replacement to No interruption but it returns the same value of the previous template. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


