### PR TITLE
[DBParameterGroup] Fix NPE on non-modifiable parameter for null defau…

### DIFF
--- a/aws-rds-dbparametergroup/src/main/java/software/amazon/rds/dbparametergroup/BaseHandlerStd.java
+++ b/aws-rds-dbparametergroup/src/main/java/software/amazon/rds/dbparametergroup/BaseHandlerStd.java
@@ -353,7 +353,7 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
                     }
                     final Parameter defaultParam = defaultParams.get(name);
                     //Parameter is not modifiable and input model contains different value from default value
-                    return value != null && !defaultParam.isModifiable() && !defaultParam.parameterValue().equals(value);
+                    return value != null && !defaultParam.isModifiable() && !value.equals(defaultParam.parameterValue());
                 })
                 .map(Map.Entry::getKey)
                 .collect(Collectors.toSet());

--- a/aws-rds-dbparametergroup/src/test/java/software/amazon/rds/dbparametergroup/AbstractTestBase.java
+++ b/aws-rds-dbparametergroup/src/test/java/software/amazon/rds/dbparametergroup/AbstractTestBase.java
@@ -181,12 +181,25 @@ public abstract class AbstractTestBase {
             final boolean mockDescribeParameters,
             final boolean isPaginated
     ) {
-        mockDescribeDbParametersResponse(proxyClient, firstParamApplyType, secondParamApplyType, isModifiable, mockDescribeParameters, isPaginated, 1);
+        mockDescribeDbParametersResponse(proxyClient, firstParamApplyType, "system_value", secondParamApplyType, isModifiable, mockDescribeParameters, isPaginated, 1);
     }
 
     void mockDescribeDbParametersResponse(
             final ProxyClient<RdsClient> proxyClient,
             final String firstParamApplyType,
+            final String secondParamValue,
+            final String secondParamApplyType,
+            final boolean isModifiable,
+            final boolean mockDescribeParameters,
+            final boolean isPaginated
+    ) {
+        mockDescribeDbParametersResponse(proxyClient, firstParamApplyType, secondParamValue, secondParamApplyType, isModifiable, mockDescribeParameters, isPaginated, 1);
+    }
+
+    void mockDescribeDbParametersResponse(
+            final ProxyClient<RdsClient> proxyClient,
+            final String firstParamApplyType,
+            final String secondParamValue,
             final String secondParamApplyType,
             final boolean isModifiable,
             final boolean mockDescribeParameters,
@@ -206,7 +219,7 @@ public abstract class AbstractTestBase {
                 .build();
         Parameter param2 = Parameter.builder()
                 .parameterName("param2")
-                .parameterValue("system_value")
+                .parameterValue(secondParamValue)
                 .isModifiable(isModifiable)
                 .applyType(secondParamApplyType)
                 .build();

--- a/aws-rds-dbparametergroup/src/test/java/software/amazon/rds/dbparametergroup/CreateHandlerTest.java
+++ b/aws-rds-dbparametergroup/src/test/java/software/amazon/rds/dbparametergroup/CreateHandlerTest.java
@@ -202,6 +202,24 @@ public class CreateHandlerTest extends AbstractTestBase {
     }
 
     @Test
+    public void handleRequest_UnmodifiableParameterFailWithNullValue() {
+        mockCreateCall();
+        mockDescribeDbParametersResponse(proxyClient, "static",null, "dynamic", false, false, false);
+
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+                .clientRequestToken(getClientRequestToken())
+                .desiredResourceState(RESOURCE_MODEL)
+                .logicalResourceIdentifier(LOGICAL_RESOURCE_IDENTIFIER).build();
+        try {
+            handler.handleRequest(proxy, proxyClient, request, new CallbackContext(), EMPTY_REQUEST_LOGGER);
+        } catch (CfnInvalidRequestException e) {
+            assertThat(e.getMessage()).isEqualTo("Invalid request provided: Unmodifiable DB Parameter: param1");
+        }
+
+        verify(proxyClient.client()).createDBParameterGroup(any(CreateDbParameterGroupRequest.class));
+    }
+
+    @Test
     public void handleRequest_InProgressFailedUnsupportedParams() {
         mockCreateCall();
         when(rdsClient.describeEngineDefaultParameters(any(DescribeEngineDefaultParametersRequest.class)))

--- a/aws-rds-dbparametergroup/src/test/java/software/amazon/rds/dbparametergroup/UpdateHandlerTest.java
+++ b/aws-rds-dbparametergroup/src/test/java/software/amazon/rds/dbparametergroup/UpdateHandlerTest.java
@@ -178,7 +178,10 @@ public class UpdateHandlerTest extends AbstractTestBase {
         assertThat(response.getErrorCode()).isNull();
 
         verify(rdsClient).resetDBParameterGroup(captor.capture());
-        assertThat(captor.getValue().parameters().get(0).applyMethod().toString().equals("pending-reboot")).isTrue();
+        assertThat(captor.getValue().parameters()
+                .stream().parallel()
+                .filter(parameter -> parameter.parameterName().equals("param1")).findAny().get()
+                .applyMethod().toString().equals("pending-reboot")).isTrue();
         verify(rdsClient).describeEngineDefaultParameters(any(DescribeEngineDefaultParametersRequest.class));
     }
 


### PR DESCRIPTION
…lt value

*Issue #, if available:*

*Description of changes:*
This change reverts the comparison order for DBParameterGroups value for non-modifiable parameters. The code now compares the current value with the default value to prevent parameters with null default values from breaking the handlers. The check now fails when trying to modify such values instead of throwing a cryptic NPE.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
