### PR TITLE
[DBInstance][DBCluster] Fix drift detection on `StorageType`

### DIFF
--- a/aws-rds-dbcluster/aws-rds-dbcluster.json
+++ b/aws-rds-dbcluster/aws-rds-dbcluster.json
@@ -402,8 +402,8 @@
     "/properties/DBClusterIdentifier": "$lowercase(DBClusterIdentifier)",
     "/properties/DBClusterParameterGroupName": "$lowercase(DBClusterParameterGroupName)",
     "/properties/DBSubnetGroupName": "$lowercase(DBSubnetGroupName)",
-    "/properties/Engine": "$lowercase(Engine)",
     "/properties/EnableHttpEndpoint": "$lowercase($string(EngineMode)) = 'serverless' ? EnableHttpEndpoint : false",
+    "/properties/Engine": "$lowercase(Engine)",
     "/properties/EngineVersion": "$join([$string(EngineVersion), \".*\"])",
     "/properties/KmsKeyId": "$join([\"arn:(aws)[-]{0,1}[a-z]{0,2}[-]{0,1}[a-z]{0,3}:kms:[a-z]{2}[-]{1}[a-z]{3,10}[-]{0,1}[a-z]{0,10}[-]{1}[1-3]{1}:[0-9]{12}[:]{1}key\\/\", KmsKeyId])",
     "/properties/MasterUserSecret/KmsKeyId": "$join([\"arn:(aws)[-]{0,1}[a-z]{0,2}[-]{0,1}[a-z]{0,3}:kms:[a-z]{2}[-]{1}[a-z]{3,10}[-]{0,1}[a-z]{0,10}[-]{1}[1-3]{1}:[0-9]{12}[:]{1}key\\/\", MasterUserSecret.KmsKeyId])",
@@ -411,7 +411,8 @@
     "/properties/PerformanceInsightsKmsKeyId": "$join([\"arn:(aws)[-]{0,1}[a-z]{0,2}[-]{0,1}[a-z]{0,3}:kms:[a-z]{2}[-]{1}[a-z]{3,10}[-]{0,1}[a-z]{0,10}[-]{1}[1-3]{1}:[0-9]{12}[:]{1}key\\/\", PerformanceInsightsKmsKeyId])",
     "/properties/PreferredMaintenanceWindow": "$lowercase(PreferredMaintenanceWindow)",
     "/properties/SnapshotIdentifier": "$lowercase(SnapshotIdentifier)",
-    "/properties/SourceDBClusterIdentifier": "$lowercase(SourceDBClusterIdentifier)"
+    "/properties/SourceDBClusterIdentifier": "$lowercase(SourceDBClusterIdentifier)",
+    "/properties/StorageType": "$lowercase(StorageType)"
   },
   "readOnlyProperties": [
     "/properties/DBClusterArn",

--- a/aws-rds-dbcluster/src/test/java/software/amazon/rds/dbcluster/SchemaTest.java
+++ b/aws-rds-dbcluster/src/test/java/software/amazon/rds/dbcluster/SchemaTest.java
@@ -207,10 +207,21 @@ public class SchemaTest {
     @Test
     public void testDrift_NetworkType_Lowercase() {
         final ResourceModel input = ResourceModel.builder()
-                .networkType("IO1")
+                .networkType("IPV4")
                 .build();
         final ResourceModel output = ResourceModel.builder()
-                .networkType("io1")
+                .networkType("ipv4")
+                .build();
+        ResourceDriftTestHelper.assertResourceNotDrifted(input, output, resourceSchema);
+    }
+
+    @Test
+    public void testDrift_StorageType_Lowercase() {
+        final ResourceModel input = ResourceModel.builder()
+                .storageType("GP3")
+                .build();
+        final ResourceModel output = ResourceModel.builder()
+                .storageType("gp3")
                 .build();
         ResourceDriftTestHelper.assertResourceNotDrifted(input, output, resourceSchema);
     }

--- a/aws-rds-dbinstance/aws-rds-dbinstance.json
+++ b/aws-rds-dbinstance/aws-rds-dbinstance.json
@@ -445,8 +445,8 @@
     "/properties/DBClusterIdentifier": "$lowercase(DBClusterIdentifier)",
     "/properties/DBClusterSnapshotIdentifier": "$lowercase(DBClusterSnapshotIdentifier)",
     "/properties/DBInstanceIdentifier": "$lowercase(DBInstanceIdentifier)",
-    "/properties/DBParameterGroupName": "$lowercase(DBParameterGroupName)",
     "/properties/DBName": "$lowercase(DBName) $OR $uppercase(DBName)",
+    "/properties/DBParameterGroupName": "$lowercase(DBParameterGroupName)",
     "/properties/DBSnapshotIdentifier": "$lowercase(DBSnapshotIdentifier)",
     "/properties/DBSubnetGroupName": "$lowercase(DBSubnetGroupName)",
     "/properties/Engine": "$lowercase(Engine)",
@@ -458,7 +458,8 @@
     "/properties/PerformanceInsightsKMSKeyId": "$join([\"arn:(aws)[-]{0,1}[a-z]{0,2}[-]{0,1}[a-z]{0,3}:kms:[a-z]{2}[-]{1}[a-z]{3,10}[-]{0,1}[a-z]{0,10}[-]{1}[1-3]{1}:[0-9]{12}[:]{1}key\\/\", PerformanceInsightsKMSKeyId])",
     "/properties/PreferredMaintenanceWindow": "$lowercase(PreferredMaintenanceWindow)",
     "/properties/SourceDBInstanceAutomatedBackupsArn": "$lowercase(SourceDBInstanceAutomatedBackupsArn)",
-    "/properties/SourceDBInstanceIdentifier": "$lowercase(SourceDBInstanceIdentifier)"
+    "/properties/SourceDBInstanceIdentifier": "$lowercase(SourceDBInstanceIdentifier)",
+    "/properties/StorageType": "$lowercase(StorageType)"
   },
   "createOnlyProperties": [
     "/properties/CharacterSetName",

--- a/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/SchemaTest.java
+++ b/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/SchemaTest.java
@@ -237,10 +237,21 @@ public class SchemaTest {
     @Test
     public void testDrift_NetworkType_Lowercase() {
         final ResourceModel input = ResourceModel.builder()
-                .networkType("IO1")
+                .networkType("IPV4")
                 .build();
         final ResourceModel output = ResourceModel.builder()
-                .networkType("io1")
+                .networkType("ipv4")
+                .build();
+        ResourceDriftTestHelper.assertResourceNotDrifted(input, output, resourceSchema);
+    }
+
+    @Test
+    public void testDrift_StorageType_Lowercase() {
+        final ResourceModel input = ResourceModel.builder()
+                .storageType("GP3")
+                .build();
+        final ResourceModel output = ResourceModel.builder()
+                .storageType("gp3")
                 .build();
         ResourceDriftTestHelper.assertResourceNotDrifted(input, output, resourceSchema);
     }


### PR DESCRIPTION
This commit adds an additional `PropertyTransform` directive for `StorageType` in both `DBInstance` and `DBCluster` resources. The motivation for the change is to eliminate a false drift detection on this attribute that occurs on the lowercase-coalescing done by RDS API.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
