### PR TITLE
[DBInstance][DBCluster] Case-insensitive NetworkType drift detection

### DIFF
--- a/aws-rds-dbcluster/aws-rds-dbcluster.json
+++ b/aws-rds-dbcluster/aws-rds-dbcluster.json
@@ -407,6 +407,7 @@
     "/properties/EngineVersion": "$join([$string(EngineVersion), \".*\"])",
     "/properties/KmsKeyId": "$join([\"arn:(aws)[-]{0,1}[a-z]{0,2}[-]{0,1}[a-z]{0,3}:kms:[a-z]{2}[-]{1}[a-z]{3,10}[-]{0,1}[a-z]{0,10}[-]{1}[1-3]{1}:[0-9]{12}[:]{1}key\\/\", KmsKeyId])",
     "/properties/MasterUserSecret/KmsKeyId": "$join([\"arn:(aws)[-]{0,1}[a-z]{0,2}[-]{0,1}[a-z]{0,3}:kms:[a-z]{2}[-]{1}[a-z]{3,10}[-]{0,1}[a-z]{0,10}[-]{1}[1-3]{1}:[0-9]{12}[:]{1}key\\/\", MasterUserSecret.KmsKeyId])",
+    "/properties/NetworkType": "$lowercase(NetworkType)",
     "/properties/PerformanceInsightsKmsKeyId": "$join([\"arn:(aws)[-]{0,1}[a-z]{0,2}[-]{0,1}[a-z]{0,3}:kms:[a-z]{2}[-]{1}[a-z]{3,10}[-]{0,1}[a-z]{0,10}[-]{1}[1-3]{1}:[0-9]{12}[:]{1}key\\/\", PerformanceInsightsKmsKeyId])",
     "/properties/PreferredMaintenanceWindow": "$lowercase(PreferredMaintenanceWindow)",
     "/properties/SnapshotIdentifier": "$lowercase(SnapshotIdentifier)",

--- a/aws-rds-dbcluster/src/test/java/software/amazon/rds/dbcluster/SchemaTest.java
+++ b/aws-rds-dbcluster/src/test/java/software/amazon/rds/dbcluster/SchemaTest.java
@@ -203,4 +203,15 @@ public class SchemaTest {
 
         ResourceDriftTestHelper.assertResourceNotDrifted(input, output, resourceSchema);
     }
+
+    @Test
+    public void testDrift_NetworkType_Lowercase() {
+        final ResourceModel input = ResourceModel.builder()
+                .networkType("IO1")
+                .build();
+        final ResourceModel output = ResourceModel.builder()
+                .networkType("io1")
+                .build();
+        ResourceDriftTestHelper.assertResourceNotDrifted(input, output, resourceSchema);
+    }
 }

--- a/aws-rds-dbinstance/aws-rds-dbinstance.json
+++ b/aws-rds-dbinstance/aws-rds-dbinstance.json
@@ -453,6 +453,7 @@
     "/properties/EngineVersion": "$join([$string(EngineVersion), \".*\"])",
     "/properties/KmsKeyId": "$join([\"arn:(aws)[-]{0,1}[a-z]{0,2}[-]{0,1}[a-z]{0,3}:kms:[a-z]{2}[-]{1}[a-z]{3,10}[-]{0,1}[a-z]{0,10}[-]{1}[1-3]{1}:[0-9]{12}[:]{1}key\\/\", KmsKeyId])",
     "/properties/MasterUserSecret/KmsKeyId": "$join([\"arn:(aws)[-]{0,1}[a-z]{0,2}[-]{0,1}[a-z]{0,3}:kms:[a-z]{2}[-]{1}[a-z]{3,10}[-]{0,1}[a-z]{0,10}[-]{1}[1-3]{1}:[0-9]{12}[:]{1}key\\/\", MasterUserSecret.KmsKeyId])",
+    "/properties/NetworkType": "$lowercase(NetworkType)",
     "/properties/OptionGroupName": "$lowercase(OptionGroupName)",
     "/properties/PerformanceInsightsKMSKeyId": "$join([\"arn:(aws)[-]{0,1}[a-z]{0,2}[-]{0,1}[a-z]{0,3}:kms:[a-z]{2}[-]{1}[a-z]{3,10}[-]{0,1}[a-z]{0,10}[-]{1}[1-3]{1}:[0-9]{12}[:]{1}key\\/\", PerformanceInsightsKMSKeyId])",
     "/properties/PreferredMaintenanceWindow": "$lowercase(PreferredMaintenanceWindow)",

--- a/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/SchemaTest.java
+++ b/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/SchemaTest.java
@@ -233,4 +233,15 @@ public class SchemaTest {
                 .build();
         ResourceDriftTestHelper.assertResourceNotDrifted(input, output, resourceSchema);
     }
+
+    @Test
+    public void testDrift_NetworkType_Lowercase() {
+        final ResourceModel input = ResourceModel.builder()
+                .networkType("IO1")
+                .build();
+        final ResourceModel output = ResourceModel.builder()
+                .networkType("io1")
+                .build();
+        ResourceDriftTestHelper.assertResourceNotDrifted(input, output, resourceSchema);
+    }
 }


### PR DESCRIPTION
This commit enables case-insensitive drift detection on `NetworkType`. The RDS API downcases the input which might cause a false drift.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
