### PR TITLE
[Common] Implement Drift Detector Test Helper

### DIFF
--- a/aws-rds-cfn-test-common/pom.xml
+++ b/aws-rds-cfn-test-common/pom.xml
@@ -60,6 +60,12 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
+            <groupId>com.ibm.jsonata4java</groupId>
+            <artifactId>JSONata4Java</artifactId>
+            <version>2.2.5</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-junit-jupiter</artifactId>
             <version>4.3.1</version>

--- a/aws-rds-cfn-test-common/src/main/java/software/amazon/rds/test/common/schema/ResourceDriftTestHelper.java
+++ b/aws-rds-cfn-test-common/src/main/java/software/amazon/rds/test/common/schema/ResourceDriftTestHelper.java
@@ -1,0 +1,139 @@
+package software.amazon.rds.test.common.schema;
+
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.util.Objects;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+import org.assertj.core.api.Assertions;
+import org.json.JSONObject;
+
+import com.api.jsonata4java.expressions.EvaluateException;
+import com.api.jsonata4java.expressions.Expressions;
+import com.api.jsonata4java.expressions.ParseException;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableSet;
+
+public class ResourceDriftTestHelper {
+
+    private final static Set<Class<?>> primitiveTypes = ImmutableSet.of(
+            Integer.class,
+            String.class,
+            Boolean.class
+    );
+
+    private static final String PROPERTIES = "/properties";
+    private static final String PROPERTY_OR_SPLIT_REGEX = "\\s+\\$OR\\s+";
+    private static final String PROPERTY_PATH_SEPARATOR = "/";
+
+    public static void assertResourceNotDrifted(
+            final Object input,
+            final Object output,
+            final JSONObject resourceSchema
+    ) {
+        assertResourceNotDrifted(input, output, resourceSchema, PROPERTIES);
+    }
+
+    public static void assertResourceNotDrifted(
+            final Object input,
+            final Object output,
+            final JSONObject resourceSchema,
+            final String basePath
+    ) {
+        if (input == null || output == null) {
+            Assertions.assertThat(input).isEqualTo(output);
+            return;
+        }
+        Assertions.assertThat(input).hasSameClassAs(output);
+
+        final JSONObject propertyTransformMap = resourceSchema.getJSONObject("propertyTransform");
+        final ObjectMapper objectMapper = new ObjectMapper();
+
+        JsonNode inputJsonNode = null;
+        try {
+            // JSONata accepts JsonNode as an input. The easiest way to get a JsonNode from an object
+            // is to convert it to a string and parse immediately.
+            inputJsonNode = objectMapper.readTree(objectMapper.writeValueAsString(input));
+        } catch (JsonProcessingException e) {
+            Assertions.fail(e.getMessage());
+        }
+
+        final Field[] fields = input.getClass().getDeclaredFields();
+
+        NextField:
+        for (final Field field : fields) {
+            // This code assumes that all data fields will have a @JsonProperty annotation.
+            final JsonProperty annotation = field.getAnnotation(JsonProperty.class);
+            if (annotation == null) {
+                continue;
+            }
+            final String fieldName = annotation.value();
+            field.setAccessible(true);
+            Object inputFieldVal = null;
+            Object outputFieldVal = null;
+            try {
+                inputFieldVal = field.get(input);
+                outputFieldVal = field.get(output);
+            } catch (IllegalAccessException e) {
+                Assertions.fail(e.getMessage());
+            }
+            if (Objects.equals(inputFieldVal, outputFieldVal)) {
+                continue;
+            }
+            final String propertyTransformPath = basePath + PROPERTY_PATH_SEPARATOR + fieldName;
+            if (!primitiveTypes.contains(field.getType())) {
+                assertResourceNotDrifted(inputFieldVal, outputFieldVal, resourceSchema, propertyTransformPath);
+                continue;
+            }
+            final String propertyTransform = propertyTransformMap.getString(propertyTransformPath);
+            if (propertyTransform != null) {
+                // $OR is a CFN-specific feature. We need to split the expression into or-expressions and test
+                // the results independently. The test passes if any of these alternative variants match.
+                final String[] orExprs = propertyTransform.split(PROPERTY_OR_SPLIT_REGEX);
+                for (final String expr : orExprs) {
+                    JsonNode altInputFieldVal = null;
+                    try {
+                        final Expressions compiledExpr = Expressions.parse(expr);
+                        altInputFieldVal = compiledExpr.evaluate(inputJsonNode);
+                    } catch (ParseException | IOException | EvaluateException e) {
+                        Assertions.fail(e.getMessage());
+                    }
+
+                    // Boolean and Integer are going to be tested as is: no regexp.
+                    if (outputFieldVal instanceof Boolean) {
+                        if (Objects.equals(altInputFieldVal.asBoolean(), outputFieldVal)) {
+                            continue NextField;
+                        }
+                        break;
+                    }
+
+                    if (outputFieldVal instanceof Integer) {
+                        if (Objects.equals(altInputFieldVal.asInt(), outputFieldVal)) {
+                            continue NextField;
+                        }
+                        break;
+                    }
+
+                    // Please review the contents of primitiveClasses if this assertion fails. The failing field type
+                    // might require a separate comparator.
+                    if (!(outputFieldVal instanceof String)) {
+                        Assertions.fail("Unhandled field type: %s", field.getClass().getName());
+                    }
+
+                    // JSONata would return a string evaluation result in quotes, e.g "\"result\"", we need to strip it.
+                    final String transformedVal = altInputFieldVal.toString().replaceAll("^\"|\"$", "");
+                    // Add regexp anchors to avoid loose comparisons.
+                    final Pattern pattern = Pattern.compile("^" + transformedVal + "$");
+                    if (pattern.matcher((String) outputFieldVal).matches()) {
+                        continue NextField;
+                    }
+                }
+            }
+            Assertions.fail("Field %s drifted: input: %s, output: %s", fieldName, inputFieldVal, outputFieldVal);
+        }
+    }
+}

--- a/aws-rds-cfn-test-common/src/test/java/software/amazon/rds/test/common/schema/ResourceDriftTestHelperTest.java
+++ b/aws-rds-cfn-test-common/src/test/java/software/amazon/rds/test/common/schema/ResourceDriftTestHelperTest.java
@@ -1,0 +1,225 @@
+package software.amazon.rds.test.common.schema;
+
+import org.assertj.core.api.Assertions;
+import org.json.JSONObject;
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+
+class ResourceDriftTestHelperTest {
+
+    private final static JSONObject RESOURCE_SCHEMA = new JSONObject("{" +
+            "\"propertyTransform\": {" +
+            "\"/properties/BoolProperty\": \"BoolProperty or true\"," +
+            "\"/properties/IntegerProperty\": \"IntegerProperty * IntegerProperty\"," +
+            "\"/properties/StringProperty\": \"$lowercase(StringProperty)\"," +
+            "\"/properties/NestedObject/StringProperty\": \"$join([StringProperty, '-pass'])\"" +
+            "}" +
+            "}");
+
+    @Builder
+    static class TestDataClass {
+        @JsonProperty(value = "BoolProperty")
+        private final Boolean boolProperty;
+
+        @JsonProperty(value = "IntegerProperty")
+        private final Integer integerProperty;
+
+        @JsonProperty(value = "StringProperty")
+        private final String stringProperty;
+
+        @JsonProperty(value = "NestedObject")
+        private final TestDataClass nestedObject;
+    }
+
+    @Test
+    public void test_assertResourceNotDrifted_NullVsNull() {
+        ResourceDriftTestHelper.assertResourceNotDrifted(null, null, RESOURCE_SCHEMA);
+    }
+
+    @Test
+    public void test_assertResourceNotDrifted_NullVsNonNull_Drifted() {
+        Assertions.assertThatThrownBy(() -> {
+            ResourceDriftTestHelper.assertResourceNotDrifted(null, 42, RESOURCE_SCHEMA);
+        }).isInstanceOf(AssertionError.class);
+    }
+
+    @Test
+    public void test_assertResourceNotDrifted_NonNullVsNull_Drifted() {
+        Assertions.assertThatThrownBy(() -> {
+            ResourceDriftTestHelper.assertResourceNotDrifted(42, null, RESOURCE_SCHEMA);
+        }).isInstanceOf(AssertionError.class);
+    }
+
+    @Test
+    public void test_assertResourceNotDrifted_BooleanVsBoolean() {
+        ResourceDriftTestHelper.assertResourceNotDrifted(true, true, RESOURCE_SCHEMA);
+    }
+
+    @Test
+    public void test_assertResourceNotDrifted_IntegerVsInteger() {
+        ResourceDriftTestHelper.assertResourceNotDrifted(42, 42, RESOURCE_SCHEMA);
+    }
+
+    @Test
+    public void test_assertResourceNotDrifted_StringVsString() {
+        ResourceDriftTestHelper.assertResourceNotDrifted("test-string", "test-string", RESOURCE_SCHEMA);
+    }
+
+    @Test
+    public void test_assertResourceNotDrifted_CompareBoolProperty_TrueVsTrue() {
+        final TestDataClass input = TestDataClass.builder()
+                .boolProperty(true)
+                .build();
+        final TestDataClass output = TestDataClass.builder()
+                .boolProperty(true)
+                .build();
+        ResourceDriftTestHelper.assertResourceNotDrifted(input, output, RESOURCE_SCHEMA);
+    }
+
+    @Test
+    public void test_assertResourceNotDrifted_CompareBoolProperty_FalseVsFalse() {
+        final TestDataClass input = TestDataClass.builder()
+                .boolProperty(false)
+                .build();
+        final TestDataClass output = TestDataClass.builder()
+                .boolProperty(false)
+                .build();
+        ResourceDriftTestHelper.assertResourceNotDrifted(input, output, RESOURCE_SCHEMA);
+    }
+
+    // This test uses the following propertyTransform from RESOURCE_SCHEMA: BoolProperty or true
+    // The output would be compared to the input directly: true Vs false and to the transformed value: true Vs true.
+    @Test
+    public void test_assertResourceNotDrifted_CompareBoolProperty_FalseVsTrue_EvalPropertyTransform() {
+        final TestDataClass input = TestDataClass.builder()
+                .boolProperty(false)
+                .build();
+        final TestDataClass output = TestDataClass.builder()
+                .boolProperty(true)
+                .build();
+        ResourceDriftTestHelper.assertResourceNotDrifted(input, output, RESOURCE_SCHEMA);
+    }
+
+    // In this test input value true would mismatch the output value false.
+    // PropertyTransform would evaluate: BoolProperty(true) or true -> true.
+    // This value still mismatches with the output, so the assertion fails.
+    @Test
+    public void test_assertResourceNotDrifted_CompareBoolProperty_TrueVsFalse_EvalPropertyTransform_Drifted() {
+        final TestDataClass input = TestDataClass.builder()
+                .boolProperty(true)
+                .build();
+        final TestDataClass output = TestDataClass.builder()
+                .boolProperty(false)
+                .build();
+        Assertions.assertThatThrownBy(() -> {
+            ResourceDriftTestHelper.assertResourceNotDrifted(input, output, RESOURCE_SCHEMA);
+        }).isInstanceOf(AssertionError.class);
+    }
+
+    @Test
+    public void test_assertResourceNotDrifted_CompareIntegerProperty_SameValue() {
+        final TestDataClass input = TestDataClass.builder()
+                .integerProperty(42)
+                .build();
+        final TestDataClass output = TestDataClass.builder()
+                .integerProperty(42)
+                .build();
+        ResourceDriftTestHelper.assertResourceNotDrifted(input, output, RESOURCE_SCHEMA);
+    }
+
+    @Test
+    public void test_assertResourceNotDrifted_CompareIntegerProperty_EvalPropertyTransform() {
+        final TestDataClass input = TestDataClass.builder()
+                .integerProperty(16)
+                .build();
+        final TestDataClass output = TestDataClass.builder()
+                .integerProperty(256)
+                .build();
+        ResourceDriftTestHelper.assertResourceNotDrifted(input, output, RESOURCE_SCHEMA);
+    }
+
+    @Test
+    public void test_assertResourceNotDrifted_CompareIntegerProperty_EvalPropertyTransform_Drifted() {
+        final TestDataClass input = TestDataClass.builder()
+                .integerProperty(16)
+                .build();
+        final TestDataClass output = TestDataClass.builder()
+                .integerProperty(17)
+                .build();
+        Assertions.assertThatThrownBy(() -> {
+            ResourceDriftTestHelper.assertResourceNotDrifted(input, output, RESOURCE_SCHEMA);
+        }).isInstanceOf(AssertionError.class);
+    }
+
+    @Test
+    public void test_assertResourceNotDrifted_CompareStringProperty_SameValue() {
+        final TestDataClass input = TestDataClass.builder()
+                .stringProperty("TestString")
+                .build();
+        final TestDataClass output = TestDataClass.builder()
+                .stringProperty("TestString")
+                .build();
+        ResourceDriftTestHelper.assertResourceNotDrifted(input, output, RESOURCE_SCHEMA);
+    }
+
+    @Test
+    public void test_assertResourceNotDrifted_CompareStringProperty_EvalPropertyTransform() {
+        final TestDataClass input = TestDataClass.builder()
+                .stringProperty("TestString")
+                .build();
+        final TestDataClass output = TestDataClass.builder()
+                .stringProperty("teststring")
+                .build();
+        ResourceDriftTestHelper.assertResourceNotDrifted(input, output, RESOURCE_SCHEMA);
+    }
+
+    @Test
+    public void test_assertResourceNotDrifted_CompareStringProperty_EvalPropertyTransform_Drifted() {
+        final TestDataClass input = TestDataClass.builder()
+                .stringProperty("TestString")
+                .build();
+        final TestDataClass output = TestDataClass.builder()
+                .stringProperty("teststring123")
+                .build();
+        Assertions.assertThatThrownBy(() -> {
+            ResourceDriftTestHelper.assertResourceNotDrifted(input, output, RESOURCE_SCHEMA);
+        }).isInstanceOf(AssertionError.class);
+    }
+
+    @Test
+    public void test_assertResourceNotDrifted_CompareNestedObject_SameValue() {
+        final TestDataClass input = TestDataClass.builder()
+                .nestedObject(TestDataClass.builder().stringProperty("test-string").build())
+                .build();
+        final TestDataClass output = TestDataClass.builder()
+                .nestedObject(TestDataClass.builder().stringProperty("test-string").build())
+                .build();
+        ResourceDriftTestHelper.assertResourceNotDrifted(input, output, RESOURCE_SCHEMA);
+    }
+
+    @Test
+    public void test_assertResourceNotDrifted_CompareNestedObject_EvalPropertyTransform() {
+        final TestDataClass input = TestDataClass.builder()
+                .nestedObject(TestDataClass.builder().stringProperty("test-string").build())
+                .build();
+        final TestDataClass output = TestDataClass.builder()
+                .nestedObject(TestDataClass.builder().stringProperty("test-string-pass").build())
+                .build();
+        ResourceDriftTestHelper.assertResourceNotDrifted(input, output, RESOURCE_SCHEMA);
+    }
+
+    @Test
+    public void test_assertResourceNotDrifted_CompareNestedObject_EvalPropertyTransform_Drifted() {
+        final TestDataClass input = TestDataClass.builder()
+                .nestedObject(TestDataClass.builder().stringProperty("test-string").build())
+                .build();
+        final TestDataClass output = TestDataClass.builder()
+                .nestedObject(TestDataClass.builder().stringProperty("test-string-no-pass").build())
+                .build();
+        Assertions.assertThatThrownBy(() -> {
+            ResourceDriftTestHelper.assertResourceNotDrifted(input, output, RESOURCE_SCHEMA);
+        }).isInstanceOf(AssertionError.class);
+    }
+}

--- a/aws-rds-dbcluster/aws-rds-dbcluster.json
+++ b/aws-rds-dbcluster/aws-rds-dbcluster.json
@@ -400,7 +400,9 @@
     "/properties/DBSubnetGroupName": "$lowercase(DBSubnetGroupName)",
     "/properties/SnapshotIdentifier": "$lowercase(SnapshotIdentifier)",
     "/properties/SourceDBClusterIdentifier": "$lowercase(SourceDBClusterIdentifier)",
-    "/properties/MasterUserSecret/KmsKeyId": "$join([\"arn:(aws)[-]{0,1}[a-z]{0,2}[-]{0,1}[a-z]{0,3}:kms:[a-z]{2}[-]{1}[a-z]{3,10}[-]{0,1}[a-z]{0,10}[-]{1}[1-3]{1}:[0-9]{12}[:]{1}key\\/\", KMSKeyId])"
+    "/properties/MasterUserSecret/KmsKeyId": "$join([\"arn:(aws)[-]{0,1}[a-z]{0,2}[-]{0,1}[a-z]{0,3}:kms:[a-z]{2}[-]{1}[a-z]{3,10}[-]{0,1}[a-z]{0,10}[-]{1}[1-3]{1}:[0-9]{12}[:]{1}key\\/\", KmsKeyId])",
+    "/properties/KmsKeyId": "$join([\"arn:(aws)[-]{0,1}[a-z]{0,2}[-]{0,1}[a-z]{0,3}:kms:[a-z]{2}[-]{1}[a-z]{3,10}[-]{0,1}[a-z]{0,10}[-]{1}[1-3]{1}:[0-9]{12}[:]{1}key\\/\", KmsKeyId])",
+    "/properties/PerformanceInsightsKmsKeyId": "$join([\"arn:(aws)[-]{0,1}[a-z]{0,2}[-]{0,1}[a-z]{0,3}:kms:[a-z]{2}[-]{1}[a-z]{3,10}[-]{0,1}[a-z]{0,10}[-]{1}[1-3]{1}:[0-9]{12}[:]{1}key\\/\", PerformanceInsightsKmsKeyId])"
   },
   "readOnlyProperties": [
     "/properties/DBClusterArn",

--- a/aws-rds-dbcluster/src/test/java/software/amazon/rds/dbcluster/SchemaTest.java
+++ b/aws-rds-dbcluster/src/test/java/software/amazon/rds/dbcluster/SchemaTest.java
@@ -1,0 +1,108 @@
+package software.amazon.rds.dbcluster;
+
+import org.json.JSONObject;
+import org.junit.jupiter.api.Test;
+
+import software.amazon.rds.test.common.schema.ResourceDriftTestHelper;
+
+public class SchemaTest {
+
+    private static final JSONObject resourceSchema = new Configuration().resourceSchemaJsonObject();
+
+    @Test
+    public void testDrift_DBClusterIdentifier_Lowercase() {
+        final ResourceModel input = ResourceModel.builder()
+                .dBClusterIdentifier("DBClusterIdentifier")
+                .build();
+        final ResourceModel output = ResourceModel.builder()
+                .dBClusterIdentifier("dbclusteridentifier")
+                .build();
+
+        ResourceDriftTestHelper.assertResourceNotDrifted(input, output, resourceSchema);
+    }
+
+    @Test
+    public void testDrift_DBClusterParameterGroupName_Lowercase() {
+        final ResourceModel input = ResourceModel.builder()
+                .dBClusterParameterGroupName("DBClusterParameterGroupName")
+                .build();
+        final ResourceModel output = ResourceModel.builder()
+                .dBClusterParameterGroupName("dbclusterparametergroupname")
+                .build();
+
+        ResourceDriftTestHelper.assertResourceNotDrifted(input, output, resourceSchema);
+    }
+
+    @Test
+    public void testDrift_DBSubnetGroupName_Lowercase() {
+        final ResourceModel input = ResourceModel.builder()
+                .dBSubnetGroupName("DBSubnetGroupName")
+                .build();
+        final ResourceModel output = ResourceModel.builder()
+                .dBSubnetGroupName("dbsubnetgroupname")
+                .build();
+
+        ResourceDriftTestHelper.assertResourceNotDrifted(input, output, resourceSchema);
+    }
+
+    @Test
+    public void testDrift_SnapshotIdentifier_Lowercase() {
+        final ResourceModel input = ResourceModel.builder()
+                .snapshotIdentifier("SnapshotIdentifier")
+                .build();
+        final ResourceModel output = ResourceModel.builder()
+                .snapshotIdentifier("snapshotidentifier")
+                .build();
+
+        ResourceDriftTestHelper.assertResourceNotDrifted(input, output, resourceSchema);
+    }
+
+    @Test
+    public void testDrift_SourceDBClusterIdentifier_Lowercase() {
+        final ResourceModel input = ResourceModel.builder()
+                .sourceDBClusterIdentifier("SourceDBClusterIdentifier")
+                .build();
+        final ResourceModel output = ResourceModel.builder()
+                .sourceDBClusterIdentifier("sourcedbclusteridentifier")
+                .build();
+
+        ResourceDriftTestHelper.assertResourceNotDrifted(input, output, resourceSchema);
+    }
+
+    @Test
+    public void testDrift_KmsKeyId_ExpandArn() {
+        final ResourceModel input = ResourceModel.builder()
+                .kmsKeyId("test-kms-key-id")
+                .build();
+        final ResourceModel output = ResourceModel.builder()
+                .kmsKeyId("arn:aws:kms:us-east-1:123456789012:key/test-kms-key-id")
+                .build();
+        ResourceDriftTestHelper.assertResourceNotDrifted(input, output, resourceSchema);
+    }
+
+    @Test
+    public void testDrift_PerformanceInsightsKmsKeyId_ExpandArn() {
+        final ResourceModel input = ResourceModel.builder()
+                .performanceInsightsKmsKeyId("test-kms-key-id")
+                .build();
+        final ResourceModel output = ResourceModel.builder()
+                .performanceInsightsKmsKeyId("arn:aws:kms:us-east-1:123456789012:key/test-kms-key-id")
+                .build();
+        ResourceDriftTestHelper.assertResourceNotDrifted(input, output, resourceSchema);
+    }
+
+    @Test
+    public void testDrift_MasterUserSecret_KmsKeyId_ExpandArn() {
+        final ResourceModel input = ResourceModel.builder()
+                .masterUserSecret(MasterUserSecret.builder()
+                        .kmsKeyId("test-kms-key-id")
+                        .build())
+                .build();
+        final ResourceModel output = ResourceModel.builder()
+                .masterUserSecret(MasterUserSecret.builder()
+                        .kmsKeyId("arn:aws:kms:us-east-1:123456789012:key/test-kms-key-id")
+                        .build())
+                .build();
+        ResourceDriftTestHelper.assertResourceNotDrifted(input, output, resourceSchema);
+    }
+}

--- a/aws-rds-dbclusterendpoint/src/main/java/software/amazon/rds/dbclusterendpoint/Configuration.java
+++ b/aws-rds-dbclusterendpoint/src/main/java/software/amazon/rds/dbclusterendpoint/Configuration.java
@@ -1,8 +1,15 @@
 package software.amazon.rds.dbclusterendpoint;
 
+import org.json.JSONObject;
+import org.json.JSONTokener;
+
 class Configuration extends BaseConfiguration {
 
     public Configuration() {
         super("aws-rds-dbclusterendpoint.json");
+    }
+
+    public JSONObject resourceSchemaJsonObject() {
+        return new JSONObject(new JSONTokener(this.getClass().getClassLoader().getResourceAsStream(schemaFilename)));
     }
 }

--- a/aws-rds-dbclusterendpoint/src/test/java/software/amazon/rds/dbclusterendpoint/SchemaTest.java
+++ b/aws-rds-dbclusterendpoint/src/test/java/software/amazon/rds/dbclusterendpoint/SchemaTest.java
@@ -1,0 +1,35 @@
+package software.amazon.rds.dbclusterendpoint;
+
+import org.json.JSONObject;
+import org.junit.jupiter.api.Test;
+
+import software.amazon.rds.test.common.schema.ResourceDriftTestHelper;
+
+public class SchemaTest {
+
+    private static final JSONObject resourceSchema = new Configuration().resourceSchemaJsonObject();
+
+    @Test
+    public void testDrift_DBClusterIdentifier_Lowercase() {
+        final ResourceModel input = ResourceModel.builder()
+                .dBClusterIdentifier("DBClusterIdentifier")
+                .build();
+        final ResourceModel output = ResourceModel.builder()
+                .dBClusterIdentifier("dbclusteridentifier")
+                .build();
+
+        ResourceDriftTestHelper.assertResourceNotDrifted(input, output, resourceSchema);
+    }
+
+    @Test
+    public void testDrift_DBClusterEndpointIdentifier_Lowercase() {
+        final ResourceModel input = ResourceModel.builder()
+                .dBClusterEndpointIdentifier("DBClusterEndpointIdentifier")
+                .build();
+        final ResourceModel output = ResourceModel.builder()
+                .dBClusterEndpointIdentifier("dbclusterendpointidentifier")
+                .build();
+
+        ResourceDriftTestHelper.assertResourceNotDrifted(input, output, resourceSchema);
+    }
+}

--- a/aws-rds-dbclusterparametergroup/src/main/java/software/amazon/rds/dbclusterparametergroup/Configuration.java
+++ b/aws-rds-dbclusterparametergroup/src/main/java/software/amazon/rds/dbclusterparametergroup/Configuration.java
@@ -14,7 +14,7 @@ class Configuration extends BaseConfiguration {
         super("aws-rds-dbclusterparametergroup.json");
     }
 
-    public JSONObject resourceSchemaJSONObject() {
+    public JSONObject resourceSchemaJsonObject() {
         return new JSONObject(new JSONTokener(this.getClass().getClassLoader().getResourceAsStream(schemaFilename)));
     }
 

--- a/aws-rds-dbclusterparametergroup/src/test/java/software/amazon/rds/dbclusterparametergroup/SchemaTest.java
+++ b/aws-rds-dbclusterparametergroup/src/test/java/software/amazon/rds/dbclusterparametergroup/SchemaTest.java
@@ -1,0 +1,23 @@
+package software.amazon.rds.dbclusterparametergroup;
+
+import org.json.JSONObject;
+import org.junit.jupiter.api.Test;
+
+import software.amazon.rds.test.common.schema.ResourceDriftTestHelper;
+
+public class SchemaTest {
+
+    private static final JSONObject resourceSchema = new Configuration().resourceSchemaJsonObject();
+
+    @Test
+    public void testDrift_DBClusterParameterGroupName_Lowercase() {
+        final ResourceModel input = ResourceModel.builder()
+                .dBClusterParameterGroupName("DBClusterParameterGroupName")
+                .build();
+        final ResourceModel output = ResourceModel.builder()
+                .dBClusterParameterGroupName("dbclusterparametergroupname")
+                .build();
+
+        ResourceDriftTestHelper.assertResourceNotDrifted(input, output, resourceSchema);
+    }
+}

--- a/aws-rds-dbinstance/aws-rds-dbinstance.json
+++ b/aws-rds-dbinstance/aws-rds-dbinstance.json
@@ -447,7 +447,9 @@
     "/properties/OptionGroupName": "$lowercase(OptionGroupName)",
     "/properties/SourceDBInstanceAutomatedBackupsArn": "$lowercase(SourceDBInstanceAutomatedBackupsArn)",
     "/properties/SourceDBInstanceIdentifier": "$lowercase(SourceDBInstanceIdentifier)",
-    "/properties/MasterUserSecret/KmsKeyId": "$join([\"arn:(aws)[-]{0,1}[a-z]{0,2}[-]{0,1}[a-z]{0,3}:kms:[a-z]{2}[-]{1}[a-z]{3,10}[-]{0,1}[a-z]{0,10}[-]{1}[1-3]{1}:[0-9]{12}[:]{1}key\\/\", KMSKeyId])"
+    "/properties/MasterUserSecret/KmsKeyId": "$join([\"arn:(aws)[-]{0,1}[a-z]{0,2}[-]{0,1}[a-z]{0,3}:kms:[a-z]{2}[-]{1}[a-z]{3,10}[-]{0,1}[a-z]{0,10}[-]{1}[1-3]{1}:[0-9]{12}[:]{1}key\\/\", KmsKeyId])",
+    "/properties/KmsKeyId": "$join([\"arn:(aws)[-]{0,1}[a-z]{0,2}[-]{0,1}[a-z]{0,3}:kms:[a-z]{2}[-]{1}[a-z]{3,10}[-]{0,1}[a-z]{0,10}[-]{1}[1-3]{1}:[0-9]{12}[:]{1}key\\/\", KmsKeyId])",
+    "/properties/PerformanceInsightsKMSKeyId": "$join([\"arn:(aws)[-]{0,1}[a-z]{0,2}[-]{0,1}[a-z]{0,3}:kms:[a-z]{2}[-]{1}[a-z]{3,10}[-]{0,1}[a-z]{0,10}[-]{1}[1-3]{1}:[0-9]{12}[:]{1}key\\/\", PerformanceInsightsKMSKeyId])"
   },
   "createOnlyProperties": [
     "/properties/CharacterSetName",

--- a/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/SchemaTest.java
+++ b/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/SchemaTest.java
@@ -1,0 +1,156 @@
+package software.amazon.rds.dbinstance;
+
+import org.json.JSONObject;
+import org.junit.jupiter.api.Test;
+
+import software.amazon.rds.test.common.schema.ResourceDriftTestHelper;
+
+public class SchemaTest {
+
+    private static final JSONObject resourceSchema = new Configuration().resourceSchemaJsonObject();
+
+    @Test
+    public void testDrift_DBClusterIdentifier_Lowercase() {
+        final ResourceModel input = ResourceModel.builder()
+                .dBClusterIdentifier("DBClusterIdentifier")
+                .build();
+        final ResourceModel output = ResourceModel.builder()
+                .dBClusterIdentifier("dbclusteridentifier")
+                .build();
+
+        ResourceDriftTestHelper.assertResourceNotDrifted(input, output, resourceSchema);
+    }
+
+    @Test
+    public void testDrift_DBClusterSnapshotIdentifier_Lowercase() {
+        final ResourceModel input = ResourceModel.builder()
+                .dBClusterIdentifier("DBClusterSnapshotIdentifier")
+                .build();
+        final ResourceModel output = ResourceModel.builder()
+                .dBClusterIdentifier("dbclustersnapshotidentifier")
+                .build();
+
+        ResourceDriftTestHelper.assertResourceNotDrifted(input, output, resourceSchema);
+    }
+
+    @Test
+    public void testDrift_DBInstanceIdentifier_Lowercase() {
+        final ResourceModel input = ResourceModel.builder()
+                .dBInstanceIdentifier("DBInstanceIdentifier")
+                .build();
+        final ResourceModel output = ResourceModel.builder()
+                .dBInstanceIdentifier("dbinstanceidentifier")
+                .build();
+
+        ResourceDriftTestHelper.assertResourceNotDrifted(input, output, resourceSchema);
+    }
+
+    @Test
+    public void testDrift_DBParameterGroupName_Lowercase() {
+        final ResourceModel input = ResourceModel.builder()
+                .dBParameterGroupName("DBParameterGroupName")
+                .build();
+        final ResourceModel output = ResourceModel.builder()
+                .dBParameterGroupName("dbparametergroupname")
+                .build();
+
+        ResourceDriftTestHelper.assertResourceNotDrifted(input, output, resourceSchema);
+    }
+
+    @Test
+    public void testDrift_DBSubnetGroupName_Lowercase() {
+        final ResourceModel input = ResourceModel.builder()
+                .dBSubnetGroupName("DBSubnetGroupName")
+                .build();
+        final ResourceModel output = ResourceModel.builder()
+                .dBSubnetGroupName("dbsubnetgroupname")
+                .build();
+
+        ResourceDriftTestHelper.assertResourceNotDrifted(input, output, resourceSchema);
+    }
+
+    @Test
+    public void testDrift_DBSnapshotIdentifier_Lowercase() {
+        final ResourceModel input = ResourceModel.builder()
+                .dBSnapshotIdentifier("DBSnapshotIdentifier")
+                .build();
+        final ResourceModel output = ResourceModel.builder()
+                .dBSnapshotIdentifier("dbsnapshotidentifier")
+                .build();
+
+        ResourceDriftTestHelper.assertResourceNotDrifted(input, output, resourceSchema);
+    }
+
+    @Test
+    public void testDrift_OptionGroupName_Lowercase() {
+        final ResourceModel input = ResourceModel.builder()
+                .optionGroupName("OptionGroupName")
+                .build();
+        final ResourceModel output = ResourceModel.builder()
+                .optionGroupName("optiongroupname")
+                .build();
+
+        ResourceDriftTestHelper.assertResourceNotDrifted(input, output, resourceSchema);
+    }
+
+    @Test
+    public void testDrift_SourceDBInstanceAutomatedBackupsArn_Lowercase() {
+        final ResourceModel input = ResourceModel.builder()
+                .optionGroupName("SourceDBInstanceAutomatedBackupsArn")
+                .build();
+        final ResourceModel output = ResourceModel.builder()
+                .optionGroupName("sourcedbinstanceautomatedbackupsarn")
+                .build();
+
+        ResourceDriftTestHelper.assertResourceNotDrifted(input, output, resourceSchema);
+    }
+
+    @Test
+    public void testDrift_SourceDBInstanceIdentifier_Lowercase() {
+        final ResourceModel input = ResourceModel.builder()
+                .sourceDBInstanceIdentifier("SourceDBInstanceIdentifier")
+                .build();
+        final ResourceModel output = ResourceModel.builder()
+                .sourceDBInstanceIdentifier("sourcedbinstanceidentifier")
+                .build();
+
+        ResourceDriftTestHelper.assertResourceNotDrifted(input, output, resourceSchema);
+    }
+
+    @Test
+    public void testDrift_KmsKeyId_ExpandArn() {
+        final ResourceModel input = ResourceModel.builder()
+                .kmsKeyId("test-kms-key-id")
+                .build();
+        final ResourceModel output = ResourceModel.builder()
+                .kmsKeyId("arn:aws:kms:us-east-1:123456789012:key/test-kms-key-id")
+                .build();
+        ResourceDriftTestHelper.assertResourceNotDrifted(input, output, resourceSchema);
+    }
+
+    @Test
+    public void testDrift_PerformanceInsightsKMSKeyId_ExpandArn() {
+        final ResourceModel input = ResourceModel.builder()
+                .performanceInsightsKMSKeyId("test-kms-key-id")
+                .build();
+        final ResourceModel output = ResourceModel.builder()
+                .performanceInsightsKMSKeyId("arn:aws:kms:us-east-1:123456789012:key/test-kms-key-id")
+                .build();
+        ResourceDriftTestHelper.assertResourceNotDrifted(input, output, resourceSchema);
+    }
+
+    @Test
+    public void testDrift_MasterUserSecret_KmsKeyId_ExpandArn() {
+        final ResourceModel input = ResourceModel.builder()
+                .masterUserSecret(MasterUserSecret.builder()
+                        .kmsKeyId("test-kms-key-id")
+                        .build())
+                .build();
+        final ResourceModel output = ResourceModel.builder()
+                .masterUserSecret(MasterUserSecret.builder()
+                        .kmsKeyId("arn:aws:kms:us-east-1:123456789012:key/test-kms-key-id")
+                        .build())
+                .build();
+        ResourceDriftTestHelper.assertResourceNotDrifted(input, output, resourceSchema);
+    }
+}

--- a/aws-rds-dbparametergroup/src/test/java/software/amazon/rds/dbparametergroup/SchemaTest.java
+++ b/aws-rds-dbparametergroup/src/test/java/software/amazon/rds/dbparametergroup/SchemaTest.java
@@ -1,0 +1,23 @@
+package software.amazon.rds.dbparametergroup;
+
+import org.json.JSONObject;
+import org.junit.jupiter.api.Test;
+
+import software.amazon.rds.test.common.schema.ResourceDriftTestHelper;
+
+public class SchemaTest {
+
+    private static final JSONObject resourceSchema = new Configuration().resourceSchemaJsonObject();
+
+    @Test
+    public void testDrift_DBParameterGroupName_Lowercase() {
+        final ResourceModel input = ResourceModel.builder()
+                .dBParameterGroupName("DBParameterGroupName")
+                .build();
+        final ResourceModel output = ResourceModel.builder()
+                .dBParameterGroupName("dbparametergroupname")
+                .build();
+
+        ResourceDriftTestHelper.assertResourceNotDrifted(input, output, resourceSchema);
+    }
+}

--- a/aws-rds-dbsubnetgroup/src/main/java/software/amazon/rds/dbsubnetgroup/Configuration.java
+++ b/aws-rds-dbsubnetgroup/src/main/java/software/amazon/rds/dbsubnetgroup/Configuration.java
@@ -4,12 +4,19 @@ package software.amazon.rds.dbsubnetgroup;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.json.JSONObject;
+import org.json.JSONTokener;
+
 import com.amazonaws.util.CollectionUtils;
 
 class Configuration extends BaseConfiguration {
 
     public Configuration() {
         super("aws-rds-dbsubnetgroup.json");
+    }
+
+    public JSONObject resourceSchemaJsonObject() {
+        return new JSONObject(new JSONTokener(this.getClass().getClassLoader().getResourceAsStream(schemaFilename)));
     }
 
     public Map<String, String> resourceDefinedTags(final ResourceModel model) {

--- a/aws-rds-dbsubnetgroup/src/test/java/software/amazon/rds/dbsubnetgroup/SchemaTest.java
+++ b/aws-rds-dbsubnetgroup/src/test/java/software/amazon/rds/dbsubnetgroup/SchemaTest.java
@@ -1,0 +1,22 @@
+package software.amazon.rds.dbsubnetgroup;
+
+import org.json.JSONObject;
+import org.junit.jupiter.api.Test;
+
+import software.amazon.rds.test.common.schema.ResourceDriftTestHelper;
+
+public class SchemaTest {
+    private static final JSONObject resourceSchema = new Configuration().resourceSchemaJsonObject();
+
+    @Test
+    public void testDrift_DBSubnetGroupName_Lowercase() {
+        final ResourceModel input = ResourceModel.builder()
+                .dBSubnetGroupName("DBSubnetGroupName")
+                .build();
+        final ResourceModel output = ResourceModel.builder()
+                .dBSubnetGroupName("dbsubnetgroupname")
+                .build();
+
+        ResourceDriftTestHelper.assertResourceNotDrifted(input, output, resourceSchema);
+    }
+}

--- a/aws-rds-eventsubscription/src/main/java/software/amazon/rds/eventsubscription/Configuration.java
+++ b/aws-rds-eventsubscription/src/main/java/software/amazon/rds/eventsubscription/Configuration.java
@@ -3,12 +3,19 @@ package software.amazon.rds.eventsubscription;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.json.JSONObject;
+import org.json.JSONTokener;
+
 import com.amazonaws.util.CollectionUtils;
 
 class Configuration extends BaseConfiguration {
 
     public Configuration() {
         super("aws-rds-eventsubscription.json");
+    }
+
+    public JSONObject resourceSchemaJsonObject() {
+        return new JSONObject(new JSONTokener(this.getClass().getClassLoader().getResourceAsStream(schemaFilename)));
     }
 
     public Map<String, String> resourceDefinedTags(final ResourceModel model) {

--- a/aws-rds-eventsubscription/src/test/java/software/amazon/rds/eventsubscription/SchemaTest.java
+++ b/aws-rds-eventsubscription/src/test/java/software/amazon/rds/eventsubscription/SchemaTest.java
@@ -1,0 +1,23 @@
+package software.amazon.rds.eventsubscription;
+
+import org.json.JSONObject;
+import org.junit.jupiter.api.Test;
+
+import software.amazon.rds.test.common.schema.ResourceDriftTestHelper;
+
+public class SchemaTest {
+
+    private static final JSONObject resourceSchema = new Configuration().resourceSchemaJsonObject();
+
+    @Test
+    public void testDrift_SubscriptionName_Lowercase() {
+        final ResourceModel input = ResourceModel.builder()
+                .subscriptionName("SubscriptionName")
+                .build();
+        final ResourceModel output = ResourceModel.builder()
+                .subscriptionName("subscriptionname")
+                .build();
+
+        ResourceDriftTestHelper.assertResourceNotDrifted(input, output, resourceSchema);
+    }
+}

--- a/aws-rds-optiongroup/src/test/java/software/amazon/rds/optiongroup/SchemaTest.java
+++ b/aws-rds-optiongroup/src/test/java/software/amazon/rds/optiongroup/SchemaTest.java
@@ -1,0 +1,23 @@
+package software.amazon.rds.optiongroup;
+
+import org.json.JSONObject;
+import org.junit.jupiter.api.Test;
+
+import software.amazon.rds.test.common.schema.ResourceDriftTestHelper;
+
+public class SchemaTest {
+
+    private static final JSONObject resourceSchema = new Configuration().resourceSchemaJsonObject();
+
+    @Test
+    public void testDrift_OptionGroupName_Lowercase() {
+        final ResourceModel input = ResourceModel.builder()
+                .optionGroupName("OptionGroupName")
+                .build();
+        final ResourceModel output = ResourceModel.builder()
+                .optionGroupName("optiongroupname")
+                .build();
+
+        ResourceDriftTestHelper.assertResourceNotDrifted(input, output, resourceSchema);
+    }
+}


### PR DESCRIPTION
This commit implements a new test helper called `ResourceDriftTestHelper`. This is an assertion helper that checks if there is a drift between an input and an output, based on the resource schema definition provided.

In particular, the drift detector would engage `propertyTransform` instructions from the schema and compare the transform formula result with the output. If neither the original input value nor any of the transformation outputs match the output, the resource is considered to have drifted.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Signed-off-by: Oleg Sidorov <sidorovo@amazon.com>

