### PR TITLE
[DBInstance] Mark `AllowMajorVersionUpgrade` as WriteOnly

### DIFF
--- a/aws-rds-dbinstance/aws-rds-dbinstance.json
+++ b/aws-rds-dbinstance/aws-rds-dbinstance.json
@@ -490,6 +490,7 @@
     "/properties/TdeCredentialPassword"
   ],
   "writeOnlyProperties": [
+    "/properties/AllowMajorVersionUpgrade",
     "/properties/CertificateRotationRestart",
     "/properties/DBSnapshotIdentifier",
     "/properties/DeleteAutomatedBackups",


### PR DESCRIPTION
This commit marks `AllowMajorVersionUpgrade` as a write-only property. The motivation is similar to
https://github.com/aws-cloudformation/aws-cloudformation-resource-providers-rds/pull/401 in terms of the nature of the attribute: the RDS API won't accept it upon a create and won't serve it back with a describe-db-instances. The flag is only used upon a modify request to indicate that a major engine version could be changed.

Refs https://github.com/aws-cloudformation/aws-cloudformation-resource-providers-rds/issues/400.
Fixes https://github.com/aws-cloudformation/cloudformation-coverage-roadmap/issues/1511.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Signed-off-by: Oleg Sidorov <sidorovo@amazon.com>