### PR TITLE
[DBCluster] Only set ServerlessV2 scaling configuration once during restore scenarios

### DIFF
--- a/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/Translator.java
+++ b/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/Translator.java
@@ -221,7 +221,6 @@ public class Translator {
                 .performanceInsightsRetentionPeriod(desiredModel.getPerformanceInsightsRetentionPeriod())
                 .preferredMaintenanceWindow(desiredModel.getPreferredMaintenanceWindow())
                 .scalingConfiguration(translateScalingConfigurationToSdk(desiredModel.getScalingConfiguration()))
-                .serverlessV2ScalingConfiguration(translateServerlessV2ScalingConfiguration(desiredModel.getServerlessV2ScalingConfiguration()))
                 .storageType(desiredModel.getStorageType());
 
         if (EngineMode.fromString(desiredModel.getEngineMode()) != EngineMode.Serverless) {

--- a/aws-rds-dbcluster/src/test/java/software/amazon/rds/dbcluster/CreateHandlerTest.java
+++ b/aws-rds-dbcluster/src/test/java/software/amazon/rds/dbcluster/CreateHandlerTest.java
@@ -381,9 +381,10 @@ public class CreateHandlerTest extends AbstractHandlerTest {
     public void handleRequest_RestoreDbClusterFromSnapshot_ServerlessV2ScalingConfiguration() {
         when(rdsProxy.client().restoreDBClusterFromSnapshot(any(RestoreDbClusterFromSnapshotRequest.class)))
                 .thenReturn(RestoreDbClusterFromSnapshotResponse.builder().build());
+        when(rdsProxy.client().describeEvents(any(DescribeEventsRequest.class)))
+                .thenReturn(DescribeEventsResponse.builder().build());
 
         final CallbackContext context = new CallbackContext();
-        context.setModified(true);
 
         test_handleRequest_base(
                 context,
@@ -396,7 +397,7 @@ public class CreateHandlerTest extends AbstractHandlerTest {
 
         final ArgumentCaptor<RestoreDbClusterFromSnapshotRequest> captor = ArgumentCaptor.forClass(RestoreDbClusterFromSnapshotRequest.class);
         verify(rdsProxy.client(), times(1)).restoreDBClusterFromSnapshot(captor.capture());
-        verify(rdsProxy.client(), times(2)).describeDBClusters(any(DescribeDbClustersRequest.class));
+        verify(rdsProxy.client(), times(3)).describeDBClusters(any(DescribeDbClustersRequest.class));
 
         Assertions.assertThat(captor.getValue().serverlessV2ScalingConfiguration()).isNotNull();
         Assertions.assertThat(captor.getValue().serverlessV2ScalingConfiguration()).isEqualTo(
@@ -405,6 +406,10 @@ public class CreateHandlerTest extends AbstractHandlerTest {
                         .minCapacity(SERVERLESS_V2_SCALING_CONFIGURATION.getMinCapacity())
                         .build()
         );
+
+        final ArgumentCaptor<ModifyDbClusterRequest> modifyCaptor = ArgumentCaptor.forClass(ModifyDbClusterRequest.class);
+        verify(rdsProxy.client(), times(1)).modifyDBCluster(modifyCaptor.capture());
+        Assertions.assertThat(modifyCaptor.getValue().serverlessV2ScalingConfiguration()).isNull();
     }
 
     @Test
@@ -482,9 +487,10 @@ public class CreateHandlerTest extends AbstractHandlerTest {
     public void handleRequest_RestoreDbClusterToPointInTime_ServerlessV2ScalingConfiguration() {
         when(rdsProxy.client().restoreDBClusterToPointInTime(any(RestoreDbClusterToPointInTimeRequest.class)))
                 .thenReturn(RestoreDbClusterToPointInTimeResponse.builder().build());
+        when(rdsProxy.client().describeEvents(any(DescribeEventsRequest.class)))
+                .thenReturn(DescribeEventsResponse.builder().build());
 
         final CallbackContext context = new CallbackContext();
-        context.setModified(true);
 
         test_handleRequest_base(
                 context,
@@ -497,7 +503,7 @@ public class CreateHandlerTest extends AbstractHandlerTest {
 
         final ArgumentCaptor<RestoreDbClusterToPointInTimeRequest> captor = ArgumentCaptor.forClass(RestoreDbClusterToPointInTimeRequest.class);
         verify(rdsProxy.client(), times(1)).restoreDBClusterToPointInTime(captor.capture());
-        verify(rdsProxy.client(), times(2)).describeDBClusters(any(DescribeDbClustersRequest.class));
+        verify(rdsProxy.client(), times(3)).describeDBClusters(any(DescribeDbClustersRequest.class));
 
         Assertions.assertThat(captor.getValue().serverlessV2ScalingConfiguration()).isNotNull();
         Assertions.assertThat(captor.getValue().serverlessV2ScalingConfiguration()).isEqualTo(
@@ -506,6 +512,10 @@ public class CreateHandlerTest extends AbstractHandlerTest {
                         .minCapacity(SERVERLESS_V2_SCALING_CONFIGURATION.getMinCapacity())
                         .build()
         );
+
+        final ArgumentCaptor<ModifyDbClusterRequest> modifyCaptor = ArgumentCaptor.forClass(ModifyDbClusterRequest.class);
+        verify(rdsProxy.client(), times(1)).modifyDBCluster(modifyCaptor.capture());
+        Assertions.assertThat(modifyCaptor.getValue().serverlessV2ScalingConfiguration()).isNull();
     }
 
     @Test

--- a/aws-rds-dbcluster/src/test/java/software/amazon/rds/dbcluster/TranslatorTest.java
+++ b/aws-rds-dbcluster/src/test/java/software/amazon/rds/dbcluster/TranslatorTest.java
@@ -13,6 +13,7 @@ import software.amazon.awssdk.services.rds.RdsClient;
 import software.amazon.awssdk.services.rds.model.DBCluster;
 import software.amazon.awssdk.services.rds.model.DomainMembership;
 import software.amazon.awssdk.services.rds.model.ModifyDbClusterRequest;
+import software.amazon.awssdk.services.rds.model.RestoreDbClusterFromSnapshotRequest;
 import software.amazon.awssdk.services.rds.model.RestoreDbClusterToPointInTimeRequest;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.ProxyClient;
@@ -343,6 +344,36 @@ public class TranslatorTest extends AbstractHandlerTest {
 
         assertThat(request.useLatestRestorableTime()).isEqualTo(false);
         assertThat(request.restoreToTime()).isEqualTo("2019-03-07T23:45:00Z");
+    }
+
+    @Test
+    public void restoreDBClusterToPointInTimeServerlessV2() {
+        final ResourceModel model = ResourceModel.builder()
+                .serverlessV2ScalingConfiguration(SERVERLESS_V2_SCALING_CONFIGURATION)
+                .build();
+        final RestoreDbClusterToPointInTimeRequest request = Translator.restoreDbClusterToPointInTimeRequest(model, Tagging.TagSet.emptySet());
+
+        assertThat(request.serverlessV2ScalingConfiguration()).isNotNull();
+        assertThat(request.serverlessV2ScalingConfiguration().minCapacity()).isEqualTo(1.0);
+        assertThat(request.serverlessV2ScalingConfiguration().maxCapacity()).isEqualTo(10.0);
+
+        final ModifyDbClusterRequest modifyRequest = Translator.modifyDbClusterAfterCreateRequest(model);
+        assertThat(modifyRequest.serverlessV2ScalingConfiguration()).isNull();
+    }
+
+    @Test
+    public void restoreDBClusterFromSnapshotServerlessV2() {
+        final ResourceModel model = ResourceModel.builder()
+                .serverlessV2ScalingConfiguration(SERVERLESS_V2_SCALING_CONFIGURATION)
+                .build();
+        final RestoreDbClusterFromSnapshotRequest request = Translator.restoreDbClusterFromSnapshotRequest(model, Tagging.TagSet.emptySet());
+
+        assertThat(request.serverlessV2ScalingConfiguration()).isNotNull();
+        assertThat(request.serverlessV2ScalingConfiguration().minCapacity()).isEqualTo(1.0);
+        assertThat(request.serverlessV2ScalingConfiguration().maxCapacity()).isEqualTo(10.0);
+
+        final ModifyDbClusterRequest modifyRequest = Translator.modifyDbClusterAfterCreateRequest(model);
+        assertThat(modifyRequest.serverlessV2ScalingConfiguration()).isNull();
     }
 
     @Override


### PR DESCRIPTION
This PR fixes an issue with restore scenarios for DBCluster where setting Serverless v2 config twice would occasionally return InternalErrors when setting ServerlessV2 config on Modify Call that followed restore.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
