### PR TITLE
[DBInstance] Add DBSystemID read-only property

### DIFF
--- a/aws-rds-dbinstance/aws-rds-dbinstance.json
+++ b/aws-rds-dbinstance/aws-rds-dbinstance.json
@@ -179,6 +179,10 @@
       "type": "string",
       "description": "A DB subnet group to associate with the DB instance. If you update this value, the new subnet group must be a subnet group in a new VPC."
     },
+    "DBSystemId": {
+      "type": "string",
+      "description": "The Oracle system ID (Oracle SID) for a container database (CDB). The Oracle SID is also the name of the CDB. This setting is valid for RDS Custom only."
+    },
     "DeleteAutomatedBackups": {
       "type": "boolean",
       "description": "A value that indicates whether to remove automated backups immediately after the DB instance is deleted. This parameter isn't case-sensitive. The default is to remove automated backups immediately after the DB instance is deleted."
@@ -453,7 +457,8 @@
     "/properties/Endpoint/Port",
     "/properties/Endpoint/HostedZoneId",
     "/properties/DbiResourceId",
-    "/properties/DBInstanceArn"
+    "/properties/DBInstanceArn",
+    "/properties/DBSystemId"
   ],
   "primaryIdentifier": [
     "/properties/DBInstanceIdentifier"

--- a/aws-rds-dbinstance/docs/README.md
+++ b/aws-rds-dbinstance/docs/README.md
@@ -872,3 +872,7 @@ The AWS Region-unique, immutable identifier for the DB instance. This identifier
 #### DBInstanceArn
 
 The Amazon Resource Name (ARN) for the DB instance.
+
+#### DBSystemId
+
+The Oracle system ID (Oracle SID) for a container database (CDB). The Oracle SID is also the name of the CDB. This setting is valid for RDS Custom only.

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/Translator.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/Translator.java
@@ -630,6 +630,7 @@ public class Translator {
                 .dBParameterGroupName(dbParameterGroupName)
                 .dBSecurityGroups(translateDbSecurityGroupsFromSdk(dbInstance.dbSecurityGroups()))
                 .dBSubnetGroupName(translateDbSubnetGroupFromSdk(dbInstance.dbSubnetGroup()))
+                .dBSystemId(dbInstance.dbSystemId())
                 .domain(domain)
                 .domainIAMRoleName(domainIAMRoleName)
                 .deletionProtection(dbInstance.deletionProtection())


### PR DESCRIPTION
This PR exposes read-only property DBSystemID for DBInstance. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
