### PR TITLE
[DBInstance][DBCluster] Update isNoPendingChanges to check for all PendingModifiedValues

### DIFF
--- a/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/BaseHandlerStd.java
+++ b/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/BaseHandlerStd.java
@@ -11,7 +11,6 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Stream;
 
 import org.apache.commons.collections.CollectionUtils;
 
@@ -148,7 +147,7 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
     }
 
     @Override
-    public final ProgressEvent<ResourceModel, CallbackContext> handleRequest(
+    public ProgressEvent<ResourceModel, CallbackContext> handleRequest(
             final AmazonWebServicesClientProxy proxy,
             final ResourceHandlerRequest<ResourceModel> request,
             final CallbackContext callbackContext,

--- a/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/BaseHandlerStd.java
+++ b/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/BaseHandlerStd.java
@@ -234,7 +234,6 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
 
     protected boolean isNoPendingChanges(final DBCluster dbCluster) {
         final ClusterPendingModifiedValues modifiedValues = dbCluster.pendingModifiedValues();
-
         return modifiedValues == null || (
                 modifiedValues.pendingCloudwatchLogsExports() == null &&
                         modifiedValues.dbClusterIdentifier() == null &&

--- a/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/BaseHandlerStd.java
+++ b/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/BaseHandlerStd.java
@@ -11,6 +11,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Stream;
 
 import org.apache.commons.collections.CollectionUtils;
 
@@ -234,10 +235,16 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
 
     protected boolean isNoPendingChanges(final DBCluster dbCluster) {
         final ClusterPendingModifiedValues modifiedValues = dbCluster.pendingModifiedValues();
+
         return modifiedValues == null || (
-                modifiedValues.masterUserPassword() == null &&
+                modifiedValues.pendingCloudwatchLogsExports() == null &&
+                        modifiedValues.dbClusterIdentifier() == null &&
+                        modifiedValues.masterUserPassword() == null &&
                         modifiedValues.iamDatabaseAuthenticationEnabled() == null &&
-                        modifiedValues.engineVersion() == null);
+                        modifiedValues.engineVersion() == null &&
+                        modifiedValues.backupRetentionPeriod() == null &&
+                        modifiedValues.allocatedStorage() == null &&
+                        modifiedValues.iops() == null);
     }
 
     protected boolean isDBClusterStabilized(

--- a/aws-rds-dbcluster/src/test/java/software/amazon/rds/dbcluster/BaseHandlerStdTest.java
+++ b/aws-rds-dbcluster/src/test/java/software/amazon/rds/dbcluster/BaseHandlerStdTest.java
@@ -1,0 +1,131 @@
+package software.amazon.rds.dbcluster;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.services.ec2.Ec2Client;
+import software.amazon.awssdk.services.rds.RdsClient;
+import software.amazon.awssdk.services.rds.model.ClusterPendingModifiedValues;
+import software.amazon.awssdk.services.rds.model.DBCluster;
+import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
+import software.amazon.cloudformation.proxy.Logger;
+import software.amazon.cloudformation.proxy.ProgressEvent;
+import software.amazon.cloudformation.proxy.ProxyClient;
+import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
+import software.amazon.rds.common.handler.HandlerConfig;
+
+class BaseHandlerStdTest {
+
+    class TestBaseHandlerStd extends BaseHandlerStd {
+
+        public TestBaseHandlerStd(HandlerConfig config) {
+            super(config);
+        }
+
+        @Override
+        protected ProgressEvent<ResourceModel, CallbackContext> handleRequest(AmazonWebServicesClientProxy proxy, ResourceHandlerRequest<ResourceModel> request, CallbackContext callbackContext, ProxyClient<RdsClient> rdsProxyClient, ProxyClient<Ec2Client> ec2ProxyClient, Logger logger) {
+            return null;
+        }
+
+        @Override
+        public ProgressEvent<ResourceModel, CallbackContext> handleRequest(
+                AmazonWebServicesClientProxy proxy,
+                ResourceHandlerRequest<ResourceModel> request,
+                CallbackContext callbackContext,
+                Logger logger
+        ) {
+            return null;
+        }
+    }
+
+    private TestBaseHandlerStd handler;
+
+    @BeforeEach
+    public void setUp() {
+        handler = new TestBaseHandlerStd(null);
+    }
+
+    @Test
+    void isNoPendingChanges_NonEmptyDBClusterIdentifier() {
+        Assertions.assertThat(handler.isNoPendingChanges(
+                DBCluster.builder()
+                        .pendingModifiedValues(
+                                ClusterPendingModifiedValues.builder()
+                                        .dbClusterIdentifier("DBClusterIdentifier")
+                                        .build())
+                        .build()
+        )).isFalse();
+    }
+
+    @Test
+    void isNoPendingChanges_NonEmptyMasterUserPassword() {
+        Assertions.assertThat(handler.isNoPendingChanges(
+                DBCluster.builder()
+                        .pendingModifiedValues(
+                                ClusterPendingModifiedValues.builder()
+                                        .masterUserPassword("MasterUserPassword")
+                                        .build())
+                        .build()
+        )).isFalse();
+    }
+
+    @Test
+    void isNoPendingChanges_NonEmptyIAMDatabaseAuthenticationEnabled() {
+        Assertions.assertThat(handler.isNoPendingChanges(
+                DBCluster.builder()
+                        .pendingModifiedValues(
+                                ClusterPendingModifiedValues.builder()
+                                        .iamDatabaseAuthenticationEnabled(true)
+                                        .build())
+                        .build()
+        )).isFalse();
+    }
+
+    @Test
+    void isNoPendingChanges_NonEmptyEngineVersion() {
+        Assertions.assertThat(handler.isNoPendingChanges(
+                DBCluster.builder()
+                        .pendingModifiedValues(
+                                ClusterPendingModifiedValues.builder()
+                                        .engineVersion("11.3")
+                                        .build())
+                        .build()
+        )).isFalse();
+    }
+
+    @Test
+    void isNoPendingChanges_NonEmptyBackupRetentionPeriod() {
+        Assertions.assertThat(handler.isNoPendingChanges(
+                DBCluster.builder()
+                        .pendingModifiedValues(
+                                ClusterPendingModifiedValues.builder()
+                                        .backupRetentionPeriod(42)
+                                        .build())
+                        .build()
+        )).isFalse();
+    }
+
+    @Test
+    void isNoPendingChanges_NonEmptyAllocatedStorage() {
+        Assertions.assertThat(handler.isNoPendingChanges(
+                DBCluster.builder()
+                        .pendingModifiedValues(
+                                ClusterPendingModifiedValues.builder()
+                                        .allocatedStorage(42)
+                                        .build())
+                        .build()
+        )).isFalse();
+    }
+
+    @Test
+    void isNoPendingChanges_NonEmptyIops() {
+        Assertions.assertThat(handler.isNoPendingChanges(
+                DBCluster.builder()
+                        .pendingModifiedValues(
+                                ClusterPendingModifiedValues.builder()
+                                        .iops(42)
+                                        .build())
+                        .build()
+        )).isFalse();
+    }
+}

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/BaseHandlerStd.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/BaseHandlerStd.java
@@ -612,7 +612,8 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
                 CollectionUtils.isNullOrEmpty(pending.processorFeatures()) &&
                 pending.iamDatabaseAuthenticationEnabled() == null &&
                 pending.automationMode() == null &&
-                pending.resumeFullAutomationModeTime() == null
+                pending.resumeFullAutomationModeTime() == null &&
+                pending.storageThroughput() == null
         );
     }
 

--- a/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/BaseHandlerStdTest.java
+++ b/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/BaseHandlerStdTest.java
@@ -377,6 +377,18 @@ class BaseHandlerStdTest {
     }
 
     @Test
+    void isNoPendingChanges_NonEmptyStorageThroughputReturnsFalse() {
+        Assertions.assertThat(handler.isNoPendingChanges(
+                DBInstance.builder()
+                        .pendingModifiedValues(
+                                PendingModifiedValues.builder()
+                                        .storageThroughput(42)
+                                        .build())
+                        .build()
+        )).isFalse();
+    }
+
+    @Test
     void isNoPendingChanges_NonEmptyReturnsFalse() {
         Assertions.assertThat(handler.isNoPendingChanges(
                 DBInstance.builder()


### PR DESCRIPTION
This PR attempts to bring DBCluster and DBInstance to a consistant state with their respective isNoPendingChanges methods.

Both ClusterPendingModifiedValues and PendingModifiedValues (DBInstance) had aditional variables that weren't checked in their respective isNoPendingChanges. The could lead to a longer stabilization period than necessary.