### PR TITLE
[DBCluster] Report `DbClusterRoleAlreadyExistsException` exception

### DIFF
--- a/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/CreateHandler.java
+++ b/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/CreateHandler.java
@@ -81,7 +81,7 @@ public class CreateHandler extends BaseHandlerStd {
                     }
                     return progress;
                 })
-                .then(progress -> addAssociatedRoles(proxy, rdsProxyClient, progress, progress.getResourceModel().getAssociatedRoles()))
+                .then(progress -> addAssociatedRoles(proxy, rdsProxyClient, progress, progress.getResourceModel().getAssociatedRoles(), false))
                 .then(progress -> new ReadHandler().handleRequest(proxy, request, callbackContext, rdsProxyClient, ec2ProxyClient, logger));
     }
 

--- a/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/UpdateHandler.java
+++ b/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/UpdateHandler.java
@@ -85,7 +85,8 @@ public class UpdateHandler extends BaseHandlerStd {
                         rdsProxyClient,
                         progress,
                         request.getPreviousResourceState().getAssociatedRoles(),
-                        progress.getResourceModel().getAssociatedRoles()))
+                        progress.getResourceModel().getAssociatedRoles(),
+                        BooleanUtils.isTrue(request.getRollback())))
                 .then(progress -> updateTags(proxy, rdsProxyClient, progress, previousTags, desiredTags))
                 .then(progress -> new ReadHandler().handleRequest(proxy, request, callbackContext, rdsProxyClient, ec2ProxyClient, logger));
     }


### PR DESCRIPTION
This commit alters the error rule set for adding associated roles to DBCluster. The current implementation soft-fails an already-exists exception for historical reasons.

The error can occur in 2 major cases:
  - Update failed to remove a role and a rollback would fail due to a resource conflict.
  - The same role was added under distinct feature names and this specific engine requires all roles to be unique.

This CR preserves soft-failing for a failed rollback (recovery mode) but exposes `DbClusterRoleAlreadyExistsException` on a regular update.

Refs https://github.com/aws-cloudformation/aws-cloudformation-resource-providers-rds/issues/373.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Signed-off-by: Oleg Sidorov <sidorovo@amazon.com>