### PR TITLE
[DBInstance] Address corner cases for storage parameters used with ModifyAfterCreate workflows

### DIFF
--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/Translator.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/Translator.java
@@ -104,13 +104,6 @@ public class Translator {
                 .tags(Tagging.translateTagsToSdk(tagSet))
                 .useDefaultProcessorFeatures(model.getUseDefaultProcessorFeatures())
                 .vpcSecurityGroupIds(CollectionUtils.isNotEmpty(model.getVPCSecurityGroups()) ? model.getVPCSecurityGroups() : null);
-
-        if (ResourceModelHelper.isStorageParametersModified(model)) {
-            builder.allocatedStorage(getAllocatedStorage(model))
-                    .iops(model.getIops())
-                    .storageThroughput(model.getStorageThroughput())
-                    .storageType(model.getStorageType());
-        }
         return builder.build();
     }
 
@@ -127,21 +120,12 @@ public class Translator {
                 .dbSnapshotIdentifier(model.getDBSnapshotIdentifier())
                 .dbSubnetGroupName(model.getDBSubnetGroupName())
                 .engine(model.getEngine())
-                .iops(model.getIops())
                 .licenseModel(model.getLicenseModel())
                 .multiAZ(model.getMultiAZ())
                 .networkType(model.getNetworkType())
                 .optionGroupName(model.getOptionGroupName())
-                .port(translatePortToSdk(model.getPort()))
-                .storageType(model.getStorageType())
-                .storageThroughput(model.getStorageThroughput());
+                .port(translatePortToSdk(model.getPort()));
 
-        if (ResourceModelHelper.isStorageParametersModified(model)) {
-            builder.allocatedStorage(getAllocatedStorage(model))
-                    .iops(model.getIops())
-                    .storageThroughput(model.getStorageThroughput())
-                    .storageType(model.getStorageType());
-        }
         return builder.build();
     }
 
@@ -179,13 +163,6 @@ public class Translator {
                 .tdeCredentialPassword(model.getTdeCredentialPassword())
                 .useDefaultProcessorFeatures(model.getUseDefaultProcessorFeatures())
                 .vpcSecurityGroupIds(CollectionUtils.isNotEmpty(model.getVPCSecurityGroups()) ? model.getVPCSecurityGroups() : null);
-
-        if (ResourceModelHelper.isStorageParametersModified(model)) {
-            builder.allocatedStorage(getAllocatedStorage(model))
-                    .iops(model.getIops())
-                    .storageThroughput(model.getStorageThroughput())
-                    .storageType(model.getStorageType());
-        }
         return builder.build();
     }
 
@@ -330,12 +307,6 @@ public class Translator {
                 .useLatestRestorableTime(model.getUseLatestRestorableTime())
                 .vpcSecurityGroupIds(CollectionUtils.isNotEmpty(model.getVPCSecurityGroups()) ? model.getVPCSecurityGroups() : null);
 
-        if (ResourceModelHelper.isStorageParametersModified(model)) {
-            builder.allocatedStorage(getAllocatedStorage(model))
-                    .iops(model.getIops())
-                    .storageThroughput(model.getStorageThroughput())
-                    .storageType(model.getStorageType());
-        }
         return builder.build();
     }
 

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/Translator.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/Translator.java
@@ -105,7 +105,7 @@ public class Translator {
                 .useDefaultProcessorFeatures(model.getUseDefaultProcessorFeatures())
                 .vpcSecurityGroupIds(CollectionUtils.isNotEmpty(model.getVPCSecurityGroups()) ? model.getVPCSecurityGroups() : null);
 
-        if (!ResourceModelHelper.isSqlServer(model)) {
+        if (ResourceModelHelper.isStorageParametersModified(model)) {
             builder.allocatedStorage(getAllocatedStorage(model))
                     .iops(model.getIops())
                     .storageThroughput(model.getStorageThroughput())
@@ -136,7 +136,7 @@ public class Translator {
                 .storageType(model.getStorageType())
                 .storageThroughput(model.getStorageThroughput());
 
-        if (!ResourceModelHelper.isSqlServer(model)) {
+        if (ResourceModelHelper.isStorageParametersModified(model)) {
             builder.allocatedStorage(getAllocatedStorage(model))
                     .iops(model.getIops())
                     .storageThroughput(model.getStorageThroughput())
@@ -180,7 +180,7 @@ public class Translator {
                 .useDefaultProcessorFeatures(model.getUseDefaultProcessorFeatures())
                 .vpcSecurityGroupIds(CollectionUtils.isNotEmpty(model.getVPCSecurityGroups()) ? model.getVPCSecurityGroups() : null);
 
-        if (!ResourceModelHelper.isSqlServer(model)) {
+        if (ResourceModelHelper.isStorageParametersModified(model)) {
             builder.allocatedStorage(getAllocatedStorage(model))
                     .iops(model.getIops())
                     .storageThroughput(model.getStorageThroughput())
@@ -330,7 +330,7 @@ public class Translator {
                 .useLatestRestorableTime(model.getUseLatestRestorableTime())
                 .vpcSecurityGroupIds(CollectionUtils.isNotEmpty(model.getVPCSecurityGroups()) ? model.getVPCSecurityGroups() : null);
 
-        if (!ResourceModelHelper.isSqlServer(model)) {
+        if (ResourceModelHelper.isStorageParametersModified(model)) {
             builder.allocatedStorage(getAllocatedStorage(model))
                     .iops(model.getIops())
                     .storageThroughput(model.getStorageThroughput())
@@ -535,7 +535,7 @@ public class Translator {
                 .preferredBackupWindow(model.getPreferredBackupWindow())
                 .preferredMaintenanceWindow(model.getPreferredMaintenanceWindow());
 
-        if (ResourceModelHelper.isSqlServer(model)) {
+        if (ResourceModelHelper.isStorageParametersModified(model)) {
             builder.allocatedStorage(getAllocatedStorage(model));
             builder.iops(model.getIops());
             builder.storageThroughput(model.getStorageThroughput());

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/util/ResourceModelHelper.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/util/ResourceModelHelper.java
@@ -33,7 +33,7 @@ public final class ResourceModelHelper {
                                 StringUtils.hasValue(model.getMonitoringRoleArn()) ||
                                 Optional.ofNullable(model.getBackupRetentionPeriod()).orElse(0) > 0 ||
                                 Optional.ofNullable(model.getMonitoringInterval()).orElse(0) > 0 ||
-                                (isSqlServer(model) &&  isStorageParametersModified(model)) ||
+                                isStorageParametersModified(model) ||
                                 BooleanUtils.isTrue(model.getManageMasterUserPassword()) ||
                                 BooleanUtils.isTrue(model.getDeletionProtection()) ||
                                 BooleanUtils.isTrue(model.getEnablePerformanceInsights())
@@ -46,12 +46,6 @@ public final class ResourceModelHelper {
                 Optional.ofNullable(model.getMaxAllocatedStorage()).orElse(0) > 0 ||
                 Optional.ofNullable(model.getStorageThroughput()).orElse(0) > 0 ||
                 StringUtils.hasValue(model.getStorageType());
-    }
-
-    public static boolean isSqlServer(final ResourceModel model) {
-        final String engine = model.getEngine();
-        // treat unknown engines as SQLServer
-        return engine == null || engine.startsWith(SQLSERVER_ENGINE_PREFIX);
     }
 
     public static boolean isRestoreToPointInTime(final ResourceModel model) {

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/util/ResourceModelHelper.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/util/ResourceModelHelper.java
@@ -10,8 +10,6 @@ import java.util.Optional;
 import java.util.Set;
 
 public final class ResourceModelHelper {
-    private static final String SQLSERVER_ENGINE_PREFIX = "sqlserver";
-
     private static final Set<String> SQLSERVER_ENGINES_WITH_MIRRORING = ImmutableSet.of(
             "sqlserver-ee",
             "sqlserver-se"

--- a/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/CreateHandlerTest.java
+++ b/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/CreateHandlerTest.java
@@ -1544,9 +1544,12 @@ public class CreateHandlerTest extends AbstractHandlerTest {
         when(rdsProxy.client().restoreDBInstanceFromDBSnapshot(any(RestoreDbInstanceFromDbSnapshotRequest.class)))
                 .thenReturn(RestoreDbInstanceFromDbSnapshotResponse.builder().build());
 
+        when(rdsProxy.client().describeEvents(any(DescribeEventsRequest.class)))
+                .thenReturn(DescribeEventsResponse.builder().build());
+
         final CallbackContext context = new CallbackContext();
         context.setCreated(false);
-        context.setUpdated(true);
+        context.setUpdated(false);
         context.setRebooted(true);
         context.setUpdatedRoles(true);
 
@@ -1563,7 +1566,11 @@ public class CreateHandlerTest extends AbstractHandlerTest {
 
         ArgumentCaptor<RestoreDbInstanceFromDbSnapshotRequest> restoreCaptor = ArgumentCaptor.forClass(RestoreDbInstanceFromDbSnapshotRequest.class);
         verify(rdsProxy.client(), times(1)).restoreDBInstanceFromDBSnapshot(restoreCaptor.capture());
-        Assertions.assertThat(restoreCaptor.getValue().storageType()).isEqualTo(STORAGE_TYPE_GP2);
+        Assertions.assertThat(restoreCaptor.getValue().storageType()).isNull();
+
+        ArgumentCaptor<ModifyDbInstanceRequest> modifyCaptor = ArgumentCaptor.forClass(ModifyDbInstanceRequest.class);
+        verify(rdsProxy.client(), times(1)).modifyDBInstance(modifyCaptor.capture());
+        Assertions.assertThat(modifyCaptor.getValue().storageType()).isEqualTo(STORAGE_TYPE_GP2);
     }
 
     @Test

--- a/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/CreateHandlerTest.java
+++ b/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/CreateHandlerTest.java
@@ -886,7 +886,7 @@ public class CreateHandlerTest extends AbstractHandlerTest {
     }
 
     @Test
-    public void handleRequest_CreateReadReplica_AllocatedStorage_ShouldUpdate() {
+    public void handleRequest_CreateReadReplica_AllocatedStorage() {
         final CallbackContext context = new CallbackContext();
         context.setCreated(false);
         context.setUpdated(false);
@@ -912,7 +912,7 @@ public class CreateHandlerTest extends AbstractHandlerTest {
 
         ArgumentCaptor<CreateDbInstanceReadReplicaRequest> captor = ArgumentCaptor.forClass(CreateDbInstanceReadReplicaRequest.class);
         verify(rdsProxy.client(), times(1)).createDBInstanceReadReplica(captor.capture());
-        Assertions.assertThat(captor.getValue().allocatedStorage()).isEqualTo(ALLOCATED_STORAGE);
+        Assertions.assertThat(captor.getValue().allocatedStorage()).isNull();
         verify(rdsProxy.client(), times(3)).describeDBInstances(any(DescribeDbInstancesRequest.class));
         ArgumentCaptor<ModifyDbInstanceRequest> modifyCaptor = ArgumentCaptor.forClass(ModifyDbInstanceRequest.class);
         verify(rdsProxy.client(), times(1)).modifyDBInstance(modifyCaptor.capture());
@@ -920,7 +920,7 @@ public class CreateHandlerTest extends AbstractHandlerTest {
     }
 
     @Test
-    public void handleRequest_RestoreDBInstanceFromSnapshot_AllocatedStorage_ShouldNotUpdate_Success() {
+    public void handleRequest_RestoreDBInstanceFromSnapshot_AllocatedStorage() {
         final CallbackContext context = new CallbackContext();
         context.setCreated(false);
         context.setUpdated(false);
@@ -949,7 +949,7 @@ public class CreateHandlerTest extends AbstractHandlerTest {
 
         ArgumentCaptor<RestoreDbInstanceFromDbSnapshotRequest> captor = ArgumentCaptor.forClass(RestoreDbInstanceFromDbSnapshotRequest.class);
         verify(rdsProxy.client(), times(1)).restoreDBInstanceFromDBSnapshot(captor.capture());
-        Assertions.assertThat(captor.getValue().allocatedStorage()).isEqualTo(ALLOCATED_STORAGE);
+        Assertions.assertThat(captor.getValue().allocatedStorage()).isNull();
         verify(rdsProxy.client(), times(3)).describeDBInstances(any(DescribeDbInstancesRequest.class));
         ArgumentCaptor<ModifyDbInstanceRequest> modifyCaptor = ArgumentCaptor.forClass(ModifyDbInstanceRequest.class);
         verify(rdsProxy.client(), times(1)).modifyDBInstance(modifyCaptor.capture());
@@ -1469,10 +1469,12 @@ public class CreateHandlerTest extends AbstractHandlerTest {
 
         when(rdsProxy.client().restoreDBInstanceFromDBSnapshot(any(RestoreDbInstanceFromDbSnapshotRequest.class)))
                 .thenReturn(RestoreDbInstanceFromDbSnapshotResponse.builder().build());
+        when(rdsProxy.client().describeEvents(any(DescribeEventsRequest.class)))
+                .thenReturn(DescribeEventsResponse.builder().build());
 
         final CallbackContext context = new CallbackContext();
         context.setCreated(false);
-        context.setUpdated(true);
+        context.setUpdated(false);
         context.setRebooted(true);
         context.setUpdatedRoles(true);
 
@@ -1488,7 +1490,11 @@ public class CreateHandlerTest extends AbstractHandlerTest {
 
         ArgumentCaptor<RestoreDbInstanceFromDbSnapshotRequest> restoreCaptor = ArgumentCaptor.forClass(RestoreDbInstanceFromDbSnapshotRequest.class);
         verify(rdsProxy.client(), times(1)).restoreDBInstanceFromDBSnapshot(restoreCaptor.capture());
-        Assertions.assertThat(restoreCaptor.getValue().storageType()).isEqualTo(STORAGE_TYPE_GP2);
+        Assertions.assertThat(restoreCaptor.getValue().storageType()).isNull();
+
+        ArgumentCaptor<ModifyDbInstanceRequest> modifyCaptor = ArgumentCaptor.forClass(ModifyDbInstanceRequest.class);
+        verify(rdsProxy.client(), times(1)).modifyDBInstance(modifyCaptor.capture());
+        Assertions.assertThat(modifyCaptor.getValue().storageType()).isEqualTo(STORAGE_TYPE_GP2);
     }
 
     @Test

--- a/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/CreateHandlerTest.java
+++ b/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/CreateHandlerTest.java
@@ -886,7 +886,7 @@ public class CreateHandlerTest extends AbstractHandlerTest {
     }
 
     @Test
-    public void handleRequest_CreateReadReplica_AllocatedStorage_ShouldNotUpdate_Success() {
+    public void handleRequest_CreateReadReplica_AllocatedStorage_ShouldUpdate() {
         final CallbackContext context = new CallbackContext();
         context.setCreated(false);
         context.setUpdated(false);
@@ -895,6 +895,8 @@ public class CreateHandlerTest extends AbstractHandlerTest {
 
         when(rdsProxy.client().createDBInstanceReadReplica(any(CreateDbInstanceReadReplicaRequest.class)))
                 .thenReturn(CreateDbInstanceReadReplicaResponse.builder().build());
+        when(rdsProxy.client().describeEvents(any(DescribeEventsRequest.class)))
+                .thenReturn(DescribeEventsResponse.builder().build());
 
         test_handleRequest_base(
                 context,
@@ -911,7 +913,10 @@ public class CreateHandlerTest extends AbstractHandlerTest {
         ArgumentCaptor<CreateDbInstanceReadReplicaRequest> captor = ArgumentCaptor.forClass(CreateDbInstanceReadReplicaRequest.class);
         verify(rdsProxy.client(), times(1)).createDBInstanceReadReplica(captor.capture());
         Assertions.assertThat(captor.getValue().allocatedStorage()).isEqualTo(ALLOCATED_STORAGE);
-        verify(rdsProxy.client(), times(2)).describeDBInstances(any(DescribeDbInstancesRequest.class));
+        verify(rdsProxy.client(), times(3)).describeDBInstances(any(DescribeDbInstancesRequest.class));
+        ArgumentCaptor<ModifyDbInstanceRequest> modifyCaptor = ArgumentCaptor.forClass(ModifyDbInstanceRequest.class);
+        verify(rdsProxy.client(), times(1)).modifyDBInstance(modifyCaptor.capture());
+        Assertions.assertThat(modifyCaptor.getValue().allocatedStorage()).isEqualTo(ALLOCATED_STORAGE);
     }
 
     @Test
@@ -927,6 +932,8 @@ public class CreateHandlerTest extends AbstractHandlerTest {
         when(rdsProxy.client().describeDBSnapshots(any(DescribeDbSnapshotsRequest.class)))
                 .thenReturn(DescribeDbSnapshotsResponse.builder()
                         .dbSnapshots(ImmutableList.of(DBSnapshot.builder().build())).build());
+        when(rdsProxy.client().describeEvents(any(DescribeEventsRequest.class)))
+                .thenReturn(DescribeEventsResponse.builder().build());
 
         test_handleRequest_base(
                 context,
@@ -943,7 +950,10 @@ public class CreateHandlerTest extends AbstractHandlerTest {
         ArgumentCaptor<RestoreDbInstanceFromDbSnapshotRequest> captor = ArgumentCaptor.forClass(RestoreDbInstanceFromDbSnapshotRequest.class);
         verify(rdsProxy.client(), times(1)).restoreDBInstanceFromDBSnapshot(captor.capture());
         Assertions.assertThat(captor.getValue().allocatedStorage()).isEqualTo(ALLOCATED_STORAGE);
-        verify(rdsProxy.client(), times(2)).describeDBInstances(any(DescribeDbInstancesRequest.class));
+        verify(rdsProxy.client(), times(3)).describeDBInstances(any(DescribeDbInstancesRequest.class));
+        ArgumentCaptor<ModifyDbInstanceRequest> modifyCaptor = ArgumentCaptor.forClass(ModifyDbInstanceRequest.class);
+        verify(rdsProxy.client(), times(1)).modifyDBInstance(modifyCaptor.capture());
+        Assertions.assertThat(modifyCaptor.getValue().allocatedStorage()).isEqualTo(ALLOCATED_STORAGE);
     }
 
     @Test

--- a/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/TranslatorTest.java
+++ b/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/TranslatorTest.java
@@ -326,14 +326,14 @@ class TranslatorTest extends AbstractHandlerTest {
                 .build();
 
         final RestoreDbInstanceFromDbSnapshotRequest request = Translator.restoreDbInstanceFromSnapshotRequest(model, Tagging.TagSet.emptySet());
-        assertThat(request.storageType()).isEqualTo("gp3");
-        assertThat(request.iops()).isEqualTo(100);
-        assertThat(request.storageThroughput()).isEqualTo(200);
-        assertThat(request.allocatedStorage()).isEqualTo(300);
+        assertThat(request.storageType()).isNull();
+        assertThat(request.iops()).isNull();
+        assertThat(request.storageThroughput()).isNull();
+        assertThat(request.allocatedStorage()).isNull();
     }
 
     @Test
-    public void test_restoreDbInstanceToPointInTimeRequest_shouldBeSetOnCreate() {
+    public void test_restoreDbInstanceToPointInTimeRequest_shouldNotBeSetOnCreate() {
         final ResourceModel model = RESOURCE_MODEL_BLDR()
                 .dBSnapshotIdentifier("snapshot")
                 .storageType("gp3")
@@ -343,14 +343,14 @@ class TranslatorTest extends AbstractHandlerTest {
                 .build();
 
         final RestoreDbInstanceToPointInTimeRequest request = Translator.restoreDbInstanceToPointInTimeRequest(model, Tagging.TagSet.emptySet());
-        assertThat(request.storageType()).isEqualTo("gp3");
-        assertThat(request.iops()).isEqualTo(100);
-        assertThat(request.storageThroughput()).isEqualTo(200);
-        assertThat(request.allocatedStorage()).isEqualTo(300);
+        assertThat(request.storageType()).isNull();
+        assertThat(request.iops()).isNull();
+        assertThat(request.storageThroughput()).isNull();
+        assertThat(request.allocatedStorage()).isNull();
     }
 
     @Test
-    public void test_restoreFromSnapshotRequestV12_shouldBeSetOnRestore() {
+    public void test_restoreFromSnapshotRequestV12_shouldNotBeSetOnRestore() {
         final ResourceModel model = RESOURCE_MODEL_BLDR()
                 .dBSnapshotIdentifier("snapshot")
                 .storageType("gp3")
@@ -360,11 +360,10 @@ class TranslatorTest extends AbstractHandlerTest {
                 .build();
 
         final RestoreDbInstanceFromDbSnapshotRequest request = Translator.restoreDbInstanceFromSnapshotRequestV12(model);
-        assertThat(request.storageType()).isEqualTo("gp3");
-        assertThat(request.iops()).isEqualTo(100);
-        assertThat(request.storageThroughput()).isEqualTo(200);
-        assertThat(request.allocatedStorage()).isEqualTo(300);
-
+        assertThat(request.storageType()).isNull();
+        assertThat(request.iops()).isNull();
+        assertThat(request.storageThroughput()).isNull();
+        assertThat(request.allocatedStorage()).isNull();
     }
 
     @Test
@@ -375,7 +374,7 @@ class TranslatorTest extends AbstractHandlerTest {
                 .build();
 
         final RestoreDbInstanceFromDbSnapshotRequest request = Translator.restoreDbInstanceFromSnapshotRequest(model, Tagging.TagSet.emptySet());
-        assertThat(request.storageType()).isEqualTo("gp2");
+        assertThat(request.storageType()).isNull();
     }
 
     @Test
@@ -386,7 +385,7 @@ class TranslatorTest extends AbstractHandlerTest {
                 .build();
 
         final RestoreDbInstanceToPointInTimeRequest request = Translator.restoreDbInstanceToPointInTimeRequest(model, Tagging.TagSet.emptySet());
-        assertThat(request.storageType()).isEqualTo("gp2");
+        assertThat(request.storageType()).isNull();
     }
 
     @Test
@@ -397,7 +396,7 @@ class TranslatorTest extends AbstractHandlerTest {
                 .build();
 
         final RestoreDbInstanceFromDbSnapshotRequest request = Translator.restoreDbInstanceFromSnapshotRequestV12(model);
-        assertThat(request.storageType()).isEqualTo("gp2");
+        assertThat(request.storageType()).isNull();
     }
 
     @Test

--- a/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/TranslatorTest.java
+++ b/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/TranslatorTest.java
@@ -486,21 +486,22 @@ class TranslatorTest extends AbstractHandlerTest {
     }
 
     @Test
-    public void test_modifyAfterCreate_shouldNotSetGP3Parameters() {
+    public void test_modifyAfterCreate_shouldSetStorageParameters() {
         final ResourceModel model = RESOURCE_MODEL_BLDR()
                 .storageType("gp3")
                 .storageThroughput(100)
                 .iops(200)
+                .engine("sqlserver-ee")
                 .build();
 
         final ModifyDbInstanceRequest request = Translator.modifyDbInstanceAfterCreateRequest(model);
-        assertThat(request.iops()).isNull();
-        assertThat(request.storageThroughput()).isNull();
-        assertThat(request.storageType()).isNull();
+        assertThat(request.iops()).isEqualTo(200);
+        assertThat(request.storageThroughput()).isEqualTo(100);
+        assertThat(request.storageType()).isEqualTo("gp3");
     }
 
     @Test
-    public void test_modifyAfterCreate_shouldSetGP3ParametersForSqlServer() {
+    public void test_modifyAfterCreate_shouldSetGP3ParametersWhenPresent() {
         final ResourceModel model = RESOURCE_MODEL_BLDR()
                 .storageType("gp3")
                 .storageThroughput(100)

--- a/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/util/ResourceModelHelperTest.java
+++ b/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/util/ResourceModelHelperTest.java
@@ -78,7 +78,7 @@ public class ResourceModelHelperTest {
                 .allocatedStorage("100")
                 .build();
 
-        assertThat(ResourceModelHelper.shouldUpdateAfterCreate(model)).isFalse();
+        assertThat(ResourceModelHelper.shouldUpdateAfterCreate(model)).isTrue();
     }
 
     @Test
@@ -236,6 +236,6 @@ public class ResourceModelHelperTest {
                 .storageType("gp2")
                 .build();
 
-        assertThat(ResourceModelHelper.shouldUpdateAfterCreate(model)).isFalse();
+        assertThat(ResourceModelHelper.shouldUpdateAfterCreate(model)).isTrue();
     }
 }


### PR DESCRIPTION
This PR is a follow-up on  #438 which addresses more corner cases by not specifying Storage parameters on initial calls. This way engines that do not support those parameters on initial call can be properly updated

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
