### PR TITLE
[DBCluster] Add RestoreToTime attribute

### DIFF
--- a/aws-rds-dbcluster/aws-rds-dbcluster.json
+++ b/aws-rds-dbcluster/aws-rds-dbcluster.json
@@ -207,6 +207,10 @@
       "description": "The Amazon Resource Name (ARN) of the source DB instance or DB cluster if this DB cluster is created as a Read Replica.",
       "type": "string"
     },
+    "RestoreToTime": {
+      "description": "The date and time to restore the DB cluster to. Value must be a time in Universal Coordinated Time (UTC) format. An example: 2015-03-07T23:45:00Z",
+      "type": "string"
+    },
     "RestoreType": {
       "description": "The type of restore to be performed. You can specify one of the following values:\nfull-copy - The new DB cluster is restored as a full copy of the source DB cluster.\ncopy-on-write - The new DB cluster is restored as a clone of the source DB cluster.",
       "type": "string",

--- a/aws-rds-dbcluster/docs/README.md
+++ b/aws-rds-dbcluster/docs/README.md
@@ -54,6 +54,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
         "<a href="#preferredmaintenancewindow" title="PreferredMaintenanceWindow">PreferredMaintenanceWindow</a>" : <i>String</i>,
         "<a href="#publiclyaccessible" title="PubliclyAccessible">PubliclyAccessible</a>" : <i>Boolean</i>,
         "<a href="#replicationsourceidentifier" title="ReplicationSourceIdentifier">ReplicationSourceIdentifier</a>" : <i>String</i>,
+        "<a href="#restoretotime" title="RestoreToTime">RestoreToTime</a>" : <i>String</i>,
         "<a href="#restoretype" title="RestoreType">RestoreType</a>" : <i>String</i>,
         "<a href="#serverlessv2scalingconfiguration" title="ServerlessV2ScalingConfiguration">ServerlessV2ScalingConfiguration</a>" : <i><a href="serverlessv2scalingconfiguration.md">ServerlessV2ScalingConfiguration</a></i>,
         "<a href="#scalingconfiguration" title="ScalingConfiguration">ScalingConfiguration</a>" : <i><a href="scalingconfiguration.md">ScalingConfiguration</a></i>,
@@ -119,6 +120,7 @@ Properties:
     <a href="#preferredmaintenancewindow" title="PreferredMaintenanceWindow">PreferredMaintenanceWindow</a>: <i>String</i>
     <a href="#publiclyaccessible" title="PubliclyAccessible">PubliclyAccessible</a>: <i>Boolean</i>
     <a href="#replicationsourceidentifier" title="ReplicationSourceIdentifier">ReplicationSourceIdentifier</a>: <i>String</i>
+    <a href="#restoretotime" title="RestoreToTime">RestoreToTime</a>: <i>String</i>
     <a href="#restoretype" title="RestoreType">RestoreType</a>: <i>String</i>
     <a href="#serverlessv2scalingconfiguration" title="ServerlessV2ScalingConfiguration">ServerlessV2ScalingConfiguration</a>: <i><a href="serverlessv2scalingconfiguration.md">ServerlessV2ScalingConfiguration</a></i>
     <a href="#scalingconfiguration" title="ScalingConfiguration">ScalingConfiguration</a>: <i><a href="scalingconfiguration.md">ScalingConfiguration</a></i>
@@ -561,6 +563,16 @@ _Update requires_: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/l
 #### ReplicationSourceIdentifier
 
 The Amazon Resource Name (ARN) of the source DB instance or DB cluster if this DB cluster is created as a Read Replica.
+
+_Required_: No
+
+_Type_: String
+
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+
+#### RestoreToTime
+
+The date and time to restore the DB cluster to. Value must be a time in Universal Coordinated Time (UTC) format. An example: 2015-03-07T23:45:00Z
 
 _Required_: No
 

--- a/aws-rds-dbcluster/src/test/java/software/amazon/rds/dbcluster/TranslatorTest.java
+++ b/aws-rds-dbcluster/src/test/java/software/amazon/rds/dbcluster/TranslatorTest.java
@@ -1,6 +1,7 @@
 package software.amazon.rds.dbcluster;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Collection;
 import java.util.Random;
@@ -13,8 +14,11 @@ import software.amazon.awssdk.services.rds.RdsClient;
 import software.amazon.awssdk.services.rds.model.DBCluster;
 import software.amazon.awssdk.services.rds.model.DomainMembership;
 import software.amazon.awssdk.services.rds.model.ModifyDbClusterRequest;
+import software.amazon.awssdk.services.rds.model.RestoreDbClusterToPointInTimeRequest;
+import software.amazon.cloudformation.exceptions.CfnInvalidRequestException;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.ProxyClient;
+import software.amazon.rds.common.handler.Tagging;
 import software.amazon.rds.test.common.core.HandlerName;
 import software.amazon.rds.test.common.core.TestUtils;
 
@@ -329,6 +333,31 @@ public class TranslatorTest extends AbstractHandlerTest {
         assertThat(request.allocatedStorage()).isEqualTo(200);
     }
 
+    @Test
+    public void restoreDBClusterToPointInTime() {
+        final ResourceModel model = ResourceModel.builder()
+                .engineMode(EngineMode.Provisioned.toString())
+                .enableIAMDatabaseAuthentication(true)
+                .useLatestRestorableTime(false)
+                .restoreToTime("2019-03-07T23:45:00Z")
+                .build();
+        final RestoreDbClusterToPointInTimeRequest request = Translator.restoreDbClusterToPointInTimeRequest(model, Tagging.TagSet.emptySet());
+
+        assertThat(request.useLatestRestorableTime()).isEqualTo(false);
+        assertThat(request.restoreToTime()).isEqualTo("2019-03-07T23:45:00Z");
+    }
+
+    @Test
+    public void restoreDBClusterToPointInTimeInvalidFormat() {
+        final ResourceModel model = ResourceModel.builder()
+                .engineMode(EngineMode.Provisioned.toString())
+                .enableIAMDatabaseAuthentication(true)
+                .useLatestRestorableTime(false)
+                .restoreToTime("invalid-format")
+                .build();
+        assertThatThrownBy(() -> Translator.restoreDbClusterToPointInTimeRequest(model, Tagging.TagSet.emptySet()))
+                .isInstanceOf(CfnInvalidRequestException.class);
+    }
     @Override
     protected BaseHandlerStd getHandler() {
         return null;


### PR DESCRIPTION
*Description of changes:*
Adding RestoreToTime attribute to `RestoreDbClusterToPointInTimeRequest`.
THere were no need to update `isRestoreToPointInTime` as `SourceDBClusterIdentifier`still mandatory in case of RestoreToTime.
```
    private boolean isRestoreToPointInTime(final ResourceModel model) {
        return StringUtils.hasValue(model.getSourceDBClusterIdentifier());
    }
```

Ref: https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/aurora-pitr.html

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
