### PR TITLE
[DBInstance] Fix null-pointer exception in `ImmutabilityHelper`

### DIFF
--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/util/ImmutabilityHelper.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/util/ImmutabilityHelper.java
@@ -2,10 +2,11 @@ package software.amazon.rds.dbinstance.util;
 
 import java.util.List;
 
+import org.apache.commons.lang3.BooleanUtils;
+
 import com.amazonaws.util.StringUtils;
 import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableList;
-import org.apache.commons.lang3.BooleanUtils;
 import software.amazon.rds.dbinstance.ResourceModel;
 
 
@@ -49,7 +50,7 @@ public final class ImmutabilityHelper {
 
     static boolean isAvailabilityZoneChangeMutable(final ResourceModel previous, final ResourceModel desired) {
         return Objects.equal(previous.getAvailabilityZone(), desired.getAvailabilityZone()) ||
-                (StringUtils.isNullOrEmpty(desired.getAvailabilityZone()) && desired.getMultiAZ());
+                (StringUtils.isNullOrEmpty(desired.getAvailabilityZone()) && BooleanUtils.isTrue(desired.getMultiAZ()));
     }
 
     private static boolean isReadReplicaPromotion(final ResourceModel previous, final ResourceModel desired) {

--- a/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/util/ImmutabilityHelperTest.java
+++ b/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/util/ImmutabilityHelperTest.java
@@ -237,4 +237,30 @@ class ImmutabilityHelperTest {
             assertThat(ImmutabilityHelper.isChangeMutable(test.previous, test.desired)).isEqualTo(test.expect);
         }
     }
+
+    @Test
+    public void test_isAvailabilityZoneMutable_RemoveAvailabilityZoneAttributeMultiAZ() {
+        final ResourceModel previous = ResourceModel.builder()
+                .availabilityZone("test-availability-zone")
+                .multiAZ(true)
+                .build();
+        final ResourceModel desired = ResourceModel.builder()
+                .availabilityZone(null)
+                .multiAZ(true)
+                .build();
+        assertThat(ImmutabilityHelper.isAvailabilityZoneChangeMutable(previous, desired)).isTrue();
+    }
+
+    @Test
+    public void test_isAvailabilityZoneMutable_RemoveAvailabilityZoneAttributeNoMultiAZ() {
+        final ResourceModel previous = ResourceModel.builder()
+                .availabilityZone("test-availability-zone")
+                .multiAZ(null)
+                .build();
+        final ResourceModel desired = ResourceModel.builder()
+                .availabilityZone(null)
+                .multiAZ(null)
+                .build();
+        assertThat(ImmutabilityHelper.isAvailabilityZoneChangeMutable(previous, desired)).isFalse();
+    }
 }


### PR DESCRIPTION
This commit addresses a null-pointer exception in `ImmutabilityHelper.isAvailabilityZoneChangeMutable` that might occur if `DBInstance.MultiAZ` is not provided and the handler attempts to alter the instance's `AvailabilityZone` attribute. The commit adds a `BooleanUtils` safety guard to ensure no null-deref would occur.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Signed-off-by: Oleg Sidorov <sidorovo@amazon.com>

