### PR TITLE
[DBClusterParameterGroup] Limit max filter size to 100

### DIFF
--- a/aws-rds-dbclusterparametergroup/src/main/java/software/amazon/rds/dbclusterparametergroup/Translator.java
+++ b/aws-rds-dbclusterparametergroup/src/main/java/software/amazon/rds/dbclusterparametergroup/Translator.java
@@ -8,7 +8,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import org.apache.commons.collections.MapUtils;
+import org.apache.commons.collections.CollectionUtils;
 
 import com.amazonaws.arn.Arn;
 import software.amazon.awssdk.services.rds.model.ApplyMethod;
@@ -31,8 +31,10 @@ public class Translator {
     public static final String RESOURCE_PREFIX = "cluster-pg:";
     public static final String FILTER_PARAMETER_NAME = "parameter-name";
 
-    static CreateDbClusterParameterGroupRequest createDbClusterParameterGroupRequest(final ResourceModel model,
-                                                                                     final Tagging.TagSet tags) {
+    static CreateDbClusterParameterGroupRequest createDbClusterParameterGroupRequest(
+            final ResourceModel model,
+            final Tagging.TagSet tags
+    ) {
         return CreateDbClusterParameterGroupRequest.builder()
                 .dbClusterParameterGroupName(model.getDBClusterParameterGroupName())
                 .dbParameterGroupFamily(model.getFamily())
@@ -41,15 +43,19 @@ public class Translator {
                 .build();
     }
 
-    static DescribeDbClusterParametersRequest describeDbClusterParametersFilteredRequest(final ResourceModel model, final String marker) {
-        if (MapUtils.isEmpty(model.getParameters())) {
-            throw new CfnInternalFailureException(new Exception("Model parameters should not be empty"));
+    static DescribeDbClusterParametersRequest describeDbClusterParametersFilteredRequest(
+            final ResourceModel model,
+            final List<String> parameterNames,
+            final String marker
+    ) {
+        if (CollectionUtils.isEmpty(parameterNames)) {
+            throw new CfnInternalFailureException(new Exception("Parameter names should not be empty"));
         }
         return DescribeDbClusterParametersRequest.builder()
                 .dbClusterParameterGroupName(model.getDBClusterParameterGroupName())
                 .filters(Filter.builder()
                         .name(FILTER_PARAMETER_NAME)
-                        .values(model.getParameters().keySet())
+                        .values(parameterNames)
                         .build())
                 .marker(marker)
                 .build();
@@ -77,8 +83,10 @@ public class Translator {
                 .build();
     }
 
-    static ModifyDbClusterParameterGroupRequest modifyDbClusterParameterGroupRequest(final ResourceModel model,
-                                                                                     final Collection<Parameter> parameters) {
+    static ModifyDbClusterParameterGroupRequest modifyDbClusterParameterGroupRequest(
+            final ResourceModel model,
+            final Collection<Parameter> parameters
+    ) {
         return ModifyDbClusterParameterGroupRequest.builder()
                 .dbClusterParameterGroupName(model.getDBClusterParameterGroupName())
                 .parameters(parameters)
@@ -110,8 +118,7 @@ public class Translator {
                 .collect(Collectors.toCollection(LinkedHashSet::new));
     }
 
-    public static Parameter buildParameterWithNewValue(final String newValue,
-                                                       final Parameter parameter) {
+    public static Parameter buildParameterWithNewValue(final String newValue, final Parameter parameter) {
         final Parameter.Builder param = parameter.toBuilder()
                 .parameterValue(newValue);
 
@@ -130,7 +137,7 @@ public class Translator {
     }
 
     public static Arn buildClusterParameterGroupArn(final ResourceHandlerRequest<ResourceModel> request) {
-        String resource = RESOURCE_PREFIX + request.getDesiredResourceState().getDBClusterParameterGroupName();
+        final String resource = RESOURCE_PREFIX + request.getDesiredResourceState().getDBClusterParameterGroupName();
         return Arn.builder()
                 .withPartition(request.getAwsPartition())
                 .withRegion(request.getRegion())

--- a/aws-rds-dbclusterparametergroup/src/test/java/software/amazon/rds/dbclusterparametergroup/TranslatorTest.java
+++ b/aws-rds-dbclusterparametergroup/src/test/java/software/amazon/rds/dbclusterparametergroup/TranslatorTest.java
@@ -1,18 +1,16 @@
 package software.amazon.rds.dbclusterparametergroup;
 
-import com.google.common.collect.ImmutableMap;
-
-import org.assertj.core.api.Assertions;
-import org.junit.jupiter.api.Test;
-import software.amazon.awssdk.services.rds.model.DescribeDbClusterParametersRequest;
-import software.amazon.awssdk.services.rds.model.DescribeDbClustersRequest;
-import software.amazon.awssdk.services.rds.model.DescribeDbClustersResponse;
-import software.amazon.awssdk.services.rds.model.Filter;
-import software.amazon.cloudformation.exceptions.CfnInternalFailureException;
-
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Collections;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import com.google.common.collect.ImmutableList;
+import software.amazon.awssdk.services.rds.model.DescribeDbClusterParametersRequest;
+import software.amazon.awssdk.services.rds.model.Filter;
+import software.amazon.cloudformation.exceptions.CfnInternalFailureException;
 
 public class TranslatorTest {
 
@@ -20,9 +18,8 @@ public class TranslatorTest {
     public void describeDbClusterParametersFilteredRequest_throwIfParametersEmpty() {
         Assertions.assertThatThrownBy(() -> {
             Translator.describeDbClusterParametersFilteredRequest(
-                    ResourceModel.builder()
-                            .parameters(Collections.emptyMap())
-                            .build(),
+                    ResourceModel.builder().build(),
+                    Collections.emptyList(),
                     null
             );
         }).isInstanceOf(CfnInternalFailureException.class);
@@ -31,11 +28,10 @@ public class TranslatorTest {
     @Test
     public void describeDbClusterParametersFilteredRequest_shouldSetParameterNameFilters() {
         final DescribeDbClusterParametersRequest request = Translator.describeDbClusterParametersFilteredRequest(
-                ResourceModel.builder()
-                        .dBClusterParameterGroupName("DBClusterParameterGroup")
-                        .parameters(ImmutableMap.of("key1", "value1", "key2", "value2"))
-                        .build(),
-                null);
+                ResourceModel.builder().dBClusterParameterGroupName("DBClusterParameterGroup").build(),
+                ImmutableList.of("key1", "key2"),
+                null
+        );
         assertThat(request.filters().size()).isEqualTo(1);
         final Filter filter = request.filters().get(0);
         assertThat(filter.name()).isEqualTo("parameter-name");


### PR DESCRIPTION
This commit limits the parameter name filter size to 100 elements per request. RDS API would reject a request containing more than 100 parameter names in the filter. The commit removes the recursive progressChain tailing and proposes a simplistic sequential current parameter accumulator buildup.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Signed-off-by: Oleg Sidorov <sidorovo@amazon.com>