### PR TITLE
[DBInstance][DBCluster] Fix update scenarios when ManageMasterUserPassword is unchanged

### DIFF
--- a/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/Translator.java
+++ b/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/Translator.java
@@ -302,6 +302,9 @@ public class Translator {
     }
 
     private static Boolean getManageMasterUserPassword(final ResourceModel previous, final ResourceModel desired) {
+        if (Objects.equals(previous.getManageMasterUserPassword(), desired.getManageMasterUserPassword())) {
+            return null;
+        }
         if (null != desired.getManageMasterUserPassword()) {
             return desired.getManageMasterUserPassword();
         }

--- a/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/Translator.java
+++ b/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/Translator.java
@@ -308,7 +308,7 @@ public class Translator {
         if (null != desired.getManageMasterUserPassword()) {
             return desired.getManageMasterUserPassword();
         }
-        if (BooleanUtils.isTrue(previous.getManageMasterUserPassword()) && BooleanUtils.isNotTrue(desired.getManageMasterUserPassword())) {
+        if (BooleanUtils.isTrue(previous.getManageMasterUserPassword())) {
             return false;
         }
         return null;

--- a/aws-rds-dbcluster/src/test/java/software/amazon/rds/dbcluster/TranslatorTest.java
+++ b/aws-rds-dbcluster/src/test/java/software/amazon/rds/dbcluster/TranslatorTest.java
@@ -214,6 +214,25 @@ public class TranslatorTest extends AbstractHandlerTest {
     }
 
     @Test
+    public void translateManageMasterUserPassword_fromExplicitFalseToExplicitFalse() {
+        final ResourceModel prev = RESOURCE_MODEL.toBuilder()
+                .manageMasterUserPassword(false)
+                .masterUserPassword("password")
+                .masterUserSecret(MasterUserSecret.builder().kmsKeyId("key").build())
+                .build();
+        final ResourceModel desired = RESOURCE_MODEL.toBuilder()
+                .manageMasterUserPassword(false)
+                .masterUserPassword("password")
+                .masterUserSecret(MasterUserSecret.builder().kmsKeyId("key").build())
+                .build();
+
+        final ModifyDbClusterRequest request = Translator.modifyDbClusterRequest(prev, desired, false);
+
+        assertThat(request.manageMasterUserPassword()).isNull();
+        assertThat(request.masterUserSecretKmsKeyId()).isNull();
+    }
+
+    @Test
     public void test_translateScalingConfigurationToSdk_null() {
         assertThat(Translator.translateScalingConfigurationToSdk(null)).isNull();
     }

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/Translator.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/Translator.java
@@ -490,10 +490,13 @@ public class Translator {
     }
 
     private static Boolean getManageMasterUserPassword(final ResourceModel previous, final ResourceModel desired) {
+        if (Objects.equals(previous.getManageMasterUserPassword(), desired.getManageMasterUserPassword())) {
+            return null;
+        }
         if (null != desired.getManageMasterUserPassword()) {
             return desired.getManageMasterUserPassword();
         }
-        if (BooleanUtils.isTrue(previous.getManageMasterUserPassword()) && BooleanUtils.isNotTrue(desired.getManageMasterUserPassword())) {
+        if (BooleanUtils.isTrue(previous.getManageMasterUserPassword())) {
             return false;
         }
         return null;

--- a/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/TranslatorTest.java
+++ b/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/TranslatorTest.java
@@ -614,6 +614,26 @@ class TranslatorTest extends AbstractHandlerTest {
     }
 
     @Test
+    public void test_translateManageMasterUserPassword_fromExplicitFalseToExplicitFalse() {
+        final ResourceModel prev = RESOURCE_MODEL_BLDR()
+                .manageMasterUserPassword(false)
+                .masterUserPassword("password")
+                .masterUserSecret(MasterUserSecret.builder().kmsKeyId("key").build())
+                .build();
+        final ResourceModel desired = RESOURCE_MODEL_BLDR()
+                .manageMasterUserPassword(false)
+                .masterUserPassword("password")
+                .masterUserSecret(MasterUserSecret.builder().kmsKeyId("key").build())
+
+                .build();
+
+        final ModifyDbInstanceRequest request = Translator.modifyDbInstanceRequest(prev, desired, false);
+
+        assertThat(request.manageMasterUserPassword()).isNull();
+        assertThat(request.masterUserSecretKmsKeyId()).isNull();
+    }
+
+    @Test
     public void test_translateManageMasterUserPassword_fromUnsetToSet_withSpecificKey() {
         final ResourceModel prev = RESOURCE_MODEL_BLDR()
                 .masterUserPassword("password")


### PR DESCRIPTION
Fix an error when Modify call would fail if the customer has set `ManageMasterUserPassword` to false explicitly. If the customer also does  not change their password in the same operation, RDS would reject the change stating that `MasterUserPassword` is required when `ManageMasterUserPassword` is false.

With this change DBInstance and DBCluster update handlers omit sending `ManageMasterUserPassword` parameter when it is not changed in the template.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
