### PR TITLE
[DBInstance] Allocated storage size workflow improvements

### DIFF
--- a/aws-rds-cfn-common/pom.xml
+++ b/aws-rds-cfn-common/pom.xml
@@ -27,12 +27,12 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>utils</artifactId>
-            <version>2.19.12</version>
+            <version>2.19.14</version>
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>rds</artifactId>
-            <version>2.19.12</version>
+            <version>2.19.14</version>
         </dependency>
         <dependency>
             <groupId>software.amazon.cloudformation</groupId>

--- a/aws-rds-customdbengineversion/pom.xml
+++ b/aws-rds-customdbengineversion/pom.xml
@@ -22,7 +22,7 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>rds</artifactId>
-            <version>2.19.12</version>
+            <version>2.19.14</version>
         </dependency>
         <dependency>
             <groupId>software.amazon.rds.common</groupId>

--- a/aws-rds-dbclusterendpoint/pom.xml
+++ b/aws-rds-dbclusterendpoint/pom.xml
@@ -29,7 +29,7 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>rds</artifactId>
-            <version>2.19.12</version>
+            <version>2.19.14</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/software.amazon.cloudformation/aws-cloudformation-rpdk-java-plugin -->
         <dependency>

--- a/aws-rds-dbclusterparametergroup/pom.xml
+++ b/aws-rds-dbclusterparametergroup/pom.xml
@@ -29,7 +29,7 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>rds</artifactId>
-            <version>2.19.12</version>
+            <version>2.19.14</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/software.amazon.cloudformation/aws-cloudformation-rpdk-java-plugin -->
         <dependency>

--- a/aws-rds-dbinstance/pom.xml
+++ b/aws-rds-dbinstance/pom.xml
@@ -32,12 +32,12 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>rds</artifactId>
-            <version>2.19.12</version>
+            <version>2.19.14</version>
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>ec2</artifactId>
-            <version>2.19.12</version>
+            <version>2.19.14</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/software.amazon.cloudformation/aws-cloudformation-rpdk-java-plugin -->
         <dependency>

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/Translator.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/Translator.java
@@ -75,6 +75,7 @@ public class Translator {
             final Tagging.TagSet tagSet
     ) {
         return CreateDbInstanceReadReplicaRequest.builder()
+                .allocatedStorage(getAllocatedStorage(model))
                 .autoMinorVersionUpgrade(model.getAutoMinorVersionUpgrade())
                 .availabilityZone(model.getAvailabilityZone())
                 .customIamInstanceProfile(model.getCustomIAMInstanceProfile())
@@ -113,7 +114,8 @@ public class Translator {
     public static RestoreDbInstanceFromDbSnapshotRequest restoreDbInstanceFromSnapshotRequestV12(
             final ResourceModel model
     ) {
-        final RestoreDbInstanceFromDbSnapshotRequest.Builder builder = RestoreDbInstanceFromDbSnapshotRequest.builder()
+        return RestoreDbInstanceFromDbSnapshotRequest.builder()
+                .allocatedStorage(getAllocatedStorage(model))
                 .autoMinorVersionUpgrade(model.getAutoMinorVersionUpgrade())
                 .availabilityZone(model.getAvailabilityZone())
                 .customIamInstanceProfile(model.getCustomIAMInstanceProfile())
@@ -123,24 +125,23 @@ public class Translator {
                 .dbSnapshotIdentifier(model.getDBSnapshotIdentifier())
                 .dbSubnetGroupName(model.getDBSubnetGroupName())
                 .engine(model.getEngine())
+                .iops(model.getIops())
                 .licenseModel(model.getLicenseModel())
                 .multiAZ(model.getMultiAZ())
                 .networkType(model.getNetworkType())
                 .optionGroupName(model.getOptionGroupName())
-                .port(translatePortToSdk(model.getPort()));
-
-        if (ResourceModelHelper.shouldSetStorageTypeOnRestoreFromSnapshot(model)) {
-            builder.storageType(model.getStorageType());
-        }
-
-        return builder.build();
+                .port(translatePortToSdk(model.getPort()))
+                .storageType(model.getStorageType())
+                .storageThroughput(model.getStorageThroughput())
+                .build();
     }
 
     public static RestoreDbInstanceFromDbSnapshotRequest restoreDbInstanceFromSnapshotRequest(
             final ResourceModel model,
             final Tagging.TagSet tagSet
     ) {
-        final RestoreDbInstanceFromDbSnapshotRequest.Builder builder = RestoreDbInstanceFromDbSnapshotRequest.builder()
+        return RestoreDbInstanceFromDbSnapshotRequest.builder()
+                .allocatedStorage(getAllocatedStorage(model))
                 .autoMinorVersionUpgrade(model.getAutoMinorVersionUpgrade())
                 .availabilityZone(model.getAvailabilityZone())
                 .customIamInstanceProfile(model.getCustomIAMInstanceProfile())
@@ -157,6 +158,7 @@ public class Translator {
                 .enableCloudwatchLogsExports(model.getEnableCloudwatchLogsExports())
                 .enableIAMDatabaseAuthentication(model.getEnableIAMDatabaseAuthentication())
                 .engine(model.getEngine())
+                .iops(model.getIops())
                 .licenseModel(model.getLicenseModel())
                 .multiAZ(model.getMultiAZ())
                 .networkType(model.getNetworkType())
@@ -168,13 +170,10 @@ public class Translator {
                 .tdeCredentialArn(model.getTdeCredentialArn())
                 .tdeCredentialPassword(model.getTdeCredentialPassword())
                 .useDefaultProcessorFeatures(model.getUseDefaultProcessorFeatures())
-                .vpcSecurityGroupIds(CollectionUtils.isNotEmpty(model.getVPCSecurityGroups()) ? model.getVPCSecurityGroups() : null);
-
-        if (ResourceModelHelper.shouldSetStorageTypeOnRestoreFromSnapshot(model)) {
-            builder.storageType(model.getStorageType());
-        }
-
-        return builder.build();
+                .vpcSecurityGroupIds(CollectionUtils.isNotEmpty(model.getVPCSecurityGroups()) ? model.getVPCSecurityGroups() : null)
+                .storageType(model.getStorageType())
+                .storageThroughput(model.getStorageThroughput())
+                .build();
     }
 
     public static CreateDbInstanceRequest createDbInstanceRequestV12(
@@ -283,7 +282,8 @@ public class Translator {
     ) {
         final Instant restoreTimeInstant = StringUtils.isNotBlank(model.getRestoreTime()) ? ZonedDateTime.parse(model.getRestoreTime()).toInstant() : null;
 
-        final RestoreDbInstanceToPointInTimeRequest.Builder builder = RestoreDbInstanceToPointInTimeRequest.builder()
+        return RestoreDbInstanceToPointInTimeRequest.builder()
+                .allocatedStorage(getAllocatedStorage(model))
                 .autoMinorVersionUpgrade(model.getAutoMinorVersionUpgrade())
                 .availabilityZone(model.getAvailabilityZone())
                 .copyTagsToSnapshot(model.getCopyTagsToSnapshot())
@@ -317,13 +317,10 @@ public class Translator {
                 .tdeCredentialPassword(model.getTdeCredentialPassword())
                 .useDefaultProcessorFeatures(model.getUseDefaultProcessorFeatures())
                 .useLatestRestorableTime(model.getUseLatestRestorableTime())
-                .vpcSecurityGroupIds(CollectionUtils.isNotEmpty(model.getVPCSecurityGroups()) ? model.getVPCSecurityGroups() : null);
-
-        if (ResourceModelHelper.shouldSetStorageTypeOnRestoreFromSnapshot(model)) {
-            builder.storageType(model.getStorageType());
-        }
-
-        return builder.build();
+                .vpcSecurityGroupIds(CollectionUtils.isNotEmpty(model.getVPCSecurityGroups()) ? model.getVPCSecurityGroups() : null)
+                .storageType(model.getStorageType())
+                .storageThroughput(model.getStorageThroughput())
+                .build();
     }
 
     public static ModifyDbInstanceRequest modifyDbInstanceRequestV12(
@@ -465,7 +462,6 @@ public class Translator {
         return ModifyDbInstanceRequest.builder()
                 .applyImmediately(Boolean.TRUE)
                 .dbInstanceIdentifier(model.getDBInstanceIdentifier())
-                .allocatedStorage(getAllocatedStorage(model))
                 .backupRetentionPeriod(model.getBackupRetentionPeriod())
                 .dbParameterGroupName(model.getDBParameterGroupName())
                 .dbSecurityGroups(model.getDBSecurityGroups())
@@ -481,22 +477,14 @@ public class Translator {
         final ModifyDbInstanceRequest.Builder builder = ModifyDbInstanceRequest.builder()
                 .applyImmediately(Boolean.TRUE)
                 .dbInstanceIdentifier(model.getDBInstanceIdentifier())
-                .allocatedStorage(getAllocatedStorage(model))
                 .backupRetentionPeriod(model.getBackupRetentionPeriod())
                 .caCertificateIdentifier(model.getCACertificateIdentifier())
                 .dbParameterGroupName(model.getDBParameterGroupName())
                 .engineVersion(model.getEngineVersion())
-                .iops(model.getIops())
                 .masterUserPassword(model.getMasterUserPassword())
                 .maxAllocatedStorage(model.getMaxAllocatedStorage())
                 .preferredBackupWindow(model.getPreferredBackupWindow())
                 .preferredMaintenanceWindow(model.getPreferredMaintenanceWindow());
-
-        if (StorageType.GP3.equals(StorageType.fromString(model.getStorageType()))) {
-            builder.storageThroughput(model.getStorageThroughput());
-            builder.iops(model.getIops());
-            builder.storageType(model.getStorageType());
-        }
         return builder.build();
     }
 

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/util/ResourceModelHelper.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/util/ResourceModelHelper.java
@@ -11,11 +11,6 @@ import java.util.Optional;
 import java.util.Set;
 
 public final class ResourceModelHelper {
-    private static final Set<StorageType> STORAGE_TYPES_SET_ON_MODIFY_AFTER_CREATE = ImmutableSet.of(
-            StorageType.GP3,
-            StorageType.IO1
-    );
-
     private static final Set<String> SQLSERVER_ENGINES_WITH_MIRRORING = ImmutableSet.of(
             "sqlserver-ee",
             "sqlserver-se"
@@ -28,7 +23,6 @@ public final class ResourceModelHelper {
                 isRestoreToPointInTime(model)) &&
                 (
                         !CollectionUtils.isNullOrEmpty(model.getDBSecurityGroups()) ||
-                                StringUtils.hasValue(model.getAllocatedStorage()) ||
                                 StringUtils.hasValue(model.getCACertificateIdentifier()) ||
                                 StringUtils.hasValue(model.getDBParameterGroupName()) ||
                                 StringUtils.hasValue(model.getEngineVersion()) ||
@@ -59,10 +53,6 @@ public final class ResourceModelHelper {
 
     public static boolean isRestoreFromClusterSnapshot(final ResourceModel model) {
         return StringUtils.hasValue(model.getDBClusterSnapshotIdentifier());
-    }
-
-    public static boolean shouldSetStorageTypeOnRestoreFromSnapshot(final ResourceModel model) {
-        return !STORAGE_TYPES_SET_ON_MODIFY_AFTER_CREATE.contains(StorageType.fromString(model.getStorageType())) && shouldUpdateAfterCreate(model);
     }
 
     public static boolean shouldReboot(final ResourceModel model) {

--- a/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/CreateHandlerTest.java
+++ b/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/CreateHandlerTest.java
@@ -804,13 +804,8 @@ public class CreateHandlerTest extends AbstractHandlerTest {
                 expectSuccess()
         );
 
-        ArgumentCaptor<ModifyDbInstanceRequest> modifyCaptor = ArgumentCaptor.forClass(ModifyDbInstanceRequest.class);
-        verify(rdsProxy.client(), times(1)).modifyDBInstance(modifyCaptor.capture());
         verify(rdsProxy.client(), times(2)).describeDBInstances(any(DescribeDbInstancesRequest.class));
         verify(rdsProxy.client(), times(1)).describeEvents(any(DescribeEventsRequest.class));
-
-        Assertions.assertThat(modifyCaptor.getValue().allocatedStorage()).isEqualTo(100);
-        Assertions.assertThat(modifyCaptor.getValue().iops()).isEqualTo(3000);
     }
 
     @Test
@@ -888,12 +883,7 @@ public class CreateHandlerTest extends AbstractHandlerTest {
     }
 
     @Test
-    public void handleRequest_CreateReadReplica_AllocatedStorage_ShouldUpdate_Success() {
-        when(rdsProxy.client().modifyDBInstance(any(ModifyDbInstanceRequest.class)))
-                .thenReturn(ModifyDbInstanceResponse.builder().build());
-        when(rdsProxy.client().describeEvents(any(DescribeEventsRequest.class)))
-                .thenReturn(DescribeEventsResponse.builder().build());
-
+    public void handleRequest_CreateReadReplica_AllocatedStorage_ShouldNotUpdate_Success() {
         final CallbackContext context = new CallbackContext();
         context.setCreated(true);
         context.setUpdated(false);
@@ -910,9 +900,7 @@ public class CreateHandlerTest extends AbstractHandlerTest {
                 expectSuccess()
         );
 
-        verify(rdsProxy.client(), times(1)).modifyDBInstance(any(ModifyDbInstanceRequest.class));
-        verify(rdsProxy.client(), times(2)).describeDBInstances(any(DescribeDbInstancesRequest.class));
-        verify(rdsProxy.client(), times(1)).describeEvents(any(DescribeEventsRequest.class));
+        verify(rdsProxy.client(), times(1)).describeDBInstances(any(DescribeDbInstancesRequest.class));
     }
 
     @Test

--- a/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/CreateHandlerTest.java
+++ b/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/CreateHandlerTest.java
@@ -15,6 +15,7 @@ import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.stream.Stream;
 
+import com.google.common.collect.ImmutableList;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -759,7 +760,6 @@ public class CreateHandlerTest extends AbstractHandlerTest {
 
     @Test
     public void handleRequest_CreateNewInstance_ShouldNotUpdateAfterCreate_CACertificateIdentifier_Success() {
-
         final DBInstance dbInstance = DB_INSTANCE_BASE.toBuilder()
                 .caCertificateIdentifier(CA_CERTIFICATE_IDENTIFIER_NON_EMPTY)
                 .build();
@@ -885,10 +885,13 @@ public class CreateHandlerTest extends AbstractHandlerTest {
     @Test
     public void handleRequest_CreateReadReplica_AllocatedStorage_ShouldNotUpdate_Success() {
         final CallbackContext context = new CallbackContext();
-        context.setCreated(true);
+        context.setCreated(false);
         context.setUpdated(false);
         context.setRebooted(false);
         context.setUpdatedRoles(true);
+
+        when(rdsProxy.client().createDBInstanceReadReplica(any(CreateDbInstanceReadReplicaRequest.class)))
+                .thenReturn(CreateDbInstanceReadReplicaResponse.builder().build());
 
         test_handleRequest_base(
                 context,
@@ -900,7 +903,42 @@ public class CreateHandlerTest extends AbstractHandlerTest {
                 expectSuccess()
         );
 
-        verify(rdsProxy.client(), times(1)).describeDBInstances(any(DescribeDbInstancesRequest.class));
+
+        ArgumentCaptor<CreateDbInstanceReadReplicaRequest> captor = ArgumentCaptor.forClass(CreateDbInstanceReadReplicaRequest.class);
+        verify(rdsProxy.client(), times(1)).createDBInstanceReadReplica(captor.capture());
+        Assertions.assertThat(captor.getValue().allocatedStorage()).isEqualTo(ALLOCATED_STORAGE);
+        verify(rdsProxy.client(), times(2)).describeDBInstances(any(DescribeDbInstancesRequest.class));
+    }
+
+    @Test
+    public void handleRequest_RestoreDBInstanceFromSnapshot_AllocatedStorage_ShouldNotUpdate_Success() {
+        final CallbackContext context = new CallbackContext();
+        context.setCreated(false);
+        context.setUpdated(false);
+        context.setRebooted(false);
+        context.setUpdatedRoles(true);
+
+        when(rdsProxy.client().restoreDBInstanceFromDBSnapshot(any(RestoreDbInstanceFromDbSnapshotRequest.class)))
+                .thenReturn(RestoreDbInstanceFromDbSnapshotResponse.builder().build());
+        when(rdsProxy.client().describeDBSnapshots(any(DescribeDbSnapshotsRequest.class)))
+                .thenReturn(DescribeDbSnapshotsResponse.builder()
+                        .dbSnapshots(ImmutableList.of(DBSnapshot.builder().build())).build());
+
+        test_handleRequest_base(
+                context,
+                () -> DB_INSTANCE_ACTIVE,
+                () -> RESOURCE_MODEL_BAREBONE_BLDR()
+                        .dBSnapshotIdentifier(DB_SNAPSHOT_IDENTIFIER_NON_EMPTY)
+                        .allocatedStorage(ALLOCATED_STORAGE.toString())
+                        .build(),
+                expectSuccess()
+        );
+
+
+        ArgumentCaptor<RestoreDbInstanceFromDbSnapshotRequest> captor = ArgumentCaptor.forClass(RestoreDbInstanceFromDbSnapshotRequest.class);
+        verify(rdsProxy.client(), times(1)).restoreDBInstanceFromDBSnapshot(captor.capture());
+        Assertions.assertThat(captor.getValue().allocatedStorage()).isEqualTo(ALLOCATED_STORAGE);
+        verify(rdsProxy.client(), times(3)).describeDBInstances(any(DescribeDbInstancesRequest.class));
     }
 
     @Test

--- a/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/TranslatorTest.java
+++ b/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/TranslatorTest.java
@@ -314,40 +314,56 @@ class TranslatorTest extends AbstractHandlerTest {
         Assertions.assertEquals("default", request.dbParameterGroupName());
     }
 
-    @ParameterizedTest
-    @ValueSource(strings = {"io1", "gp3"})
-    public void test_restoreFromSnapshotRequest_storageType_shouldBeSetOnUpdate(final String storageType) {
+    @Test
+    public void test_restoreFromSnapshotRequest_storageType_shouldBeSetOnUpdate() {
         final ResourceModel model = RESOURCE_MODEL_BLDR()
                 .dBSnapshotIdentifier("snapshot")
-                .storageType(storageType)
+                .storageType("gp3")
+                .iops(100)
+                .storageThroughput(200)
+                .allocatedStorage("300")
                 .build();
 
         final RestoreDbInstanceFromDbSnapshotRequest request = Translator.restoreDbInstanceFromSnapshotRequest(model, Tagging.TagSet.emptySet());
-        assertThat(request.storageType()).isNull();
+        assertThat(request.storageType()).isEqualTo("gp3");
+        assertThat(request.iops()).isEqualTo(100);
+        assertThat(request.storageThroughput()).isEqualTo(200);
+        assertThat(request.allocatedStorage()).isEqualTo(300);
     }
 
-    @ParameterizedTest
-    @ValueSource(strings = {"io1", "gp3"})
-    public void test_restoreDbInstanceToPointInTimeRequest_shouldBeSetOnUpdate(final String storageType) {
+    @Test
+    public void test_restoreDbInstanceToPointInTimeRequest_shouldBeSetOnCreate() {
         final ResourceModel model = RESOURCE_MODEL_BLDR()
                 .dBSnapshotIdentifier("snapshot")
-                .storageType(storageType)
+                .storageType("gp3")
+                .iops(100)
+                .storageThroughput(200)
+                .allocatedStorage("300")
                 .build();
 
         final RestoreDbInstanceToPointInTimeRequest request = Translator.restoreDbInstanceToPointInTimeRequest(model, Tagging.TagSet.emptySet());
-        assertThat(request.storageType()).isNull();
+        assertThat(request.storageType()).isEqualTo("gp3");
+        assertThat(request.iops()).isEqualTo(100);
+        assertThat(request.storageThroughput()).isEqualTo(200);
+        assertThat(request.allocatedStorage()).isEqualTo(300);
     }
 
-    @ParameterizedTest
-    @ValueSource(strings = {"io1", "gp3"})
-    public void test_restoreFromSnapshotRequestV12_shouldBeSetOnUpdate(final String storageType) {
+    @Test
+    public void test_restoreFromSnapshotRequestV12_shouldBeSetOnRestore() {
         final ResourceModel model = RESOURCE_MODEL_BLDR()
                 .dBSnapshotIdentifier("snapshot")
-                .storageType(storageType)
+                .storageType("gp3")
+                .iops(100)
+                .storageThroughput(200)
+                .allocatedStorage("300")
                 .build();
 
         final RestoreDbInstanceFromDbSnapshotRequest request = Translator.restoreDbInstanceFromSnapshotRequestV12(model);
-        assertThat(request.storageType()).isNull();
+        assertThat(request.storageType()).isEqualTo("gp3");
+        assertThat(request.iops()).isEqualTo(100);
+        assertThat(request.storageThroughput()).isEqualTo(200);
+        assertThat(request.allocatedStorage()).isEqualTo(300);
+
     }
 
     @Test
@@ -449,7 +465,7 @@ class TranslatorTest extends AbstractHandlerTest {
     }
 
     @Test
-    public void test_modifyAfterCreate_shouldSetGP3Parameters() {
+    public void test_modifyAfterCreate_shouldNotSetGP3Parameters() {
         final ResourceModel model = RESOURCE_MODEL_BLDR()
                 .storageType("gp3")
                 .storageThroughput(100)
@@ -457,9 +473,9 @@ class TranslatorTest extends AbstractHandlerTest {
                 .build();
 
         final ModifyDbInstanceRequest request = Translator.modifyDbInstanceAfterCreateRequest(model);
-        assertThat(request.iops()).isEqualTo(200);
-        assertThat(request.storageThroughput()).isEqualTo(100);
-        assertThat(request.storageType()).isEqualTo("gp3");
+        assertThat(request.iops()).isNull();
+        assertThat(request.storageThroughput()).isNull();
+        assertThat(request.storageType()).isNull();
     }
 
     @Test

--- a/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/TranslatorTest.java
+++ b/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/TranslatorTest.java
@@ -17,6 +17,7 @@ import software.amazon.awssdk.services.rds.model.CreateDbInstanceReadReplicaRequ
 import software.amazon.awssdk.services.rds.model.CreateDbInstanceRequest;
 import software.amazon.awssdk.services.rds.model.DBInstance;
 import software.amazon.awssdk.services.rds.model.DomainMembership;
+import software.amazon.awssdk.services.rds.model.Endpoint;
 import software.amazon.awssdk.services.rds.model.ModifyDbInstanceRequest;
 import software.amazon.awssdk.services.rds.model.RestoreDbInstanceFromDbSnapshotRequest;
 import software.amazon.awssdk.services.rds.model.RestoreDbInstanceToPointInTimeRequest;
@@ -739,6 +740,17 @@ class TranslatorTest extends AbstractHandlerTest {
         assertThat(certificateDetails).isNotNull();
         assertThat(certificateDetails.getCAIdentifier()).isEqualTo("identifier");
         assertThat(certificateDetails.getValidTill()).isEqualTo("2023-01-09T15:55:37.123Z");
+    }
+
+    @Test
+    public void translateDbInstanceFromSdk_port_getFromEndpoint() {
+        final DBInstance dbInstance = DBInstance.builder()
+                .endpoint(Endpoint.builder().port(123).build())
+                .dbInstancePort(0)
+                .build();
+
+        final ResourceModel model = Translator.translateDbInstanceFromSdk(dbInstance);
+        assertThat(model.getPort()).isEqualTo("123");
     }
 
         // Stub methods to satisfy the interface. This is a 1-time thing.

--- a/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/util/ResourceModelHelperTest.java
+++ b/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/util/ResourceModelHelperTest.java
@@ -78,7 +78,7 @@ public class ResourceModelHelperTest {
                 .allocatedStorage("100")
                 .build();
 
-        assertThat(ResourceModelHelper.shouldUpdateAfterCreate(model)).isTrue();
+        assertThat(ResourceModelHelper.shouldUpdateAfterCreate(model)).isFalse();
     }
 
     @Test
@@ -88,7 +88,7 @@ public class ResourceModelHelperTest {
                 .allocatedStorage("100")
                 .build();
 
-        assertThat(ResourceModelHelper.shouldUpdateAfterCreate(model)).isTrue();
+        assertThat(ResourceModelHelper.shouldUpdateAfterCreate(model)).isFalse();
     }
 
     @Test
@@ -100,29 +100,6 @@ public class ResourceModelHelperTest {
                 .build();
 
         assertThat(ResourceModelHelper.shouldUpdateAfterCreate(model)).isTrue();
-    }
-
-    @ParameterizedTest
-    @ValueSource(strings = {"gp3", "io1"})
-    public void shouldSetStorageTypeOnRestoreFromSnapshot_whenStorageType_shouldBeSetOnModify(final String storageType) {
-        final ResourceModel model = ResourceModel.builder()
-                .storageType(storageType)
-                .allocatedStorage("100")
-                .dBSnapshotIdentifier("identifier")
-                .build();
-
-        assertThat(ResourceModelHelper.shouldSetStorageTypeOnRestoreFromSnapshot(model)).isFalse();
-    }
-
-    @Test
-    public void shouldSetStorageTypeOnRestoreFromSnapshot_whenStorageTypeGP2() {
-        final ResourceModel model = ResourceModel.builder()
-                .dBSnapshotIdentifier("identifier")
-                .storageType("gp2")
-                .allocatedStorage("100")
-                .build();
-
-        assertThat(ResourceModelHelper.shouldSetStorageTypeOnRestoreFromSnapshot(model)).isTrue();
     }
 
     @Test

--- a/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/util/ResourceModelHelperTest.java
+++ b/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/util/ResourceModelHelperTest.java
@@ -82,13 +82,33 @@ public class ResourceModelHelperTest {
     }
 
     @Test
-    public void shouldUpdateAfterCreate_whenReadReplicaAndAllocatedStorage() {
+    public void shouldUpdateAfterCreate_whenRestoreFromSnapshotAndMasterUserPassword() {
         final ResourceModel model = ResourceModel.builder()
-                .sourceDBInstanceIdentifier("identifier")
-                .allocatedStorage("100")
+                .dBSnapshotIdentifier("identifier")
+                .masterUserPassword("password")
                 .build();
 
-        assertThat(ResourceModelHelper.shouldUpdateAfterCreate(model)).isFalse();
+        assertThat(ResourceModelHelper.shouldUpdateAfterCreate(model)).isTrue();
+    }
+
+    @Test
+    public void shouldUpdateAfterCreate_whenReadReplicaAndPreferredMaintenanceWindow() {
+        final ResourceModel model = ResourceModel.builder()
+                .sourceDBInstanceIdentifier("identifier")
+                .preferredMaintenanceWindow("window")
+                .build();
+
+        assertThat(ResourceModelHelper.shouldUpdateAfterCreate(model)).isTrue();
+    }
+
+    @Test
+    public void shouldUpdateAfterCreate_whenReadReplicaAndMaxAllocatedStorage() {
+        final ResourceModel model = ResourceModel.builder()
+                .sourceDBInstanceIdentifier("identifier")
+                .maxAllocatedStorage(100)
+                .build();
+
+        assertThat(ResourceModelHelper.shouldUpdateAfterCreate(model)).isTrue();
     }
 
     @Test

--- a/aws-rds-dbparametergroup/pom.xml
+++ b/aws-rds-dbparametergroup/pom.xml
@@ -22,7 +22,7 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>rds</artifactId>
-            <version>2.19.12</version>
+            <version>2.19.14</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/software.amazon.cloudformation/aws-cloudformation-rpdk-java-plugin -->
         <dependency>

--- a/aws-rds-dbsubnetgroup/pom.xml
+++ b/aws-rds-dbsubnetgroup/pom.xml
@@ -22,7 +22,7 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>rds</artifactId>
-            <version>2.19.12</version>
+            <version>2.19.14</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/software.amazon.cloudformation/aws-cloudformation-rpdk-java-plugin -->
         <dependency>

--- a/aws-rds-eventsubscription/pom.xml
+++ b/aws-rds-eventsubscription/pom.xml
@@ -28,7 +28,7 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>rds</artifactId>
-            <version>2.19.12</version>
+            <version>2.19.14</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/software.amazon.cloudformation/aws-cloudformation-rpdk-java-plugin -->
         <dependency>

--- a/aws-rds-globalcluster/pom.xml
+++ b/aws-rds-globalcluster/pom.xml
@@ -28,7 +28,7 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>rds</artifactId>
-            <version>2.19.12</version>
+            <version>2.19.14</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/software.amazon.cloudformation/aws-cloudformation-rpdk-java-plugin -->
         <dependency>

--- a/aws-rds-optiongroup/pom.xml
+++ b/aws-rds-optiongroup/pom.xml
@@ -22,7 +22,7 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>rds</artifactId>
-            <version>2.19.12</version>
+            <version>2.19.14</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/software.amazon.cloudformation/aws-cloudformation-rpdk-java-plugin -->
         <dependency>


### PR DESCRIPTION
This PR modifies DBInstance in a way that would remove `storage-optimization` step when restoring DBInstance from Snapshot or restoring instance to Point in time.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
