### PR TITLE
[DBInstance] Fix false drift detection on Oracle DBName

### DIFF
--- a/aws-rds-dbinstance/aws-rds-dbinstance.json
+++ b/aws-rds-dbinstance/aws-rds-dbinstance.json
@@ -442,7 +442,7 @@
     "/properties/DBClusterSnapshotIdentifier": "$lowercase(DBClusterSnapshotIdentifier)",
     "/properties/DBInstanceIdentifier": "$lowercase(DBInstanceIdentifier)",
     "/properties/DBParameterGroupName": "$lowercase(DBParameterGroupName)",
-    "/properties/DBName": "$lowercase(DBName)",
+    "/properties/DBName": "$lowercase(DBName) $OR $uppercase(DBName)",
     "/properties/DBSnapshotIdentifier": "$lowercase(DBSnapshotIdentifier)",
     "/properties/DBSubnetGroupName": "$lowercase(DBSubnetGroupName)",
     "/properties/Engine": "$lowercase(Engine)",

--- a/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/SchemaTest.java
+++ b/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/SchemaTest.java
@@ -211,4 +211,15 @@ public class SchemaTest {
                 .build();
         ResourceDriftTestHelper.assertResourceNotDrifted(input, output, resourceSchema);
     }
+
+    @Test
+    public void testDrift_DBName_Oracle_Uppercase() {
+        final ResourceModel input = ResourceModel.builder()
+                .dBName("Oracle_DB")
+                .build();
+        final ResourceModel output = ResourceModel.builder()
+                .dBName("ORACLE_DB")
+                .build();
+        ResourceDriftTestHelper.assertResourceNotDrifted(input, output, resourceSchema);
+    }
 }


### PR DESCRIPTION
Oracle engine uppercases the database name. This causes a false drift alarm. This commit adds uppercased DBName spelling to the list of valid options RDS API could return.

Fixes https://github.com/aws-cloudformation/cloudformation-coverage-roadmap/issues/1530.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
