### PR TITLE
[DBInstance] Set `EnablePerformanceInsights` on Restore

### DIFF
--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/Translator.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/Translator.java
@@ -292,7 +292,7 @@ public class Translator {
             final ResourceModel model,
             final Tagging.TagSet tagSet
     ) {
-        final Instant restoreTimeInstant = StringUtils.isNotBlank(model.getRestoreTime())? Commons.parseTimestamp(model.getRestoreTime()) :null;
+        final Instant restoreTimeInstant = StringUtils.isNotBlank(model.getRestoreTime()) ? Commons.parseTimestamp(model.getRestoreTime()) : null;
 
         final RestoreDbInstanceToPointInTimeRequest.Builder builder = RestoreDbInstanceToPointInTimeRequest.builder()
                 .autoMinorVersionUpgrade(model.getAutoMinorVersionUpgrade())
@@ -521,6 +521,7 @@ public class Translator {
                 .dbInstanceIdentifier(model.getDBInstanceIdentifier())
                 .dbParameterGroupName(model.getDBParameterGroupName())
                 .deletionProtection(model.getDeletionProtection())
+                .enablePerformanceInsights(model.getEnablePerformanceInsights())
                 .engineVersion(model.getEngineVersion())
                 .manageMasterUserPassword(model.getManageMasterUserPassword())
                 .masterUserPassword(model.getMasterUserPassword())

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/util/ResourceModelHelper.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/util/ResourceModelHelper.java
@@ -37,7 +37,8 @@ public final class ResourceModelHelper {
                                 Optional.ofNullable(model.getStorageThroughput()).orElse(0) > 0 ||
                                 (isSqlServer(model) && StringUtils.hasValue(model.getAllocatedStorage())) ||
                                 BooleanUtils.isTrue(model.getManageMasterUserPassword()) ||
-                                BooleanUtils.isTrue(model.getDeletionProtection())
+                                BooleanUtils.isTrue(model.getDeletionProtection()) ||
+                                BooleanUtils.isTrue(model.getEnablePerformanceInsights())
                 );
     }
 

--- a/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/TranslatorTest.java
+++ b/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/TranslatorTest.java
@@ -966,6 +966,15 @@ class TranslatorTest extends AbstractHandlerTest {
     }
 
     @Test
+    public void test_modifyAfterCreate_shouldSetEnablePerformanceInsights() {
+        final ResourceModel model = RESOURCE_MODEL_BLDR()
+                .enablePerformanceInsights(true)
+                .build();
+        final ModifyDbInstanceRequest request = Translator.modifyDbInstanceAfterCreateRequest(model);
+        assertThat(request.enablePerformanceInsights()).isTrue();
+    }
+
+    @Test
     public void test_restoreDbInstanceFromSnapshot_shouldKeepCopyTagsToSnapshotEmptyIfUnset() {
         final ResourceModel model = ResourceModel.builder()
                 .build();

--- a/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/util/ResourceModelHelperTest.java
+++ b/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/util/ResourceModelHelperTest.java
@@ -1,11 +1,10 @@
 package software.amazon.rds.dbinstance.util;
 
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
-import software.amazon.rds.dbinstance.ResourceModel;
-
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+import software.amazon.rds.dbinstance.ResourceModel;
 
 public class ResourceModelHelperTest {
 
@@ -161,5 +160,32 @@ public class ResourceModelHelperTest {
                 .deletionProtection(true)
                 .build();
         assertThat(ResourceModelHelper.shouldUpdateAfterCreate(model)).isTrue();
+    }
+
+    @Test
+    public void shouldUpdateAfterCreate_enablePerformanceInsights() {
+        final ResourceModel model = ResourceModel.builder()
+                .dBSnapshotIdentifier("db-snapshot-identifier")
+                .enablePerformanceInsights(true)
+                .build();
+        assertThat(ResourceModelHelper.shouldUpdateAfterCreate(model)).isTrue();
+    }
+
+    @Test
+    public void shouldNotUpdateAfterCreate_enablePerformanceInsightsIsFalse() {
+        final ResourceModel model = ResourceModel.builder()
+                .dBSnapshotIdentifier("db-snapshot-identifier")
+                .enablePerformanceInsights(false)
+                .build();
+        assertThat(ResourceModelHelper.shouldUpdateAfterCreate(model)).isFalse();
+    }
+
+    @Test
+    public void shouldNotUpdateAfterCreate_enablePerformanceInsightsIsNull() {
+        final ResourceModel model = ResourceModel.builder()
+                .dBSnapshotIdentifier("db-snapshot-identifier")
+                .enablePerformanceInsights(null)
+                .build();
+        assertThat(ResourceModelHelper.shouldUpdateAfterCreate(model)).isFalse();
     }
 }


### PR DESCRIPTION
This commit enables modify-after-create handler step on instances that are being restored from a snapshot and have `EnablePerformanceInsights` set to true. The flag was not set previously becuase `RestoreDBInstanceFromDBSnapshot` would not expose the corresponding attribute and CFN would detect a false resource drift.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
