### PR TITLE
[DBInstance] Set AllocatedStorage/Iops unconditionally on Update if IO1 Storage type is used

### DIFF
--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/Translator.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/Translator.java
@@ -350,9 +350,14 @@ public class Translator {
                 .replicaMode(diff(previousModel.getReplicaMode(), desiredModel.getReplicaMode()));
 
         if (BooleanUtils.isNotTrue(isRollback)) {
-            builder.allocatedStorage(diff(getAllocatedStorage(previousModel), getAllocatedStorage(desiredModel)));
             builder.engineVersion(diff(previousModel.getEngineVersion(), desiredModel.getEngineVersion()));
-            builder.iops(diff(previousModel.getIops(), desiredModel.getIops()));
+            if (isIo1Storage(desiredModel)) {
+                builder.iops(desiredModel.getIops());
+                builder.allocatedStorage(getAllocatedStorage(desiredModel));
+            } else {
+                builder.allocatedStorage(diff(getAllocatedStorage(previousModel), getAllocatedStorage(desiredModel)));
+                builder.iops(diff(previousModel.getIops(), desiredModel.getIops()));
+            }
         }
 
         return builder.build();

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/Translator.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/Translator.java
@@ -352,8 +352,8 @@ public class Translator {
         if (BooleanUtils.isNotTrue(isRollback)) {
             builder.engineVersion(diff(previousModel.getEngineVersion(), desiredModel.getEngineVersion()));
             if (isIo1Storage(desiredModel)) {
-                builder.iops(desiredModel.getIops());
                 builder.allocatedStorage(getAllocatedStorage(desiredModel));
+                builder.iops(desiredModel.getIops());
             } else {
                 builder.allocatedStorage(diff(getAllocatedStorage(previousModel), getAllocatedStorage(desiredModel)));
                 builder.iops(diff(previousModel.getIops(), desiredModel.getIops()));
@@ -416,8 +416,8 @@ public class Translator {
         if (BooleanUtils.isNotTrue(isRollback)) {
             builder.engineVersion(diff(previousModel.getEngineVersion(), desiredModel.getEngineVersion()));
             if (isIo1Storage(desiredModel)) {
-                builder.iops(desiredModel.getIops());
                 builder.allocatedStorage(getAllocatedStorage(desiredModel));
+                builder.iops(desiredModel.getIops());
             } else {
                 builder.allocatedStorage(diff(getAllocatedStorage(previousModel), getAllocatedStorage(desiredModel)));
                 builder.iops(diff(previousModel.getIops(), desiredModel.getIops()));

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/Translator.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/Translator.java
@@ -412,9 +412,14 @@ public class Translator {
         }
 
         if (BooleanUtils.isNotTrue(isRollback)) {
-            builder.allocatedStorage(diff(getAllocatedStorage(previousModel), getAllocatedStorage(desiredModel)));
             builder.engineVersion(diff(previousModel.getEngineVersion(), desiredModel.getEngineVersion()));
-            builder.iops(diff(previousModel.getIops(), desiredModel.getIops()));
+            if (isIo1Storage(desiredModel)) {
+                builder.iops(desiredModel.getIops());
+                builder.allocatedStorage(getAllocatedStorage(desiredModel));
+            } else {
+                builder.allocatedStorage(diff(getAllocatedStorage(previousModel), getAllocatedStorage(desiredModel)));
+                builder.iops(diff(previousModel.getIops(), desiredModel.getIops()));
+            }
         }
 
         if (shouldSetProcessorFeatures(previousModel, desiredModel)) {
@@ -449,6 +454,11 @@ public class Translator {
         }
 
         return builder.build();
+    }
+
+    private static Boolean isIo1Storage(final ResourceModel model) {
+        return StorageType.IO1.toString().equalsIgnoreCase(model.getStorageType()) ||
+                (StringUtils.isEmpty(model.getStorageType()) && model.getIops() != null);
     }
 
     private static Boolean getManageMasterUserPassword(final ResourceModel previous, final ResourceModel desired) {

--- a/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/TranslatorTest.java
+++ b/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/TranslatorTest.java
@@ -786,6 +786,39 @@ class TranslatorTest extends AbstractHandlerTest {
         assertThat(request.allocatedStorage()).isNull();
     }
 
+    @Test
+    public void modifyDbInstanceRequestV12_shouldIncludeAllocatedStorage_ifStorageTypeIsIo1_andIopsOnlyChanged() {
+        final ResourceModel previous = RESOURCE_MODEL_BLDR().storageType("io1").iops(1000).build();
+        final ResourceModel desired = RESOURCE_MODEL_BLDR().storageType("io1").iops(1200).build();
+
+        final ModifyDbInstanceRequest request = Translator.modifyDbInstanceRequestV12(previous, desired, false);
+
+        assertThat(request.iops()).isEqualTo(1200);
+        assertThat(request.allocatedStorage()).isEqualTo(ALLOCATED_STORAGE);
+    }
+
+    @Test
+    public void modifyDbInstanceRequestV12_shouldIncludeAllocatedStorage_ifStorageTypeIsImplicitIo1_andIopsOnlyChanged() {
+        final ResourceModel previous = RESOURCE_MODEL_BLDR().storageType(null).iops(1000).build();
+        final ResourceModel desired = RESOURCE_MODEL_BLDR().storageType(null).iops(1200).build();
+
+        final ModifyDbInstanceRequest request = Translator.modifyDbInstanceRequestV12(previous, desired, false);
+
+        assertThat(request.iops()).isEqualTo(1200);
+        assertThat(request.allocatedStorage()).isEqualTo(ALLOCATED_STORAGE);
+    }
+
+    @Test
+    public void modifyDbInstanceRequestV12_shouldNotIncludeAllocatedStorage_ifStorageTypeIsGP2_andIopsOnlyChanged() {
+        final ResourceModel previous = RESOURCE_MODEL_BLDR().iops(1000).build();
+        final ResourceModel desired = RESOURCE_MODEL_BLDR().iops(1200).build();
+
+        final ModifyDbInstanceRequest request = Translator.modifyDbInstanceRequestV12(previous, desired, false);
+
+        assertThat(request.iops()).isEqualTo(1200);
+        assertThat(request.allocatedStorage()).isNull();
+    }
+
     // Stub methods to satisfy the interface. This is a 1-time thing.
 
     @Override

--- a/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/TranslatorTest.java
+++ b/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/TranslatorTest.java
@@ -725,7 +725,40 @@ class TranslatorTest extends AbstractHandlerTest {
         assertThat(certificateDetails.getValidTill()).isEqualTo("2023-01-09T15:55:37.123Z");
     }
 
-        // Stub methods to satisfy the interface. This is a 1-time thing.
+    @Test
+    public void modifyDbInstanceRequest_shouldIncludeAllocatedStorage_ifStorageTypeIsIo1_andIopsOnlyChanged() {
+        final ResourceModel previous = RESOURCE_MODEL_BLDR().storageType("io1").iops(1000).build();
+        final ResourceModel desired = RESOURCE_MODEL_BLDR().storageType("io1").iops(1200).build();
+
+        final ModifyDbInstanceRequest request = Translator.modifyDbInstanceRequest(previous, desired, false);
+
+        assertThat(request.iops()).isEqualTo(1200);
+        assertThat(request.allocatedStorage()).isEqualTo(ALLOCATED_STORAGE);
+    }
+
+    @Test
+    public void modifyDbInstanceRequest_shouldIncludeAllocatedStorage_ifStorageTypeIsImplicitIo1_andIopsOnlyChanged() {
+        final ResourceModel previous = RESOURCE_MODEL_BLDR().storageType(null).iops(1000).build();
+        final ResourceModel desired = RESOURCE_MODEL_BLDR().storageType(null).iops(1200).build();
+
+        final ModifyDbInstanceRequest request = Translator.modifyDbInstanceRequest(previous, desired, false);
+
+        assertThat(request.iops()).isEqualTo(1200);
+        assertThat(request.allocatedStorage()).isEqualTo(ALLOCATED_STORAGE);
+    }
+
+    @Test
+    public void modifyDbInstanceRequest_shouldNotIncludeAllocatedStorage_ifStorageTypeIsGP2_andIopsOnlyChanged() {
+        final ResourceModel previous = RESOURCE_MODEL_BLDR().iops(1000).build();
+        final ResourceModel desired = RESOURCE_MODEL_BLDR().iops(1200).build();
+
+        final ModifyDbInstanceRequest request = Translator.modifyDbInstanceRequest(previous, desired, false);
+
+        assertThat(request.iops()).isEqualTo(1200);
+        assertThat(request.allocatedStorage()).isNull();
+    }
+
+    // Stub methods to satisfy the interface. This is a 1-time thing.
 
     @Override
     protected BaseHandlerStd getHandler() {


### PR DESCRIPTION
This PR addresses an issue when customer updates only Iops or AllocatedStorageSize value for the instance that uses IO1 storage type. Previously, such requests would fail because both parameters must be present. Now such updates should succeed. 

In other cases AllocatedStorageSize is omitted in order to prevent unwanted StorageOptimization step.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
