### PR TITLE
Fix Secrets Manager noop case for DBCluster and DBInstance

### DIFF
--- a/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/Translator.java
+++ b/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/Translator.java
@@ -243,10 +243,20 @@ public class Translator {
             builder.manageMasterUserPassword(true);
             builder.masterUserSecretKmsKeyId(desiredModel.getMasterUserSecret().getKmsKeyId());
         } else {
-            builder.manageMasterUserPassword(false);
+            builder.manageMasterUserPassword(getManageMasterUserPassword(previousModel, desiredModel));
         }
 
         return builder.build();
+    }
+
+    private static Boolean getManageMasterUserPassword(final ResourceModel previous, final ResourceModel desired) {
+        if (null != desired.getManageMasterUserPassword()) {
+            return desired.getManageMasterUserPassword();
+        }
+        if (BooleanUtils.isTrue(previous.getManageMasterUserPassword()) && BooleanUtils.isNotTrue(desired.getManageMasterUserPassword())) {
+            return false;
+        }
+        return null;
     }
 
     static CloudwatchLogsExportConfiguration cloudwatchLogsExportConfiguration(

--- a/aws-rds-dbcluster/src/test/java/software/amazon/rds/dbcluster/TranslatorTest.java
+++ b/aws-rds-dbcluster/src/test/java/software/amazon/rds/dbcluster/TranslatorTest.java
@@ -129,7 +129,24 @@ public class TranslatorTest extends AbstractHandlerTest {
         assertThat(model.getDomain()).isEqualTo(DOMAIN_NON_EMPTY);
         assertThat(model.getDomainIAMRoleName()).isEqualTo(DOMAIN_IAM_ROLE_NAME_NON_EMPTY);
     }
-@Test
+
+    @Test
+    public void translateManageMasterUserPassword_fromUnsetToUnset() {
+        final ResourceModel prev = RESOURCE_MODEL.toBuilder()
+                .masterUserPassword("password")
+                .build();
+        final ResourceModel desired = RESOURCE_MODEL.toBuilder()
+                .masterUserPassword("password")
+                .build();
+
+        final ModifyDbClusterRequest request = Translator.modifyDbClusterRequest(prev, desired, false);
+
+        assertThat(request.manageMasterUserPassword()).isNull();
+        assertThat(request.masterUserSecretKmsKeyId()).isNull();
+        assertThat(request.masterUserPassword()).isNull();
+    }
+
+    @Test
     public void translateManageMasterUserPassword_fromSetToUnset() {
         final ResourceModel prev = RESOURCE_MODEL.toBuilder()
                 .manageMasterUserPassword(true)

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/Translator.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/Translator.java
@@ -383,7 +383,6 @@ public class Translator {
                 .maxAllocatedStorage(diff(previousModel.getMaxAllocatedStorage(), desiredModel.getMaxAllocatedStorage()))
                 .monitoringInterval(diff(previousModel.getMonitoringInterval(), desiredModel.getMonitoringInterval()))
                 .monitoringRoleArn(diff(previousModel.getMonitoringRoleArn(), desiredModel.getMonitoringRoleArn()))
-                .masterUserPassword(diff(previousModel.getMasterUserPassword(), desiredModel.getMasterUserPassword()))
                 .multiAZ(diff(previousModel.getMultiAZ(), desiredModel.getMultiAZ()))
                 .networkType(diff(previousModel.getNetworkType(), desiredModel.getNetworkType()))
                 .optionGroupName(diff(previousModel.getOptionGroupName(), desiredModel.getOptionGroupName()))
@@ -441,10 +440,20 @@ public class Translator {
             builder.manageMasterUserPassword(true);
             builder.masterUserSecretKmsKeyId(desiredModel.getMasterUserSecret().getKmsKeyId());
         } else {
-            builder.manageMasterUserPassword(false);
+            builder.manageMasterUserPassword(getManageMasterUserPassword(previousModel, desiredModel));
         }
 
         return builder.build();
+    }
+
+    private static Boolean getManageMasterUserPassword(final ResourceModel previous, final ResourceModel desired) {
+        if (null != desired.getManageMasterUserPassword()) {
+            return desired.getManageMasterUserPassword();
+        }
+        if (BooleanUtils.isTrue(previous.getManageMasterUserPassword()) && BooleanUtils.isNotTrue(desired.getManageMasterUserPassword())) {
+            return false;
+        }
+        return null;
     }
 
     public static ModifyDbInstanceRequest modifyDbInstanceAfterCreateRequestV12(final ResourceModel model) {

--- a/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/TranslatorTest.java
+++ b/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/TranslatorTest.java
@@ -480,6 +480,22 @@ class TranslatorTest extends AbstractHandlerTest {
     }
 
     @Test
+    public void translateManageMasterUserPassword_fromUnsetToUnset() {
+        final ResourceModel prev = RESOURCE_MODEL_BLDR()
+                .masterUserPassword("password")
+                .build();
+        final ResourceModel desired = RESOURCE_MODEL_BLDR()
+                .masterUserPassword("password")
+                .build();
+
+        final ModifyDbInstanceRequest request = Translator.modifyDbInstanceRequest(prev, desired, false);
+
+        assertThat(request.manageMasterUserPassword()).isNull();
+        assertThat(request.masterUserSecretKmsKeyId()).isNull();
+        assertThat(request.masterUserPassword()).isNull();
+    }
+
+    @Test
     public void translateManageMasterUserPassword_fromSetToUnset() {
         final ResourceModel prev = RESOURCE_MODEL_BLDR()
                 .manageMasterUserPassword(true)


### PR DESCRIPTION
This PR fixes a bug with Update DBCluster and DBInstance introduced by SecretsManager integration that would manifest when no-update was needed for either ManageMasterUserPassword or MasterUserPassword option.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
