### PR TITLE
[DBInstance] Mark `UseDefaultProcessorFeatures` as write-only

### DIFF
--- a/aws-rds-dbinstance/aws-rds-dbinstance.json
+++ b/aws-rds-dbinstance/aws-rds-dbinstance.json
@@ -512,6 +512,7 @@
     "/properties/SourceDbiResourceId",
     "/properties/SourceRegion",
     "/properties/TdeCredentialPassword",
+    "/properties/UseDefaultProcessorFeatures",
     "/properties/UseLatestRestorableTime"
   ],
   "readOnlyProperties": [


### PR DESCRIPTION
The motivation for this change is to get aligned with the SDK which does not expose the attribute for the describe API interface. I.e. the attribute is write-only from the API perspective, hence keeping it as read-write would cause a false drift.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.