### PR TITLE
[DBCluster][DBInstance] Fix empty feature name in `AssiciatedRoles`

### DIFF
--- a/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/BaseHandlerStd.java
+++ b/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/BaseHandlerStd.java
@@ -463,7 +463,7 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
             return role == null && sdkRole == null;
         }
         return Objects.equals(role.getRoleArn(), sdkRole.roleArn()) &&
-                Objects.equals(role.getFeatureName(), sdkRole.featureName());
+                Objects.equals(StringUtils.trimToNull(role.getFeatureName()), StringUtils.trimToNull(sdkRole.featureName()));
     }
 
     protected ProgressEvent<ResourceModel, CallbackContext> updateTags(

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/BaseHandlerStd.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/BaseHandlerStd.java
@@ -5,8 +5,8 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.BiFunction;
@@ -19,7 +19,6 @@ import org.apache.commons.lang3.BooleanUtils;
 
 import com.amazonaws.util.CollectionUtils;
 import com.google.common.collect.ImmutableList;
-import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.ec2.Ec2Client;
 import software.amazon.awssdk.services.ec2.model.DescribeSecurityGroupsResponse;
 import software.amazon.awssdk.services.ec2.model.SecurityGroup;
@@ -88,14 +87,14 @@ import software.amazon.rds.common.handler.Tagging;
 import software.amazon.rds.common.logging.LoggingProxyClient;
 import software.amazon.rds.common.logging.RequestLogger;
 import software.amazon.rds.common.printer.FilteredJsonPrinter;
+import software.amazon.rds.common.request.RequestValidationException;
+import software.amazon.rds.common.request.ValidatedRequest;
 import software.amazon.rds.common.request.Validations;
 import software.amazon.rds.dbinstance.client.ApiVersion;
 import software.amazon.rds.dbinstance.client.ApiVersionDispatcher;
 import software.amazon.rds.dbinstance.client.Ec2ClientProvider;
 import software.amazon.rds.dbinstance.client.RdsClientProvider;
 import software.amazon.rds.dbinstance.client.VersionedProxyClient;
-import software.amazon.rds.common.request.RequestValidationException;
-import software.amazon.rds.common.request.ValidatedRequest;
 import software.amazon.rds.dbinstance.status.DBInstanceStatus;
 import software.amazon.rds.dbinstance.status.DBParameterGroupStatus;
 import software.amazon.rds.dbinstance.status.DomainMembershipStatus;
@@ -728,7 +727,7 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
                 rdsProxyClient,
                 model,
                 (roles) -> roles.anyMatch(role -> role.roleArn().equals(lookupRole.getRoleArn()) &&
-                        (role.featureName() == null || role.featureName().equals(lookupRole.getFeatureName())))
+                        Objects.equals(StringUtils.trimToNull(role.featureName()), StringUtils.trimToNull(lookupRole.getFeatureName())))
         );
     }
 

--- a/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/BaseHandlerStdTest.java
+++ b/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/BaseHandlerStdTest.java
@@ -29,7 +29,7 @@ import software.amazon.rds.common.request.ValidatedRequest;
 
 class BaseHandlerStdTest {
 
-    class TestBaseHandlerStd extends BaseHandlerStd {
+    static class TestBaseHandlerStd extends BaseHandlerStd {
 
         public TestBaseHandlerStd(HandlerConfig config) {
             super(config);


### PR DESCRIPTION
This commit addresses a role mutate stabilization issue that occurs if the role association feature name is an empty string. RDS API treats this as a no-value and returns an null feature name back. Both `DBInstance` and `DBCluster` handlers stabilize on both `RoleARN` and `FeatureName` attributes upon an addition, hence this discrepancy between an empty string and a null value cause an infinite stabilization.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
