### PR TITLE
[DBSubnetGroup] Trim whitespaces for subnetIDs when building Create and Modify DBSubnetGroup requests

### DIFF
--- a/aws-rds-dbsubnetgroup/src/main/java/software/amazon/rds/dbsubnetgroup/Translator.java
+++ b/aws-rds-dbsubnetgroup/src/main/java/software/amazon/rds/dbsubnetgroup/Translator.java
@@ -9,6 +9,7 @@ import java.util.stream.Collectors;
 
 import com.amazonaws.arn.Arn;
 import com.amazonaws.util.CollectionUtils;
+import com.amazonaws.util.StringUtils;
 import software.amazon.awssdk.services.rds.model.CreateDbSubnetGroupRequest;
 import software.amazon.awssdk.services.rds.model.DBSubnetGroup;
 import software.amazon.awssdk.services.rds.model.DeleteDbSubnetGroupRequest;
@@ -30,7 +31,7 @@ public class Translator {
         return CreateDbSubnetGroupRequest.builder()
                 .dbSubnetGroupName(model.getDBSubnetGroupName())
                 .dbSubnetGroupDescription(model.getDBSubnetGroupDescription())
-                .subnetIds(model.getSubnetIds().stream().sorted().collect(Collectors.toCollection(LinkedHashSet::new)))
+                .subnetIds(model.getSubnetIds().stream().map(StringUtils::trim).sorted().collect(Collectors.toCollection(LinkedHashSet::new)))
                 .tags(Tagging.translateTagsToSdk(tags)).build();
     }
 
@@ -50,7 +51,7 @@ public class Translator {
         return ModifyDbSubnetGroupRequest.builder()
                 .dbSubnetGroupName(model.getDBSubnetGroupName())
                 .dbSubnetGroupDescription(model.getDBSubnetGroupDescription())
-                .subnetIds(model.getSubnetIds().stream().sorted().collect(Collectors.toCollection(LinkedHashSet::new)))
+                .subnetIds(model.getSubnetIds().stream().map(StringUtils::trim).sorted().collect(Collectors.toCollection(LinkedHashSet::new)))
                 .build();
     }
 

--- a/aws-rds-dbsubnetgroup/src/test/java/software/amazon/rds/dbsubnetgroup/TranslatorTest.java
+++ b/aws-rds-dbsubnetgroup/src/test/java/software/amazon/rds/dbsubnetgroup/TranslatorTest.java
@@ -1,0 +1,38 @@
+package software.amazon.rds.dbsubnetgroup;
+
+import com.google.common.collect.ImmutableList;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.awssdk.services.rds.model.CreateDbSubnetGroupRequest;
+import software.amazon.awssdk.services.rds.model.ModifyDbSubnetGroupRequest;
+import software.amazon.rds.common.handler.Tagging;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(MockitoExtension.class)
+public class TranslatorTest {
+
+    @Test
+    public void createDBSubnetGroupTrimsWhitespaces() {
+        final CreateDbSubnetGroupRequest request = Translator.createDbSubnetGroupRequest(ResourceModel.builder()
+                .subnetIds(ImmutableList.of(
+                        " \t\n\r\nsubnet1",
+                        "subnet2 \t\n\r\n",
+                        " \t\n\r\nsubnet3 \t\n\r\n")).build(),
+                Tagging.TagSet.builder().build());
+
+        assertThat(request.subnetIds()).containsExactly("subnet1", "subnet2", "subnet3");
+    }
+
+    @Test
+    public void modifyDBSubnetGroupTrimsWhitespaces() {
+        final ModifyDbSubnetGroupRequest request = Translator.modifyDbSubnetGroupRequest(ResourceModel.builder()
+                .subnetIds(ImmutableList.of(
+                        " \t\n\r\nsubnet1",
+                        "subnet2 \t\n\r\n",
+                        " \t\n\r\nsubnet3 \t\n\r\n")).build());
+
+        assertThat(request.subnetIds()).containsExactly("subnet1", "subnet2", "subnet3");
+    }
+}


### PR DESCRIPTION
This PR addresses the issue when subnetIDs contain extraneous white-space characters. Before this change, white-space padded SubnetIds would be silently treated as non-existing subnets, which potentially could result in unintentional removal of such subnets from DBSubnetGroup. This change removes whitespace-padding , eliminating the issue.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
