### PR TITLE
[DBInstance] Modify after create - storage parameters fixes

### DIFF
--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/util/ResourceModelHelper.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/util/ResourceModelHelper.java
@@ -32,12 +32,17 @@ public final class ResourceModelHelper {
                                 StringUtils.hasValue(model.getPreferredBackupWindow()) ||
                                 StringUtils.hasValue(model.getPreferredMaintenanceWindow()) ||
                                 Optional.ofNullable(model.getBackupRetentionPeriod()).orElse(0) > 0 ||
-                                Optional.ofNullable(model.getIops()).orElse(0) > 0 ||
-                                Optional.ofNullable(model.getMaxAllocatedStorage()).orElse(0) > 0 ||
-                                Optional.ofNullable(model.getStorageThroughput()).orElse(0) > 0 ||
-                                (isSqlServer(model) && StringUtils.hasValue(model.getAllocatedStorage())) ||
+                                (isSqlServer(model) && isStorageParametersModified(model)) ||
                                 BooleanUtils.isTrue(model.getManageMasterUserPassword())
                 );
+    }
+
+    public static boolean isStorageParametersModified(final ResourceModel model) {
+        return StringUtils.hasValue(model.getAllocatedStorage()) ||
+                Optional.ofNullable(model.getIops()).orElse(0) > 0 ||
+                Optional.ofNullable(model.getMaxAllocatedStorage()).orElse(0) > 0 ||
+                Optional.ofNullable(model.getStorageThroughput()).orElse(0) > 0 ||
+                StringUtils.hasValue(model.getStorageType());
     }
 
     public static boolean isSqlServer(final ResourceModel model) {

--- a/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/AbstractHandlerTest.java
+++ b/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/AbstractHandlerTest.java
@@ -197,6 +197,7 @@ public abstract class AbstractHandlerTest extends AbstractTestBase<DBInstance, R
 
     protected static final DBInstance DB_INSTANCE_BASE;
     protected static final DBInstance DB_INSTANCE_ACTIVE;
+    protected static final DBInstance DB_INSTANCE_SQLSERVER_ACTIVE;
     protected static final DBInstance DB_INSTANCE_DELETING;
     protected static final DBInstance DB_INSTANCE_MODIFYING;
     protected static final DBInstance DB_INSTANCE_EMPTY_PORT;
@@ -559,6 +560,10 @@ public abstract class AbstractHandlerTest extends AbstractTestBase<DBInstance, R
                 .storageEncrypted(STORAGE_ENCRYPTED_NO)
                 .masterUsername(MASTER_USERNAME)
                 .promotionTier(PROMOTION_TIER_DEFAULT)
+                .build();
+
+        DB_INSTANCE_SQLSERVER_ACTIVE = DB_INSTANCE_ACTIVE.toBuilder()
+                .engine(ENGINE_SQLSERVER_SE)
                 .build();
 
         DB_INSTANCE_DELETING = DB_INSTANCE_ACTIVE.toBuilder()

--- a/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/CreateHandlerTest.java
+++ b/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/CreateHandlerTest.java
@@ -790,6 +790,7 @@ public class CreateHandlerTest extends AbstractHandlerTest {
                 .thenReturn(DescribeEventsResponse.builder().build());
 
         final DBInstance dbInstance = DB_INSTANCE_BASE.toBuilder()
+                .engine(ENGINE_SQLSERVER_SE)
                 .allocatedStorage(100)
                 .iops(3000)
                 .build();
@@ -1154,7 +1155,7 @@ public class CreateHandlerTest extends AbstractHandlerTest {
 
         test_handleRequest_base(
                 context,
-                () -> DB_INSTANCE_ACTIVE,
+                () -> DB_INSTANCE_SQLSERVER_ACTIVE,
                 () -> RESOURCE_MODEL_BAREBONE_BLDR()
                         .sourceDBInstanceIdentifier(SOURCE_DB_INSTANCE_IDENTIFIER_NON_EMPTY) // Read replica
                         .iops(IOPS_DEFAULT)
@@ -1182,7 +1183,7 @@ public class CreateHandlerTest extends AbstractHandlerTest {
 
         test_handleRequest_base(
                 context,
-                () -> DB_INSTANCE_ACTIVE,
+                () -> DB_INSTANCE_SQLSERVER_ACTIVE,
                 () -> RESOURCE_MODEL_BAREBONE_BLDR()
                         .sourceDBInstanceIdentifier(SOURCE_DB_INSTANCE_IDENTIFIER_NON_EMPTY) // Read replica
                         .maxAllocatedStorage(MAX_ALLOCATED_STORAGE_DEFAULT)

--- a/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/util/ResourceModelHelperTest.java
+++ b/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/util/ResourceModelHelperTest.java
@@ -154,4 +154,35 @@ public class ResourceModelHelperTest {
         assertThat(ResourceModelHelper.shouldUpdateAfterCreate(model)).isTrue();
     }
 
+    @Test
+    public void shouldUpdateAfterCreate_whenRestoreFromSnapshotAndStorageTypeSpecified() {
+        final ResourceModel model = ResourceModel.builder()
+                .dBSnapshotIdentifier("snapshot")
+                .storageType("gp2")
+                .build();
+
+        assertThat(ResourceModelHelper.shouldUpdateAfterCreate(model)).isTrue();
+    }
+
+    @Test
+    public void shouldUpdateAfterCreate_whenRestoreFromSnapshotAndSqlServerEngineAndStorageTypeSpecified() {
+        final ResourceModel model = ResourceModel.builder()
+                .dBSnapshotIdentifier("snapshot")
+                .engine("sqlserver")
+                .storageType("gp2")
+                .build();
+
+        assertThat(ResourceModelHelper.shouldUpdateAfterCreate(model)).isTrue();
+    }
+
+    @Test
+    public void shouldUpdateAfterCreate_whenRestoreFromSnapshotAndAuroraEngineAndStorageTypeSpecified() {
+        final ResourceModel model = ResourceModel.builder()
+                .engine("aurora-postgres")
+                .dBSnapshotIdentifier("snapshot")
+                .storageType("gp2")
+                .build();
+
+        assertThat(ResourceModelHelper.shouldUpdateAfterCreate(model)).isFalse();
+    }
 }


### PR DESCRIPTION
This PR modifies logic for ModifyAfterCreate when storage parameters were updated. Previously, modify request would run for any engine if storage parameters were modified. Now modify only runs for SQL server.

In addition, previously if storage type was set on DBInstance, modify after create workflow would not run. Now it correctly triggers modify after create.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
