### PR TITLE
[DBInstance] Set source instance engine on read replica

### DIFF
--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/CreateHandler.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/CreateHandler.java
@@ -9,6 +9,7 @@ import org.apache.commons.lang3.BooleanUtils;
 import com.amazonaws.util.StringUtils;
 import software.amazon.awssdk.services.ec2.Ec2Client;
 import software.amazon.awssdk.services.rds.RdsClient;
+import software.amazon.awssdk.services.rds.model.DBInstance;
 import software.amazon.awssdk.services.rds.model.DBSnapshot;
 import software.amazon.awssdk.services.rds.model.SourceType;
 import software.amazon.awssdk.utils.ImmutableMap;
@@ -91,6 +92,10 @@ public class CreateHandler extends BaseHandlerStd {
                         return safeAddTags(this::restoreDbInstanceToPointInTimeRequest)
                                 .invoke(proxy, rdsProxyClient.defaultClient(), progress, allTags);
                     } else if (ResourceModelHelper.isReadReplica(progress.getResourceModel())) {
+                        if (StringUtils.isNullOrEmpty(progress.getResourceModel().getEngine())) {
+                            final DBInstance sourceDBInstance = fetchSourceDBInstance(rdsProxyClient.defaultClient(), progress.getResourceModel());
+                            progress.getResourceModel().setEngine(sourceDBInstance.engine());
+                        }
                         // createDBInstanceReadReplica is not a versioned call.
                         return safeAddTags(this::createDbInstanceReadReplica)
                                 .invoke(proxy, rdsProxyClient.defaultClient(), progress, allTags);


### PR DESCRIPTION
This commit adds an additional source db instance fetch upon a read replica create. At the moment, storage-related attributes are being set upon a create for non-SQLServer engines only. Due to the safeguard in place, the handler treats all unset engine types as SQLServer and hence sets no storage-related attributes on read replicas.

The idea is to set the replica engine type from the source instance so the handler doesn't have to make a guess whether it is a SQLServer engine.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
