### PR TITLE
[DBInstance] Set storage parameters on ModifyAfterCreate workflows if they are specified in the model

### DIFF
--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/Translator.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/Translator.java
@@ -105,7 +105,7 @@ public class Translator {
                 .useDefaultProcessorFeatures(model.getUseDefaultProcessorFeatures())
                 .vpcSecurityGroupIds(CollectionUtils.isNotEmpty(model.getVPCSecurityGroups()) ? model.getVPCSecurityGroups() : null);
 
-        if (!ResourceModelHelper.isSqlServer(model)) {
+        if (ResourceModelHelper.isStorageParametersModified(model)) {
             builder.allocatedStorage(getAllocatedStorage(model))
                     .iops(model.getIops())
                     .storageThroughput(model.getStorageThroughput())
@@ -136,7 +136,7 @@ public class Translator {
                 .storageType(model.getStorageType())
                 .storageThroughput(model.getStorageThroughput());
 
-        if (!ResourceModelHelper.isSqlServer(model)) {
+        if (ResourceModelHelper.isStorageParametersModified(model)) {
             builder.allocatedStorage(getAllocatedStorage(model))
                     .iops(model.getIops())
                     .storageThroughput(model.getStorageThroughput())
@@ -180,7 +180,7 @@ public class Translator {
                 .useDefaultProcessorFeatures(model.getUseDefaultProcessorFeatures())
                 .vpcSecurityGroupIds(CollectionUtils.isNotEmpty(model.getVPCSecurityGroups()) ? model.getVPCSecurityGroups() : null);
 
-        if (!ResourceModelHelper.isSqlServer(model)) {
+        if (ResourceModelHelper.isStorageParametersModified(model)) {
             builder.allocatedStorage(getAllocatedStorage(model))
                     .iops(model.getIops())
                     .storageThroughput(model.getStorageThroughput())
@@ -330,7 +330,7 @@ public class Translator {
                 .useLatestRestorableTime(model.getUseLatestRestorableTime())
                 .vpcSecurityGroupIds(CollectionUtils.isNotEmpty(model.getVPCSecurityGroups()) ? model.getVPCSecurityGroups() : null);
 
-        if (!ResourceModelHelper.isSqlServer(model)) {
+        if (ResourceModelHelper.isStorageParametersModified(model)) {
             builder.allocatedStorage(getAllocatedStorage(model))
                     .iops(model.getIops())
                     .storageThroughput(model.getStorageThroughput())
@@ -535,7 +535,7 @@ public class Translator {
                 .preferredBackupWindow(model.getPreferredBackupWindow())
                 .preferredMaintenanceWindow(model.getPreferredMaintenanceWindow());
 
-        if (ResourceModelHelper.isSqlServer(model)) {
+        if (ResourceModelHelper.isStorageParametersModified(model)) {
             builder.allocatedStorage(getAllocatedStorage(model));
             builder.iops(model.getIops());
             builder.storageThroughput(model.getStorageThroughput());

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/util/ResourceModelHelper.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/util/ResourceModelHelper.java
@@ -33,7 +33,7 @@ public final class ResourceModelHelper {
                                 StringUtils.hasValue(model.getMonitoringRoleArn()) ||
                                 Optional.ofNullable(model.getBackupRetentionPeriod()).orElse(0) > 0 ||
                                 Optional.ofNullable(model.getMonitoringInterval()).orElse(0) > 0 ||
-                                (isSqlServer(model) &&  isStorageParametersModified(model)) ||
+                                isStorageParametersModified(model) ||
                                 BooleanUtils.isTrue(model.getManageMasterUserPassword()) ||
                                 BooleanUtils.isTrue(model.getDeletionProtection()) ||
                                 BooleanUtils.isTrue(model.getEnablePerformanceInsights())
@@ -46,12 +46,6 @@ public final class ResourceModelHelper {
                 Optional.ofNullable(model.getMaxAllocatedStorage()).orElse(0) > 0 ||
                 Optional.ofNullable(model.getStorageThroughput()).orElse(0) > 0 ||
                 StringUtils.hasValue(model.getStorageType());
-    }
-
-    public static boolean isSqlServer(final ResourceModel model) {
-        final String engine = model.getEngine();
-        // treat unknown engines as SQLServer
-        return engine == null || engine.startsWith(SQLSERVER_ENGINE_PREFIX);
     }
 
     public static boolean isRestoreToPointInTime(final ResourceModel model) {

--- a/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/CreateHandlerTest.java
+++ b/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/CreateHandlerTest.java
@@ -886,7 +886,7 @@ public class CreateHandlerTest extends AbstractHandlerTest {
     }
 
     @Test
-    public void handleRequest_CreateReadReplica_AllocatedStorage_ShouldNotUpdate_Success() {
+    public void handleRequest_CreateReadReplica_AllocatedStorage_ShouldUpdate() {
         final CallbackContext context = new CallbackContext();
         context.setCreated(false);
         context.setUpdated(false);
@@ -895,6 +895,8 @@ public class CreateHandlerTest extends AbstractHandlerTest {
 
         when(rdsProxy.client().createDBInstanceReadReplica(any(CreateDbInstanceReadReplicaRequest.class)))
                 .thenReturn(CreateDbInstanceReadReplicaResponse.builder().build());
+        when(rdsProxy.client().describeEvents(any(DescribeEventsRequest.class)))
+                .thenReturn(DescribeEventsResponse.builder().build());
 
         test_handleRequest_base(
                 context,
@@ -911,7 +913,10 @@ public class CreateHandlerTest extends AbstractHandlerTest {
         ArgumentCaptor<CreateDbInstanceReadReplicaRequest> captor = ArgumentCaptor.forClass(CreateDbInstanceReadReplicaRequest.class);
         verify(rdsProxy.client(), times(1)).createDBInstanceReadReplica(captor.capture());
         Assertions.assertThat(captor.getValue().allocatedStorage()).isEqualTo(ALLOCATED_STORAGE);
-        verify(rdsProxy.client(), times(2)).describeDBInstances(any(DescribeDbInstancesRequest.class));
+        verify(rdsProxy.client(), times(3)).describeDBInstances(any(DescribeDbInstancesRequest.class));
+        ArgumentCaptor<ModifyDbInstanceRequest> modifyCaptor = ArgumentCaptor.forClass(ModifyDbInstanceRequest.class);
+        verify(rdsProxy.client(), times(1)).modifyDBInstance(modifyCaptor.capture());
+        Assertions.assertThat(modifyCaptor.getValue().allocatedStorage()).isEqualTo(ALLOCATED_STORAGE);
     }
 
     @Test
@@ -927,6 +932,8 @@ public class CreateHandlerTest extends AbstractHandlerTest {
         when(rdsProxy.client().describeDBSnapshots(any(DescribeDbSnapshotsRequest.class)))
                 .thenReturn(DescribeDbSnapshotsResponse.builder()
                         .dbSnapshots(ImmutableList.of(DBSnapshot.builder().build())).build());
+        when(rdsProxy.client().describeEvents(any(DescribeEventsRequest.class)))
+                .thenReturn(DescribeEventsResponse.builder().build());
 
         test_handleRequest_base(
                 context,
@@ -943,7 +950,10 @@ public class CreateHandlerTest extends AbstractHandlerTest {
         ArgumentCaptor<RestoreDbInstanceFromDbSnapshotRequest> captor = ArgumentCaptor.forClass(RestoreDbInstanceFromDbSnapshotRequest.class);
         verify(rdsProxy.client(), times(1)).restoreDBInstanceFromDBSnapshot(captor.capture());
         Assertions.assertThat(captor.getValue().allocatedStorage()).isEqualTo(ALLOCATED_STORAGE);
-        verify(rdsProxy.client(), times(2)).describeDBInstances(any(DescribeDbInstancesRequest.class));
+        verify(rdsProxy.client(), times(3)).describeDBInstances(any(DescribeDbInstancesRequest.class));
+        ArgumentCaptor<ModifyDbInstanceRequest> modifyCaptor = ArgumentCaptor.forClass(ModifyDbInstanceRequest.class);
+        verify(rdsProxy.client(), times(1)).modifyDBInstance(modifyCaptor.capture());
+        Assertions.assertThat(modifyCaptor.getValue().allocatedStorage()).isEqualTo(ALLOCATED_STORAGE);
     }
 
     @Test

--- a/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/TranslatorTest.java
+++ b/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/TranslatorTest.java
@@ -486,21 +486,22 @@ class TranslatorTest extends AbstractHandlerTest {
     }
 
     @Test
-    public void test_modifyAfterCreate_shouldNotSetGP3Parameters() {
+    public void test_modifyAfterCreate_shouldSetStorageParameters() {
         final ResourceModel model = RESOURCE_MODEL_BLDR()
                 .storageType("gp3")
                 .storageThroughput(100)
                 .iops(200)
+                .engine("sqlserver-ee")
                 .build();
 
         final ModifyDbInstanceRequest request = Translator.modifyDbInstanceAfterCreateRequest(model);
-        assertThat(request.iops()).isNull();
-        assertThat(request.storageThroughput()).isNull();
-        assertThat(request.storageType()).isNull();
+        assertThat(request.iops()).isEqualTo(200);
+        assertThat(request.storageThroughput()).isEqualTo(100);
+        assertThat(request.storageType()).isEqualTo("gp3");
     }
 
     @Test
-    public void test_modifyAfterCreate_shouldSetGP3ParametersForSqlServer() {
+    public void test_modifyAfterCreate_shouldSetGP3ParametersWhenPresent() {
         final ResourceModel model = RESOURCE_MODEL_BLDR()
                 .storageType("gp3")
                 .storageThroughput(100)

--- a/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/util/ResourceModelHelperTest.java
+++ b/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/util/ResourceModelHelperTest.java
@@ -78,7 +78,7 @@ public class ResourceModelHelperTest {
                 .allocatedStorage("100")
                 .build();
 
-        assertThat(ResourceModelHelper.shouldUpdateAfterCreate(model)).isFalse();
+        assertThat(ResourceModelHelper.shouldUpdateAfterCreate(model)).isTrue();
     }
 
     @Test
@@ -236,6 +236,6 @@ public class ResourceModelHelperTest {
                 .storageType("gp2")
                 .build();
 
-        assertThat(ResourceModelHelper.shouldUpdateAfterCreate(model)).isFalse();
+        assertThat(ResourceModelHelper.shouldUpdateAfterCreate(model)).isTrue();
     }
 }


### PR DESCRIPTION
Previously DBInstance handlers assumed that only SQL Server needs to update storage parameters on ModifyAfterCreate scenarios. This PR changes this logic to update the storage parameters if storage parameters were modified.

The main motivation behind this change is that the customers are able to omit Engine for their DBInstance. That in turn requires us to fetch Engine of the future SQL Instance from DBSnapshot, DBClusterSnapshot, read replica's primary instance, etc. Not all scenarios were covered, leading to instance having wrong storage parameters.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
