### PR TITLE
[DBInstance] Fix drift on enhanced monitoring when restoring from a snapshot

### DIFF
--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/Translator.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/Translator.java
@@ -528,6 +528,8 @@ public class Translator {
                 .masterUserPassword(model.getMasterUserPassword())
                 .masterUserSecretKmsKeyId(model.getMasterUserSecret() != null ? model.getMasterUserSecret().getKmsKeyId() : null)
                 .maxAllocatedStorage(model.getMaxAllocatedStorage())
+                .monitoringInterval(model.getMonitoringInterval())
+                .monitoringRoleArn(model.getMonitoringRoleArn())
                 .preferredBackupWindow(model.getPreferredBackupWindow())
                 .preferredMaintenanceWindow(model.getPreferredMaintenanceWindow());
 

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/util/ResourceModelHelper.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/util/ResourceModelHelper.java
@@ -31,10 +31,12 @@ public final class ResourceModelHelper {
                                 StringUtils.hasValue(model.getMasterUserPassword()) ||
                                 StringUtils.hasValue(model.getPreferredBackupWindow()) ||
                                 StringUtils.hasValue(model.getPreferredMaintenanceWindow()) ||
+                                StringUtils.hasValue(model.getMonitoringRoleArn()) ||
                                 Optional.ofNullable(model.getBackupRetentionPeriod()).orElse(0) > 0 ||
                                 Optional.ofNullable(model.getIops()).orElse(0) > 0 ||
                                 Optional.ofNullable(model.getMaxAllocatedStorage()).orElse(0) > 0 ||
                                 Optional.ofNullable(model.getStorageThroughput()).orElse(0) > 0 ||
+                                Optional.ofNullable(model.getMonitoringInterval()).orElse(0) > 0 ||
                                 (isSqlServer(model) && StringUtils.hasValue(model.getAllocatedStorage())) ||
                                 BooleanUtils.isTrue(model.getManageMasterUserPassword()) ||
                                 BooleanUtils.isTrue(model.getDeletionProtection()) ||

--- a/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/TranslatorTest.java
+++ b/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/TranslatorTest.java
@@ -975,6 +975,20 @@ class TranslatorTest extends AbstractHandlerTest {
     }
 
     @Test
+    public void test_modifyAfterCreate_shouldSetEnhancedMonitoring() {
+        final String monitoringRoleArn = "monitoring-role-arn";
+        final int monitoringInterval = 42;
+        final ResourceModel model = RESOURCE_MODEL_BLDR()
+                .monitoringRoleArn(monitoringRoleArn)
+                .monitoringInterval(monitoringInterval)
+                .build();
+        final ModifyDbInstanceRequest request = Translator.modifyDbInstanceAfterCreateRequest(model);
+
+        assertThat(request.monitoringRoleArn()).isEqualTo(monitoringRoleArn);
+        assertThat(request.monitoringInterval()).isEqualTo(monitoringInterval);
+    }
+
+    @Test
     public void test_restoreDbInstanceFromSnapshot_shouldKeepCopyTagsToSnapshotEmptyIfUnset() {
         final ResourceModel model = ResourceModel.builder()
                 .build();

--- a/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/util/ResourceModelHelperTest.java
+++ b/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/util/ResourceModelHelperTest.java
@@ -188,4 +188,22 @@ public class ResourceModelHelperTest {
                 .build();
         assertThat(ResourceModelHelper.shouldUpdateAfterCreate(model)).isFalse();
     }
+
+    @Test
+    public void shouldUpdateAfterCreate_monitoringIntervalIsSet() {
+        final ResourceModel model = ResourceModel.builder()
+                .dBSnapshotIdentifier("db-snapshot-identifier")
+                .monitoringInterval(42)
+                .build();
+        assertThat(ResourceModelHelper.shouldUpdateAfterCreate(model)).isTrue();
+    }
+
+    @Test
+    public void shouldUpdateAfterCreate_monitoringRoleArnIsSet() {
+        final ResourceModel model = ResourceModel.builder()
+                .dBSnapshotIdentifier("db-snapshot-identifier")
+                .monitoringRoleArn("monitoring-role-arn")
+                .build();
+        assertThat(ResourceModelHelper.shouldUpdateAfterCreate(model)).isTrue();
+    }
 }


### PR DESCRIPTION
This commit fixes a false drift detection on DBInstance resources when they are being restore from a snapshot with enabled enhanced monitoring. The commit enforces an update-after-create operation on restorable instances if the monitoring is on.

Documentation: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_Monitoring.OS.Enabling.html#USER_Monitoring.OS.Enabling.Prerequisites

Refs https://github.com/aws-cloudformation/cloudformation-coverage-roadmap/issues/1569.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
