### PR TITLE
[DBInstance] Handle CustomDBParameterGroup in case of MySql Engine

### DIFF
--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/Translator.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/Translator.java
@@ -111,6 +111,11 @@ public class Translator {
                     .storageThroughput(model.getStorageThroughput())
                     .storageType(model.getStorageType());
         }
+
+        if (ResourceModelHelper.isMySQL(model)) {
+            builder.dbParameterGroupName(model.getDBParameterGroupName());
+        }
+
         return builder.build();
     }
 
@@ -580,7 +585,8 @@ public class Translator {
                 .build();
     }
 
-    public static DescribeSecurityGroupsRequest describeSecurityGroupsRequest(final String vpcId, final String groupName) {
+    public static DescribeSecurityGroupsRequest describeSecurityGroupsRequest(final String vpcId,
+                                                                              final String groupName) {
         return DescribeSecurityGroupsRequest.builder()
                 .filters(
                         Filter.builder().name("vpc-id").values(vpcId).build(),

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/util/ResourceModelHelper.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/util/ResourceModelHelper.java
@@ -1,16 +1,18 @@
 package software.amazon.rds.dbinstance.util;
 
-import com.amazonaws.util.StringUtils;
-import com.google.common.collect.ImmutableSet;
-import org.apache.commons.lang3.BooleanUtils;
-import software.amazon.awssdk.utils.CollectionUtils;
-import software.amazon.rds.dbinstance.ResourceModel;
-
 import java.util.Optional;
 import java.util.Set;
 
+import org.apache.commons.lang3.BooleanUtils;
+
+import com.amazonaws.util.StringUtils;
+import com.google.common.collect.ImmutableSet;
+import software.amazon.awssdk.utils.CollectionUtils;
+import software.amazon.rds.dbinstance.ResourceModel;
+
 public final class ResourceModelHelper {
     private static final String SQLSERVER_ENGINE_PREFIX = "sqlserver";
+    private static final String MYSQL_ENGINE_PREFIX = "mysql";
 
     private static final Set<String> SQLSERVER_ENGINES_WITH_MIRRORING = ImmutableSet.of(
             "sqlserver-ee",
@@ -33,7 +35,7 @@ public final class ResourceModelHelper {
                                 StringUtils.hasValue(model.getMonitoringRoleArn()) ||
                                 Optional.ofNullable(model.getBackupRetentionPeriod()).orElse(0) > 0 ||
                                 Optional.ofNullable(model.getMonitoringInterval()).orElse(0) > 0 ||
-                                (isSqlServer(model) &&  isStorageParametersModified(model)) ||
+                                (isSqlServer(model) && isStorageParametersModified(model)) ||
                                 BooleanUtils.isTrue(model.getManageMasterUserPassword()) ||
                                 BooleanUtils.isTrue(model.getDeletionProtection()) ||
                                 BooleanUtils.isTrue(model.getEnablePerformanceInsights())
@@ -52,6 +54,11 @@ public final class ResourceModelHelper {
         final String engine = model.getEngine();
         // treat unknown engines as SQLServer
         return engine == null || engine.startsWith(SQLSERVER_ENGINE_PREFIX);
+    }
+
+    public static boolean isMySQL(final ResourceModel model) {
+        final String engine = model.getEngine();
+        return engine != null && engine.startsWith(MYSQL_ENGINE_PREFIX);
     }
 
     public static boolean isRestoreToPointInTime(final ResourceModel model) {

--- a/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/TranslatorTest.java
+++ b/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/TranslatorTest.java
@@ -281,14 +281,6 @@ class TranslatorTest extends AbstractHandlerTest {
     }
 
     @Test
-    public void test_createReadReplicaRequest_parameterGroupNotSet() {
-        final ResourceModel model = RESOURCE_MODEL_BLDR().build();
-
-        final CreateDbInstanceReadReplicaRequest request = Translator.createDbInstanceReadReplicaRequest(model, Tagging.TagSet.builder().build());
-        Assertions.assertNull(request.dbParameterGroupName());
-    }
-
-    @Test
     public void test_createReadReplicaRequest_blankSourceRegionIsNotSet() {
         final ResourceModel model = ResourceModel.builder()
                 .sourceRegion("")


### PR DESCRIPTION
*Description of changes:*
When a customer creates a Read Replica of a MySQL engine, it is necessary for it to share the same DBParameterGroup as the source instance. If this is not met, the creation will fail. This pull request ensures that we add the DBParameterGroup during the create call. Currently, the DBParameterGroup is set at ModifyAfterCreate, which handles most cases but not this specific one.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
