### PR TITLE
[DBCluster] Resolve false drift detection

### DIFF
--- a/aws-rds-cfn-test-common/src/main/java/software/amazon/rds/test/common/schema/ResourceDriftTestHelper.java
+++ b/aws-rds-cfn-test-common/src/main/java/software/amazon/rds/test/common/schema/ResourceDriftTestHelper.java
@@ -89,8 +89,8 @@ public class ResourceDriftTestHelper {
                 assertResourceNotDrifted(inputFieldVal, outputFieldVal, resourceSchema, propertyTransformPath);
                 continue;
             }
-            final String propertyTransform = propertyTransformMap.getString(propertyTransformPath);
-            if (propertyTransform != null) {
+            if (propertyTransformMap.has(propertyTransformPath)) {
+                final String propertyTransform = propertyTransformMap.getString(propertyTransformPath);
                 // $OR is a CFN-specific feature. We need to split the expression into or-expressions and test
                 // the results independently. The test passes if any of these alternative variants match.
                 final String[] orExprs = propertyTransform.split(PROPERTY_OR_SPLIT_REGEX);

--- a/aws-rds-dbcluster/aws-rds-dbcluster.json
+++ b/aws-rds-dbcluster/aws-rds-dbcluster.json
@@ -398,11 +398,13 @@
     "/properties/DBClusterIdentifier": "$lowercase(DBClusterIdentifier)",
     "/properties/DBClusterParameterGroupName": "$lowercase(DBClusterParameterGroupName)",
     "/properties/DBSubnetGroupName": "$lowercase(DBSubnetGroupName)",
-    "/properties/SnapshotIdentifier": "$lowercase(SnapshotIdentifier)",
-    "/properties/SourceDBClusterIdentifier": "$lowercase(SourceDBClusterIdentifier)",
-    "/properties/MasterUserSecret/KmsKeyId": "$join([\"arn:(aws)[-]{0,1}[a-z]{0,2}[-]{0,1}[a-z]{0,3}:kms:[a-z]{2}[-]{1}[a-z]{3,10}[-]{0,1}[a-z]{0,10}[-]{1}[1-3]{1}:[0-9]{12}[:]{1}key\\/\", KmsKeyId])",
+    "/properties/EnableHttpEndpoint": "$lowercase($string(EngineMode)) = 'serverless' ? EnableHttpEndpoint : false",
     "/properties/KmsKeyId": "$join([\"arn:(aws)[-]{0,1}[a-z]{0,2}[-]{0,1}[a-z]{0,3}:kms:[a-z]{2}[-]{1}[a-z]{3,10}[-]{0,1}[a-z]{0,10}[-]{1}[1-3]{1}:[0-9]{12}[:]{1}key\\/\", KmsKeyId])",
-    "/properties/PerformanceInsightsKmsKeyId": "$join([\"arn:(aws)[-]{0,1}[a-z]{0,2}[-]{0,1}[a-z]{0,3}:kms:[a-z]{2}[-]{1}[a-z]{3,10}[-]{0,1}[a-z]{0,10}[-]{1}[1-3]{1}:[0-9]{12}[:]{1}key\\/\", PerformanceInsightsKmsKeyId])"
+    "/properties/MasterUserSecret/KmsKeyId": "$join([\"arn:(aws)[-]{0,1}[a-z]{0,2}[-]{0,1}[a-z]{0,3}:kms:[a-z]{2}[-]{1}[a-z]{3,10}[-]{0,1}[a-z]{0,10}[-]{1}[1-3]{1}:[0-9]{12}[:]{1}key\\/\", KmsKeyId])",
+    "/properties/PerformanceInsightsKmsKeyId": "$join([\"arn:(aws)[-]{0,1}[a-z]{0,2}[-]{0,1}[a-z]{0,3}:kms:[a-z]{2}[-]{1}[a-z]{3,10}[-]{0,1}[a-z]{0,10}[-]{1}[1-3]{1}:[0-9]{12}[:]{1}key\\/\", PerformanceInsightsKmsKeyId])",
+    "/properties/PreferredMaintenanceWindow": "$lowercase(PreferredMaintenanceWindow)",
+    "/properties/SnapshotIdentifier": "$lowercase(SnapshotIdentifier)",
+    "/properties/SourceDBClusterIdentifier": "$lowercase(SourceDBClusterIdentifier)"
   },
   "readOnlyProperties": [
     "/properties/DBClusterArn",


### PR DESCRIPTION
This commit addresses known false drift detection on the following attributes:
- `EnableHttpEndpoint`
- `PreferredMaintenanceWindow`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Signed-off-by: Oleg Sidorov <sidorovo@amazon.com>

