### PR TITLE
[DBInstance] Correct RestoreDBInstanceFromDBSnapshot workflow when gp3 storage is used

### DIFF
--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/StorageType.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/StorageType.java
@@ -1,0 +1,23 @@
+package software.amazon.rds.dbinstance;
+
+public enum StorageType {
+    GP2("gp2"),
+    GP3("gp3"),
+    IO1("io1"),
+    MAGNETIC("magnetic");
+
+    private final String value;
+
+    public static StorageType fromString(final String value) {
+        for (final StorageType storageType: StorageType.values()) {
+            if (storageType.value.equalsIgnoreCase(value)) {
+                return storageType;
+            }
+        }
+        return null;
+    }
+
+    StorageType(final String value) {
+        this.value = value;
+    }
+}

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/Translator.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/Translator.java
@@ -425,7 +425,7 @@ public class Translator {
     }
 
     public static ModifyDbInstanceRequest modifyDbInstanceAfterCreateRequestV12(final ResourceModel model) {
-        final ModifyDbInstanceRequest.Builder builder = ModifyDbInstanceRequest.builder()
+        return ModifyDbInstanceRequest.builder()
                 .applyImmediately(Boolean.TRUE)
                 .dbInstanceIdentifier(model.getDBInstanceIdentifier())
                 .allocatedStorage(getAllocatedStorage(model))
@@ -436,14 +436,8 @@ public class Translator {
                 .iops(model.getIops())
                 .masterUserPassword(model.getMasterUserPassword())
                 .preferredBackupWindow(model.getPreferredBackupWindow())
-                .preferredMaintenanceWindow(model.getPreferredMaintenanceWindow());
-
-        if (STORAGE_TYPE_GP3.equalsIgnoreCase(model.getStorageType())) {
-            builder.storageThroughput(model.getStorageThroughput());
-            builder.iops(model.getIops());
-            builder.storageType(model.getStorageType());
-        }
-        return builder.build();
+                .preferredMaintenanceWindow(model.getPreferredMaintenanceWindow())
+                .build();
     }
 
     public static ModifyDbInstanceRequest modifyDbInstanceAfterCreateRequest(final ResourceModel model) {

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/Translator.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/Translator.java
@@ -44,8 +44,6 @@ import software.amazon.rds.common.handler.Tagging;
 import software.amazon.rds.dbinstance.util.ResourceModelHelper;
 
 public class Translator {
-    private final static String STORAGE_TYPE_GP3 = "gp3";
-
     public static DescribeDbInstancesRequest describeDbInstancesRequest(final ResourceModel model) {
         return DescribeDbInstancesRequest.builder()
                 .dbInstanceIdentifier(model.getDBInstanceIdentifier())
@@ -455,7 +453,7 @@ public class Translator {
                 .preferredBackupWindow(model.getPreferredBackupWindow())
                 .preferredMaintenanceWindow(model.getPreferredMaintenanceWindow());
 
-        if (STORAGE_TYPE_GP3.equalsIgnoreCase(model.getStorageType())) {
+        if (StorageType.GP3.equals(StorageType.fromString(model.getStorageType()))) {
             builder.storageThroughput(model.getStorageThroughput());
             builder.iops(model.getIops());
             builder.storageType(model.getStorageType());

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/Translator.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/Translator.java
@@ -27,8 +27,6 @@ import software.amazon.awssdk.services.rds.model.AddRoleToDbInstanceRequest;
 import software.amazon.awssdk.services.rds.model.CloudwatchLogsExportConfiguration;
 import software.amazon.awssdk.services.rds.model.CreateDbInstanceReadReplicaRequest;
 import software.amazon.awssdk.services.rds.model.CreateDbInstanceRequest;
-import software.amazon.awssdk.services.rds.model.DBParameterGroupStatus;
-import software.amazon.awssdk.services.rds.model.DBSubnetGroup;
 import software.amazon.awssdk.services.rds.model.DeleteDbInstanceRequest;
 import software.amazon.awssdk.services.rds.model.DescribeDbClustersRequest;
 import software.amazon.awssdk.services.rds.model.DescribeDbEngineVersionsRequest;
@@ -46,6 +44,8 @@ import software.amazon.rds.common.handler.Tagging;
 import software.amazon.rds.dbinstance.util.ResourceModelHelper;
 
 public class Translator {
+    private final static String STORAGE_TYPE_GP3 = "gp3";
+
     public static DescribeDbInstancesRequest describeDbInstancesRequest(final ResourceModel model) {
         return DescribeDbInstancesRequest.builder()
                 .dbInstanceIdentifier(model.getDBInstanceIdentifier())
@@ -164,7 +164,6 @@ public class Translator {
                 .port(translatePortToSdk(model.getPort()))
                 .processorFeatures(translateProcessorFeaturesToSdk(model.getProcessorFeatures()))
                 .publiclyAccessible(model.getPubliclyAccessible())
-                .storageThroughput(model.getStorageThroughput())
                 .tags(Tagging.translateTagsToSdk(tagSet))
                 .tdeCredentialArn(model.getTdeCredentialArn())
                 .tdeCredentialPassword(model.getTdeCredentialPassword())
@@ -426,7 +425,7 @@ public class Translator {
     }
 
     public static ModifyDbInstanceRequest modifyDbInstanceAfterCreateRequestV12(final ResourceModel model) {
-        return ModifyDbInstanceRequest.builder()
+        final ModifyDbInstanceRequest.Builder builder = ModifyDbInstanceRequest.builder()
                 .applyImmediately(Boolean.TRUE)
                 .dbInstanceIdentifier(model.getDBInstanceIdentifier())
                 .allocatedStorage(getAllocatedStorage(model))
@@ -437,12 +436,18 @@ public class Translator {
                 .iops(model.getIops())
                 .masterUserPassword(model.getMasterUserPassword())
                 .preferredBackupWindow(model.getPreferredBackupWindow())
-                .preferredMaintenanceWindow(model.getPreferredMaintenanceWindow())
-                .build();
+                .preferredMaintenanceWindow(model.getPreferredMaintenanceWindow());
+
+        if (STORAGE_TYPE_GP3.equalsIgnoreCase(model.getStorageType())) {
+            builder.storageThroughput(model.getStorageThroughput());
+            builder.iops(model.getIops());
+            builder.storageType(model.getStorageType());
+        }
+        return builder.build();
     }
 
     public static ModifyDbInstanceRequest modifyDbInstanceAfterCreateRequest(final ResourceModel model) {
-        return ModifyDbInstanceRequest.builder()
+        final ModifyDbInstanceRequest.Builder builder = ModifyDbInstanceRequest.builder()
                 .applyImmediately(Boolean.TRUE)
                 .dbInstanceIdentifier(model.getDBInstanceIdentifier())
                 .allocatedStorage(getAllocatedStorage(model))
@@ -454,8 +459,14 @@ public class Translator {
                 .masterUserPassword(model.getMasterUserPassword())
                 .maxAllocatedStorage(model.getMaxAllocatedStorage())
                 .preferredBackupWindow(model.getPreferredBackupWindow())
-                .preferredMaintenanceWindow(model.getPreferredMaintenanceWindow())
-                .build();
+                .preferredMaintenanceWindow(model.getPreferredMaintenanceWindow());
+
+        if (STORAGE_TYPE_GP3.equalsIgnoreCase(model.getStorageType())) {
+            builder.storageThroughput(model.getStorageThroughput());
+            builder.iops(model.getIops());
+            builder.storageType(model.getStorageType());
+        }
+        return builder.build();
     }
 
     public static ModifyDbInstanceRequest updateAllocatedStorageRequest(final ResourceModel desiredModel) {

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/util/ResourceModelHelper.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/util/ResourceModelHelper.java
@@ -11,9 +11,12 @@ import java.util.Objects;
 import java.util.Optional;
 
 public final class ResourceModelHelper {
-    private final static String STORAGE_TYPE_IO1 = "io1";
+    private static final List<String> STORAGE_TYPES_SET_ON_MODIFY_AFTER_CREATE = Arrays.asList(
+            "io1",
+            "gp3"
+    );
 
-    protected static final List<String> SQLSERVER_ENGINES_WITH_MIRRORING = Arrays.asList(
+    private static final List<String> SQLSERVER_ENGINES_WITH_MIRRORING = Arrays.asList(
             "sqlserver-ee",
             "sqlserver-se"
     );
@@ -35,7 +38,8 @@ public final class ResourceModelHelper {
                                 StringUtils.hasValue(model.getPreferredMaintenanceWindow()) ||
                                 Optional.ofNullable(model.getBackupRetentionPeriod()).orElse(0) > 0 ||
                                 Optional.ofNullable(model.getIops()).orElse(0) > 0 ||
-                                Optional.ofNullable(model.getMaxAllocatedStorage()).orElse(0) > 0
+                                Optional.ofNullable(model.getMaxAllocatedStorage()).orElse(0) > 0 ||
+                                Optional.ofNullable(model.getStorageThroughput()).orElse(0) > 0
                 );
     }
 
@@ -63,7 +67,7 @@ public final class ResourceModelHelper {
     }
 
     public static boolean shouldSetStorageTypeOnRestoreFromSnapshot(final ResourceModel model) {
-        return !Objects.equals(model.getStorageType(), STORAGE_TYPE_IO1) && shouldUpdateAfterCreate(model);
+        return !STORAGE_TYPES_SET_ON_MODIFY_AFTER_CREATE.contains(model.getStorageType()) && shouldUpdateAfterCreate(model);
     }
 
     public static boolean shouldReboot(final ResourceModel model) {

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/util/ResourceModelHelper.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/util/ResourceModelHelper.java
@@ -1,22 +1,22 @@
 package software.amazon.rds.dbinstance.util;
 
 import com.amazonaws.util.StringUtils;
+import com.google.common.collect.ImmutableSet;
 import org.apache.commons.lang3.BooleanUtils;
 import software.amazon.awssdk.utils.CollectionUtils;
 import software.amazon.rds.dbinstance.ResourceModel;
+import software.amazon.rds.dbinstance.StorageType;
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 
 public final class ResourceModelHelper {
-    private static final List<String> STORAGE_TYPES_SET_ON_MODIFY_AFTER_CREATE = Arrays.asList(
-            "io1",
-            "gp3"
+    private static final Set<StorageType> STORAGE_TYPES_SET_ON_MODIFY_AFTER_CREATE = ImmutableSet.of(
+            StorageType.GP3,
+            StorageType.IO1
     );
 
-    private static final List<String> SQLSERVER_ENGINES_WITH_MIRRORING = Arrays.asList(
+    private static final Set<String> SQLSERVER_ENGINES_WITH_MIRRORING = ImmutableSet.of(
             "sqlserver-ee",
             "sqlserver-se"
     );
@@ -67,7 +67,7 @@ public final class ResourceModelHelper {
     }
 
     public static boolean shouldSetStorageTypeOnRestoreFromSnapshot(final ResourceModel model) {
-        return !STORAGE_TYPES_SET_ON_MODIFY_AFTER_CREATE.contains(model.getStorageType()) && shouldUpdateAfterCreate(model);
+        return !STORAGE_TYPES_SET_ON_MODIFY_AFTER_CREATE.contains(StorageType.fromString(model.getStorageType())) && shouldUpdateAfterCreate(model);
     }
 
     public static boolean shouldReboot(final ResourceModel model) {

--- a/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/TranslatorTest.java
+++ b/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/TranslatorTest.java
@@ -471,19 +471,6 @@ class TranslatorTest extends AbstractHandlerTest {
         assertThat(request.storageThroughput()).isEqualTo(100);
         assertThat(request.storageType()).isEqualTo("gp3");
     }
-    @Test
-    public void test_modifyAfterCreateV12_shouldSetGP3Parameters() {
-        final ResourceModel model = RESOURCE_MODEL_BLDR()
-                .storageType("gp3")
-                .storageThroughput(100)
-                .iops(200)
-                .build();
-
-        final ModifyDbInstanceRequest request = Translator.modifyDbInstanceAfterCreateRequestV12(model);
-        assertThat(request.iops()).isEqualTo(200);
-        assertThat(request.storageThroughput()).isEqualTo(100);
-        assertThat(request.storageType()).isEqualTo("gp3");
-    }
 
     // Stub methods to satisfy the interface. This is a 1-time thing.
 

--- a/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/util/ResourceModelHelperTest.java
+++ b/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/util/ResourceModelHelperTest.java
@@ -1,6 +1,8 @@
 package software.amazon.rds.dbinstance.util;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import software.amazon.rds.dbinstance.ResourceModel;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
@@ -94,16 +96,19 @@ public class ResourceModelHelperTest {
         final ResourceModel model = ResourceModel.builder()
                 .cACertificateIdentifier("identifier")
                 .allocatedStorage("100")
+                .dBSnapshotIdentifier("identifier")
                 .build();
 
         assertThat(ResourceModelHelper.shouldUpdateAfterCreate(model)).isTrue();
     }
 
-    @Test
-    public void shouldSetStorageTypeOnRestoreFromSnapshot_whenStorageTypeIO1() {
+    @ParameterizedTest
+    @ValueSource(strings = {"gp3", "io1"})
+    public void shouldSetStorageTypeOnRestoreFromSnapshot_whenStorageType_shouldBeSetOnModify(final String storageType) {
         final ResourceModel model = ResourceModel.builder()
-                .storageType("io1")
+                .storageType(storageType)
                 .allocatedStorage("100")
+                .dBSnapshotIdentifier("identifier")
                 .build();
 
         assertThat(ResourceModelHelper.shouldSetStorageTypeOnRestoreFromSnapshot(model)).isFalse();
@@ -112,10 +117,21 @@ public class ResourceModelHelperTest {
     @Test
     public void shouldSetStorageTypeOnRestoreFromSnapshot_whenStorageTypeGP2() {
         final ResourceModel model = ResourceModel.builder()
+                .dBSnapshotIdentifier("identifier")
                 .storageType("gp2")
                 .allocatedStorage("100")
                 .build();
 
-        assertThat(ResourceModelHelper.shouldSetStorageTypeOnRestoreFromSnapshot(model)).isFalse();
+        assertThat(ResourceModelHelper.shouldSetStorageTypeOnRestoreFromSnapshot(model)).isTrue();
+    }
+
+    @Test
+    public void shouldUpdateAfterCreate_whenStorageThroughputIsSet() {
+        final ResourceModel model = ResourceModel.builder()
+                .dBSnapshotIdentifier("identifier")
+                .storageThroughput(100)
+                .build();
+
+        assertThat(ResourceModelHelper.shouldUpdateAfterCreate(model)).isTrue();
     }
 }


### PR DESCRIPTION
This PR addresses the issue with DBInstance RestoreDBInstanceFromDBSnapshot workflow when gp3 storage is used. It is not possible to specify allocated storage size during restore, which results in invalid requests. This change omits setting storage type for GP3 and defers update to correct values to ModifyAfterCreate.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
