### PR TITLE
[Common] Handle `SdkServiceException`

### DIFF
--- a/aws-rds-cfn-common/src/main/java/software/amazon/rds/common/handler/Commons.java
+++ b/aws-rds-cfn-common/src/main/java/software/amazon/rds/common/handler/Commons.java
@@ -3,6 +3,7 @@ package software.amazon.rds.common.handler;
 import java.util.function.Function;
 
 import software.amazon.awssdk.core.exception.SdkClientException;
+import software.amazon.awssdk.core.exception.SdkServiceException;
 import software.amazon.awssdk.services.rds.model.KmsKeyNotAccessibleException;
 import software.amazon.cloudformation.proxy.HandlerErrorCode;
 import software.amazon.cloudformation.proxy.ProgressEvent;
@@ -33,6 +34,7 @@ public final class Commons {
             .withErrorClasses(ErrorStatus.failWith(HandlerErrorCode.AccessDenied),
                     KmsKeyNotAccessibleException.class)
             .withErrorClasses(ErrorStatus.failWith(HandlerErrorCode.ServiceInternalError),
+                    SdkServiceException.class,
                     SdkClientException.class)
             .build();
 

--- a/aws-rds-cfn-common/src/test/java/software/amazon/rds/common/handler/CommonsTest.java
+++ b/aws-rds-cfn-common/src/test/java/software/amazon/rds/common/handler/CommonsTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.awscore.exception.AwsErrorDetails;
 import software.amazon.awssdk.awscore.exception.AwsServiceException;
 import software.amazon.awssdk.core.exception.SdkClientException;
+import software.amazon.awssdk.core.exception.SdkServiceException;
 import software.amazon.cloudformation.proxy.HandlerErrorCode;
 import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.rds.common.error.ErrorCode;
@@ -82,6 +83,13 @@ public class CommonsTest {
     @Test
     public void handle_SdkClientException() {
         final ErrorStatus status = Commons.DEFAULT_ERROR_RULE_SET.handle(SdkClientException.builder().build());
+        assertThat(status).isInstanceOf(HandlerErrorStatus.class);
+        assertThat(((HandlerErrorStatus) status).getHandlerErrorCode()).isEqualTo(HandlerErrorCode.ServiceInternalError);
+    }
+
+    @Test
+    public void handle_SdkServiceException() {
+        final ErrorStatus status = Commons.DEFAULT_ERROR_RULE_SET.handle(SdkServiceException.builder().build());
         assertThat(status).isInstanceOf(HandlerErrorStatus.class);
         assertThat(((HandlerErrorStatus) status).getHandlerErrorCode()).isEqualTo(HandlerErrorCode.ServiceInternalError);
     }


### PR DESCRIPTION
This commit adds another SDK-related exception class to the default error rule set. The semantics of `SdkServiceException` is pretty similar to `SdkClientException`, with the difference that the issue occurred on the server side (e.g. backend unavailable).

The exception is being handled as an internal service error and hence would be retried.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Signed-off-by: Oleg Sidorov <sidorovo@amazon.com>