### PR TITLE
[DBInstance] Fix empty `MasterUserSecret` on Update

### DIFF
--- a/aws-rds-cfn-common/src/main/java/software/amazon/rds/common/printer/FilteredJsonPrinter.java
+++ b/aws-rds-cfn-common/src/main/java/software/amazon/rds/common/printer/FilteredJsonPrinter.java
@@ -11,7 +11,7 @@ import com.fasterxml.jackson.annotation.PropertyAccessor;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.ser.FilterProvider;
 import com.fasterxml.jackson.databind.ser.impl.SimpleBeanPropertyFilter;
@@ -35,7 +35,7 @@ public class FilteredJsonPrinter implements JsonPrinter {
     public FilteredJsonPrinter(String... filterFields) {
         this.filterFields = filterFields;
         mapper = new ObjectMapper()
-                .setPropertyNamingStrategy(PropertyNamingStrategy.UPPER_CAMEL_CASE)
+                .setPropertyNamingStrategy(PropertyNamingStrategies.UPPER_CAMEL_CASE)
                 .enable(SerializationFeature.INDENT_OUTPUT)
                 .disable(SerializationFeature.FAIL_ON_EMPTY_BEANS);
         mapper.registerModule(new JavaTimeModule());

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/Translator.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/Translator.java
@@ -354,16 +354,11 @@ public class Translator {
                 .dbParameterGroupName(diff(previousModel.getDBParameterGroupName(), desiredModel.getDBParameterGroupName()))
                 .dbSecurityGroups(diff(previousModel.getDBSecurityGroups(), desiredModel.getDBSecurityGroups()))
                 .engineVersion(diff(previousModel.getEngineVersion(), desiredModel.getEngineVersion()))
-                .manageMasterUserPassword(diff(previousModel.getManageMasterUserPassword(), desiredModel.getManageMasterUserPassword()))
                 .masterUserPassword(diff(previousModel.getMasterUserPassword(), desiredModel.getMasterUserPassword()))
-                .masterUserSecretKmsKeyId(diff(previousModel.getMasterUserSecret(), desiredModel.getMasterUserSecret()) != null ? desiredModel.getMasterUserSecret().getKmsKeyId() : null)
                 .multiAZ(diff(previousModel.getMultiAZ(), desiredModel.getMultiAZ()))
-                .networkType(diff(previousModel.getNetworkType(), desiredModel.getNetworkType()))
                 .optionGroupName(diff(previousModel.getOptionGroupName(), desiredModel.getOptionGroupName()))
                 .preferredBackupWindow(diff(previousModel.getPreferredBackupWindow(), desiredModel.getPreferredBackupWindow()))
-                .preferredMaintenanceWindow(diff(previousModel.getPreferredMaintenanceWindow(), desiredModel.getPreferredMaintenanceWindow()))
-                .publiclyAccessible(diff(previousModel.getPubliclyAccessible(), desiredModel.getPubliclyAccessible()))
-                .replicaMode(diff(previousModel.getReplicaMode(), desiredModel.getReplicaMode()));
+                .preferredMaintenanceWindow(diff(previousModel.getPreferredMaintenanceWindow(), desiredModel.getPreferredMaintenanceWindow()));
 
         if (BooleanUtils.isNotTrue(isRollback)) {
             builder.engineVersion(diff(previousModel.getEngineVersion(), desiredModel.getEngineVersion()));
@@ -466,7 +461,9 @@ public class Translator {
 
         if (BooleanUtils.isTrue(desiredModel.getManageMasterUserPassword())) {
             builder.manageMasterUserPassword(true);
-            builder.masterUserSecretKmsKeyId(desiredModel.getMasterUserSecret().getKmsKeyId());
+            if (desiredModel.getMasterUserSecret() != null) {
+                builder.masterUserSecretKmsKeyId(desiredModel.getMasterUserSecret().getKmsKeyId());
+            }
         } else {
             builder.manageMasterUserPassword(getManageMasterUserPassword(previousModel, desiredModel));
         }

--- a/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/TranslatorTest.java
+++ b/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/TranslatorTest.java
@@ -515,13 +515,13 @@ class TranslatorTest extends AbstractHandlerTest {
     }
 
     @Test
-    public void translateMasterUserSecret_sdkSecretEmpty() {
+    public void test_translateMasterUserSecret_sdkSecretEmpty() {
         assertThat(Translator.translateMasterUserSecret(null))
                 .isEqualTo(MasterUserSecret.builder().build());
     }
 
     @Test
-    public void translateMasterUserSecret_sdkSecretSet() {
+    public void test_translateMasterUserSecret_sdkSecretSet() {
         final software.amazon.rds.dbinstance.MasterUserSecret secret = Translator.translateMasterUserSecret(
                 software.amazon.awssdk.services.rds.model.MasterUserSecret.builder()
                         .secretArn("arn")
@@ -533,7 +533,7 @@ class TranslatorTest extends AbstractHandlerTest {
     }
 
     @Test
-    public void translateManageMasterUserPassword_fromUnsetToUnset() {
+    public void test_translateManageMasterUserPassword_fromUnsetToUnset() {
         final ResourceModel prev = RESOURCE_MODEL_BLDR()
                 .masterUserPassword("password")
                 .build();
@@ -549,7 +549,7 @@ class TranslatorTest extends AbstractHandlerTest {
     }
 
     @Test
-    public void translateManageMasterUserPassword_fromSetToUnset() {
+    public void test_translateManageMasterUserPassword_fromSetToUnset() {
         final ResourceModel prev = RESOURCE_MODEL_BLDR()
                 .manageMasterUserPassword(true)
                 .masterUserSecret(MasterUserSecret.builder().kmsKeyId("key").build())
@@ -564,7 +564,7 @@ class TranslatorTest extends AbstractHandlerTest {
     }
 
     @Test
-    public void translateManageMasterUserPassword_explicitUnset() {
+    public void test_translateManageMasterUserPassword_explicitUnset() {
         final ResourceModel prev = RESOURCE_MODEL_BLDR()
                 .manageMasterUserPassword(true)
                 .masterUserSecret(MasterUserSecret.builder().kmsKeyId("key1").build())
@@ -581,7 +581,7 @@ class TranslatorTest extends AbstractHandlerTest {
     }
 
     @Test
-    public void translateManageMasterUserPassword_fromUnsetToSet_withDefaultKey() {
+    public void test_translateManageMasterUserPassword_fromUnsetToSet_withDefaultKey() {
         final ResourceModel prev = RESOURCE_MODEL_BLDR()
                 .masterUserPassword("password")
                 .build();
@@ -597,7 +597,23 @@ class TranslatorTest extends AbstractHandlerTest {
     }
 
     @Test
-    public void translateManageMasterUserPassword_fromUnsetToSet_withSpecificKey() {
+    public void test_translateManageMasterUserPassword_fromUnsetToSet_emptyMasterUserSecret() {
+        final ResourceModel prev = RESOURCE_MODEL_BLDR()
+                .masterUserPassword("password")
+                .build();
+        final ResourceModel desired = RESOURCE_MODEL_BLDR()
+                .manageMasterUserPassword(true)
+                .masterUserSecret(null)
+                .build();
+
+        final ModifyDbInstanceRequest request = Translator.modifyDbInstanceRequest(prev, desired, false);
+
+        assertThat(request.manageMasterUserPassword()).isTrue();
+        assertThat(request.masterUserSecretKmsKeyId()).isNull();
+    }
+
+    @Test
+    public void test_translateManageMasterUserPassword_fromUnsetToSet_withSpecificKey() {
         final ResourceModel prev = RESOURCE_MODEL_BLDR()
                 .masterUserPassword("password")
                 .build();


### PR DESCRIPTION
This commit addresses an issue with an empty `MasterUserSecret` input upon a DBInstance modification. The attribute itself is optional even when `ManageMasterUserPassword` is set to true: the service would use a pre-provisioned KMS key instead.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
