### PR TITLE
[DBInstance][DBCluster] Fix false drift on EngineVersion

### DIFF
--- a/aws-rds-cfn-test-common/src/main/java/software/amazon/rds/test/common/schema/ResourceDriftTestHelper.java
+++ b/aws-rds-cfn-test-common/src/main/java/software/amazon/rds/test/common/schema/ResourceDriftTestHelper.java
@@ -126,9 +126,10 @@ public class ResourceDriftTestHelper {
 
                     // JSONata would return a string evaluation result in quotes, e.g "\"result\"", we need to strip it.
                     final String transformedVal = altInputFieldVal.toString().replaceAll("^\"|\"$", "");
+
                     // Add regexp anchors to avoid loose comparisons.
                     final Pattern pattern = Pattern.compile("^" + transformedVal + "$");
-                    if (pattern.matcher((String) outputFieldVal).matches()) {
+                    if (transformedVal.equals(outputFieldVal) || pattern.matcher((String) outputFieldVal).matches()) {
                         continue NextField;
                     }
                 }

--- a/aws-rds-dbcluster/aws-rds-dbcluster.json
+++ b/aws-rds-dbcluster/aws-rds-dbcluster.json
@@ -399,6 +399,7 @@
     "/properties/DBClusterParameterGroupName": "$lowercase(DBClusterParameterGroupName)",
     "/properties/DBSubnetGroupName": "$lowercase(DBSubnetGroupName)",
     "/properties/EnableHttpEndpoint": "$lowercase($string(EngineMode)) = 'serverless' ? EnableHttpEndpoint : false",
+    "/properties/EngineVersion": "$join([$string(EngineVersion), \".*\"])",
     "/properties/KmsKeyId": "$join([\"arn:(aws)[-]{0,1}[a-z]{0,2}[-]{0,1}[a-z]{0,3}:kms:[a-z]{2}[-]{1}[a-z]{3,10}[-]{0,1}[a-z]{0,10}[-]{1}[1-3]{1}:[0-9]{12}[:]{1}key\\/\", KmsKeyId])",
     "/properties/MasterUserSecret/KmsKeyId": "$join([\"arn:(aws)[-]{0,1}[a-z]{0,2}[-]{0,1}[a-z]{0,3}:kms:[a-z]{2}[-]{1}[a-z]{3,10}[-]{0,1}[a-z]{0,10}[-]{1}[1-3]{1}:[0-9]{12}[:]{1}key\\/\", KmsKeyId])",
     "/properties/PerformanceInsightsKmsKeyId": "$join([\"arn:(aws)[-]{0,1}[a-z]{0,2}[-]{0,1}[a-z]{0,3}:kms:[a-z]{2}[-]{1}[a-z]{3,10}[-]{0,1}[a-z]{0,10}[-]{1}[1-3]{1}:[0-9]{12}[:]{1}key\\/\", PerformanceInsightsKmsKeyId])",

--- a/aws-rds-dbcluster/src/test/java/software/amazon/rds/dbcluster/SchemaTest.java
+++ b/aws-rds-dbcluster/src/test/java/software/amazon/rds/dbcluster/SchemaTest.java
@@ -156,4 +156,39 @@ public class SchemaTest {
                 .build();
         ResourceDriftTestHelper.assertResourceNotDrifted(input, output, resourceSchema);
     }
+
+    @Test
+    public void testDrift_EngineVersion_MajorVersionOnly() {
+        final ResourceModel input = ResourceModel.builder()
+                .engineVersion("5")
+                .build();
+        final ResourceModel output = ResourceModel.builder()
+                .engineVersion("5.6.40")
+                .build();
+        ResourceDriftTestHelper.assertResourceNotDrifted(input, output, resourceSchema);
+    }
+
+    @Test
+    public void testDrift_EngineVersion_MajorAndMinorVersion() {
+        final ResourceModel input = ResourceModel.builder()
+                .engineVersion("5.6")
+                .build();
+        final ResourceModel output = ResourceModel.builder()
+                .engineVersion("5.6.40")
+                .build();
+        ResourceDriftTestHelper.assertResourceNotDrifted(input, output, resourceSchema);
+    }
+
+    @Test
+    public void testDrift_EngineVersion_MinorMismatch_ShouldDrift() {
+        final ResourceModel input = ResourceModel.builder()
+                .engineVersion("5.6")
+                .build();
+        final ResourceModel output = ResourceModel.builder()
+                .engineVersion("5.7.40")
+                .build();
+        Assertions.assertThatThrownBy(() -> {
+            ResourceDriftTestHelper.assertResourceNotDrifted(input, output, resourceSchema);
+        }).isInstanceOf(AssertionError.class);
+    }
 }

--- a/aws-rds-dbinstance/aws-rds-dbinstance.json
+++ b/aws-rds-dbinstance/aws-rds-dbinstance.json
@@ -440,6 +440,7 @@
   "propertyTransform": {
     "/properties/DBClusterIdentifier": "$lowercase(DBClusterIdentifier)",
     "/properties/DBClusterSnapshotIdentifier": "$lowercase(DBClusterSnapshotIdentifier)",
+    "/properties/EngineVersion": "$join([$string(EngineVersion), \".*\"])",
     "/properties/DBInstanceIdentifier": "$lowercase(DBInstanceIdentifier)",
     "/properties/DBParameterGroupName": "$lowercase(DBParameterGroupName)",
     "/properties/DBSubnetGroupName": "$lowercase(DBSubnetGroupName)",

--- a/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/SchemaTest.java
+++ b/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/SchemaTest.java
@@ -1,6 +1,7 @@
 package software.amazon.rds.dbinstance;
 
 import org.json.JSONObject;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import software.amazon.rds.test.common.schema.ResourceDriftTestHelper;
@@ -152,5 +153,40 @@ public class SchemaTest {
                         .build())
                 .build();
         ResourceDriftTestHelper.assertResourceNotDrifted(input, output, resourceSchema);
+    }
+
+    @Test
+    public void testDrift_EngineVersion_MajorVersionOnly() {
+        final ResourceModel input = ResourceModel.builder()
+                .engineVersion("5")
+                .build();
+        final ResourceModel output = ResourceModel.builder()
+                .engineVersion("5.6.40")
+                .build();
+        ResourceDriftTestHelper.assertResourceNotDrifted(input, output, resourceSchema);
+    }
+
+    @Test
+    public void testDrift_EngineVersion_MajorAndMinorVersion() {
+        final ResourceModel input = ResourceModel.builder()
+                .engineVersion("5.6")
+                .build();
+        final ResourceModel output = ResourceModel.builder()
+                .engineVersion("5.6.40")
+                .build();
+        ResourceDriftTestHelper.assertResourceNotDrifted(input, output, resourceSchema);
+    }
+
+    @Test
+    public void testDrift_EngineVersion_MinorMismatch_ShouldDrift() {
+        final ResourceModel input = ResourceModel.builder()
+                .engineVersion("5.6")
+                .build();
+        final ResourceModel output = ResourceModel.builder()
+                .engineVersion("5.7.40")
+                .build();
+        Assertions.assertThatThrownBy(() -> {
+            ResourceDriftTestHelper.assertResourceNotDrifted(input, output, resourceSchema);
+        }).isInstanceOf(AssertionError.class);
     }
 }


### PR DESCRIPTION
This commit introduces an additional propertyTransform directive to DBInstance and DBCluster schemas. The transformation would be used by the drift detector to compare engine versions. The original input value is used as a prefix:
  - Assume only major version "5" is provided.
    - Resulting version "5.6.40" is not a drift.
    - Resulting version "5.6.40.patch1" is not a drift.
    - Resulting version "8.0.0" is a drift.
  - Assume major and minor versions are provided: "5.6".
    - Resulting version "5.6.40" is not a drift.
    - Resulting version "5.6.40.patch1" is not a drift.
    - Resulting version "5.12.1" is a drift.
    - Resulting version "8.0.0" is a drift.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Signed-off-by: Oleg Sidorov <sidorovo@amazon.com>