### PR TITLE
[DBInstance] Unset `AllocatedStorage` and `Iops` on rollback

### DIFF
--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/Translator.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/Translator.java
@@ -326,7 +326,6 @@ public class Translator {
                 .dbInstanceIdentifier(desiredModel.getDBInstanceIdentifier())
                 .dbParameterGroupName(diff(previousModel.getDBParameterGroupName(), desiredModel.getDBParameterGroupName()))
                 .dbSecurityGroups(diff(previousModel.getDBSecurityGroups(), desiredModel.getDBSecurityGroups()))
-                .engineVersion(diff(previousModel.getEngineVersion(), desiredModel.getEngineVersion()))
                 .masterUserPassword(diff(previousModel.getMasterUserPassword(), desiredModel.getMasterUserPassword()))
                 .multiAZ(diff(previousModel.getMultiAZ(), desiredModel.getMultiAZ()))
                 .networkType(diff(previousModel.getNetworkType(), desiredModel.getNetworkType()))
@@ -336,16 +335,10 @@ public class Translator {
                 .publiclyAccessible(diff(previousModel.getPubliclyAccessible(), desiredModel.getPubliclyAccessible()))
                 .replicaMode(diff(previousModel.getReplicaMode(), desiredModel.getReplicaMode()));
 
-        if (BooleanUtils.isTrue(isRollback)) {
-            builder.allocatedStorage(
-                    canUpdateAllocatedStorage(previousModel.getAllocatedStorage(), desiredModel.getAllocatedStorage()) ? getAllocatedStorage(desiredModel) : getAllocatedStorage(previousModel)
-            );
-            builder.iops(
-                    canUpdateIops(previousModel.getIops(), desiredModel.getIops()) ? desiredModel.getIops() : previousModel.getIops()
-            );
-        } else {
-            builder.allocatedStorage(getAllocatedStorage(desiredModel));
-            builder.iops(desiredModel.getIops());
+        if (BooleanUtils.isNotTrue(isRollback)) {
+            builder.allocatedStorage(diff(getAllocatedStorage(previousModel), getAllocatedStorage(desiredModel)));
+            builder.engineVersion(diff(previousModel.getEngineVersion(), desiredModel.getEngineVersion()));
+            builder.iops(diff(previousModel.getIops(), desiredModel.getIops()));
         }
 
         return builder.build();
@@ -401,17 +394,10 @@ public class Translator {
             builder.cloudwatchLogsExportConfiguration(cloudwatchLogsExportConfiguration);
         }
 
-        if (BooleanUtils.isTrue(isRollback)) {
-            builder.allocatedStorage(
-                    canUpdateAllocatedStorage(previousModel.getAllocatedStorage(), desiredModel.getAllocatedStorage()) ? getAllocatedStorage(desiredModel) : getAllocatedStorage(previousModel)
-            );
-            builder.iops(
-                    canUpdateIops(previousModel.getIops(), desiredModel.getIops()) ? desiredModel.getIops() : previousModel.getIops()
-            );
-        } else {
-            builder.allocatedStorage(getAllocatedStorage(desiredModel));
-            builder.iops(desiredModel.getIops());
+        if (BooleanUtils.isNotTrue(isRollback)) {
+            builder.allocatedStorage(diff(getAllocatedStorage(previousModel), getAllocatedStorage(desiredModel)));
             builder.engineVersion(diff(previousModel.getEngineVersion(), desiredModel.getEngineVersion()));
+            builder.iops(diff(previousModel.getIops(), desiredModel.getIops()));
         }
 
         if (shouldSetProcessorFeatures(previousModel, desiredModel)) {
@@ -798,26 +784,6 @@ public class Translator {
         return Optional.ofNullable(collection)
                 .map(Collection::stream)
                 .orElseGet(Stream::empty);
-    }
-
-    @VisibleForTesting
-    static boolean canUpdateAllocatedStorage(final String fromAllocatedStorage, final String toAllocatedStorage) {
-        if (fromAllocatedStorage == null || toAllocatedStorage == null) {
-            return true;
-        }
-        final int from, to;
-        try {
-            from = Integer.parseInt(fromAllocatedStorage);
-            to = Integer.parseInt(toAllocatedStorage);
-        } catch (NumberFormatException e) {
-            return true;
-        }
-        return to >= from;
-    }
-
-    @VisibleForTesting
-    static boolean canUpdateIops(final Integer fromIops, final Integer toIops) {
-        return fromIops == null || toIops == null || toIops >= fromIops;
     }
 
     @VisibleForTesting

--- a/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/TranslatorTest.java
+++ b/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/TranslatorTest.java
@@ -6,10 +6,10 @@ import java.util.Collection;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-
-import com.google.common.collect.ImmutableList;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+
+import com.google.common.collect.ImmutableList;
 import software.amazon.awssdk.services.ec2.Ec2Client;
 import software.amazon.awssdk.services.rds.RdsClient;
 import software.amazon.awssdk.services.rds.model.CreateDbInstanceReadReplicaRequest;
@@ -88,7 +88,7 @@ class TranslatorTest extends AbstractHandlerTest {
                 .build();
         final Boolean isRollback = true;
         final ModifyDbInstanceRequest request = Translator.modifyDbInstanceRequest(previousModel, desiredModel, isRollback);
-        assertThat(request.allocatedStorage()).isEqualTo(ALLOCATED_STORAGE_INCR);
+        assertThat(request.allocatedStorage()).isNull();
     }
 
     @Test
@@ -101,7 +101,7 @@ class TranslatorTest extends AbstractHandlerTest {
                 .build();
         final Boolean isRollback = true;
         final ModifyDbInstanceRequest request = Translator.modifyDbInstanceRequestV12(previousModel, desiredModel, isRollback);
-        assertThat(request.allocatedStorage()).isEqualTo(ALLOCATED_STORAGE_INCR);
+        assertThat(request.allocatedStorage()).isNull();
     }
 
     @Test
@@ -114,7 +114,7 @@ class TranslatorTest extends AbstractHandlerTest {
                 .build();
         final Boolean isRollback = true;
         final ModifyDbInstanceRequest request = Translator.modifyDbInstanceRequest(previousModel, desiredModel, isRollback);
-        assertThat(request.allocatedStorage()).isEqualTo(ALLOCATED_STORAGE); // should stay unchanged
+        assertThat(request.allocatedStorage()).isNull();
     }
 
     @Test
@@ -127,7 +127,7 @@ class TranslatorTest extends AbstractHandlerTest {
                 .build();
         final Boolean isRollback = true;
         final ModifyDbInstanceRequest request = Translator.modifyDbInstanceRequestV12(previousModel, desiredModel, isRollback);
-        assertThat(request.allocatedStorage()).isEqualTo(ALLOCATED_STORAGE); // should stay unchanged
+        assertThat(request.allocatedStorage()).isNull();
     }
 
     @Test
@@ -192,7 +192,7 @@ class TranslatorTest extends AbstractHandlerTest {
                 .build();
         final Boolean isRollback = true;
         final ModifyDbInstanceRequest request = Translator.modifyDbInstanceRequest(previousModel, desiredModel, isRollback);
-        assertThat(request.iops()).isEqualTo(IOPS_INCR);
+        assertThat(request.iops()).isNull();
     }
 
     @Test
@@ -205,7 +205,7 @@ class TranslatorTest extends AbstractHandlerTest {
                 .build();
         final Boolean isRollback = true;
         final ModifyDbInstanceRequest request = Translator.modifyDbInstanceRequestV12(previousModel, desiredModel, isRollback);
-        assertThat(request.iops()).isEqualTo(IOPS_INCR);
+        assertThat(request.iops()).isNull();
     }
 
     @Test
@@ -218,7 +218,7 @@ class TranslatorTest extends AbstractHandlerTest {
                 .build();
         final Boolean isRollback = true;
         final ModifyDbInstanceRequest request = Translator.modifyDbInstanceRequest(previousModel, desiredModel, isRollback);
-        assertThat(request.iops()).isEqualTo(IOPS_DEFAULT);
+        assertThat(request.iops()).isNull();
     }
 
     @Test
@@ -231,7 +231,7 @@ class TranslatorTest extends AbstractHandlerTest {
                 .build();
         final Boolean isRollback = true;
         final ModifyDbInstanceRequest request = Translator.modifyDbInstanceRequestV12(previousModel, desiredModel, isRollback);
-        assertThat(request.iops()).isEqualTo(IOPS_DEFAULT);
+        assertThat(request.iops()).isNull();
     }
 
     @Test
@@ -445,17 +445,6 @@ class TranslatorTest extends AbstractHandlerTest {
         final ResourceModel model = Translator.translateDbInstanceFromSdk(instance);
         assertThat(model.getDomain()).isEqualTo(DOMAIN_NON_EMPTY);
         assertThat(model.getDomainIAMRoleName()).isEqualTo(DOMAIN_IAM_ROLE_NAME_NON_EMPTY);
-    }
-
-    @Test
-    public void test_canUpdateAllocatedStorage_nullArg() {
-        assertThat(Translator.canUpdateAllocatedStorage(null, "42")).isTrue();
-        assertThat(Translator.canUpdateAllocatedStorage("42", null)).isTrue();
-    }
-
-    @Test
-    public void test_canUpdateAllocatedStorage_NumberFormatException() {
-        assertThat(Translator.canUpdateAllocatedStorage("123", "invalid")).isTrue();
     }
 
     @Test


### PR DESCRIPTION
This commit changes the handler behavior on a rollback update. The current strategy is to ensure `AllocatedStorage` and `Iops` changeability. Effectively, this means that the handler would ensure that neither of these attributes is being reduced upon a rollback. An attempt to reduce the corresponding attribute is known to be rejected by the RDS API, hence the handler would keep the old (pre-rollback) value. This commit alters this strategy to providing no pre-rollback values at all if either of these attributes is identifier as non-updatable. The translator would provide a null-value instead.

The motivation behind this change is to expand the applicability of the "keep whatever is working" on a case when the initial update failed. The existing approach would only work if the initial change was applied successfully and failure happened somewhere down the stack tree. The change would be invalid if the initial update never went through.

Refs https://github.com/aws-cloudformation/cloudformation-coverage-roadmap/issues/1312.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Signed-off-by: Oleg Sidorov <sidorovo@amazon.com>