### PR TITLE
[DBInstance] Update event-matching predicates

### DIFF
--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/BaseHandlerStd.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/BaseHandlerStd.java
@@ -20,7 +20,6 @@ import org.apache.commons.lang3.BooleanUtils;
 
 import com.amazonaws.util.CollectionUtils;
 import com.google.common.collect.ImmutableList;
-import software.amazon.awssdk.awscore.exception.AwsServiceException;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.ec2.Ec2Client;
 import software.amazon.awssdk.services.ec2.model.DescribeSecurityGroupsResponse;
@@ -166,18 +165,18 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
 
     //TODO: This list should be gone eventually. Event ID should be checked instead.
     private static final List<Predicate<Event>> EVENT_FAIL_CHECKERS = ImmutableList.of(
-            (e) -> isEventMessageContains(e, "Failed to join a host to a domain"),
-            (e) -> isEventMessageContains(e, "Failed to join cluster instance"),
-            (e) -> isEventMessageContains(e, "Insufficient instance capacity for instance type"),
-            (e) -> isEventMessageContains(e, "Insufficient instance capacity for storage volume type"),
-            (e) -> isEventMessageContains(e, "RDS Custom couldn't modify the DB instance"),
-            (e) -> isEventMessageContains(e, "The DB engine version upgrade failed"),
-            (e) -> isEventMessageContains(e, "The instance could not be upgraded"),
-            (e) -> isEventMessageContains(e, "The storage volume limitation was exceeded"),
-            (e) -> isEventMessageContains(e, "The update of the replica mode failed"),
-            (e) -> isEventMessageContains(e, "Unable to modify database instance class"),
-            (e) -> isEventMessageContains(e, "Unable to modify the DB instance class because no IP addresses are available in the specified subnets"),
-            (e) -> isEventMessageContains(e, "You can't create the DB instance because of incompatible resources")
+            (e) -> isEventMessageContains(e, "failed to join a host to a domain"),
+            (e) -> isEventMessageContains(e, "failed to join cluster instance"),
+            (e) -> isEventMessageContains(e, "insufficient instance capacity"),
+            (e) -> isEventMessageContains(e, "rds custom couldn't modify the db instance"),
+            (e) -> isEventMessageContains(e, "the db engine version upgrade failed"),
+            (e) -> isEventMessageContains(e, "the instance could not be upgraded"),
+            (e) -> isEventMessageContains(e, "the storage volume limitation was exceeded"),
+            (e) -> isEventMessageContains(e, "the update of the replica mode failed"),
+            (e) -> isEventMessageContains(e, "unable to modify database instance class"),
+            (e) -> isEventMessageContains(e, "unable to modify the db instance class"),
+            (e) -> isEventMessageContains(e, "you can't create the db instance"),
+            (e) -> isEventMessageContains(e, "instance is in a state that cannot be upgraded")
     );
 
     protected static final ErrorRuleSet DEFAULT_DB_INSTANCE_ERROR_RULE_SET = ErrorRuleSet
@@ -1013,7 +1012,8 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
         if (event != null) {
             final String msg = event.message();
             if (msg != null) {
-                return msg.contains(fragment);
+                return msg.toLowerCase(Locale.getDefault())
+                        .contains(fragment.toLowerCase(Locale.getDefault()));
             }
         }
         return false;


### PR DESCRIPTION
This commit updates the list of predicates which is used to detect failure events upon a DBInstance stabilization. The list gets a new matcher. The matcher would perform a case-insensitive match now.

This change is a follow-up on https://github.com/aws-cloudformation/aws-cloudformation-resource-providers-rds/pull/345

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Signed-off-by: Oleg Sidorov <sidorovo@amazon.com>