### PR TITLE
[DBInstance][DBCluster] Add support for SecretsManager integration

### DIFF
--- a/aws-rds-cfn-common/pom.xml
+++ b/aws-rds-cfn-common/pom.xml
@@ -27,12 +27,12 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>utils</artifactId>
-            <version>2.18.24</version>
+            <version>2.19.4</version>
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>rds</artifactId>
-            <version>2.18.24</version>
+            <version>2.19.4</version>
         </dependency>
         <dependency>
             <groupId>software.amazon.cloudformation</groupId>

--- a/aws-rds-cfn-test-common/src/main/java/software/amazon/rds/test/common/core/ServiceProvider.java
+++ b/aws-rds-cfn-test-common/src/main/java/software/amazon/rds/test/common/core/ServiceProvider.java
@@ -9,7 +9,8 @@ public enum ServiceProvider {
     IAM("iam"),
     KMS("kms"),
     RDS("rds"),
-    SDK("sdk");
+    SDK("sdk"),
+    ASM("secretsmanager");
 
     private final String name;
 
@@ -22,13 +23,15 @@ public enum ServiceProvider {
         return this.name;
     }
 
-    private static final Map<String, ServiceProvider> SERVICE_CLIENT_CLASSES = ImmutableMap.of(
-            "Ec2Client", EC2,
-            "IamClient", IAM,
-            "KmsClient", KMS,
-            "RdsClient", RDS,
-            "SdkClient", SDK
-    );
+    private static final Map<String, ServiceProvider> SERVICE_CLIENT_CLASSES = ImmutableMap.<String, ServiceProvider>builder()
+            .put("Ec2Client", EC2)
+            .put("IamClient", IAM)
+            .put("KmsClient", KMS)
+            .put("RdsClient", RDS)
+            .put("SdkClient", SDK)
+            .put("AsmClient", ASM)
+            .build();
+
 
     public static ServiceProvider fromString(final String s) {
         for (final ServiceProvider provider : ServiceProvider.values()) {

--- a/aws-rds-customdbengineversion/pom.xml
+++ b/aws-rds-customdbengineversion/pom.xml
@@ -22,7 +22,7 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>rds</artifactId>
-            <version>2.18.24</version>
+            <version>2.19.4</version>
         </dependency>
         <dependency>
             <groupId>software.amazon.rds.common</groupId>

--- a/aws-rds-dbcluster/aws-rds-dbcluster.json
+++ b/aws-rds-dbcluster/aws-rds-dbcluster.json
@@ -136,6 +136,10 @@
       "description": "The version number of the database engine to use.",
       "type": "string"
     },
+    "ManageMasterUserPassword": {
+      "description": "A value that indicates whether to manage the master user password with AWS Secrets Manager.",
+      "type": "boolean"
+    },
     "Iops": {
       "description": "The amount of Provisioned IOPS (input/output operations per second) to be initially allocated for each DB instance in the Multi-AZ DB cluster.",
       "type": "integer"
@@ -153,6 +157,10 @@
     "MasterUserPassword": {
       "description": "The master password for the DB instance.",
       "type": "string"
+    },
+    "MasterUserSecret": {
+      "$ref": "#/definitions/MasterUserSecret",
+      "description": "Contains the secret managed by RDS in AWS Secrets Manager for the master user password."
     },
     "MonitoringInterval": {
       "description": "The interval, in seconds, between points when Enhanced Monitoring metrics are collected for the DB cluster. To turn off collecting Enhanced Monitoring metrics, specify 0. The default is 0.",
@@ -369,6 +377,20 @@
       "required": [
         "Key"
       ]
+    },
+    "MasterUserSecret": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "SecretArn": {
+          "type": "string",
+          "description": "The Amazon Resource Name (ARN) of the secret."
+        },
+        "KmsKeyId": {
+          "type": "string",
+          "description": "The AWS KMS key identifier that is used to encrypt the secret."
+        }
+      }
     }
   },
   "additionalProperties": false,
@@ -377,7 +399,8 @@
     "/properties/DBClusterParameterGroupName": "$lowercase(DBClusterParameterGroupName)",
     "/properties/DBSubnetGroupName": "$lowercase(DBSubnetGroupName)",
     "/properties/SnapshotIdentifier": "$lowercase(SnapshotIdentifier)",
-    "/properties/SourceDBClusterIdentifier": "$lowercase(SourceDBClusterIdentifier)"
+    "/properties/SourceDBClusterIdentifier": "$lowercase(SourceDBClusterIdentifier)",
+    "/properties/MasterUserSecret/KmsKeyId": "$join([\"arn:(aws)[-]{0,1}[a-z]{0,2}[-]{0,1}[a-z]{0,3}:kms:[a-z]{2}[-]{1}[a-z]{3,10}[-]{0,1}[a-z]{0,10}[-]{1}[1-3]{1}:[0-9]{12}[:]{1}key\\/\", KMSKeyId])"
   },
   "readOnlyProperties": [
     "/properties/DBClusterArn",
@@ -386,7 +409,8 @@
     "/properties/Endpoint/Address",
     "/properties/Endpoint/Port",
     "/properties/ReadEndpoint/Port",
-    "/properties/ReadEndpoint/Address"
+    "/properties/ReadEndpoint/Address",
+    "/properties/MasterUserSecret/SecretArn"
   ],
   "createOnlyProperties": [
     "/properties/AvailabilityZones",
@@ -432,7 +456,9 @@
         "rds:DescribeDBClusters",
         "rds:ModifyDBCluster",
         "rds:RestoreDBClusterFromSnapshot",
-        "rds:RestoreDBClusterToPointInTime"
+        "rds:RestoreDBClusterToPointInTime",
+        "secretsmanager:CreateSecret",
+        "secretsmanager:TagResource"
       ],
       "timeoutInMinutes": 2160
     },
@@ -454,7 +480,9 @@
         "rds:ModifyDBInstance",
         "rds:RemoveFromGlobalCluster",
         "rds:RemoveRoleFromDBCluster",
-        "rds:RemoveTagsFromResource"
+        "rds:RemoveTagsFromResource",
+        "secretsmanager:CreateSecret",
+        "secretsmanager:TagResource"
       ],
       "timeoutInMinutes": 2160
     },

--- a/aws-rds-dbcluster/docs/README.md
+++ b/aws-rds-dbcluster/docs/README.md
@@ -37,10 +37,12 @@ To declare this entity in your AWS CloudFormation template, use the following sy
         "<a href="#engine" title="Engine">Engine</a>" : <i>String</i>,
         "<a href="#enginemode" title="EngineMode">EngineMode</a>" : <i>String</i>,
         "<a href="#engineversion" title="EngineVersion">EngineVersion</a>" : <i>String</i>,
+        "<a href="#managemasteruserpassword" title="ManageMasterUserPassword">ManageMasterUserPassword</a>" : <i>Boolean</i>,
         "<a href="#iops" title="Iops">Iops</a>" : <i>Integer</i>,
         "<a href="#kmskeyid" title="KmsKeyId">KmsKeyId</a>" : <i>String</i>,
         "<a href="#masterusername" title="MasterUsername">MasterUsername</a>" : <i>String</i>,
         "<a href="#masteruserpassword" title="MasterUserPassword">MasterUserPassword</a>" : <i>String</i>,
+        "<a href="#masterusersecret" title="MasterUserSecret">MasterUserSecret</a>" : <i><a href="masterusersecret.md">MasterUserSecret</a></i>,
         "<a href="#monitoringinterval" title="MonitoringInterval">MonitoringInterval</a>" : <i>Integer</i>,
         "<a href="#monitoringrolearn" title="MonitoringRoleArn">MonitoringRoleArn</a>" : <i>String</i>,
         "<a href="#networktype" title="NetworkType">NetworkType</a>" : <i>String</i>,
@@ -100,10 +102,12 @@ Properties:
     <a href="#engine" title="Engine">Engine</a>: <i>String</i>
     <a href="#enginemode" title="EngineMode">EngineMode</a>: <i>String</i>
     <a href="#engineversion" title="EngineVersion">EngineVersion</a>: <i>String</i>
+    <a href="#managemasteruserpassword" title="ManageMasterUserPassword">ManageMasterUserPassword</a>: <i>Boolean</i>
     <a href="#iops" title="Iops">Iops</a>: <i>Integer</i>
     <a href="#kmskeyid" title="KmsKeyId">KmsKeyId</a>: <i>String</i>
     <a href="#masterusername" title="MasterUsername">MasterUsername</a>: <i>String</i>
     <a href="#masteruserpassword" title="MasterUserPassword">MasterUserPassword</a>: <i>String</i>
+    <a href="#masterusersecret" title="MasterUserSecret">MasterUserSecret</a>: <i><a href="masterusersecret.md">MasterUserSecret</a></i>
     <a href="#monitoringinterval" title="MonitoringInterval">MonitoringInterval</a>: <i>Integer</i>
     <a href="#monitoringrolearn" title="MonitoringRoleArn">MonitoringRoleArn</a>: <i>String</i>
     <a href="#networktype" title="NetworkType">NetworkType</a>: <i>String</i>
@@ -392,6 +396,16 @@ _Type_: String
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 
+#### ManageMasterUserPassword
+
+A value that indicates whether to manage the master user password with AWS Secrets Manager.
+
+_Required_: No
+
+_Type_: Boolean
+
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+
 #### Iops
 
 The amount of Provisioned IOPS (input/output operations per second) to be initially allocated for each DB instance in the Multi-AZ DB cluster.
@@ -433,6 +447,14 @@ The master password for the DB instance.
 _Required_: No
 
 _Type_: String
+
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+
+#### MasterUserSecret
+
+_Required_: No
+
+_Type_: <a href="masterusersecret.md">MasterUserSecret</a>
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 
@@ -700,3 +722,7 @@ Returns the <code>Port</code> value.
 #### Address
 
 Returns the <code>Address</code> value.
+
+#### SecretArn
+
+Returns the <code>SecretArn</code> value.

--- a/aws-rds-dbcluster/docs/masterusersecret.md
+++ b/aws-rds-dbcluster/docs/masterusersecret.md
@@ -29,4 +29,3 @@ _Required_: No
 _Type_: String
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
-

--- a/aws-rds-dbcluster/docs/masterusersecret.md
+++ b/aws-rds-dbcluster/docs/masterusersecret.md
@@ -1,0 +1,32 @@
+# AWS::RDS::DBCluster MasterUserSecret
+
+## Syntax
+
+To declare this entity in your AWS CloudFormation template, use the following syntax:
+
+### JSON
+
+<pre>
+{
+    "<a href="#kmskeyid" title="KmsKeyId">KmsKeyId</a>" : <i>String</i>
+}
+</pre>
+
+### YAML
+
+<pre>
+<a href="#kmskeyid" title="KmsKeyId">KmsKeyId</a>: <i>String</i>
+</pre>
+
+## Properties
+
+#### KmsKeyId
+
+The AWS KMS key identifier that is used to encrypt the secret.
+
+_Required_: No
+
+_Type_: String
+
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+

--- a/aws-rds-dbcluster/pom.xml
+++ b/aws-rds-dbcluster/pom.xml
@@ -29,12 +29,12 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>rds</artifactId>
-            <version>2.18.24</version>
+            <version>2.19.4</version>
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>ec2</artifactId>
-            <version>2.18.24</version>
+            <version>2.19.4</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/software.amazon.cloudformation/aws-cloudformation-rpdk-java-plugin -->
         <dependency>

--- a/aws-rds-dbcluster/resource-role.yaml
+++ b/aws-rds-dbcluster/resource-role.yaml
@@ -48,6 +48,8 @@ Resources:
                 - "rds:RemoveTagsFromResource"
                 - "rds:RestoreDBClusterFromSnapshot"
                 - "rds:RestoreDBClusterToPointInTime"
+                - "secretsmanager:CreateSecret"
+                - "secretsmanager:TagResource"
                 Resource: "*"
 Outputs:
   ExecutionRoleArn:

--- a/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/BaseHandlerStd.java
+++ b/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/BaseHandlerStd.java
@@ -73,6 +73,7 @@ import software.amazon.rds.common.printer.JsonPrinter;
 
 public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
     public static final String RESOURCE_IDENTIFIER = "dbcluster";
+    private static final String MASTER_USER_SECRET_ACTIVE = "active";
     public static final String STACK_NAME = "rds";
     protected static final int RESOURCE_ID_MAX_LENGTH = 63;
 
@@ -247,7 +248,16 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
         assertNoDBClusterTerminalStatus(dbCluster);
 
         return isDBClusterAvailable(dbCluster) &&
-                isNoPendingChanges(dbCluster);
+                isNoPendingChanges(dbCluster) &&
+                isMasterUserSecretStabilized(dbCluster);
+    }
+
+    private static boolean isMasterUserSecretStabilized(DBCluster dbCluster) {
+        if (dbCluster.masterUserSecret() == null ||
+                CollectionUtils.isEmpty(dbCluster.dbClusterMembers())) {
+            return true;
+        }
+        return MASTER_USER_SECRET_ACTIVE.equalsIgnoreCase(dbCluster.masterUserSecret().secretStatus());
     }
 
     protected boolean isClusterRemovedFromGlobalCluster(

--- a/aws-rds-dbcluster/src/test/java/software/amazon/rds/dbcluster/TranslatorTest.java
+++ b/aws-rds-dbcluster/src/test/java/software/amazon/rds/dbcluster/TranslatorTest.java
@@ -129,6 +129,69 @@ public class TranslatorTest extends AbstractHandlerTest {
         assertThat(model.getDomain()).isEqualTo(DOMAIN_NON_EMPTY);
         assertThat(model.getDomainIAMRoleName()).isEqualTo(DOMAIN_IAM_ROLE_NAME_NON_EMPTY);
     }
+@Test
+    public void translateManageMasterUserPassword_fromSetToUnset() {
+        final ResourceModel prev = RESOURCE_MODEL.toBuilder()
+                .manageMasterUserPassword(true)
+                .masterUserSecret(MasterUserSecret.builder().kmsKeyId("key").build())
+                .build();
+        final ResourceModel desired = RESOURCE_MODEL.toBuilder()
+                .build();
+
+        final ModifyDbClusterRequest request = Translator.modifyDbClusterRequest(prev, desired, false);
+
+        assertThat(request.manageMasterUserPassword()).isFalse();
+        assertThat(request.masterUserSecretKmsKeyId()).isNull();
+    }
+
+    @Test
+    public void translateManageMasterUserPassword_explicitUnset() {
+        final ResourceModel prev = RESOURCE_MODEL.toBuilder()
+                .manageMasterUserPassword(true)
+                .masterUserSecret(MasterUserSecret.builder().kmsKeyId("key1").build())
+                .build();
+        final ResourceModel desired = RESOURCE_MODEL.toBuilder()
+                .manageMasterUserPassword(false)
+                .masterUserSecret(MasterUserSecret.builder().kmsKeyId("key1").build())
+                .build();
+
+        final ModifyDbClusterRequest request = Translator.modifyDbClusterRequest(prev, desired, false);
+
+        assertThat(request.manageMasterUserPassword()).isFalse();
+        assertThat(request.masterUserSecretKmsKeyId()).isNull();
+    }
+
+    @Test
+    public void translateManageMasterUserPassword_fromUnsetToSet_withDefaultKey() {
+        final ResourceModel prev = RESOURCE_MODEL.toBuilder()
+                .masterUserPassword("password")
+                .build();
+        final ResourceModel desired = RESOURCE_MODEL.toBuilder()
+                .manageMasterUserPassword(true)
+                .masterUserSecret(MasterUserSecret.builder().kmsKeyId(null).build())
+                .build();
+
+        final ModifyDbClusterRequest request = Translator.modifyDbClusterRequest(prev, desired, false);
+
+        assertThat(request.manageMasterUserPassword()).isTrue();
+        assertThat(request.masterUserSecretKmsKeyId()).isNull();
+    }
+
+    @Test
+    public void translateManageMasterUserPassword_fromUnsetToSet_withSpecificKey() {
+        final ResourceModel prev = RESOURCE_MODEL.toBuilder()
+                .masterUserPassword("password")
+                .build();
+        final ResourceModel desired = RESOURCE_MODEL.toBuilder()
+                .manageMasterUserPassword(true)
+                .masterUserSecret(MasterUserSecret.builder().kmsKeyId("myKey").build())
+                .build();
+
+        final ModifyDbClusterRequest request = Translator.modifyDbClusterRequest(prev, desired, false);
+
+        assertThat(request.manageMasterUserPassword()).isTrue();
+        assertThat(request.masterUserSecretKmsKeyId()).isEqualTo("myKey");
+    }
 
     @Test
     public void test_translateScalingConfigurationToSdk_null() {

--- a/aws-rds-dbclusterendpoint/pom.xml
+++ b/aws-rds-dbclusterendpoint/pom.xml
@@ -29,7 +29,7 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>rds</artifactId>
-            <version>2.18.24</version>
+            <version>2.19.4</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/software.amazon.cloudformation/aws-cloudformation-rpdk-java-plugin -->
         <dependency>

--- a/aws-rds-dbclusterparametergroup/pom.xml
+++ b/aws-rds-dbclusterparametergroup/pom.xml
@@ -29,7 +29,7 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>rds</artifactId>
-            <version>2.18.24</version>
+            <version>2.19.4</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/software.amazon.cloudformation/aws-cloudformation-rpdk-java-plugin -->
         <dependency>

--- a/aws-rds-dbinstance/aws-rds-dbinstance.json
+++ b/aws-rds-dbinstance/aws-rds-dbinstance.json
@@ -78,6 +78,20 @@
       "required": [
         "Key"
       ]
+    },
+    "MasterUserSecret": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "SecretArn": {
+          "type": "string",
+          "description": "The Amazon Resource Name (ARN) of the secret."
+        },
+        "KmsKeyId": {
+          "type": "string",
+          "description": "The AWS KMS key identifier that is used to encrypt the secret."
+        }
+      }
     }
   },
   "properties": {
@@ -226,6 +240,10 @@
       "type": "string",
       "description": "The version number of the database engine to use."
     },
+    "ManageMasterUserPassword": {
+      "type": "boolean",
+      "description": "A value that indicates whether to manage the master user password with AWS Secrets Manager."
+    },
     "Iops": {
       "type": "integer",
       "description": "The number of I/O operations per second (IOPS) that the database provisions."
@@ -248,6 +266,10 @@
     "MasterUserPassword": {
       "type": "string",
       "description": "The password for the master user."
+    },
+    "MasterUserSecret": {
+      "$ref": "#/definitions/MasterUserSecret",
+      "description": "Contains the secret managed by RDS in AWS Secrets Manager for the master user password."
     },
     "MaxAllocatedStorage": {
       "type": "integer",
@@ -401,7 +423,8 @@
     "/properties/DBSnapshotIdentifier": "$lowercase(DBSnapshotIdentifier)",
     "/properties/OptionGroupName": "$lowercase(OptionGroupName)",
     "/properties/SourceDBInstanceAutomatedBackupsArn": "$lowercase(SourceDBInstanceAutomatedBackupsArn)",
-    "/properties/SourceDBInstanceIdentifier": "$lowercase(SourceDBInstanceIdentifier)"
+    "/properties/SourceDBInstanceIdentifier": "$lowercase(SourceDBInstanceIdentifier)",
+    "/properties/MasterUserSecret/KmsKeyId": "$join([\"arn:(aws)[-]{0,1}[a-z]{0,2}[-]{0,1}[a-z]{0,3}:kms:[a-z]{2}[-]{1}[a-z]{3,10}[-]{0,1}[a-z]{0,10}[-]{1}[1-3]{1}:[0-9]{12}[:]{1}key\\/\", KMSKeyId])"
   },
   "createOnlyProperties": [
     "/properties/CharacterSetName",
@@ -458,7 +481,8 @@
     "/properties/Endpoint/HostedZoneId",
     "/properties/DbiResourceId",
     "/properties/DBInstanceArn",
-    "/properties/DBSystemId"
+    "/properties/DBSystemId",
+    "/properties/MasterUserSecret/SecretArn"
   ],
   "primaryIdentifier": [
     "/properties/DBInstanceIdentifier"
@@ -488,7 +512,9 @@
         "rds:ModifyDBInstance",
         "rds:RebootDBInstance",
         "rds:RestoreDBInstanceFromDBSnapshot",
-        "rds:RestoreDBInstanceToPointInTime"
+        "rds:RestoreDBInstanceToPointInTime",
+        "secretsmanager:CreateSecret",
+        "secretsmanager:TagResource"
       ],
       "timeoutInMinutes": 2160
     },
@@ -529,7 +555,9 @@
         "rds:PromoteReadReplica",
         "rds:RebootDBInstance",
         "rds:RemoveRoleFromDBInstance",
-        "rds:RemoveTagsFromResource"
+        "rds:RemoveTagsFromResource",
+        "secretsmanager:CreateSecret",
+        "secretsmanager:TagResource"
       ],
       "timeoutInMinutes": 2160
     },

--- a/aws-rds-dbinstance/docs/README.md
+++ b/aws-rds-dbinstance/docs/README.md
@@ -41,11 +41,13 @@ To declare this entity in your AWS CloudFormation template, use the following sy
         "<a href="#endpoint" title="Endpoint">Endpoint</a>" : <i><a href="endpoint.md">Endpoint</a></i>,
         "<a href="#engine" title="Engine">Engine</a>" : <i>String</i>,
         "<a href="#engineversion" title="EngineVersion">EngineVersion</a>" : <i>String</i>,
+        "<a href="#managemasteruserpassword" title="ManageMasterUserPassword">ManageMasterUserPassword</a>" : <i>Boolean</i>,
         "<a href="#iops" title="Iops">Iops</a>" : <i>Integer</i>,
         "<a href="#kmskeyid" title="KmsKeyId">KmsKeyId</a>" : <i>String</i>,
         "<a href="#licensemodel" title="LicenseModel">LicenseModel</a>" : <i>String</i>,
         "<a href="#masterusername" title="MasterUsername">MasterUsername</a>" : <i>String</i>,
         "<a href="#masteruserpassword" title="MasterUserPassword">MasterUserPassword</a>" : <i>String</i>,
+        "<a href="#masterusersecret" title="MasterUserSecret">MasterUserSecret</a>" : <i><a href="masterusersecret.md">MasterUserSecret</a></i>,
         "<a href="#maxallocatedstorage" title="MaxAllocatedStorage">MaxAllocatedStorage</a>" : <i>Integer</i>,
         "<a href="#monitoringinterval" title="MonitoringInterval">MonitoringInterval</a>" : <i>Integer</i>,
         "<a href="#monitoringrolearn" title="MonitoringRoleArn">MonitoringRoleArn</a>" : <i>String</i>,
@@ -118,11 +120,13 @@ Properties:
     <a href="#endpoint" title="Endpoint">Endpoint</a>: <i><a href="endpoint.md">Endpoint</a></i>
     <a href="#engine" title="Engine">Engine</a>: <i>String</i>
     <a href="#engineversion" title="EngineVersion">EngineVersion</a>: <i>String</i>
+    <a href="#managemasteruserpassword" title="ManageMasterUserPassword">ManageMasterUserPassword</a>: <i>Boolean</i>
     <a href="#iops" title="Iops">Iops</a>: <i>Integer</i>
     <a href="#kmskeyid" title="KmsKeyId">KmsKeyId</a>: <i>String</i>
     <a href="#licensemodel" title="LicenseModel">LicenseModel</a>: <i>String</i>
     <a href="#masterusername" title="MasterUsername">MasterUsername</a>: <i>String</i>
     <a href="#masteruserpassword" title="MasterUserPassword">MasterUserPassword</a>: <i>String</i>
+    <a href="#masterusersecret" title="MasterUserSecret">MasterUserSecret</a>: <i><a href="masterusersecret.md">MasterUserSecret</a></i>
     <a href="#maxallocatedstorage" title="MaxAllocatedStorage">MaxAllocatedStorage</a>: <i>Integer</i>
     <a href="#monitoringinterval" title="MonitoringInterval">MonitoringInterval</a>: <i>Integer</i>
     <a href="#monitoringrolearn" title="MonitoringRoleArn">MonitoringRoleArn</a>: <i>String</i>
@@ -473,6 +477,16 @@ _Type_: String
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 
+#### ManageMasterUserPassword
+
+A value that indicates whether to manage the master user password with AWS Secrets Manager.
+
+_Required_: No
+
+_Type_: Boolean
+
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+
 #### Iops
 
 The number of I/O operations per second (IOPS) that the database provisions.
@@ -526,6 +540,14 @@ The password for the master user.
 _Required_: No
 
 _Type_: String
+
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+
+#### MasterUserSecret
+
+_Required_: No
+
+_Type_: <a href="masterusersecret.md">MasterUserSecret</a>
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 
@@ -876,3 +898,7 @@ The Amazon Resource Name (ARN) for the DB instance.
 #### DBSystemId
 
 The Oracle system ID (Oracle SID) for a container database (CDB). The Oracle SID is also the name of the CDB. This setting is valid for RDS Custom only.
+
+#### SecretArn
+
+Returns the <code>SecretArn</code> value.

--- a/aws-rds-dbinstance/docs/masterusersecret.md
+++ b/aws-rds-dbinstance/docs/masterusersecret.md
@@ -1,0 +1,32 @@
+# AWS::RDS::DBInstance MasterUserSecret
+
+## Syntax
+
+To declare this entity in your AWS CloudFormation template, use the following syntax:
+
+### JSON
+
+<pre>
+{
+    "<a href="#kmskeyid" title="KmsKeyId">KmsKeyId</a>" : <i>String</i>
+}
+</pre>
+
+### YAML
+
+<pre>
+<a href="#kmskeyid" title="KmsKeyId">KmsKeyId</a>: <i>String</i>
+</pre>
+
+## Properties
+
+#### KmsKeyId
+
+The AWS KMS key identifier that is used to encrypt the secret.
+
+_Required_: No
+
+_Type_: String
+
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+

--- a/aws-rds-dbinstance/docs/masterusersecret.md
+++ b/aws-rds-dbinstance/docs/masterusersecret.md
@@ -29,4 +29,3 @@ _Required_: No
 _Type_: String
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
-

--- a/aws-rds-dbinstance/pom.xml
+++ b/aws-rds-dbinstance/pom.xml
@@ -32,12 +32,12 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>rds</artifactId>
-            <version>2.18.24</version>
+            <version>2.19.4</version>
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>ec2</artifactId>
-            <version>2.18.24</version>
+            <version>2.19.4</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/software.amazon.cloudformation/aws-cloudformation-rpdk-java-plugin -->
         <dependency>

--- a/aws-rds-dbinstance/resource-role.yaml
+++ b/aws-rds-dbinstance/resource-role.yaml
@@ -60,6 +60,8 @@ Resources:
                 - "rds:RemoveTagsFromResource"
                 - "rds:RestoreDBInstanceFromDBSnapshot"
                 - "rds:RestoreDBInstanceToPointInTime"
+                - "secretsmanager:CreateSecret"
+                - "secretsmanager:TagResource"
                 Resource: "*"
 Outputs:
   ExecutionRoleArn:

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/BaseHandlerStd.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/BaseHandlerStd.java
@@ -101,6 +101,7 @@ import software.amazon.rds.dbinstance.util.ResourceModelHelper;
 
 public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
 
+    public static final String SECRET_STATUS_ACTIVE = "active";
     public static final String RESOURCE_IDENTIFIER = "dbinstance";
     public static final String STACK_NAME = "rds";
 
@@ -553,7 +554,8 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
                 isNoPendingChanges(dbInstance) &&
                 isVpcSecurityGroupsActive(dbInstance) &&
                 isDomainMembershipsJoined(dbInstance) &&
-                isPromotionTierUpdated(dbInstance, model);
+                isPromotionTierUpdated(dbInstance, model) &&
+                isMasterUserSecretStabilized(dbInstance);
     }
 
     protected boolean isDBInstanceStabilizedAfterReboot(
@@ -701,6 +703,13 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
                 model,
                 (roles) -> roles.noneMatch(role -> role.roleArn().equals(lookupRole.getRoleArn()))
         );
+    }
+
+    protected boolean isMasterUserSecretStabilized(final DBInstance instance) {
+        if (instance.masterUserSecret() == null) {
+            return true;
+        }
+        return SECRET_STATUS_ACTIVE.equalsIgnoreCase(instance.masterUserSecret().secretStatus());
     }
 
     protected ProgressEvent<ResourceModel, CallbackContext> updateAssociatedRoles(

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/Translator.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/Translator.java
@@ -193,10 +193,12 @@ public class Translator {
                 .dbSubnetGroupName(model.getDBSubnetGroupName())
                 .engine(model.getEngine())
                 .engineVersion(model.getEngineVersion())
+                .manageMasterUserPassword(model.getManageMasterUserPassword())
                 .iops(model.getIops())
                 .licenseModel(model.getLicenseModel())
                 .masterUserPassword(model.getMasterUserPassword())
                 .masterUsername(model.getMasterUsername())
+                .masterUserSecretKmsKeyId(model.getMasterUserSecret() == null ? null : model.getMasterUserSecret().getKmsKeyId())
                 .multiAZ(model.getMultiAZ())
                 .networkType(model.getNetworkType())
                 .optionGroupName(model.getOptionGroupName())
@@ -232,11 +234,13 @@ public class Translator {
                 .enablePerformanceInsights(model.getEnablePerformanceInsights())
                 .engine(model.getEngine())
                 .engineVersion(model.getEngineVersion())
+                .manageMasterUserPassword(model.getManageMasterUserPassword())
                 .iops(model.getIops())
                 .kmsKeyId(model.getKmsKeyId())
                 .licenseModel(model.getLicenseModel())
                 .masterUsername(model.getMasterUsername())
                 .masterUserPassword(model.getMasterUserPassword())
+                .masterUserSecretKmsKeyId(model.getMasterUserSecret() == null ? null : model.getMasterUserSecret().getKmsKeyId())
                 .maxAllocatedStorage(model.getMaxAllocatedStorage())
                 .monitoringInterval(model.getMonitoringInterval())
                 .monitoringRoleArn(model.getMonitoringRoleArn())
@@ -327,7 +331,9 @@ public class Translator {
                 .dbParameterGroupName(diff(previousModel.getDBParameterGroupName(), desiredModel.getDBParameterGroupName()))
                 .dbSecurityGroups(diff(previousModel.getDBSecurityGroups(), desiredModel.getDBSecurityGroups()))
                 .engineVersion(diff(previousModel.getEngineVersion(), desiredModel.getEngineVersion()))
+                .manageMasterUserPassword(diff(previousModel.getManageMasterUserPassword(), desiredModel.getManageMasterUserPassword()))
                 .masterUserPassword(diff(previousModel.getMasterUserPassword(), desiredModel.getMasterUserPassword()))
+                .masterUserSecretKmsKeyId(diff(previousModel.getMasterUserSecret(), desiredModel.getMasterUserSecret()) != null ? desiredModel.getMasterUserSecret().getKmsKeyId() : null)
                 .multiAZ(diff(previousModel.getMultiAZ(), desiredModel.getMultiAZ()))
                 .networkType(diff(previousModel.getNetworkType(), desiredModel.getNetworkType()))
                 .optionGroupName(diff(previousModel.getOptionGroupName(), desiredModel.getOptionGroupName()))
@@ -377,6 +383,7 @@ public class Translator {
                 .maxAllocatedStorage(diff(previousModel.getMaxAllocatedStorage(), desiredModel.getMaxAllocatedStorage()))
                 .monitoringInterval(diff(previousModel.getMonitoringInterval(), desiredModel.getMonitoringInterval()))
                 .monitoringRoleArn(diff(previousModel.getMonitoringRoleArn(), desiredModel.getMonitoringRoleArn()))
+                .masterUserPassword(diff(previousModel.getMasterUserPassword(), desiredModel.getMasterUserPassword()))
                 .multiAZ(diff(previousModel.getMultiAZ(), desiredModel.getMultiAZ()))
                 .networkType(diff(previousModel.getNetworkType(), desiredModel.getNetworkType()))
                 .optionGroupName(diff(previousModel.getOptionGroupName(), desiredModel.getOptionGroupName()))
@@ -417,6 +424,13 @@ public class Translator {
         if (shouldSetProcessorFeatures(previousModel, desiredModel)) {
             builder.processorFeatures(translateProcessorFeaturesToSdk(desiredModel.getProcessorFeatures()));
             builder.useDefaultProcessorFeatures(desiredModel.getUseDefaultProcessorFeatures());
+        }
+
+        if (BooleanUtils.isTrue(desiredModel.getManageMasterUserPassword())) {
+            builder.manageMasterUserPassword(true);
+            builder.masterUserSecretKmsKeyId(desiredModel.getMasterUserSecret().getKmsKeyId());
+        } else {
+            builder.manageMasterUserPassword(false);
         }
 
         return builder.build();
@@ -640,10 +654,12 @@ public class Translator {
                 .endpoint(endpoint)
                 .engine(dbInstance.engine())
                 .engineVersion(dbInstance.engineVersion())
+                .manageMasterUserPassword(dbInstance.masterUserSecret() != null)
                 .iops(dbInstance.iops())
                 .kmsKeyId(dbInstance.kmsKeyId())
                 .licenseModel(dbInstance.licenseModel())
                 .masterUsername(dbInstance.masterUsername())
+                .masterUserSecret(translateMasterUserSecret(dbInstance.masterUserSecret()))
                 .maxAllocatedStorage(dbInstance.maxAllocatedStorage())
                 .monitoringInterval(dbInstance.monitoringInterval())
                 .monitoringRoleArn(dbInstance.monitoringRoleArn())
@@ -833,5 +849,16 @@ public class Translator {
             allocatedStorage = Integer.parseInt(model.getAllocatedStorage());
         }
         return allocatedStorage;
+    }
+
+    public static MasterUserSecret translateMasterUserSecret(final software.amazon.awssdk.services.rds.model.MasterUserSecret sdkSecret) {
+        if (sdkSecret == null) {
+            return null;
+        }
+
+        return MasterUserSecret.builder()
+                .secretArn(sdkSecret.secretArn())
+                .kmsKeyId(sdkSecret.kmsKeyId())
+                .build();
     }
 }

--- a/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/BaseHandlerStdTest.java
+++ b/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/BaseHandlerStdTest.java
@@ -13,6 +13,7 @@ import software.amazon.awssdk.services.rds.model.DBInstance;
 import software.amazon.awssdk.services.rds.model.DBInstanceStatusInfo;
 import software.amazon.awssdk.services.rds.model.DBParameterGroupStatus;
 import software.amazon.awssdk.services.rds.model.DomainMembership;
+import software.amazon.awssdk.services.rds.model.MasterUserSecret;
 import software.amazon.awssdk.services.rds.model.PendingCloudwatchLogsExports;
 import software.amazon.awssdk.services.rds.model.PendingModifiedValues;
 import software.amazon.awssdk.services.rds.model.ProcessorFeature;
@@ -483,6 +484,36 @@ class BaseHandlerStdTest {
                                         .status("replicating")
                                         .build()
                         )
+                        .build()
+        )).isFalse();
+    }
+
+    @Test
+    void isMasterUserSecretStabilized_masterUserSecretIsNull() {
+        Assertions.assertThat(handler.isMasterUserSecretStabilized(
+                DBInstance.builder()
+                        .build()
+        )).isTrue();
+    }
+
+    @Test
+    void isMasterUserSecretStabilized_masterUserSecretStatusActive() {
+        Assertions.assertThat(handler.isMasterUserSecretStabilized(
+                DBInstance.builder()
+                        .masterUserSecret(MasterUserSecret.builder()
+                                .secretStatus("Active")
+                                .build())
+                        .build()
+        )).isTrue();
+    }
+
+    @Test
+    void isMasterUserSecretStabilized_masterUserSecretStatusCreating() {
+        Assertions.assertThat(handler.isMasterUserSecretStabilized(
+                DBInstance.builder()
+                        .masterUserSecret(MasterUserSecret.builder()
+                                .secretStatus("Creating")
+                                .build())
                         .build()
         )).isFalse();
     }

--- a/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/ListHandlerTest.java
+++ b/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/ListHandlerTest.java
@@ -96,6 +96,7 @@ public class ListHandlerTest extends AbstractHandlerTest {
         final ResourceModel expectedModel = ResourceModel.builder()
                 .associatedRoles(Collections.emptyList())
                 .enableCloudwatchLogsExports(Collections.emptyList())
+                .manageMasterUserPassword(false)
                 .processorFeatures(Collections.emptyList())
                 .tags(Collections.emptyList())
                 .dBSecurityGroups(Collections.emptyList())

--- a/aws-rds-dbparametergroup/pom.xml
+++ b/aws-rds-dbparametergroup/pom.xml
@@ -22,7 +22,7 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>rds</artifactId>
-            <version>2.18.24</version>
+            <version>2.19.4</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/software.amazon.cloudformation/aws-cloudformation-rpdk-java-plugin -->
         <dependency>

--- a/aws-rds-dbsubnetgroup/pom.xml
+++ b/aws-rds-dbsubnetgroup/pom.xml
@@ -22,7 +22,7 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>rds</artifactId>
-            <version>2.18.24</version>
+            <version>2.19.4</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/software.amazon.cloudformation/aws-cloudformation-rpdk-java-plugin -->
         <dependency>

--- a/aws-rds-eventsubscription/pom.xml
+++ b/aws-rds-eventsubscription/pom.xml
@@ -28,7 +28,7 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>rds</artifactId>
-            <version>2.18.24</version>
+            <version>2.19.4</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/software.amazon.cloudformation/aws-cloudformation-rpdk-java-plugin -->
         <dependency>

--- a/aws-rds-globalcluster/pom.xml
+++ b/aws-rds-globalcluster/pom.xml
@@ -28,7 +28,7 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>rds</artifactId>
-            <version>2.18.24</version>
+            <version>2.19.4</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/software.amazon.cloudformation/aws-cloudformation-rpdk-java-plugin -->
         <dependency>

--- a/aws-rds-optiongroup/pom.xml
+++ b/aws-rds-optiongroup/pom.xml
@@ -22,7 +22,7 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>rds</artifactId>
-            <version>2.18.24</version>
+            <version>2.19.4</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/software.amazon.cloudformation/aws-cloudformation-rpdk-java-plugin -->
         <dependency>


### PR DESCRIPTION
This PR adds support for [password management](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/rds-secrets-manager.html) with  AWS SecretsManager for DBInstance and DBCluster resources

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
