### PR TITLE
[DBParameterGroup] Include parameters in the `ReadHandler` response

### DIFF
--- a/aws-rds-cfn-common/src/main/java/software/amazon/rds/common/logging/LoggingProxyClient.java
+++ b/aws-rds-cfn-common/src/main/java/software/amazon/rds/common/logging/LoggingProxyClient.java
@@ -19,41 +19,43 @@ public class LoggingProxyClient<ClientT> implements ProxyClient<ClientT> {
     final private ProxyClient<ClientT> proxyClient;
 
     @Override
-    public <RequestT extends AwsRequest, ResponseT extends AwsResponse>
-    ResponseT
-    injectCredentialsAndInvokeV2(RequestT request, Function<RequestT, ResponseT> requestFunction) {
-        return logAndDelegate(request, requestFunction, proxyClient::injectCredentialsAndInvokeV2);
+    public <RequestT extends AwsRequest, ResponseT extends AwsResponse> ResponseT injectCredentialsAndInvokeV2(
+            final RequestT request,
+            final Function<RequestT, ResponseT> requestFunction
+    ) {
+        return logRequestResponseAndDelegate(request, requestFunction, proxyClient::injectCredentialsAndInvokeV2);
     }
 
     @Override
-    public <RequestT extends AwsRequest, ResponseT extends AwsResponse>
-    CompletableFuture<ResponseT>
-    injectCredentialsAndInvokeV2Async(RequestT request,
-                                      Function<RequestT, CompletableFuture<ResponseT>> requestFunction) {
-        return logAndDelegate(request, requestFunction, proxyClient::injectCredentialsAndInvokeV2Async);
+    public <RequestT extends AwsRequest, ResponseT extends AwsResponse> CompletableFuture<ResponseT> injectCredentialsAndInvokeV2Async(
+            final RequestT request,
+            final Function<RequestT, CompletableFuture<ResponseT>> requestFunction
+    ) {
+        return logRequestAndDelegate(request, requestFunction, proxyClient::injectCredentialsAndInvokeV2Async);
     }
 
     @Override
-    public <RequestT extends AwsRequest, ResponseT extends AwsResponse, IterableT extends SdkIterable<ResponseT>>
-    IterableT
-    injectCredentialsAndInvokeIterableV2(RequestT request, Function<RequestT, IterableT> requestFunction) {
-        return logAndDelegate(request, requestFunction, proxyClient::injectCredentialsAndInvokeIterableV2);
+    public <RequestT extends AwsRequest, ResponseT extends AwsResponse, IterableT extends SdkIterable<ResponseT>> IterableT injectCredentialsAndInvokeIterableV2(
+            final RequestT request,
+            final Function<RequestT, IterableT> requestFunction
+    ) {
+        return logRequestAndDelegate(request, requestFunction, proxyClient::injectCredentialsAndInvokeIterableV2);
     }
 
     @Override
-    public <RequestT extends AwsRequest, ResponseT extends AwsResponse>
-    ResponseInputStream<ResponseT>
-    injectCredentialsAndInvokeV2InputStream(RequestT request,
-                                            Function<RequestT, ResponseInputStream<ResponseT>> requestFunction) {
-        return logAndDelegate(request, requestFunction, proxyClient::injectCredentialsAndInvokeV2InputStream);
+    public <RequestT extends AwsRequest, ResponseT extends AwsResponse> ResponseInputStream<ResponseT> injectCredentialsAndInvokeV2InputStream(
+            final RequestT request,
+            final Function<RequestT, ResponseInputStream<ResponseT>> requestFunction
+    ) {
+        return logRequestAndDelegate(request, requestFunction, proxyClient::injectCredentialsAndInvokeV2InputStream);
     }
 
     @Override
-    public <RequestT extends AwsRequest, ResponseT extends AwsResponse>
-    ResponseBytes<ResponseT>
-    injectCredentialsAndInvokeV2Bytes(RequestT request,
-                                      Function<RequestT, ResponseBytes<ResponseT>> requestFunction) {
-        return logAndDelegate(request, requestFunction, proxyClient::injectCredentialsAndInvokeV2Bytes);
+    public <RequestT extends AwsRequest, ResponseT extends AwsResponse> ResponseBytes<ResponseT> injectCredentialsAndInvokeV2Bytes(
+            final RequestT request,
+            final Function<RequestT, ResponseBytes<ResponseT>> requestFunction
+    ) {
+        return logRequestAndDelegate(request, requestFunction, proxyClient::injectCredentialsAndInvokeV2Bytes);
     }
 
     @Override
@@ -61,10 +63,11 @@ public class LoggingProxyClient<ClientT> implements ProxyClient<ClientT> {
         return proxyClient.client();
     }
 
-    private <RequestT extends AwsRequest, ResultT> ResultT logAndDelegate(
+    private <RequestT extends AwsRequest, ResultT> ResultT logRequestResponseAndDelegate(
             final RequestT request,
             final Function<RequestT, ResultT> requestFunction,
-            final BiFunction<RequestT, Function<RequestT, ResultT>, ResultT> injectCredentials) {
+            final BiFunction<RequestT, Function<RequestT, ResultT>, ResultT> injectCredentials
+    ) {
         ResultT result = null;
         try {
             requestLogger.log(request);
@@ -76,5 +79,19 @@ public class LoggingProxyClient<ClientT> implements ProxyClient<ClientT> {
         return result;
     }
 
-
+    private <RequestT extends AwsRequest, ResultT> ResultT logRequestAndDelegate(
+            final RequestT request,
+            final Function<RequestT, ResultT> requestFunction,
+            final BiFunction<RequestT, Function<RequestT, ResultT>, ResultT> injectCredentials
+    ) {
+        ResultT result = null;
+        try {
+            requestLogger.log(request);
+            result = injectCredentials.apply(request, requestFunction);
+        } catch (Exception e) {
+            requestLogger.logAndThrow(e);
+        }
+        requestLogger.log("[Result log omitted]");
+        return result;
+    }
 }

--- a/aws-rds-cfn-common/src/main/java/software/amazon/rds/common/printer/FilteredJsonPrinter.java
+++ b/aws-rds-cfn-common/src/main/java/software/amazon/rds/common/printer/FilteredJsonPrinter.java
@@ -11,7 +11,7 @@ import com.fasterxml.jackson.annotation.PropertyAccessor;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.ser.FilterProvider;
 import com.fasterxml.jackson.databind.ser.impl.SimpleBeanPropertyFilter;
@@ -35,7 +35,7 @@ public class FilteredJsonPrinter implements JsonPrinter {
     public FilteredJsonPrinter(String... filterFields) {
         this.filterFields = filterFields;
         mapper = new ObjectMapper()
-                .setPropertyNamingStrategy(PropertyNamingStrategy.UPPER_CAMEL_CASE)
+                .setPropertyNamingStrategy(PropertyNamingStrategies.UPPER_CAMEL_CASE)
                 .enable(SerializationFeature.INDENT_OUTPUT)
                 .disable(SerializationFeature.FAIL_ON_EMPTY_BEANS);
         mapper.registerModule(new JavaTimeModule());

--- a/aws-rds-cfn-common/src/test/java/software/amazon/rds/common/logging/LoggingProxyClientTest.java
+++ b/aws-rds-cfn-common/src/test/java/software/amazon/rds/common/logging/LoggingProxyClientTest.java
@@ -82,8 +82,8 @@ class LoggingProxyClientTest extends ProxyClientTestBase {
         ResponseBytes<AwsResponse> response = ResponseBytes.fromByteArray(awsResponse, awsResponse.toString().getBytes());
         when(proxy.injectCredentialsAndInvokeV2Bytes(any(), any())).thenReturn(response);
         proxyRdsClient.injectCredentialsAndInvokeV2Bytes(awsRequest, request -> response);
-        verify(logger, times(2)).log(captor.capture());
-        assertThat(captor.getValue().contains(STACK_ID)).isTrue();
+        verify(logger, times(3)).log(captor.capture());
+        assertThat(captor.getAllValues().get(0).contains(STACK_ID)).isTrue();
     }
 
     @Test
@@ -91,8 +91,8 @@ class LoggingProxyClientTest extends ProxyClientTestBase {
         ProxyClient<RdsClient> proxyRdsClient = getProxyRdsClient(logger);
         when(proxy.injectCredentialsAndInvokeIterableV2(any(), any())).thenReturn(sdkIterable);
         proxyRdsClient.injectCredentialsAndInvokeIterableV2(awsRequest, request -> sdkIterable);
-        verify(logger, times(2)).log(captor.capture());
-        assertThat(captor.getValue().contains(AWS_ACCOUNT_ID)).isTrue();
+        verify(logger, times(3)).log(captor.capture());
+        assertThat(captor.getAllValues().get(0).contains(AWS_ACCOUNT_ID)).isTrue();
     }
 
     @Test
@@ -100,7 +100,7 @@ class LoggingProxyClientTest extends ProxyClientTestBase {
         ProxyClient<RdsClient> proxyRdsClient = getProxyRdsClient(logger);
         when(proxy.injectCredentialsAndInvokeV2Async(any(), any())).thenReturn(awsResponseCompletableFuture);
         proxyRdsClient.injectCredentialsAndInvokeV2Async(awsRequest, request -> awsResponseCompletableFuture);
-        verify(logger, times(2)).log(captor.capture());
-        assertThat(captor.getValue().contains(STACK_ID)).isTrue();
+        verify(logger, times(3)).log(captor.capture());
+        assertThat(captor.getAllValues().get(0).contains(STACK_ID)).isTrue();
     }
 }

--- a/aws-rds-cfn-test-common/src/main/java/software/amazon/rds/test/common/verification/AccessPermissionAlias.java
+++ b/aws-rds-cfn-test-common/src/main/java/software/amazon/rds/test/common/verification/AccessPermissionAlias.java
@@ -1,0 +1,13 @@
+package software.amazon.rds.test.common.verification;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+public class AccessPermissionAlias {
+    @Getter
+    private AccessPermission origin;
+
+    @Getter
+    private AccessPermission equivalent;
+}

--- a/aws-rds-cfn-test-common/src/test/java/software/amazon/rds/test/common/verification/AccessPermissionTest.java
+++ b/aws-rds-cfn-test-common/src/test/java/software/amazon/rds/test/common/verification/AccessPermissionTest.java
@@ -1,0 +1,15 @@
+package software.amazon.rds.test.common.verification;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import software.amazon.rds.test.common.core.ServiceProvider;
+
+class AccessPermissionTest {
+
+    @Test
+    public void test_toString() {
+        final AccessPermission permission = new AccessPermission(ServiceProvider.RDS, "TestMethod");
+        Assertions.assertThat(permission.toString()).isEqualTo("rds:TestMethod");
+    }
+}

--- a/aws-rds-cfn-test-common/src/test/java/software/amazon/rds/test/common/verification/AccessPermissionVerificationModeTest.java
+++ b/aws-rds-cfn-test-common/src/test/java/software/amazon/rds/test/common/verification/AccessPermissionVerificationModeTest.java
@@ -15,13 +15,16 @@ class AccessPermissionVerificationModeTest {
     static class RdsClient {
         public void testMethod() {
         }
+
+        public void testMethodAlias() {
+        }
     }
 
     @Test
     public void test_unknownPermissionThrowsMockitoAssertionError() {
         final AccessPermissionVerificationMode verificationMode = new AccessPermissionVerificationMode();
-        RdsClient mock = Mockito.mock(RdsClient.class);
 
+        RdsClient mock = Mockito.mock(RdsClient.class);
         mock.testMethod();
 
         Assertions.assertThatThrownBy(() -> {
@@ -32,10 +35,27 @@ class AccessPermissionVerificationModeTest {
     @Test
     public void test_enabledPermissionVerifiedSuccessfully() {
         final AccessPermissionVerificationMode verificationMode = new AccessPermissionVerificationMode();
-        RdsClient mock = Mockito.mock(RdsClient.class);
         verificationMode.enablePermission(new AccessPermission(ServiceProvider.RDS, "TestMethod"));
 
+        RdsClient mock = Mockito.mock(RdsClient.class);
         mock.testMethod();
+
+        Assertions.assertThatCode(() -> {
+            verificationMode.verify(new VerificationDataImpl(MockUtil.getInvocationContainer(mock), null));
+        }).doesNotThrowAnyException();
+    }
+
+    @Test
+    public void test_enabledPermissionAliasVerifiedSuccessfully() {
+        final AccessPermission origin = new AccessPermission(ServiceProvider.RDS, "TestMethodAlias");
+        final AccessPermission equivalent = new AccessPermission(ServiceProvider.RDS, "TestMethod");
+
+        final AccessPermissionVerificationMode verificationMode = new AccessPermissionVerificationMode()
+                .enablePermission(equivalent)
+                .withAliases(new AccessPermissionAlias(origin, equivalent));
+
+        RdsClient mock = Mockito.mock(RdsClient.class);
+        mock.testMethodAlias();
 
         Assertions.assertThatCode(() -> {
             verificationMode.verify(new VerificationDataImpl(MockUtil.getInvocationContainer(mock), null));

--- a/aws-rds-dbparametergroup/aws-rds-dbparametergroup.json
+++ b/aws-rds-dbparametergroup/aws-rds-dbparametergroup.json
@@ -71,23 +71,23 @@
     "/properties/Description",
     "/properties/Family"
   ],
-  "writeOnlyProperties": [
-    "/properties/Parameters"
-  ],
   "handlers": {
     "create": {
       "permissions": [
         "rds:AddTagsToResource",
         "rds:CreateDBParameterGroup",
         "rds:DescribeDBParameterGroups",
+        "rds:DescribeDBParameters",
         "rds:DescribeEngineDefaultParameters",
-        "rds:ModifyDBParameterGroup",
-        "rds:ListTagsForResource"
+        "rds:ListTagsForResource",
+        "rds:ModifyDBParameterGroup"
       ]
     },
     "read": {
       "permissions": [
         "rds:DescribeDBParameterGroups",
+        "rds:DescribeDBParameters",
+        "rds:DescribeEngineDefaultParameters",
         "rds:ListTagsForResource"
       ]
     },

--- a/aws-rds-dbparametergroup/src/test/java/software/amazon/rds/dbparametergroup/BaseHandlerStdTest.java
+++ b/aws-rds-dbparametergroup/src/test/java/software/amazon/rds/dbparametergroup/BaseHandlerStdTest.java
@@ -1,0 +1,39 @@
+package software.amazon.rds.dbparametergroup;
+
+import java.util.Map;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import com.google.common.collect.ImmutableMap;
+import software.amazon.awssdk.services.rds.model.Parameter;
+
+class BaseHandlerStdTest {
+
+    @Test
+    public void test_computeModifiedDBParameters() {
+        final Map<String, Parameter> engineDefaultParameters = ImmutableMap.of(
+                "param1", Parameter.builder().parameterName("param1").parameterValue("value1").build(),
+                "param2", Parameter.builder().parameterName("param2").parameterValue("value2").build(),
+                "param3", Parameter.builder().parameterName("param3").parameterValue("value3").build(),
+                "param4", Parameter.builder().parameterName("param4").build()
+        );
+        final Map<String, Parameter> currentDBParameters = ImmutableMap.of(
+                "param1", Parameter.builder().parameterName("param1").parameterValue("value1").build(),
+                "param2", Parameter.builder().parameterName("param2").parameterValue("value1-2").build(),
+                "param4", Parameter.builder().parameterName("param4").build(),
+                "param5", Parameter.builder().parameterName("param5").parameterValue("value5").build()
+        );
+
+        final Map<String, Parameter> modifiedParameters = BaseHandlerStd.computeModifiedDBParameters(
+                engineDefaultParameters,
+                currentDBParameters
+        );
+
+        Assertions.assertThat(modifiedParameters)
+                .isEqualTo(ImmutableMap.of(
+                        "param2", Parameter.builder().parameterName("param2").parameterValue("value1-2").build(),
+                        "param5", Parameter.builder().parameterName("param5").parameterValue("value5").build()
+                ));
+    }
+}

--- a/aws-rds-dbparametergroup/src/test/java/software/amazon/rds/dbparametergroup/TranslatorTest.java
+++ b/aws-rds-dbparametergroup/src/test/java/software/amazon/rds/dbparametergroup/TranslatorTest.java
@@ -1,0 +1,35 @@
+package software.amazon.rds.dbparametergroup;
+
+import java.util.Map;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import com.google.common.collect.ImmutableMap;
+import software.amazon.awssdk.services.rds.model.Parameter;
+
+class TranslatorTest {
+
+    @Test
+    public void test_translateParametersFromSdk() {
+        final Parameter p1 = Parameter.builder()
+                .parameterName("param name 1")
+                .parameterValue("param value 1")
+                .build();
+        final Parameter p2 = Parameter.builder()
+                .parameterName("param name 2")
+                .parameterValue("param value 2")
+                .build();
+
+        final Map<String, Parameter> parameters = ImmutableMap.of(
+                p1.parameterName(), p1,
+                p2.parameterName(), p2
+        );
+
+        Assertions.assertThat(Translator.translateParametersFromSdk(parameters))
+                .isEqualTo(ImmutableMap.of(
+                        p1.parameterName(), p1.parameterValue(),
+                        p2.parameterName(), p2.parameterValue()
+                ));
+    }
+}


### PR DESCRIPTION
This commit adds `DBParameterGroup.parameters` in the `ReadHandler` response. The motivation for this change is to enable drift detector on independent group parameters. At the moment this collection is defined as `WriteOnly`, instructing the drift detector to ignore it completely.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.