### PR TITLE
[GlobalCluster] Fix drift detection for GlobalClusterIdentifier due t…

### DIFF
--- a/aws-rds-globalcluster/aws-rds-globalcluster.json
+++ b/aws-rds-globalcluster/aws-rds-globalcluster.json
@@ -55,6 +55,9 @@
     }
   ],
   "additionalProperties": false,
+  "propertyTransform": {
+    "/properties/GlobalClusterIdentifier": "$lowercase(GlobalClusterIdentifier)"
+  },
   "createOnlyProperties": [
     "/properties/GlobalClusterIdentifier",
     "/properties/SourceDBClusterIdentifier",

--- a/aws-rds-globalcluster/inputs/inputs_1_invalid.json
+++ b/aws-rds-globalcluster/inputs/inputs_1_invalid.json
@@ -1,4 +1,4 @@
 {
-  "GlobalClusterIdentifier": "cf-contract-test-global-cluster-0",
+  "GlobalClusterIdentifier": "cf-contract-test-global-cluster-0-invalid",
   "Engine": "bogus"
 }

--- a/aws-rds-globalcluster/src/test/java/software/amazon/rds/globalcluster/AbstractTestBase.java
+++ b/aws-rds-globalcluster/src/test/java/software/amazon/rds/globalcluster/AbstractTestBase.java
@@ -59,9 +59,9 @@ public class AbstractTestBase {
     GLOBALCLUSTER_IDENTIFIER = "my-sample-globalcluster";
     SOURCECLUSTER_IDENTIFIER = "my-sample-dbcluster";
     SOURCECLUSTER_ARN = "arn:aws:rds:us-east-1:340834135580:cluster:sample-globalcluster";
-    ENGINE = "aurora";
-    ENGINE_VERSION = "5.6.mysql_aurora.1.22.2";
-    ENGINE_VERSION_MVU = "5.7.mysql_aurora.2.10.2";
+    ENGINE = "aurora-mysql";
+    ENGINE_VERSION = "5.7.mysql_aurora.2.11.1";
+    ENGINE_VERSION_MVU = "8.0.mysql_aurora.3.03.0";
     DELETION_PROTECTION = false;
 
 

--- a/aws-rds-globalcluster/template.yml
+++ b/aws-rds-globalcluster/template.yml
@@ -5,6 +5,7 @@ Description: AWS SAM template for the AWS::RDS::GlobalCluster resource type
 Globals:
   Function:
     Timeout: 60  # docker start-up times can be long for SAM CLI
+    MemorySize: 1024
 
 Resources:
   TypeFunction:
@@ -13,7 +14,6 @@ Resources:
       Handler: software.amazon.rds.globalcluster.HandlerWrapper::handleRequest
       Runtime: java8
       CodeUri: ./target/aws-rds-globalcluster-handler-1.0-SNAPSHOT.jar
-      MemorySize: 256
 
   TestEntrypoint:
     Type: AWS::Serverless::Function
@@ -21,4 +21,3 @@ Resources:
       Handler: software.amazon.rds.globalcluster.HandlerWrapper::testEntrypoint
       Runtime: java8
       CodeUri: ./target/aws-rds-globalcluster-handler-1.0-SNAPSHOT.jar
-      MemorySize: 256


### PR DESCRIPTION
[GlobalCluster] Fix drift detection for GlobalClusterIdentifier due to introduced lowercasing

+ Adjust tests to use non-deprecated engine version
+ Fix OOM issue during contract testing

*Issue #, if available:* NotAvailable

*Description of changes:* Recent introduction of GlobalClusterIdentifier lowercasing in API caused some false drifts as template value is no longer matching value returned from API. This commit addressed the drift issue together with some essential fixes for tests.

*Testing:*
- Maven tests passing
- Contract tests passing
- Fix tested via CFN CLI

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
