### PR TITLE
[DBInstance][DBCluster] Address scenario when Restored from Snapshot DBInstance/DCluster opts in into SecretsManager integration

### DIFF
--- a/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/Translator.java
+++ b/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/Translator.java
@@ -530,7 +530,7 @@ public class Translator {
     public static MasterUserSecret translateMasterUserSecretFromSdk(
             final software.amazon.awssdk.services.rds.model.MasterUserSecret sdkSecret) {
         if (sdkSecret == null) {
-            return null;
+            return MasterUserSecret.builder().build();
         }
 
         return MasterUserSecret.builder()

--- a/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/Translator.java
+++ b/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/Translator.java
@@ -241,7 +241,7 @@ public class Translator {
 
         if (BooleanUtils.isTrue(desiredModel.getManageMasterUserPassword())) {
             builder.manageMasterUserPassword(true);
-            builder.masterUserSecretKmsKeyId(desiredModel.getMasterUserSecret().getKmsKeyId());
+            builder.masterUserSecretKmsKeyId(desiredModel.getMasterUserSecret() != null ? desiredModel.getMasterUserSecret().getKmsKeyId() : null);
         } else {
             builder.manageMasterUserPassword(getManageMasterUserPassword(previousModel, desiredModel));
         }

--- a/aws-rds-dbcluster/src/test/java/software/amazon/rds/dbcluster/TranslatorTest.java
+++ b/aws-rds-dbcluster/src/test/java/software/amazon/rds/dbcluster/TranslatorTest.java
@@ -263,7 +263,7 @@ public class TranslatorTest extends AbstractHandlerTest {
     }
 
     @Test
-    public void test_modifyAfterCreate_when_manageMasterUserPasswordIsTrue_withImplicitDefaults() {
+    public void test_modifyAfterCreateWhenManageMasterUserPasswordIsTrueWithImplicitDefaults() {
         final ResourceModel desired = RESOURCE_MODEL.toBuilder()
                 .manageMasterUserPassword(true)
                 .build();
@@ -272,6 +272,27 @@ public class TranslatorTest extends AbstractHandlerTest {
 
         assertThat(request.manageMasterUserPassword()).isTrue();
         assertThat(request.masterUserSecretKmsKeyId()).isNull();
+    }
+
+    @Test
+    public void translateMasterUserSecretFromSdkTranslatesFields() {
+        final software.amazon.awssdk.services.rds.model.MasterUserSecret masterUserSecret = software.amazon.awssdk.services.rds.model.MasterUserSecret.builder()
+                .secretArn("secret-arn")
+                .kmsKeyId("key")
+                .build();
+
+        final MasterUserSecret translated = Translator.translateMasterUserSecretFromSdk(masterUserSecret);
+
+        assertThat(translated.getSecretArn()).isEqualTo("secret-arn");
+        assertThat(translated.getKmsKeyId()).isEqualTo("key");
+    }
+
+    @Test
+    public void translateMasterUserSecretFromSdkTranslatesNullValue() {
+        final MasterUserSecret translated = Translator.translateMasterUserSecretFromSdk(null);
+        assertThat(translated).isNotNull();
+        assertThat(translated.getSecretArn()).isNull();
+        assertThat(translated.getKmsKeyId()).isNull();
     }
 
     @Override

--- a/aws-rds-dbcluster/src/test/java/software/amazon/rds/dbcluster/TranslatorTest.java
+++ b/aws-rds-dbcluster/src/test/java/software/amazon/rds/dbcluster/TranslatorTest.java
@@ -262,6 +262,18 @@ public class TranslatorTest extends AbstractHandlerTest {
         assertThat(result.getSecondsUntilAutoPause()).isEqualTo(config.secondsUntilAutoPause());
     }
 
+    @Test
+    public void test_modifyAfterCreate_when_manageMasterUserPasswordIsTrue_withImplicitDefaults() {
+        final ResourceModel desired = RESOURCE_MODEL.toBuilder()
+                .manageMasterUserPassword(true)
+                .build();
+
+        final ModifyDbClusterRequest request = Translator.modifyDbClusterRequest(desired, desired, false);
+
+        assertThat(request.manageMasterUserPassword()).isTrue();
+        assertThat(request.masterUserSecretKmsKeyId()).isNull();
+    }
+
     @Override
     protected BaseHandlerStd getHandler() {
         return null;

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/Translator.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/Translator.java
@@ -519,6 +519,9 @@ public class Translator {
                 .caCertificateIdentifier(model.getCACertificateIdentifier())
                 .dbParameterGroupName(model.getDBParameterGroupName())
                 .engineVersion(model.getEngineVersion())
+                .manageMasterUserPassword(model.getManageMasterUserPassword())
+                .masterUserPassword(model.getMasterUserPassword())
+                .masterUserSecretKmsKeyId(model.getMasterUserSecret() != null ? model.getMasterUserSecret().getKmsKeyId(): null)
                 .masterUserPassword(model.getMasterUserPassword())
                 .maxAllocatedStorage(model.getMaxAllocatedStorage())
                 .preferredBackupWindow(model.getPreferredBackupWindow())
@@ -915,7 +918,7 @@ public class Translator {
 
     public static MasterUserSecret translateMasterUserSecret(final software.amazon.awssdk.services.rds.model.MasterUserSecret sdkSecret) {
         if (sdkSecret == null) {
-            return null;
+            return MasterUserSecret.builder().build();
         }
 
         return MasterUserSecret.builder()

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/util/ResourceModelHelper.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/util/ResourceModelHelper.java
@@ -35,7 +35,8 @@ public final class ResourceModelHelper {
                                 Optional.ofNullable(model.getIops()).orElse(0) > 0 ||
                                 Optional.ofNullable(model.getMaxAllocatedStorage()).orElse(0) > 0 ||
                                 Optional.ofNullable(model.getStorageThroughput()).orElse(0) > 0 ||
-                                (isSqlServer(model) && StringUtils.hasValue(model.getAllocatedStorage()))
+                                (isSqlServer(model) && StringUtils.hasValue(model.getAllocatedStorage())) ||
+                                BooleanUtils.isTrue(model.getManageMasterUserPassword())
                 );
     }
 

--- a/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/ListHandlerTest.java
+++ b/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/ListHandlerTest.java
@@ -97,6 +97,7 @@ public class ListHandlerTest extends AbstractHandlerTest {
                 .associatedRoles(Collections.emptyList())
                 .enableCloudwatchLogsExports(Collections.emptyList())
                 .manageMasterUserPassword(false)
+                .masterUserSecret(MasterUserSecret.builder().build())
                 .processorFeatures(Collections.emptyList())
                 .tags(Collections.emptyList())
                 .dBSecurityGroups(Collections.emptyList())

--- a/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/TranslatorTest.java
+++ b/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/TranslatorTest.java
@@ -495,9 +495,9 @@ class TranslatorTest extends AbstractHandlerTest {
     }
 
     @Test
-    public void translateMasterUserSecret_sdkSecretNull() {
+    public void translateMasterUserSecret_sdkSecretEmpty() {
         assertThat(Translator.translateMasterUserSecret(null))
-                .isNull();
+                .isEqualTo(MasterUserSecret.builder().build());
     }
 
     @Test
@@ -854,6 +854,19 @@ class TranslatorTest extends AbstractHandlerTest {
 
         assertThat(request.iops()).isEqualTo(1200);
         assertThat(request.allocatedStorage()).isNull();
+    }
+
+    @Test
+    public void test_modifyAfterCreate_shouldSetManageMasterUserPasswordFields() {
+        final ResourceModel model = RESOURCE_MODEL_BLDR()
+                .dBSnapshotIdentifier("snapshot")
+                .manageMasterUserPassword(true)
+                .masterUserSecret(MasterUserSecret.builder().kmsKeyId("kms-key").build())
+                .build();
+
+        final ModifyDbInstanceRequest request = Translator.modifyDbInstanceAfterCreateRequest(model);
+        assertThat(request.manageMasterUserPassword()).isTrue();
+        assertThat(request.masterUserSecretKmsKeyId()).isEqualTo("kms-key");
     }
 
     // Stub methods to satisfy the interface. This is a 1-time thing.

--- a/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/util/ResourceModelHelperTest.java
+++ b/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/util/ResourceModelHelperTest.java
@@ -143,4 +143,15 @@ public class ResourceModelHelperTest {
 
         assertThat(ResourceModelHelper.shouldUpdateAfterCreate(model)).isTrue();
     }
+
+    @Test
+    public void shouldUpdateAfterCreate_whenRestoreFromSnapshotAndManageMasterUserPassword() {
+        final ResourceModel model = ResourceModel.builder()
+                .dBSnapshotIdentifier("identifier")
+                .manageMasterUserPassword(true)
+                .build();
+
+        assertThat(ResourceModelHelper.shouldUpdateAfterCreate(model)).isTrue();
+    }
+
 }


### PR DESCRIPTION
This PR is a followup on SecretsManager integration implementation that addresses a few things:
* Correctly apply SecretsManager related modifications for RestoreFromSnapshot scenario
* Address false positive drift detection when ManageMasterUserPassword was involved for DBCluster/DBInstace

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
