### PR TITLE
[DBInstance] Set engine from snapshot on restore-from-snapshot

### DIFF
--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/CreateHandler.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/CreateHandler.java
@@ -100,6 +100,9 @@ public class CreateHandler extends BaseHandlerStd {
                             try {
                                 final DBSnapshot snapshot = fetchDBSnapshot(rdsProxyClient.defaultClient(), model);
                                 final String engine = snapshot.engine();
+                                if (StringUtils.isNullOrEmpty(progress.getResourceModel().getEngine())) {
+                                    progress.getResourceModel().setEngine(engine);
+                                }
                                 progress.getResourceModel().setMultiAZ(ResourceModelHelper.getDefaultMultiAzForEngine(engine));
                             } catch (Exception e) {
                                 return Commons.handleException(progress, e, RESTORE_DB_INSTANCE_ERROR_RULE_SET);


### PR DESCRIPTION
This commit alters the behavior of the the create handler upon a restore from a snapshot.

The restore procedure differs depending on the engine provided in the request. SQL server engines would reject storage-related set of attributes and would expect these values to be sent with a follow-up modify-after-create request. For non-SQL engines storage-related attributes could be provided as a part of the initial `RestoreDBInstanceFromDBSnapshot` request.

The issue occurs when CFN restore request contains no specific engine name: the current implementation assumes this is a SQL engine family and performs the restore-and-update scenario.

This change instructs the handler to get the engine name from the snapshot and to make a more conscious decision on the SQL/non-SQL branching. In this scenario an attempt to restore an instance from a non-SQL snapshot would cause the handler to include storage-related attributes in the restore request.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
