### PR TITLE
[DBInstance] Remove stabilization on `PromotionTier`

### DIFF
--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/BaseHandlerStd.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/BaseHandlerStd.java
@@ -614,7 +614,6 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
                 isCaCertificateChangesApplied(dbInstance, model) &&
                 isVpcSecurityGroupsActive(dbInstance) &&
                 isDomainMembershipsJoined(dbInstance) &&
-                isPromotionTierUpdated(dbInstance, model) &&
                 isMasterUserSecretStabilized(dbInstance);
     }
 
@@ -634,10 +633,6 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
 
     boolean isDBInstanceAvailable(final DBInstance dbInstance) {
         return DBInstanceStatus.Available.equalsString(dbInstance.dbInstanceStatus());
-    }
-
-    boolean isPromotionTierUpdated(final DBInstance dbInstance, final ResourceModel model) {
-        return model.getPromotionTier() == null || model.getPromotionTier().equals(dbInstance.promotionTier());
     }
 
     boolean isDomainMembershipsJoined(final DBInstance dbInstance) {

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/Translator.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/Translator.java
@@ -407,7 +407,7 @@ public class Translator {
                 .performanceInsightsRetentionPeriod(diff(previousModel.getPerformanceInsightsRetentionPeriod(), desiredModel.getPerformanceInsightsRetentionPeriod()))
                 .preferredBackupWindow(diff(previousModel.getPreferredBackupWindow(), desiredModel.getPreferredBackupWindow()))
                 .preferredMaintenanceWindow(diff(previousModel.getPreferredMaintenanceWindow(), desiredModel.getPreferredMaintenanceWindow()))
-                .promotionTier(diff(previousModel.getPromotionTier(), desiredModel.getPromotionTier()))
+                .promotionTier(desiredModel.getPromotionTier()) // promotion tier is set unconditionally
                 .publiclyAccessible(diff(previousModel.getPubliclyAccessible(), desiredModel.getPubliclyAccessible()))
                 .replicaMode(diff(previousModel.getReplicaMode(), desiredModel.getReplicaMode()))
                 .storageThroughput(diff(previousModel.getStorageThroughput(), desiredModel.getStorageThroughput()))

--- a/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/BaseHandlerStdTest.java
+++ b/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/BaseHandlerStdTest.java
@@ -56,38 +56,6 @@ class BaseHandlerStdTest {
     }
 
     @Test
-    void isPromotionTierUpdated_NullPromotionTierReturnsTrue() {
-        Assertions.assertThat(handler.isPromotionTierUpdated(
-                DBInstance.builder().build(),
-                ResourceModel.builder().build()
-        )).isTrue();
-    }
-
-    @Test
-    void isPromotionTierUpdated_MatchingPromotionTiedReturnsTrue() {
-        Assertions.assertThat(handler.isPromotionTierUpdated(
-                DBInstance.builder().promotionTier(42).build(),
-                ResourceModel.builder().promotionTier(42).build()
-        )).isTrue();
-    }
-
-    @Test
-    void isPromotionTierUpdated_EmptyModelPromotionTierReturnsTrue() {
-        Assertions.assertThat(handler.isPromotionTierUpdated(
-                DBInstance.builder().promotionTier(42).build(),
-                ResourceModel.builder().promotionTier(null).build()
-        )).isTrue();
-    }
-
-    @Test
-    void isPromotionTierUpdated_MismatchingPromotionTierReturnsFalse() {
-        Assertions.assertThat(handler.isPromotionTierUpdated(
-                DBInstance.builder().promotionTier(null).build(),
-                ResourceModel.builder().promotionTier(42).build()
-        )).isFalse();
-    }
-
-    @Test
     void isDomainMembershipsJoined_NullDomainMembershipReturnsTrue() {
         Assertions.assertThat(handler.isDomainMembershipsJoined(
                 DBInstance.builder().build()


### PR DESCRIPTION
This commit removes `PromotionTier` from the stabilization attributes. The reason for this change is that `PromotionTier` is a customer-controlled attribute and RDS API won't alter it on its own.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
