### PR TITLE
[DBInstance] Set `copyTagsToSnapshot` on `RestoreDbInstanceFromSnapshot`

### DIFF
--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/Translator.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/Translator.java
@@ -152,6 +152,7 @@ public class Translator {
         final RestoreDbInstanceFromDbSnapshotRequest.Builder builder = RestoreDbInstanceFromDbSnapshotRequest.builder()
                 .autoMinorVersionUpgrade(model.getAutoMinorVersionUpgrade())
                 .availabilityZone(model.getAvailabilityZone())
+                .copyTagsToSnapshot(model.getCopyTagsToSnapshot())
                 .customIamInstanceProfile(model.getCustomIAMInstanceProfile())
                 .dbInstanceClass(model.getDBInstanceClass())
                 .dbInstanceIdentifier(model.getDBInstanceIdentifier())

--- a/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/TranslatorTest.java
+++ b/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/TranslatorTest.java
@@ -869,6 +869,29 @@ class TranslatorTest extends AbstractHandlerTest {
         assertThat(request.masterUserSecretKmsKeyId()).isEqualTo("kms-key");
     }
 
+    @Test
+    public void test_restoreDbInstanceFromSnapshot_shouldKeepCopyTagsToSnapshotEmptyIfUnset() {
+        final ResourceModel model = ResourceModel.builder()
+                .build();
+        final RestoreDbInstanceFromDbSnapshotRequest request = Translator.restoreDbInstanceFromSnapshotRequest(
+                model,
+                Tagging.TagSet.emptySet()
+        );
+        assertThat(request.copyTagsToSnapshot()).isNull();
+    }
+
+    @Test
+    public void test_restoreDbInstanceFromSnapshot_shouldSetCopyTagsToSnapshot() {
+        final ResourceModel model = ResourceModel.builder()
+                .copyTagsToSnapshot(true)
+                .build();
+        final RestoreDbInstanceFromDbSnapshotRequest request = Translator.restoreDbInstanceFromSnapshotRequest(
+                model,
+                Tagging.TagSet.emptySet()
+        );
+        assertThat(request.copyTagsToSnapshot()).isTrue();
+    }
+
     // Stub methods to satisfy the interface. This is a 1-time thing.
 
     @Override


### PR DESCRIPTION
This commit adds a missing attribute `copyTagsToSnapshot` to the `RestoreDbInstanceFromSnapshot` translator routine. The motivation for this change is to achieve a cross-create-method consistency as the attribute is supported in all create methods used in the DBInstance handler.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Signed-off-by: Oleg Sidorov <sidorovo@amazon.com>