### PR TITLE
[DBInstance] Mark `DeleteAutomatedBackups` as WriteOnly

### DIFF
--- a/aws-rds-dbinstance/aws-rds-dbinstance.json
+++ b/aws-rds-dbinstance/aws-rds-dbinstance.json
@@ -490,7 +490,9 @@
     "/properties/TdeCredentialPassword"
   ],
   "writeOnlyProperties": [
+    "/properties/CertificateRotationRestart",
     "/properties/DBSnapshotIdentifier",
+    "/properties/DeleteAutomatedBackups",
     "/properties/MasterUserPassword",
     "/properties/Port",
     "/properties/RestoreTime",
@@ -499,8 +501,7 @@
     "/properties/SourceDbiResourceId",
     "/properties/SourceRegion",
     "/properties/TdeCredentialPassword",
-    "/properties/UseLatestRestorableTime",
-    "/properties/CertificateRotationRestart"
+    "/properties/UseLatestRestorableTime"
   ],
   "readOnlyProperties": [
     "/properties/Endpoint/Address",


### PR DESCRIPTION
This commit marks `DeleteAutomatedBackups` as a write-only property. The morivation for this change is to align this attribute behavior with its purpose: the flag is semi-virtual and is only used upon a delete. Up until this point it is an ephemeural attribute that is not stored anywhere, hence bugging CFN users with false drift detector alarms.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Fixes https://github.com/aws-cloudformation/cloudformation-coverage-roadmap/issues/1510.
Refs https://github.com/aws-cloudformation/aws-cloudformation-resource-providers-rds/issues/400.

Signed-off-by: Oleg Sidorov <sidorovo@amazon.com>