### PR TITLE
[DBInstance] Fail fast when DBInstance fails to join a domain

### DIFF
--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/BaseHandlerStd.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/BaseHandlerStd.java
@@ -46,6 +46,7 @@ import software.amazon.awssdk.services.rds.model.DbUpgradeDependencyFailureExcep
 import software.amazon.awssdk.services.rds.model.DescribeDbClustersResponse;
 import software.amazon.awssdk.services.rds.model.DescribeDbInstancesResponse;
 import software.amazon.awssdk.services.rds.model.DescribeDbSnapshotsResponse;
+import software.amazon.awssdk.services.rds.model.DomainMembership;
 import software.amazon.awssdk.services.rds.model.DomainNotFoundException;
 import software.amazon.awssdk.services.rds.model.Event;
 import software.amazon.awssdk.services.rds.model.InstanceQuotaExceededException;
@@ -554,9 +555,25 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
         }
     }
 
+    private void assertNoDomainMembershipTerminalStatus(final DBInstance dbInstance) throws CfnNotStabilizedException {
+        List<DomainMembership> terminalDomainMemberships = Optional.ofNullable(dbInstance.domainMemberships()).orElse(Collections.emptyList())
+                .stream()
+                .filter(domainMembership -> {
+                    final DomainMembershipStatus status = DomainMembershipStatus.fromString(domainMembership.status());
+                    return status != null && status.isTerminal();
+                })
+                .collect(Collectors.toList());
+
+        if (!terminalDomainMemberships.isEmpty()) {
+            throw new CfnNotStabilizedException(new Exception(String.format("Domain %s is in a terminal state",
+                    terminalDomainMemberships.get(0).domain())));
+        }
+    }
+
     private void assertNoTerminalStatus(final DBInstance dbInstance) throws CfnNotStabilizedException {
         assertNoDBInstanceTerminalStatus(dbInstance);
         assertNoOptionGroupTerminalStatus(dbInstance);
+        assertNoDomainMembershipTerminalStatus(dbInstance);
     }
 
     protected boolean isDBInstanceStabilizedAfterMutate(

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/status/DomainMembershipStatus.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/status/DomainMembershipStatus.java
@@ -1,16 +1,22 @@
 package software.amazon.rds.dbinstance.status;
 
 import software.amazon.awssdk.utils.StringUtils;
-import software.amazon.rds.common.status.Status;
+import software.amazon.rds.common.status.TerminableStatus;
 
-public enum DomainMembershipStatus implements Status {
+public enum DomainMembershipStatus implements TerminableStatus {
     Joined("joined"),
-    KerberosEnabled("kerberos-enabled");
+    KerberosEnabled("kerberos-enabled"),
+    Failed("failed", true);
 
     private final String value;
+    private final Boolean isTerminal;
 
     DomainMembershipStatus(final String value) {
+        this(value, false);
+    }
+    DomainMembershipStatus(final String value, final boolean isTerminal) {
         this.value = value;
+        this.isTerminal = isTerminal;
     }
 
     public static DomainMembershipStatus fromString(final String status) {
@@ -30,5 +36,10 @@ public enum DomainMembershipStatus implements Status {
     @Override
     public boolean equalsString(final String other) {
         return StringUtils.equals(this.value, other);
+    }
+
+    @Override
+    public boolean isTerminal() {
+        return isTerminal;
     }
 }

--- a/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/CreateHandlerTest.java
+++ b/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/CreateHandlerTest.java
@@ -58,6 +58,7 @@ import software.amazon.awssdk.services.rds.model.DescribeDbSnapshotsRequest;
 import software.amazon.awssdk.services.rds.model.DescribeDbSnapshotsResponse;
 import software.amazon.awssdk.services.rds.model.DescribeEventsRequest;
 import software.amazon.awssdk.services.rds.model.DescribeEventsResponse;
+import software.amazon.awssdk.services.rds.model.DomainMembership;
 import software.amazon.awssdk.services.rds.model.DomainNotFoundException;
 import software.amazon.awssdk.services.rds.model.InvalidSubnetException;
 import software.amazon.awssdk.services.rds.model.ModifyDbInstanceRequest;
@@ -80,6 +81,7 @@ import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 import software.amazon.rds.common.error.ErrorCode;
 import software.amazon.rds.common.handler.HandlerConfig;
 import software.amazon.rds.common.handler.Tagging;
+import software.amazon.rds.dbinstance.status.DomainMembershipStatus;
 import software.amazon.rds.dbinstance.status.OptionGroupStatus;
 import software.amazon.rds.test.common.core.HandlerName;
 
@@ -1299,6 +1301,27 @@ public class CreateHandlerTest extends AbstractHandlerTest {
                             .optionGroupMemberships(OptionGroupMembership.builder()
                                     .status(OptionGroupStatus.Failed.toString())
                                     .optionGroupName(OPTION_GROUP_NAME_MYSQL_DEFAULT)
+                                    .build()).build(),
+                    () -> RESOURCE_MODEL_BAREBONE_BLDR().build(),
+                    expectFailed(HandlerErrorCode.NotStabilized)
+            );
+        }).isInstanceOf(CfnNotStabilizedException.class);
+
+        verify(rdsProxy.client(), times(1)).createDBInstance(any(CreateDbInstanceRequest.class));
+    }
+
+    @Test
+    public void handleRequest_CreateDBInstance_DomainMembershipInTerminalState() {
+        final CallbackContext context = new CallbackContext();
+        context.setCreated(false);
+
+        Assertions.assertThatThrownBy(() -> {
+            test_handleRequest_base(
+                    context,
+                    () -> DB_INSTANCE_ACTIVE.toBuilder()
+                            .domainMemberships(DomainMembership.builder()
+                                    .status(DomainMembershipStatus.Failed.toString())
+                                    .domain("domain")
                                     .build()).build(),
                     () -> RESOURCE_MODEL_BAREBONE_BLDR().build(),
                     expectFailed(HandlerErrorCode.NotStabilized)


### PR DESCRIPTION
This PR addresses the situation when DBInstance fails to join a domain. Previously, DBInstance would wait in stabilization maximum allowed amount of time. Now, if DBInstance has failed to join a domain, CFN handler would fail immediately and inform the customer of the fault.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
