### PR TITLE
[DBInstance] Handle performance insights enablement toggle

### DIFF
--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/Translator.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/Translator.java
@@ -210,7 +210,7 @@ public class Translator {
             final ResourceModel model,
             final Tagging.TagSet tagSet
     ) {
-        return CreateDbInstanceRequest.builder()
+        final CreateDbInstanceRequest.Builder builder = CreateDbInstanceRequest.builder()
                 .allocatedStorage(getAllocatedStorage(model))
                 .autoMinorVersionUpgrade(model.getAutoMinorVersionUpgrade())
                 .availabilityZone(model.getAvailabilityZone())
@@ -229,7 +229,6 @@ public class Translator {
                 .domainIAMRoleName(model.getDomainIAMRoleName())
                 .enableCloudwatchLogsExports(model.getEnableCloudwatchLogsExports())
                 .enableIAMDatabaseAuthentication(model.getEnableIAMDatabaseAuthentication())
-                .enablePerformanceInsights(model.getEnablePerformanceInsights())
                 .engine(model.getEngine())
                 .engineVersion(model.getEngineVersion())
                 .iops(model.getIops())
@@ -244,7 +243,6 @@ public class Translator {
                 .ncharCharacterSetName(model.getNcharCharacterSetName())
                 .networkType(model.getNetworkType())
                 .optionGroupName(model.getOptionGroupName())
-                .performanceInsightsKMSKeyId(model.getPerformanceInsightsKMSKeyId())
                 .performanceInsightsRetentionPeriod(model.getPerformanceInsightsRetentionPeriod())
                 .port(translatePortToSdk(model.getPort()))
                 .preferredBackupWindow(model.getPreferredBackupWindow())
@@ -259,8 +257,17 @@ public class Translator {
                 .tdeCredentialArn(model.getTdeCredentialArn())
                 .tdeCredentialPassword(model.getTdeCredentialPassword())
                 .timezone(model.getTimezone())
-                .vpcSecurityGroupIds(CollectionUtils.isNotEmpty(model.getVPCSecurityGroups()) ? model.getVPCSecurityGroups() : null)
-                .build();
+                .vpcSecurityGroupIds(CollectionUtils.isNotEmpty(model.getVPCSecurityGroups()) ? model.getVPCSecurityGroups() : null);
+
+        // Set PerformanceInsightsKMSKeyId only if EnablePerformanceInsights is true.
+        // The point is that it is a completely legitimate create from the CFN perspective and
+        // enabling performance insights would only require toggling EnablePerformanceInsights to true.
+        if (BooleanUtils.isTrue(model.getEnablePerformanceInsights())) {
+            builder.enablePerformanceInsights(model.getEnablePerformanceInsights());
+            builder.performanceInsightsKMSKeyId(model.getPerformanceInsightsKMSKeyId());
+        }
+
+        return builder.build();
     }
 
     static RestoreDbInstanceToPointInTimeRequest restoreDbInstanceToPointInTimeRequest(
@@ -371,7 +378,6 @@ public class Translator {
                 .domain(diff(previousModel.getDomain(), desiredModel.getDomain()))
                 .domainIAMRoleName(diff(previousModel.getDomainIAMRoleName(), desiredModel.getDomainIAMRoleName()))
                 .enableIAMDatabaseAuthentication(diff(previousModel.getEnableIAMDatabaseAuthentication(), desiredModel.getEnableIAMDatabaseAuthentication()))
-                .enablePerformanceInsights(diff(previousModel.getEnablePerformanceInsights(), desiredModel.getEnablePerformanceInsights()))
                 .licenseModel(diff(previousModel.getLicenseModel(), desiredModel.getLicenseModel()))
                 .masterUserPassword(diff(previousModel.getMasterUserPassword(), desiredModel.getMasterUserPassword()))
                 .maxAllocatedStorage(diff(previousModel.getMaxAllocatedStorage(), desiredModel.getMaxAllocatedStorage()))
@@ -380,7 +386,6 @@ public class Translator {
                 .multiAZ(diff(previousModel.getMultiAZ(), desiredModel.getMultiAZ()))
                 .networkType(diff(previousModel.getNetworkType(), desiredModel.getNetworkType()))
                 .optionGroupName(diff(previousModel.getOptionGroupName(), desiredModel.getOptionGroupName()))
-                .performanceInsightsKMSKeyId(diff(previousModel.getPerformanceInsightsKMSKeyId(), desiredModel.getPerformanceInsightsKMSKeyId()))
                 .performanceInsightsRetentionPeriod(diff(previousModel.getPerformanceInsightsRetentionPeriod(), desiredModel.getPerformanceInsightsRetentionPeriod()))
                 .preferredBackupWindow(diff(previousModel.getPreferredBackupWindow(), desiredModel.getPreferredBackupWindow()))
                 .preferredMaintenanceWindow(diff(previousModel.getPreferredMaintenanceWindow(), desiredModel.getPreferredMaintenanceWindow()))
@@ -417,6 +422,25 @@ public class Translator {
         if (shouldSetProcessorFeatures(previousModel, desiredModel)) {
             builder.processorFeatures(translateProcessorFeaturesToSdk(desiredModel.getProcessorFeatures()));
             builder.useDefaultProcessorFeatures(desiredModel.getUseDefaultProcessorFeatures());
+        }
+
+        // EnablePerformanceInsights (EPI) and PerformanceInsightsKMSKeyId (PKI) are coupled parameters.
+        // The following logic stands:
+        // 0. If EPI or PKI are changed, provide the diff unconditionally.
+        // 1. if EPI is true, provide the desired PKI unconditionally.
+        // 2. if PKI is changed, provide the desired EPI unconditionally.
+        final Boolean enablePerformanceInsightsDiff = diff(previousModel.getEnablePerformanceInsights(), desiredModel.getEnablePerformanceInsights());
+        final String performanceInsightsKMSKeyIdDiff = diff(previousModel.getPerformanceInsightsKMSKeyId(), desiredModel.getPerformanceInsightsKMSKeyId());
+
+        if (enablePerformanceInsightsDiff != null || performanceInsightsKMSKeyIdDiff != null) {
+            builder.enablePerformanceInsights(enablePerformanceInsightsDiff);
+            builder.performanceInsightsKMSKeyId(performanceInsightsKMSKeyIdDiff);
+            if (BooleanUtils.isTrue(desiredModel.getEnablePerformanceInsights())) {
+                builder.performanceInsightsKMSKeyId(desiredModel.getPerformanceInsightsKMSKeyId());
+            }
+            if (performanceInsightsKMSKeyIdDiff != null) {
+                builder.enablePerformanceInsights(desiredModel.getEnablePerformanceInsights());
+            }
         }
 
         return builder.build();

--- a/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/TranslatorTest.java
+++ b/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/TranslatorTest.java
@@ -472,6 +472,150 @@ class TranslatorTest extends AbstractHandlerTest {
         assertThat(request.storageType()).isEqualTo("gp3");
     }
 
+    @Test
+    public void test_createDbInstanceRequest_SetPerformanceInsightsKMSKeyIdIfEnabled() {
+        final String kmsKeyId = "test-kms-key-id";
+        final CreateDbInstanceRequest request = Translator.createDbInstanceRequest(
+                ResourceModel.builder()
+                        .enablePerformanceInsights(true)
+                        .performanceInsightsKMSKeyId(kmsKeyId)
+                        .build(),
+                Tagging.TagSet.emptySet()
+        );
+        assertThat(request.enablePerformanceInsights()).isTrue();
+        assertThat(request.performanceInsightsKMSKeyId()).isEqualTo(kmsKeyId);
+    }
+
+    @Test
+    public void test_createDbInstanceRequest_DoNotSetPerformanceInsightsKMSKeyIdIfDisabled() {
+        final String kmsKeyId = "test-kms-key-id";
+        final CreateDbInstanceRequest request = Translator.createDbInstanceRequest(
+                ResourceModel.builder()
+                        .enablePerformanceInsights(false)
+                        .performanceInsightsKMSKeyId(kmsKeyId)
+                        .build(),
+                Tagging.TagSet.emptySet()
+        );
+        assertThat(request.enablePerformanceInsights()).isNull();
+        assertThat(request.performanceInsightsKMSKeyId()).isNull();
+    }
+
+    @Test
+    public void test_modifyDbInstanceRequest_PerformanceInsightsEnabled() {
+        final String kmsKeyId = "test-kms-key-id";
+        final ResourceModel previousModel = ResourceModel.builder()
+                .enablePerformanceInsights(true)
+                .performanceInsightsKMSKeyId(kmsKeyId)
+                .build();
+        final ResourceModel desiredModel = ResourceModel.builder()
+                .enablePerformanceInsights(true)
+                .performanceInsightsKMSKeyId(kmsKeyId)
+                .build();
+        final ModifyDbInstanceRequest request = Translator.modifyDbInstanceRequest(previousModel, desiredModel, false);
+        assertThat(request.enablePerformanceInsights()).isNull();
+        assertThat(request.performanceInsightsKMSKeyId()).isNull();
+    }
+
+    @Test
+    public void test_modifyDbInstanceRequest_PerformanceInsightsToggleDisabledToEnabled() {
+        final String kmsKeyId = "test-kms-key-id";
+        final ResourceModel previousModel = ResourceModel.builder()
+                .enablePerformanceInsights(false)
+                .performanceInsightsKMSKeyId(kmsKeyId)
+                .build();
+        final ResourceModel desiredModel = ResourceModel.builder()
+                .enablePerformanceInsights(true)
+                .performanceInsightsKMSKeyId(kmsKeyId)
+                .build();
+        final ModifyDbInstanceRequest request = Translator.modifyDbInstanceRequest(previousModel, desiredModel, false);
+        assertThat(request.enablePerformanceInsights()).isTrue();
+        assertThat(request.performanceInsightsKMSKeyId()).isEqualTo(kmsKeyId);
+    }
+
+    @Test
+    public void test_modifyDbInstanceRequest_PerformanceInsightsToggleEnabledToDisabled() {
+        final String kmsKeyId = "test-kms-key-id";
+        final ResourceModel previousModel = ResourceModel.builder()
+                .enablePerformanceInsights(true)
+                .performanceInsightsKMSKeyId(kmsKeyId)
+                .build();
+        final ResourceModel desiredModel = ResourceModel.builder()
+                .enablePerformanceInsights(false)
+                .performanceInsightsKMSKeyId(kmsKeyId)
+                .build();
+        final ModifyDbInstanceRequest request = Translator.modifyDbInstanceRequest(previousModel, desiredModel, false);
+        assertThat(request.enablePerformanceInsights()).isFalse();
+        assertThat(request.performanceInsightsKMSKeyId()).isNull();
+    }
+
+    @Test
+    public void test_modifyDbInstanceRequest_PerformanceInsightsEnabledChangeKMSKeyId() {
+        final String kmsKeyId1 = "test-kms-key-id-1";
+        final String kmsKeyId2 = "test-kms-key-id-2";
+        final ResourceModel previousModel = ResourceModel.builder()
+                .enablePerformanceInsights(true)
+                .performanceInsightsKMSKeyId(kmsKeyId1)
+                .build();
+        final ResourceModel desiredModel = ResourceModel.builder()
+                .enablePerformanceInsights(true)
+                .performanceInsightsKMSKeyId(kmsKeyId2)
+                .build();
+        final ModifyDbInstanceRequest request = Translator.modifyDbInstanceRequest(previousModel, desiredModel, false);
+        assertThat(request.enablePerformanceInsights()).isTrue();
+        assertThat(request.performanceInsightsKMSKeyId()).isEqualTo(kmsKeyId2);
+    }
+
+    @Test
+    public void test_modifyDbInstanceRequest_PerformanceInsightsDisabledChangeKMSKeyId() {
+        final String kmsKeyId1 = "test-kms-key-id-1";
+        final String kmsKeyId2 = "test-kms-key-id-2";
+        final ResourceModel previousModel = ResourceModel.builder()
+                .enablePerformanceInsights(false)
+                .performanceInsightsKMSKeyId(kmsKeyId1)
+                .build();
+        final ResourceModel desiredModel = ResourceModel.builder()
+                .enablePerformanceInsights(false)
+                .performanceInsightsKMSKeyId(kmsKeyId2)
+                .build();
+        final ModifyDbInstanceRequest request = Translator.modifyDbInstanceRequest(previousModel, desiredModel, false);
+        assertThat(request.enablePerformanceInsights()).isFalse();
+        assertThat(request.performanceInsightsKMSKeyId()).isEqualTo(kmsKeyId2);
+    }
+
+    @Test
+    public void test_modifyDbInstanceRequest_PerformanceInsightsToggleEnabledToDisabledChangeKMSKeyId() {
+        final String kmsKeyId1 = "test-kms-key-id-1";
+        final String kmsKeyId2 = "test-kms-key-id-2";
+        final ResourceModel previousModel = ResourceModel.builder()
+                .enablePerformanceInsights(true)
+                .performanceInsightsKMSKeyId(kmsKeyId1)
+                .build();
+        final ResourceModel desiredModel = ResourceModel.builder()
+                .enablePerformanceInsights(false)
+                .performanceInsightsKMSKeyId(kmsKeyId2)
+                .build();
+        final ModifyDbInstanceRequest request = Translator.modifyDbInstanceRequest(previousModel, desiredModel, false);
+        assertThat(request.enablePerformanceInsights()).isFalse();
+        assertThat(request.performanceInsightsKMSKeyId()).isEqualTo(kmsKeyId2);
+    }
+
+    @Test
+    public void test_modifyDbInstanceRequest_PerformanceInsightsToggleDisabledToEnabledChangeKMSKeyId() {
+        final String kmsKeyId1 = "test-kms-key-id-1";
+        final String kmsKeyId2 = "test-kms-key-id-2";
+        final ResourceModel previousModel = ResourceModel.builder()
+                .enablePerformanceInsights(false)
+                .performanceInsightsKMSKeyId(kmsKeyId1)
+                .build();
+        final ResourceModel desiredModel = ResourceModel.builder()
+                .enablePerformanceInsights(true)
+                .performanceInsightsKMSKeyId(kmsKeyId2)
+                .build();
+        final ModifyDbInstanceRequest request = Translator.modifyDbInstanceRequest(previousModel, desiredModel, false);
+        assertThat(request.enablePerformanceInsights()).isTrue();
+        assertThat(request.performanceInsightsKMSKeyId()).isEqualTo(kmsKeyId2);
+    }
+
     // Stub methods to satisfy the interface. This is a 1-time thing.
 
     @Override


### PR DESCRIPTION
This commit changes the way CREATE and UPDATE handlers deal with performance insights argument pair: `EnablePerformanceInsights`(EPI) and `PerformanceInsightsKMSKeyId`(PKI). RDS API is sensitive to attempts to modify PKI if performance insights is disabled. The key id must be provided all the time when EPI attribute changes the value.

The following `CREATE` logic is implemented:
  - If EPI is enabled, include both EPI and PKI in the request.
  - If EPI is disabled, include none of EPI and PKI. If PKI was provided, RDS API would reject the request. This case creates a drift, but it seems to be the only reasonable way to allow EPI enablement with a minimal change on the customer side.

The following `UPDATE` logic is implemented:
  - If none of EPI and PKI were changed, include none of EPI and PKI.
  - If any of EPI and PKI were changed, include EPI and PKI diff.
    - If EPI is changed to enabled, include PKI.
    - if PKI is changed, include EPI.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Signed-off-by: Oleg Sidorov <sidorovo@amazon.com>