### PR TITLE
[DBInstance] Fix `OptionGroupName` false drift

### DIFF
--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/Translator.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/Translator.java
@@ -703,6 +703,11 @@ public class Translator {
             domainIAMRoleName = dbInstance.domainMemberships().get(0).iamRoleName();
         }
 
+        String optionGroupName = null;
+        if (CollectionUtils.isNotEmpty(dbInstance.optionGroupMemberships())) {
+            optionGroupName = dbInstance.optionGroupMemberships().get(0).optionGroupName();
+        }
+
         return ResourceModel.builder()
                 .allocatedStorage(allocatedStorage)
                 .associatedRoles(translateAssociatedRolesFromSdk(dbInstance.associatedRoles()))
@@ -745,6 +750,7 @@ public class Translator {
                 .multiAZ(dbInstance.multiAZ())
                 .ncharCharacterSetName(dbInstance.ncharCharacterSetName())
                 .networkType(dbInstance.networkType())
+                .optionGroupName(optionGroupName)
                 .performanceInsightsKMSKeyId(dbInstance.performanceInsightsKMSKeyId())
                 .performanceInsightsRetentionPeriod(dbInstance.performanceInsightsRetentionPeriod())
                 .port(port == null ? null : port.toString())


### PR DESCRIPTION
This commit addresses a false drift issue concerning `DBInstance.OptionGroupName` attribute. The translator class is now instructed to pick it up from the `OptionGroupMembership`.

Refs https://github.com/aws-cloudformation/aws-cloudformation-resource-providers-rds/issues/400.
Fixes https://github.com/aws-cloudformation/cloudformation-coverage-roadmap/issues/1509.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Signed-off-by: Oleg Sidorov <sidorovo@amazon.com>