### PR TITLE
[DBInstance][DBCluster] Address drift on Engine property

### DIFF
--- a/aws-rds-dbcluster/aws-rds-dbcluster.json
+++ b/aws-rds-dbcluster/aws-rds-dbcluster.json
@@ -398,6 +398,7 @@
     "/properties/DBClusterIdentifier": "$lowercase(DBClusterIdentifier)",
     "/properties/DBClusterParameterGroupName": "$lowercase(DBClusterParameterGroupName)",
     "/properties/DBSubnetGroupName": "$lowercase(DBSubnetGroupName)",
+    "/properties/Engine": "$lowercase(Engine)",
     "/properties/EnableHttpEndpoint": "$lowercase($string(EngineMode)) = 'serverless' ? EnableHttpEndpoint : false",
     "/properties/EngineVersion": "$join([$string(EngineVersion), \".*\"])",
     "/properties/KmsKeyId": "$join([\"arn:(aws)[-]{0,1}[a-z]{0,2}[-]{0,1}[a-z]{0,3}:kms:[a-z]{2}[-]{1}[a-z]{3,10}[-]{0,1}[a-z]{0,10}[-]{1}[1-3]{1}:[0-9]{12}[:]{1}key\\/\", KmsKeyId])",

--- a/aws-rds-dbcluster/src/test/java/software/amazon/rds/dbcluster/SchemaTest.java
+++ b/aws-rds-dbcluster/src/test/java/software/amazon/rds/dbcluster/SchemaTest.java
@@ -191,4 +191,16 @@ public class SchemaTest {
             ResourceDriftTestHelper.assertResourceNotDrifted(input, output, resourceSchema);
         }).isInstanceOf(AssertionError.class);
     }
+
+    @Test
+    public void testDrift_Engine_CaseMismatch_ShouldNotDrift() {
+        final ResourceModel input = ResourceModel.builder()
+                .engine("aurora-MySQL")
+                .build();
+        final ResourceModel output = ResourceModel.builder()
+                .engine("aurora-mysql")
+                .build();
+
+        ResourceDriftTestHelper.assertResourceNotDrifted(input, output, resourceSchema);
+    }
 }

--- a/aws-rds-dbinstance/aws-rds-dbinstance.json
+++ b/aws-rds-dbinstance/aws-rds-dbinstance.json
@@ -440,6 +440,7 @@
   "propertyTransform": {
     "/properties/DBClusterIdentifier": "$lowercase(DBClusterIdentifier)",
     "/properties/DBClusterSnapshotIdentifier": "$lowercase(DBClusterSnapshotIdentifier)",
+    "/properties/Engine": "$lowercase(Engine)",
     "/properties/EngineVersion": "$join([$string(EngineVersion), \".*\"])",
     "/properties/DBInstanceIdentifier": "$lowercase(DBInstanceIdentifier)",
     "/properties/DBParameterGroupName": "$lowercase(DBParameterGroupName)",

--- a/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/SchemaTest.java
+++ b/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/SchemaTest.java
@@ -189,4 +189,15 @@ public class SchemaTest {
             ResourceDriftTestHelper.assertResourceNotDrifted(input, output, resourceSchema);
         }).isInstanceOf(AssertionError.class);
     }
+
+    @Test
+    public void testDrift_Engine_CaseMismatch_ShouldNotDrift() {
+        final ResourceModel input = ResourceModel.builder()
+                .engine("Postgres")
+                .build();
+        final ResourceModel output = ResourceModel.builder()
+                .engine("postgres")
+                .build();
+        ResourceDriftTestHelper.assertResourceNotDrifted(input, output, resourceSchema);
+    }
 }


### PR DESCRIPTION
This PR addresses the drift on Engine property. RDS service accepts `Engine` inputs in a case insensitive mode, meanwhile CFN detects false drift since return value for engine is always in lowercase.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
