### PR TITLE
[Common][All] Update soft failure on stack level tags to `Unauthorize…

### DIFF
--- a/aws-rds-cfn-common/src/main/java/software/amazon/rds/common/handler/Tagging.java
+++ b/aws-rds-cfn-common/src/main/java/software/amazon/rds/common/handler/Tagging.java
@@ -207,7 +207,7 @@ public final class Tagging {
         return resourceTagsErrorRuleSet;
     }
 
-    public static <M, C extends TaggingContext.Provider> ProgressEvent<M, C> createWithUnauthorizedTagging(
+    public static <M, C extends TaggingContext.Provider> ProgressEvent<M, C> createWithTaggingFallback(
             final AmazonWebServicesClientProxy proxy,
             final ProxyClient<RdsClient> rdsProxyClient,
             final HandlerMethod<M, C> handlerMethod,

--- a/aws-rds-cfn-common/src/main/java/software/amazon/rds/common/handler/Tagging.java
+++ b/aws-rds-cfn-common/src/main/java/software/amazon/rds/common/handler/Tagging.java
@@ -30,21 +30,21 @@ import software.amazon.rds.common.error.ErrorRuleSet;
 import software.amazon.rds.common.error.ErrorStatus;
 
 public final class Tagging {
-    public static final ErrorRuleSet SOFT_FAIL_IN_PROGRESS_TAGGING_ERROR_RULE_SET = ErrorRuleSet
+    public static final ErrorRuleSet IGNORE_LIST_TAGS_PERMISSION_DENIED_ERROR_RULE_SET = ErrorRuleSet
             .extend(ErrorRuleSet.EMPTY_RULE_SET)
             .withErrorCodes(ErrorStatus.ignore(OperationStatus.IN_PROGRESS),
                     ErrorCode.AccessDenied,
                     ErrorCode.AccessDeniedException)
             .build();
 
-    public static final ErrorRuleSet SOFT_FAIL_TAG_ERROR_RULE_SET = ErrorRuleSet
+    public static final ErrorRuleSet STACK_TAGS_ERROR_RULE_SET = ErrorRuleSet
             .extend(ErrorRuleSet.EMPTY_RULE_SET)
-            .withErrorCodes(ErrorStatus.ignore(),
+            .withErrorCodes(ErrorStatus.failWith(HandlerErrorCode.UnauthorizedTaggingOperation),
                     ErrorCode.AccessDenied,
                     ErrorCode.AccessDeniedException
             ).build();
 
-    public static final ErrorRuleSet HARD_FAIL_TAG_ERROR_RULE_SET = ErrorRuleSet
+    public static final ErrorRuleSet RESOURCE_TAG_ERROR_RULE_SET = ErrorRuleSet
             .extend(ErrorRuleSet.EMPTY_RULE_SET)
             .withErrorCodes(ErrorStatus.failWith(HandlerErrorCode.AccessDenied),
                     ErrorCode.AccessDenied,
@@ -184,24 +184,26 @@ public final class Tagging {
                 .build();
     }
 
-    public static ErrorRuleSet bestEffortErrorRuleSet(
+    public static ErrorRuleSet getUpdateTagsAccessDeniedRuleSet(
             final TagSet tagsToAdd,
             final TagSet tagsToRemove
     ) {
-        return bestEffortErrorRuleSet(tagsToAdd, tagsToRemove, SOFT_FAIL_TAG_ERROR_RULE_SET, HARD_FAIL_TAG_ERROR_RULE_SET);
+        return getUpdateTagsAccessDeniedRuleSet(tagsToAdd, tagsToRemove, STACK_TAGS_ERROR_RULE_SET, RESOURCE_TAG_ERROR_RULE_SET);
     }
 
-    public static ErrorRuleSet bestEffortErrorRuleSet(
+    public static ErrorRuleSet getUpdateTagsAccessDeniedRuleSet(
             final TagSet tagsToAdd,
             final TagSet tagsToRemove,
-            final ErrorRuleSet softFailErrorRuleSet,
-            final ErrorRuleSet hardFailErrorRuleSet
+            final ErrorRuleSet stackTagsErrorRuleSet,
+            final ErrorRuleSet resourceTagsErrorRuleSet
     ) {
-        // Only soft fail if the customer provided no resource-level tags
+        /* If the tagging operation comes across an AccessDenied error, we will throw an UnauthorizedTaggingOperation
+        errorCode for stack level tags. For Resource tags, if they are included, we will throw an AccessDenied error.
+        This is done to ensure backward compatibility. */
         if (tagsToAdd.getResourceTags().isEmpty() && tagsToRemove.getResourceTags().isEmpty()) {
-            return softFailErrorRuleSet;
+            return stackTagsErrorRuleSet;
         }
-        return hardFailErrorRuleSet;
+        return resourceTagsErrorRuleSet;
     }
 
     public static <M, C extends TaggingContext.Provider> ProgressEvent<M, C> safeCreate(

--- a/aws-rds-cfn-common/src/main/java/software/amazon/rds/common/handler/TaggingContext.java
+++ b/aws-rds-cfn-common/src/main/java/software/amazon/rds/common/handler/TaggingContext.java
@@ -5,7 +5,6 @@ package software.amazon.rds.common.handler;
 @lombok.ToString
 @lombok.EqualsAndHashCode
 public class TaggingContext {
-    private boolean softFailTags;
     private boolean addTagsComplete;
 
     public interface Provider {

--- a/aws-rds-cfn-common/src/test/java/software/amazon/rds/common/handler/TaggingTest.java
+++ b/aws-rds-cfn-common/src/test/java/software/amazon/rds/common/handler/TaggingTest.java
@@ -18,7 +18,6 @@ import java.util.stream.Stream;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 
@@ -342,7 +341,7 @@ public class TaggingTest extends ProxyClientTestBase {
         Mockito.when(handlerMethod.invoke(Mockito.any(), Mockito.any(), Mockito.any(ProgressEvent.class), Mockito.any(Tagging.TagSet.class)))
                 .thenReturn(ProgressEvent.success(null, progress.getCallbackContext()));
 
-        final ProgressEvent<Void, CommonsTest.TaggingCallbackContext> result = Tagging.createWithUnauthorizedTagging(null, null, handlerMethod, progress, allTags);
+        final ProgressEvent<Void, CommonsTest.TaggingCallbackContext> result = Tagging.createWithTaggingFallback(null, null, handlerMethod, progress, allTags);
 
         Assertions.assertThat(result.isSuccess()).isTrue();
         Assertions.assertThat(result.getCallbackContext().getTaggingContext().isAddTagsComplete()).isTrue();
@@ -365,7 +364,7 @@ public class TaggingTest extends ProxyClientTestBase {
         Mockito.when(handlerMethod.invoke(Mockito.any(), Mockito.any(), Mockito.any(ProgressEvent.class), Mockito.any(Tagging.TagSet.class)))
                 .thenReturn(ProgressEvent.failed(null, progress.getCallbackContext(), HandlerErrorCode.AccessDenied, FAILED_MSG));
 
-        final ProgressEvent<Void, CommonsTest.TaggingCallbackContext> result = Tagging.createWithUnauthorizedTagging(null, null, handlerMethod, progress, allTags);
+        final ProgressEvent<Void, CommonsTest.TaggingCallbackContext> result = Tagging.createWithTaggingFallback(null, null, handlerMethod, progress, allTags);
 
         Assertions.assertThat(result.isFailed()).isTrue();
         Assertions.assertThat(result.getErrorCode()).isEqualTo(HandlerErrorCode.UnauthorizedTaggingOperation);
@@ -387,7 +386,7 @@ public class TaggingTest extends ProxyClientTestBase {
         Mockito.when(handlerMethod.invoke(Mockito.any(), Mockito.any(), Mockito.any(ProgressEvent.class), Mockito.any(Tagging.TagSet.class)))
                 .thenReturn(ProgressEvent.failed(null, progress.getCallbackContext(), HandlerErrorCode.InternalFailure, FAILED_MSG));
 
-        final ProgressEvent<Void, CommonsTest.TaggingCallbackContext> result = Tagging.createWithUnauthorizedTagging(null, null, handlerMethod, progress, allTags);
+        final ProgressEvent<Void, CommonsTest.TaggingCallbackContext> result = Tagging.createWithTaggingFallback(null, null, handlerMethod, progress, allTags);
 
         Assertions.assertThat(result.isFailed()).isTrue();
         Assertions.assertThat(result.getCallbackContext().getTaggingContext().isAddTagsComplete()).isFalse();

--- a/aws-rds-cfn-common/src/test/java/software/amazon/rds/common/handler/TaggingTest.java
+++ b/aws-rds-cfn-common/src/test/java/software/amazon/rds/common/handler/TaggingTest.java
@@ -40,7 +40,6 @@ import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 import software.amazon.rds.common.error.ErrorRuleSet;
 import software.amazon.rds.common.error.ErrorStatus;
-import software.amazon.rds.common.error.IgnoreErrorStatus;
 import software.amazon.rds.common.error.UnexpectedErrorStatus;
 import software.amazon.rds.common.logging.LoggingProxyClient;
 import software.amazon.rds.common.logging.RequestLogger;
@@ -145,9 +144,9 @@ public class TaggingTest extends ProxyClientTestBase {
                         .errorCode("AccessDenied")
                         .build())
                 .build();
-        final ErrorRuleSet ruleSet = Tagging.SOFT_FAIL_TAG_ERROR_RULE_SET;
+        final ErrorRuleSet ruleSet = Tagging.STACK_TAGS_ERROR_RULE_SET;
         final ErrorStatus status = ruleSet.handle(exception);
-        assertThat(status).isInstanceOf(IgnoreErrorStatus.class);
+        assertThat(status).isInstanceOf(ErrorStatus.class);
     }
 
     @Test
@@ -157,7 +156,7 @@ public class TaggingTest extends ProxyClientTestBase {
                         .errorCode("InternalFailure")
                         .build())
                 .build();
-        final ErrorRuleSet ruleSet = Tagging.SOFT_FAIL_TAG_ERROR_RULE_SET;
+        final ErrorRuleSet ruleSet = Tagging.STACK_TAGS_ERROR_RULE_SET;
         final ErrorStatus status = ruleSet.handle(exception);
         assertThat(status).isInstanceOf(UnexpectedErrorStatus.class);
     }
@@ -165,7 +164,7 @@ public class TaggingTest extends ProxyClientTestBase {
     @Test
     void test_SoftFailErrorRuleSet_OtherException() {
         final Exception exception = new RuntimeException("test exception");
-        final ErrorRuleSet ruleSet = Tagging.SOFT_FAIL_TAG_ERROR_RULE_SET;
+        final ErrorRuleSet ruleSet = Tagging.STACK_TAGS_ERROR_RULE_SET;
         final ErrorStatus status = ruleSet.handle(exception);
         assertThat(status).isInstanceOf(UnexpectedErrorStatus.class);
     }
@@ -272,7 +271,7 @@ public class TaggingTest extends ProxyClientTestBase {
 
     @Test
     void test_bestEffortErrorRuleSet_emptyResourceTags() {
-        final ErrorRuleSet errorRuleSet = Tagging.bestEffortErrorRuleSet(
+        final ErrorRuleSet errorRuleSet = Tagging.getUpdateTagsAccessDeniedRuleSet(
                 Tagging.TagSet.builder()
                         .stackTags(Collections.singleton(Tag.builder().build()))
                         .stackTags(Collections.singleton(Tag.builder().build()))
@@ -283,12 +282,12 @@ public class TaggingTest extends ProxyClientTestBase {
                         .build()
         );
 
-        assertThat(errorRuleSet).isEqualTo(Tagging.SOFT_FAIL_TAG_ERROR_RULE_SET);
+        assertThat(errorRuleSet).isEqualTo(Tagging.STACK_TAGS_ERROR_RULE_SET);
     }
 
     @Test
     void test_bestEffortErrorRuleSet_nonEmptyResourceTags() {
-        assertThat(Tagging.bestEffortErrorRuleSet(
+        assertThat(Tagging.getUpdateTagsAccessDeniedRuleSet(
                 Tagging.TagSet.builder()
                         .stackTags(Collections.singleton(Tag.builder().build()))
                         .stackTags(Collections.singleton(Tag.builder().build()))
@@ -299,9 +298,9 @@ public class TaggingTest extends ProxyClientTestBase {
                         .stackTags(Collections.singleton(Tag.builder().build()))
                         .resourceTags(Collections.singleton(Tag.builder().build()))
                         .build()
-        )).isEqualTo(Tagging.HARD_FAIL_TAG_ERROR_RULE_SET);
+        )).isEqualTo(Tagging.RESOURCE_TAG_ERROR_RULE_SET);
 
-        assertThat(Tagging.bestEffortErrorRuleSet(
+        assertThat(Tagging.getUpdateTagsAccessDeniedRuleSet(
                 Tagging.TagSet.builder()
                         .stackTags(Collections.singleton(Tag.builder().build()))
                         .stackTags(Collections.singleton(Tag.builder().build()))
@@ -312,9 +311,9 @@ public class TaggingTest extends ProxyClientTestBase {
                         .stackTags(Collections.singleton(Tag.builder().build()))
                         .resourceTags(Collections.singleton(Tag.builder().build()))
                         .build()
-        )).isEqualTo(Tagging.HARD_FAIL_TAG_ERROR_RULE_SET);
+        )).isEqualTo(Tagging.RESOURCE_TAG_ERROR_RULE_SET);
 
-        assertThat(Tagging.bestEffortErrorRuleSet(
+        assertThat(Tagging.getUpdateTagsAccessDeniedRuleSet(
                 Tagging.TagSet.builder()
                         .stackTags(Collections.singleton(Tag.builder().build()))
                         .stackTags(Collections.singleton(Tag.builder().build()))
@@ -325,7 +324,7 @@ public class TaggingTest extends ProxyClientTestBase {
                         .stackTags(Collections.singleton(Tag.builder().build()))
                         .resourceTags(Collections.emptySet())
                         .build()
-        )).isEqualTo(Tagging.HARD_FAIL_TAG_ERROR_RULE_SET);
+        )).isEqualTo(Tagging.RESOURCE_TAG_ERROR_RULE_SET);
     }
 
     @Test

--- a/aws-rds-customdbengineversion/src/main/java/software/amazon/rds/customdbengineversion/BaseHandlerStd.java
+++ b/aws-rds-customdbengineversion/src/main/java/software/amazon/rds/customdbengineversion/BaseHandlerStd.java
@@ -185,11 +185,11 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
                 progress,
                 exception,
                 DEFAULT_CUSTOM_DB_ENGINE_VERSION_ERROR_RULE_SET.extendWith(
-                        Tagging.bestEffortErrorRuleSet(
+                        Tagging.getUpdateTagsAccessDeniedRuleSet(
                                 tagsToAdd,
                                 tagsToRemove,
-                                Tagging.SOFT_FAIL_IN_PROGRESS_TAGGING_ERROR_RULE_SET,
-                                Tagging.HARD_FAIL_TAG_ERROR_RULE_SET
+                                Tagging.IGNORE_LIST_TAGS_PERMISSION_DENIED_ERROR_RULE_SET,
+                                Tagging.RESOURCE_TAG_ERROR_RULE_SET
                         )
                 )
         );

--- a/aws-rds-customdbengineversion/src/main/java/software/amazon/rds/customdbengineversion/CreateHandler.java
+++ b/aws-rds-customdbengineversion/src/main/java/software/amazon/rds/customdbengineversion/CreateHandler.java
@@ -74,7 +74,7 @@ public class CreateHandler extends BaseHandlerStd {
                                                                                         final ProxyClient<RdsClient> proxyClient,
                                                                                         final ProgressEvent<ResourceModel, CallbackContext> progress,
                                                                                         final Tagging.TagSet allTags) {
-        return Tagging.safeCreate(proxy, proxyClient, this::createCustomEngineVersion, progress, allTags)
+        return Tagging.createWithUnauthorizedTagging(proxy, proxyClient, this::createCustomEngineVersion, progress, allTags)
                 .then(p -> Commons.execOnce(p, () -> {
                     final Tagging.TagSet extraTags = Tagging.TagSet.builder()
                             .stackTags(allTags.getStackTags())

--- a/aws-rds-customdbengineversion/src/main/java/software/amazon/rds/customdbengineversion/CreateHandler.java
+++ b/aws-rds-customdbengineversion/src/main/java/software/amazon/rds/customdbengineversion/CreateHandler.java
@@ -74,7 +74,7 @@ public class CreateHandler extends BaseHandlerStd {
                                                                                         final ProxyClient<RdsClient> proxyClient,
                                                                                         final ProgressEvent<ResourceModel, CallbackContext> progress,
                                                                                         final Tagging.TagSet allTags) {
-        return Tagging.createWithUnauthorizedTagging(proxy, proxyClient, this::createCustomEngineVersion, progress, allTags)
+        return Tagging.createWithTaggingFallback(proxy, proxyClient, this::createCustomEngineVersion, progress, allTags)
                 .then(p -> Commons.execOnce(p, () -> {
                     final Tagging.TagSet extraTags = Tagging.TagSet.builder()
                             .stackTags(allTags.getStackTags())

--- a/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/BaseHandlerStd.java
+++ b/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/BaseHandlerStd.java
@@ -501,7 +501,7 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
             return Commons.handleException(
                     progress,
                     exception,
-                    DEFAULT_DB_CLUSTER_ERROR_RULE_SET.extendWith(Tagging.bestEffortErrorRuleSet(tagsToAdd, tagsToRemove))
+                    DEFAULT_DB_CLUSTER_ERROR_RULE_SET.extendWith(Tagging.getUpdateTagsAccessDeniedRuleSet(tagsToAdd, tagsToRemove))
             );
         }
 

--- a/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/CreateHandler.java
+++ b/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/CreateHandler.java
@@ -71,11 +71,11 @@ public class CreateHandler extends BaseHandlerStd {
         return ProgressEvent.progress(model, callbackContext)
                 .then(progress -> {
                     if (isRestoreToPointInTime(model)) {
-                        return Tagging.createWithUnauthorizedTagging(proxy, rdsProxyClient, this::restoreDbClusterToPointInTime, progress, allTags);
+                        return Tagging.createWithTaggingFallback(proxy, rdsProxyClient, this::restoreDbClusterToPointInTime, progress, allTags);
                     } else if (isRestoreFromSnapshot(model)) {
-                        return Tagging.createWithUnauthorizedTagging(proxy, rdsProxyClient, this::restoreDbClusterFromSnapshot, progress, allTags);
+                        return Tagging.createWithTaggingFallback(proxy, rdsProxyClient, this::restoreDbClusterFromSnapshot, progress, allTags);
                     }
-                    return Tagging.createWithUnauthorizedTagging(proxy, rdsProxyClient, this::createDbCluster, progress, allTags);
+                    return Tagging.createWithTaggingFallback(proxy, rdsProxyClient, this::createDbCluster, progress, allTags);
                 })
                 .then(progress -> Commons.execOnce(progress, () -> {
                     final Tagging.TagSet extraTags = Tagging.TagSet.builder()

--- a/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/CreateHandler.java
+++ b/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/CreateHandler.java
@@ -71,11 +71,11 @@ public class CreateHandler extends BaseHandlerStd {
         return ProgressEvent.progress(model, callbackContext)
                 .then(progress -> {
                     if (isRestoreToPointInTime(model)) {
-                        return Tagging.safeCreate(proxy, rdsProxyClient, this::restoreDbClusterToPointInTime, progress, allTags);
+                        return Tagging.createWithUnauthorizedTagging(proxy, rdsProxyClient, this::restoreDbClusterToPointInTime, progress, allTags);
                     } else if (isRestoreFromSnapshot(model)) {
-                        return Tagging.safeCreate(proxy, rdsProxyClient, this::restoreDbClusterFromSnapshot, progress, allTags);
+                        return Tagging.createWithUnauthorizedTagging(proxy, rdsProxyClient, this::restoreDbClusterFromSnapshot, progress, allTags);
                     }
-                    return Tagging.safeCreate(proxy, rdsProxyClient, this::createDbCluster, progress, allTags);
+                    return Tagging.createWithUnauthorizedTagging(proxy, rdsProxyClient, this::createDbCluster, progress, allTags);
                 })
                 .then(progress -> Commons.execOnce(progress, () -> {
                     final Tagging.TagSet extraTags = Tagging.TagSet.builder()

--- a/aws-rds-dbcluster/src/test/java/software/amazon/rds/dbcluster/CreateHandlerTest.java
+++ b/aws-rds-dbcluster/src/test/java/software/amazon/rds/dbcluster/CreateHandlerTest.java
@@ -169,55 +169,39 @@ public class CreateHandlerTest extends AbstractHandlerTest {
     }
 
     @Test
-    public void handleRequest_CreateDbCluster_AccessDeniedTagging() {
+    public void handleRequest_CreateDbCluster_UnauthorizedTaggingOperation() {
         when(rdsProxy.client().createDBCluster(any(CreateDbClusterRequest.class)))
                 .thenThrow(
                         RdsException.builder()
+                                .message("Role not authorized to execute rds:AddTagsToResource")
                                 .awsErrorDetails(AwsErrorDetails.builder()
                                         .errorCode(ErrorCode.AccessDeniedException.toString())
                                         .build()
-                                ).build())
-                .thenReturn(CreateDbClusterResponse.builder().build());
-        when(rdsProxy.client().addRoleToDBCluster(any(AddRoleToDbClusterRequest.class)))
-                .thenReturn(AddRoleToDbClusterResponse.builder().build());
-        when(rdsProxy.client().addTagsToResource(any(AddTagsToResourceRequest.class)))
-                .thenReturn(AddTagsToResourceResponse.builder().build());
-
-        final Tagging.TagSet extraTags = Tagging.TagSet.builder()
-                .stackTags(TAG_SET.getStackTags())
-                .resourceTags(TAG_SET.getResourceTags())
-                .build();
+                                ).build());
 
         test_handleRequest_base(
                 new CallbackContext(),
                 ResourceHandlerRequest.<ResourceModel>builder()
                         .systemTags(Translator.translateTagsToRequest(Translator.translateTagsFromSdk(TAG_SET.getSystemTags())))
                         .desiredResourceTags(Translator.translateTagsToRequest(Translator.translateTagsFromSdk(TAG_SET.getStackTags()))),
-                () -> DBCLUSTER_ACTIVE,
+                null,
                 null,
                 () -> RESOURCE_MODEL.toBuilder()
                         .associatedRoles(ImmutableList.of(ROLE))
-                        .tags(Translator.translateTagsFromSdk(TAG_SET.getResourceTags()))
+                        .tags(null)
                         .build(),
-                expectSuccess()
+                expectFailed(HandlerErrorCode.UnauthorizedTaggingOperation)
         );
 
+        final Tagging.TagSet expectedRequestTags = Tagging.TagSet.builder()
+                .stackTags(TAG_SET.getStackTags())
+                .systemTags(TAG_SET.getSystemTags())
+                .build();
         ArgumentCaptor<CreateDbClusterRequest> createCaptor = ArgumentCaptor.forClass(CreateDbClusterRequest.class);
-        verify(rdsProxy.client(), times(2)).createDBCluster(createCaptor.capture());
+        verify(rdsProxy.client(), times(1)).createDBCluster(createCaptor.capture());
         final CreateDbClusterRequest requestWithAllTags = createCaptor.getAllValues().get(0);
-        final CreateDbClusterRequest requestWithSystemTags = createCaptor.getAllValues().get(1);
         Assertions.assertThat(requestWithAllTags.tags()).containsExactlyInAnyOrder(
-                Iterables.toArray(Tagging.translateTagsToSdk(TAG_SET), software.amazon.awssdk.services.rds.model.Tag.class));
-        Assertions.assertThat(requestWithSystemTags.tags()).containsExactlyInAnyOrder(
-                Iterables.toArray(TAG_SET.getSystemTags(), software.amazon.awssdk.services.rds.model.Tag.class));
-
-        verify(rdsProxy.client(), times(1)).addRoleToDBCluster(any(AddRoleToDbClusterRequest.class));
-        verify(rdsProxy.client(), times(4)).describeDBClusters(any(DescribeDbClustersRequest.class));
-
-        ArgumentCaptor<AddTagsToResourceRequest> addTagsCaptor = ArgumentCaptor.forClass(AddTagsToResourceRequest.class);
-        verify(rdsProxy.client(), times(1)).addTagsToResource(addTagsCaptor.capture());
-        Assertions.assertThat(addTagsCaptor.getValue().tags()).containsExactlyInAnyOrder(
-                Iterables.toArray(Tagging.translateTagsToSdk(extraTags), software.amazon.awssdk.services.rds.model.Tag.class));
+                Iterables.toArray(Tagging.translateTagsToSdk(expectedRequestTags), software.amazon.awssdk.services.rds.model.Tag.class));
     }
 
     @Test
@@ -352,51 +336,28 @@ public class CreateHandlerTest extends AbstractHandlerTest {
                                 .awsErrorDetails(AwsErrorDetails.builder()
                                         .errorCode(ErrorCode.AccessDeniedException.toString())
                                         .build()
-                                ).build())
-                .thenReturn(RestoreDbClusterFromSnapshotResponse.builder().build());
-        when(rdsProxy.client().modifyDBCluster(any(ModifyDbClusterRequest.class)))
-                .thenReturn(ModifyDbClusterResponse.builder().build());
-        when(rdsProxy.client().addTagsToResource(any(AddTagsToResourceRequest.class)))
-                .thenReturn(AddTagsToResourceResponse.builder().build());
-        when(rdsProxy.client().describeEvents(any(DescribeEventsRequest.class)))
-                .thenReturn(DescribeEventsResponse.builder().build());
-
-        final Tagging.TagSet extraTags = Tagging.TagSet.builder()
-                .stackTags(TAG_SET.getStackTags())
-                .resourceTags(TAG_SET.getResourceTags())
-                .build();
+                                ).build());
 
         test_handleRequest_base(
                 new CallbackContext(),
                 ResourceHandlerRequest.<ResourceModel>builder()
                         .systemTags(Translator.translateTagsToRequest(Translator.translateTagsFromSdk(TAG_SET.getSystemTags())))
                         .desiredResourceTags(Translator.translateTagsToRequest(Translator.translateTagsFromSdk(TAG_SET.getStackTags()))),
-                () -> DBCLUSTER_ACTIVE,
+                null,
                 null,
                 () -> RESOURCE_MODEL_ON_RESTORE.toBuilder()
                         .tags(Translator.translateTagsFromSdk(TAG_SET.getResourceTags()))
                         .build(),
-                expectSuccess()
+                expectFailed(HandlerErrorCode.AccessDenied)
         );
 
         ArgumentCaptor<RestoreDbClusterFromSnapshotRequest> createCaptor = ArgumentCaptor.forClass(RestoreDbClusterFromSnapshotRequest.class);
-        verify(rdsProxy.client(), times(2)).restoreDBClusterFromSnapshot(createCaptor.capture());
-        verify(rdsProxy.client(), times(1)).describeEvents(any(DescribeEventsRequest.class));
+        verify(rdsProxy.client(), times(1)).restoreDBClusterFromSnapshot(createCaptor.capture());
 
         final RestoreDbClusterFromSnapshotRequest requestWithAllTags = createCaptor.getAllValues().get(0);
-        final RestoreDbClusterFromSnapshotRequest requestWithSystemTags = createCaptor.getAllValues().get(1);
         Assertions.assertThat(requestWithAllTags.tags()).containsExactlyInAnyOrder(
                 Iterables.toArray(Tagging.translateTagsToSdk(TAG_SET), software.amazon.awssdk.services.rds.model.Tag.class));
-        Assertions.assertThat(requestWithSystemTags.tags()).containsExactlyInAnyOrder(
-                Iterables.toArray(TAG_SET.getSystemTags(), software.amazon.awssdk.services.rds.model.Tag.class));
 
-        verify(rdsProxy.client(), times(4)).describeDBClusters(any(DescribeDbClustersRequest.class));
-        verify(rdsProxy.client(), times(1)).modifyDBCluster(any(ModifyDbClusterRequest.class));
-
-        ArgumentCaptor<AddTagsToResourceRequest> addTagsCaptor = ArgumentCaptor.forClass(AddTagsToResourceRequest.class);
-        verify(rdsProxy.client(), times(1)).addTagsToResource(addTagsCaptor.capture());
-        Assertions.assertThat(addTagsCaptor.getValue().tags()).containsExactlyInAnyOrder(
-                Iterables.toArray(Tagging.translateTagsToSdk(extraTags), software.amazon.awssdk.services.rds.model.Tag.class));
     }
 
     @Test
@@ -567,14 +528,7 @@ public class CreateHandlerTest extends AbstractHandlerTest {
                                 .awsErrorDetails(AwsErrorDetails.builder()
                                         .errorCode(ErrorCode.AccessDeniedException.toString())
                                         .build()
-                                ).build())
-                .thenReturn(RestoreDbClusterToPointInTimeResponse.builder().build());
-        when(rdsProxy.client().addTagsToResource(any(AddTagsToResourceRequest.class)))
-                .thenReturn(AddTagsToResourceResponse.builder().build());
-        when(rdsProxy.client().modifyDBCluster(any(ModifyDbClusterRequest.class)))
-                .thenReturn(ModifyDbClusterResponse.builder().build());
-        when(rdsProxy.client().describeEvents(any(DescribeEventsRequest.class)))
-                .thenReturn(DescribeEventsResponse.builder().build());
+                                ).build());
 
         final Tagging.TagSet extraTags = Tagging.TagSet.builder()
                 .stackTags(TAG_SET.getStackTags())
@@ -586,30 +540,20 @@ public class CreateHandlerTest extends AbstractHandlerTest {
                 ResourceHandlerRequest.<ResourceModel>builder()
                         .systemTags(Translator.translateTagsToRequest(Translator.translateTagsFromSdk(TAG_SET.getSystemTags())))
                         .desiredResourceTags(Translator.translateTagsToRequest(Translator.translateTagsFromSdk(TAG_SET.getStackTags()))),
-                () -> DBCLUSTER_ACTIVE,
+                null,
                 null,
                 () -> RESOURCE_MODEL_ON_RESTORE_IN_TIME.toBuilder()
                         .tags(Translator.translateTagsFromSdk(TAG_SET.getResourceTags()))
                         .build(),
-                expectSuccess()
+                expectFailed(HandlerErrorCode.AccessDenied)
         );
 
         ArgumentCaptor<RestoreDbClusterToPointInTimeRequest> createCaptor = ArgumentCaptor.forClass(RestoreDbClusterToPointInTimeRequest.class);
-        verify(rdsProxy.client(), times(2)).restoreDBClusterToPointInTime(createCaptor.capture());
+        verify(rdsProxy.client(), times(1)).restoreDBClusterToPointInTime(createCaptor.capture());
 
         final RestoreDbClusterToPointInTimeRequest requestWithAllTags = createCaptor.getAllValues().get(0);
-        final RestoreDbClusterToPointInTimeRequest requestWithSystemTags = createCaptor.getAllValues().get(1);
         Assertions.assertThat(requestWithAllTags.tags()).containsExactlyInAnyOrder(
                 Iterables.toArray(Tagging.translateTagsToSdk(TAG_SET), software.amazon.awssdk.services.rds.model.Tag.class));
-        Assertions.assertThat(requestWithSystemTags.tags()).containsExactlyInAnyOrder(
-                Iterables.toArray(TAG_SET.getSystemTags(), software.amazon.awssdk.services.rds.model.Tag.class));
-
-        verify(rdsProxy.client(), times(4)).describeDBClusters(any(DescribeDbClustersRequest.class));
-
-        ArgumentCaptor<AddTagsToResourceRequest> addTagsCaptor = ArgumentCaptor.forClass(AddTagsToResourceRequest.class);
-        verify(rdsProxy.client(), times(1)).addTagsToResource(addTagsCaptor.capture());
-        Assertions.assertThat(addTagsCaptor.getValue().tags()).containsExactlyInAnyOrder(
-                Iterables.toArray(Tagging.translateTagsToSdk(extraTags), software.amazon.awssdk.services.rds.model.Tag.class));
     }
 
     @Test

--- a/aws-rds-dbclusterendpoint/src/main/java/software/amazon/rds/dbclusterendpoint/BaseHandlerStd.java
+++ b/aws-rds-dbclusterendpoint/src/main/java/software/amazon/rds/dbclusterendpoint/BaseHandlerStd.java
@@ -111,7 +111,7 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
             return Commons.handleException(
                     progress,
                     exception,
-                    DEFAULT_DB_CLUSTER_ENDPOINT_ERROR_RULE_SET.extendWith(Tagging.bestEffortErrorRuleSet(tagsToAdd, tagsToRemove))
+                    DEFAULT_DB_CLUSTER_ENDPOINT_ERROR_RULE_SET.extendWith(Tagging.getUpdateTagsAccessDeniedRuleSet(tagsToAdd, tagsToRemove))
             );
         }
         return progress;

--- a/aws-rds-dbclusterendpoint/src/main/java/software/amazon/rds/dbclusterendpoint/CreateHandler.java
+++ b/aws-rds-dbclusterendpoint/src/main/java/software/amazon/rds/dbclusterendpoint/CreateHandler.java
@@ -54,7 +54,7 @@ public class CreateHandler extends BaseHandlerStd {
                     .toString());
         }
         return ProgressEvent.progress(model, callbackContext)
-                .then(progress -> Tagging.createWithUnauthorizedTagging(proxy, proxyClient, this::createDbClusterEndpoint, progress, allTags))
+                .then(progress -> Tagging.createWithTaggingFallback(proxy, proxyClient, this::createDbClusterEndpoint, progress, allTags))
                 .then(progress -> Commons.execOnce(progress, () -> {
                             final Tagging.TagSet extraTags = Tagging.TagSet.builder()
                                     .stackTags(Tagging.translateTagsToSdk(request.getDesiredResourceTags()))

--- a/aws-rds-dbclusterendpoint/src/main/java/software/amazon/rds/dbclusterendpoint/CreateHandler.java
+++ b/aws-rds-dbclusterendpoint/src/main/java/software/amazon/rds/dbclusterendpoint/CreateHandler.java
@@ -3,14 +3,12 @@ package software.amazon.rds.dbclusterendpoint;
 import com.amazonaws.util.StringUtils;
 import software.amazon.awssdk.services.rds.RdsClient;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
-import software.amazon.cloudformation.proxy.HandlerErrorCode;
 import software.amazon.cloudformation.proxy.Logger;
 import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 import software.amazon.rds.common.handler.Commons;
 import software.amazon.rds.common.handler.HandlerConfig;
-import software.amazon.rds.common.handler.HandlerMethod;
 import software.amazon.rds.common.handler.Tagging;
 import software.amazon.rds.common.util.IdentifierFactory;
 
@@ -56,7 +54,7 @@ public class CreateHandler extends BaseHandlerStd {
                     .toString());
         }
         return ProgressEvent.progress(model, callbackContext)
-                .then(progress -> Tagging.safeCreate(proxy, proxyClient, this::createDbClusterEndpoint, progress, allTags))
+                .then(progress -> Tagging.createWithUnauthorizedTagging(proxy, proxyClient, this::createDbClusterEndpoint, progress, allTags))
                 .then(progress -> Commons.execOnce(progress, () -> {
                             final Tagging.TagSet extraTags = Tagging.TagSet.builder()
                                     .stackTags(Tagging.translateTagsToSdk(request.getDesiredResourceTags()))

--- a/aws-rds-dbclusterendpoint/src/main/java/software/amazon/rds/dbclusterendpoint/ReadHandler.java
+++ b/aws-rds-dbclusterendpoint/src/main/java/software/amazon/rds/dbclusterendpoint/ReadHandler.java
@@ -73,7 +73,7 @@ public class ReadHandler extends BaseHandlerStd {
             return Commons.handleException(
                     ProgressEvent.progress(model, context),
                     exception,
-                    DEFAULT_DB_CLUSTER_ENDPOINT_ERROR_RULE_SET.extendWith(Tagging.SOFT_FAIL_TAG_ERROR_RULE_SET)
+                    DEFAULT_DB_CLUSTER_ENDPOINT_ERROR_RULE_SET.extendWith(Tagging.STACK_TAGS_ERROR_RULE_SET)
             );
         }
         return ProgressEvent.success(model, context);

--- a/aws-rds-dbclusterendpoint/src/test/java/software/amazon/rds/dbclusterendpoint/CreateHandlerTest.java
+++ b/aws-rds-dbclusterendpoint/src/test/java/software/amazon/rds/dbclusterendpoint/CreateHandlerTest.java
@@ -179,17 +179,12 @@ public class CreateHandlerTest extends AbstractHandlerTest {
                                 .awsErrorDetails(AwsErrorDetails.builder()
                                         .errorCode(ErrorCode.AccessDeniedException.toString())
                                         .build()
-                                ).build())
-                .thenReturn(CreateDbClusterEndpointResponse.builder().build());
-        when(rdsProxy.client().addTagsToResource(any(AddTagsToResourceRequest.class)))
-                .thenReturn(AddTagsToResourceResponse.builder().build());
-
-        when(rdsProxy.client().listTagsForResource(any(ListTagsForResourceRequest.class)))
-                .thenReturn(ListTagsForResourceResponse.builder().build());
+                                ).build());
 
         final Tagging.TagSet extraTags = Tagging.TagSet.builder()
                 .stackTags(TAG_SET.getStackTags())
                 .resourceTags(TAG_SET.getResourceTags())
+
                 .build();
 
         final ProgressEvent<ResourceModel, CallbackContext> progress = test_handleRequest_base(
@@ -197,65 +192,7 @@ public class CreateHandlerTest extends AbstractHandlerTest {
                 ResourceHandlerRequest.<ResourceModel>builder()
                         .systemTags(Translator.translateTagsToRequest(Translator.translateTagsFromSdk(TAG_SET.getSystemTags())))
                         .desiredResourceTags(Translator.translateTagsToRequest(Translator.translateTagsFromSdk(TAG_SET.getStackTags()))),
-                () -> DB_CLUSTER_ENDPOINT_AVAILABLE,
                 null,
-                () -> RESOURCE_MODEL.toBuilder()
-                        .tags(Translator.translateTagsFromSdk(TAG_SET.getResourceTags()))
-                        .build(),
-                expectSuccess()
-        );
-
-        Assertions.assertThat(progress.getCallbackContext().isAddTagsComplete()).isTrue();
-        Assertions.assertThat(progress.getCallbackContext().getTaggingContext().isSoftFailTags()).isTrue();
-
-        ArgumentCaptor<CreateDbClusterEndpointRequest> createCaptor = ArgumentCaptor.forClass(CreateDbClusterEndpointRequest.class);
-        verify(rdsProxy.client(), times(2)).createDBClusterEndpoint(createCaptor.capture());
-        final CreateDbClusterEndpointRequest requestWithAllTags = createCaptor.getAllValues().get(0);
-        final CreateDbClusterEndpointRequest requestWithSystemTags = createCaptor.getAllValues().get(1);
-        Assertions.assertThat(requestWithAllTags.tags()).containsExactlyInAnyOrder(
-                Iterables.toArray(Tagging.translateTagsToSdk(TAG_SET), software.amazon.awssdk.services.rds.model.Tag.class));
-        Assertions.assertThat(requestWithSystemTags.tags()).containsExactlyInAnyOrder(
-                Iterables.toArray(TAG_SET.getSystemTags(), software.amazon.awssdk.services.rds.model.Tag.class));
-
-        verify(rdsProxy.client(), times(2)).describeDBClusterEndpoints(any(DescribeDbClusterEndpointsRequest.class));
-
-        ArgumentCaptor<AddTagsToResourceRequest> addTagsCaptor = ArgumentCaptor.forClass(AddTagsToResourceRequest.class);
-        verify(rdsProxy.client(), times(1)).addTagsToResource(addTagsCaptor.capture());
-        Assertions.assertThat(addTagsCaptor.getValue().tags()).containsExactlyInAnyOrder(
-                Iterables.toArray(Tagging.translateTagsToSdk(extraTags), software.amazon.awssdk.services.rds.model.Tag.class));
-    }
-
-
-    @Test
-    public void handleRequest_HardFailTagging() {
-        when(rdsProxy.client().createDBClusterEndpoint(any(CreateDbClusterEndpointRequest.class)))
-                .thenThrow(
-                        RdsException.builder()
-                                .awsErrorDetails(AwsErrorDetails.builder()
-                                        .errorCode(ErrorCode.AccessDeniedException.toString())
-                                        .build()
-                                ).build())
-                .thenReturn(CreateDbClusterEndpointResponse.builder().build());
-
-        when(rdsProxy.client().addTagsToResource(any(AddTagsToResourceRequest.class)))
-                .thenThrow(
-                        RdsException.builder()
-                                .awsErrorDetails(AwsErrorDetails.builder()
-                                        .errorCode(ErrorCode.AccessDeniedException.toString())
-                                        .build()
-                                ).build());
-
-        final Tagging.TagSet extraTags = Tagging.TagSet.builder()
-                .stackTags(TAG_SET.getStackTags())
-                .resourceTags(TAG_SET.getResourceTags())
-                .build();
-
-        test_handleRequest_base(
-                new CallbackContext(),
-                ResourceHandlerRequest.<ResourceModel>builder()
-                        .systemTags(Translator.translateTagsToRequest(Translator.translateTagsFromSdk(TAG_SET.getSystemTags())))
-                        .desiredResourceTags(Translator.translateTagsToRequest(Translator.translateTagsFromSdk(TAG_SET.getStackTags()))),
-                () -> DB_CLUSTER_ENDPOINT_AVAILABLE,
                 null,
                 () -> RESOURCE_MODEL.toBuilder()
                         .tags(Translator.translateTagsFromSdk(TAG_SET.getResourceTags()))
@@ -264,19 +201,47 @@ public class CreateHandlerTest extends AbstractHandlerTest {
         );
 
         ArgumentCaptor<CreateDbClusterEndpointRequest> createCaptor = ArgumentCaptor.forClass(CreateDbClusterEndpointRequest.class);
-        verify(rdsProxy.client(), times(2)).createDBClusterEndpoint(createCaptor.capture());
+        verify(rdsProxy.client(), times(1)).createDBClusterEndpoint(createCaptor.capture());
         final CreateDbClusterEndpointRequest requestWithAllTags = createCaptor.getAllValues().get(0);
-        final CreateDbClusterEndpointRequest requestWithSystemTags = createCaptor.getAllValues().get(1);
         Assertions.assertThat(requestWithAllTags.tags()).containsExactlyInAnyOrder(
                 Iterables.toArray(Tagging.translateTagsToSdk(TAG_SET), software.amazon.awssdk.services.rds.model.Tag.class));
-        Assertions.assertThat(requestWithSystemTags.tags()).containsExactlyInAnyOrder(
-                Iterables.toArray(TAG_SET.getSystemTags(), software.amazon.awssdk.services.rds.model.Tag.class));
+    }
 
-        verify(rdsProxy.client(), times(1)).describeDBClusterEndpoints(any(DescribeDbClusterEndpointsRequest.class));
 
-        ArgumentCaptor<AddTagsToResourceRequest> addTagsCaptor = ArgumentCaptor.forClass(AddTagsToResourceRequest.class);
-        verify(rdsProxy.client(), times(1)).addTagsToResource(addTagsCaptor.capture());
-        Assertions.assertThat(addTagsCaptor.getValue().tags()).containsExactlyInAnyOrder(
-                Iterables.toArray(Tagging.translateTagsToSdk(extraTags), software.amazon.awssdk.services.rds.model.Tag.class));
+    @Test
+    public void handleRequest_HardFailTagging() {
+        when(rdsProxy.client().createDBClusterEndpoint(any(CreateDbClusterEndpointRequest.class)))
+                .thenThrow(
+                        RdsException.builder()
+                                .message("Role not authorized to execute rds:AddTagsToResource")
+                                .awsErrorDetails(AwsErrorDetails.builder()
+                                        .errorCode(ErrorCode.AccessDeniedException.toString())
+                                        .build()
+                                ).build());
+
+
+
+        test_handleRequest_base(
+                new CallbackContext(),
+                ResourceHandlerRequest.<ResourceModel>builder()
+                        .systemTags(Translator.translateTagsToRequest(Translator.translateTagsFromSdk(TAG_SET.getSystemTags())))
+                        .desiredResourceTags(Translator.translateTagsToRequest(Translator.translateTagsFromSdk(TAG_SET.getStackTags()))),
+                null,
+                null,
+                () -> RESOURCE_MODEL.toBuilder()
+                        .tags(null)
+                        .build(),
+                expectFailed(HandlerErrorCode.UnauthorizedTaggingOperation)
+        );
+
+        final Tagging.TagSet expectedRequestTags = Tagging.TagSet.builder()
+                .stackTags(TAG_SET.getStackTags())
+                .systemTags(TAG_SET.getSystemTags())
+                .build();
+        ArgumentCaptor<CreateDbClusterEndpointRequest> createCaptor = ArgumentCaptor.forClass(CreateDbClusterEndpointRequest.class);
+        verify(rdsProxy.client(), times(1)).createDBClusterEndpoint(createCaptor.capture());
+        final CreateDbClusterEndpointRequest requestWithAllTags = createCaptor.getAllValues().get(0);
+        Assertions.assertThat(requestWithAllTags.tags()).containsExactlyInAnyOrder(
+                Iterables.toArray(Tagging.translateTagsToSdk(expectedRequestTags), software.amazon.awssdk.services.rds.model.Tag.class));
     }
 }

--- a/aws-rds-dbclusterendpoint/src/test/java/software/amazon/rds/dbclusterendpoint/UpdateHandlerTest.java
+++ b/aws-rds-dbclusterendpoint/src/test/java/software/amazon/rds/dbclusterendpoint/UpdateHandlerTest.java
@@ -264,7 +264,7 @@ null,
                 () -> DB_CLUSTER_ENDPOINT_AVAILABLE,
                 () -> RESOURCE_MODEL_BUILDER().build(),
                 () -> RESOURCE_MODEL_BUILDER().build(),
-                expectSuccess()
+                expectFailed(HandlerErrorCode.UnauthorizedTaggingOperation)
         );
 
         verify(rdsProxy.client(), times(1)).modifyDBClusterEndpoint(any(ModifyDbClusterEndpointRequest.class));
@@ -291,7 +291,7 @@ null,
                 () -> DB_CLUSTER_ENDPOINT_AVAILABLE,
                 () -> RESOURCE_MODEL_BUILDER().build(),
                 () -> RESOURCE_MODEL_BUILDER().build(),
-                expectSuccess()
+                expectFailed(HandlerErrorCode.UnauthorizedTaggingOperation)
         );
 
         verify(rdsProxy.client(), times(1)).modifyDBClusterEndpoint(any(ModifyDbClusterEndpointRequest.class));

--- a/aws-rds-dbclusterparametergroup/src/main/java/software/amazon/rds/dbclusterparametergroup/BaseHandlerStd.java
+++ b/aws-rds-dbclusterparametergroup/src/main/java/software/amazon/rds/dbclusterparametergroup/BaseHandlerStd.java
@@ -175,11 +175,11 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
                     progress,
                     exception,
                     DEFAULT_DB_CLUSTER_PARAMETER_GROUP_ERROR_RULE_SET.extendWith(
-                            Tagging.bestEffortErrorRuleSet(
+                            Tagging.getUpdateTagsAccessDeniedRuleSet(
                                     tagsToAdd,
                                     tagsToRemove,
-                                    Tagging.SOFT_FAIL_IN_PROGRESS_TAGGING_ERROR_RULE_SET,
-                                    Tagging.HARD_FAIL_TAG_ERROR_RULE_SET
+                                    Tagging.IGNORE_LIST_TAGS_PERMISSION_DENIED_ERROR_RULE_SET,
+                                    Tagging.RESOURCE_TAG_ERROR_RULE_SET
                             )
                     )
             );

--- a/aws-rds-dbclusterparametergroup/src/main/java/software/amazon/rds/dbclusterparametergroup/CreateHandler.java
+++ b/aws-rds-dbclusterparametergroup/src/main/java/software/amazon/rds/dbclusterparametergroup/CreateHandler.java
@@ -48,7 +48,7 @@ public class CreateHandler extends BaseHandlerStd {
 
         return ProgressEvent.progress(request.getDesiredResourceState(), callbackContext)
                 .then(progress -> setDbClusterParameterGroupNameIfMissing(request, progress))
-                .then(progress -> Tagging.createWithUnauthorizedTagging(proxy, proxyClient, this::createDbClusterParameterGroup, progress, allTags))
+                .then(progress -> Tagging.createWithTaggingFallback(proxy, proxyClient, this::createDbClusterParameterGroup, progress, allTags))
                 .then(progress -> Commons.execOnce(progress, () -> {
                     final Tagging.TagSet extraTags = Tagging.TagSet.builder()
                             .stackTags(allTags.getStackTags())

--- a/aws-rds-dbclusterparametergroup/src/main/java/software/amazon/rds/dbclusterparametergroup/CreateHandler.java
+++ b/aws-rds-dbclusterparametergroup/src/main/java/software/amazon/rds/dbclusterparametergroup/CreateHandler.java
@@ -48,7 +48,7 @@ public class CreateHandler extends BaseHandlerStd {
 
         return ProgressEvent.progress(request.getDesiredResourceState(), callbackContext)
                 .then(progress -> setDbClusterParameterGroupNameIfMissing(request, progress))
-                .then(progress -> Tagging.safeCreate(proxy, proxyClient, this::createDbClusterParameterGroup, progress, allTags))
+                .then(progress -> Tagging.createWithUnauthorizedTagging(proxy, proxyClient, this::createDbClusterParameterGroup, progress, allTags))
                 .then(progress -> Commons.execOnce(progress, () -> {
                     final Tagging.TagSet extraTags = Tagging.TagSet.builder()
                             .stackTags(allTags.getStackTags())

--- a/aws-rds-dbclusterparametergroup/src/main/java/software/amazon/rds/dbclusterparametergroup/ReadHandler.java
+++ b/aws-rds-dbclusterparametergroup/src/main/java/software/amazon/rds/dbclusterparametergroup/ReadHandler.java
@@ -89,7 +89,7 @@ public class ReadHandler extends BaseHandlerStd {
             return Commons.handleException(
                     ProgressEvent.progress(model, context),
                     exception,
-                    DEFAULT_DB_CLUSTER_PARAMETER_GROUP_ERROR_RULE_SET.extendWith(Tagging.SOFT_FAIL_TAG_ERROR_RULE_SET)
+                    DEFAULT_DB_CLUSTER_PARAMETER_GROUP_ERROR_RULE_SET.extendWith(Tagging.STACK_TAGS_ERROR_RULE_SET)
             );
         }
         return ProgressEvent.success(model, context);

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/BaseHandlerStd.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/BaseHandlerStd.java
@@ -46,7 +46,6 @@ import software.amazon.awssdk.services.rds.model.DbSubnetGroupNotFoundException;
 import software.amazon.awssdk.services.rds.model.DbUpgradeDependencyFailureException;
 import software.amazon.awssdk.services.rds.model.DescribeDbClusterSnapshotsResponse;
 import software.amazon.awssdk.services.rds.model.DescribeDbClustersResponse;
-import software.amazon.awssdk.services.rds.model.DescribeDbInstanceAutomatedBackupsRequest;
 import software.amazon.awssdk.services.rds.model.DescribeDbInstanceAutomatedBackupsResponse;
 import software.amazon.awssdk.services.rds.model.DescribeDbInstancesResponse;
 import software.amazon.awssdk.services.rds.model.DescribeDbSnapshotsResponse;
@@ -999,7 +998,7 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
             return Commons.handleException(
                     progress,
                     exception,
-                    DEFAULT_DB_INSTANCE_ERROR_RULE_SET.extendWith(Tagging.bestEffortErrorRuleSet(tagsToAdd, tagsToRemove))
+                    DEFAULT_DB_INSTANCE_ERROR_RULE_SET.extendWith(Tagging.getUpdateTagsAccessDeniedRuleSet(tagsToAdd, tagsToRemove))
             );
         }
 

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/CreateHandler.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/CreateHandler.java
@@ -183,7 +183,7 @@ public class CreateHandler extends BaseHandlerStd {
     }
 
     private HandlerMethod<ResourceModel, CallbackContext> safeAddTags(final HandlerMethod<ResourceModel, CallbackContext> handlerMethod) {
-        return (proxy, rdsProxyClient, progress, tagSet) -> progress.then(p -> Tagging.createWithUnauthorizedTagging(proxy, rdsProxyClient, handlerMethod, progress, tagSet));
+        return (proxy, rdsProxyClient, progress, tagSet) -> progress.then(p -> Tagging.createWithTaggingFallback(proxy, rdsProxyClient, handlerMethod, progress, tagSet));
     }
 
     private String fetchEngine(final ProxyClient<RdsClient> client, final ResourceModel model) {

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/CreateHandler.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/CreateHandler.java
@@ -183,7 +183,7 @@ public class CreateHandler extends BaseHandlerStd {
     }
 
     private HandlerMethod<ResourceModel, CallbackContext> safeAddTags(final HandlerMethod<ResourceModel, CallbackContext> handlerMethod) {
-        return (proxy, rdsProxyClient, progress, tagSet) -> progress.then(p -> Tagging.safeCreate(proxy, rdsProxyClient, handlerMethod, progress, tagSet));
+        return (proxy, rdsProxyClient, progress, tagSet) -> progress.then(p -> Tagging.createWithUnauthorizedTagging(proxy, rdsProxyClient, handlerMethod, progress, tagSet));
     }
 
     private String fetchEngine(final ProxyClient<RdsClient> client, final ResourceModel model) {

--- a/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/CreateHandlerTest.java
+++ b/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/CreateHandlerTest.java
@@ -32,6 +32,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
+import com.google.common.collect.Maps;
 import lombok.Getter;
 import software.amazon.awssdk.awscore.exception.AwsErrorDetails;
 import software.amazon.awssdk.core.util.SdkAutoConstructList;
@@ -248,14 +249,12 @@ public class CreateHandlerTest extends AbstractHandlerTest {
         when(rdsProxy.client().restoreDBInstanceFromDBSnapshot(any(RestoreDbInstanceFromDbSnapshotRequest.class)))
                 .thenThrow(
                         RdsException.builder()
+                                .message("Role not authorized to execute rds:AddTagsToResource")
                                 .awsErrorDetails(AwsErrorDetails.builder()
                                         .errorCode(ErrorCode.AccessDeniedException.toString())
                                         .build()
                                 ).build())
                 .thenReturn(RestoreDbInstanceFromDbSnapshotResponse.builder().build());
-
-        when(rdsProxy.client().addTagsToResource(any(AddTagsToResourceRequest.class)))
-                .thenReturn(AddTagsToResourceResponse.builder().build());
 
         when(rdsProxy.client().describeDBSnapshots(any(DescribeDbSnapshotsRequest.class)))
                 .thenReturn(DescribeDbSnapshotsResponse.builder()
@@ -270,9 +269,9 @@ public class CreateHandlerTest extends AbstractHandlerTest {
         context.setRebooted(true);
         context.setUpdatedRoles(true);
 
-        final Tagging.TagSet extraTags = Tagging.TagSet.builder()
+        final Tagging.TagSet expectedRequestTags = Tagging.TagSet.builder()
                 .stackTags(TAG_SET.getStackTags())
-                .resourceTags(TAG_SET.getResourceTags())
+                .systemTags(TAG_SET.getSystemTags())
                 .build();
 
         test_handleRequest_base(
@@ -280,35 +279,22 @@ public class CreateHandlerTest extends AbstractHandlerTest {
                 ResourceHandlerRequest.<ResourceModel>builder()
                         .systemTags(Translator.translateTagsToRequest(Translator.translateTagsFromSdk(TAG_SET.getSystemTags())))
                         .desiredResourceTags(Translator.translateTagsToRequest(Translator.translateTagsFromSdk(TAG_SET.getStackTags()))),
-                () -> DB_INSTANCE_ACTIVE,
+                null,
                 null,
                 () -> RESOURCE_MODEL_RESTORING_FROM_SNAPSHOT.toBuilder()
-                        .tags(Translator.translateTagsFromSdk(TAG_SET.getResourceTags()))
+                        .tags(null)
                         .build(),
-                expectSuccess()
+                expectFailed(HandlerErrorCode.UnauthorizedTaggingOperation)
         );
 
         ArgumentCaptor<RestoreDbInstanceFromDbSnapshotRequest> createCaptor = ArgumentCaptor.forClass(RestoreDbInstanceFromDbSnapshotRequest.class);
-        verify(rdsProxy.client(), times(2)).restoreDBInstanceFromDBSnapshot(createCaptor.capture());
+        verify(rdsProxy.client(), times(1)).restoreDBInstanceFromDBSnapshot(createCaptor.capture());
+
 
         final RestoreDbInstanceFromDbSnapshotRequest requestWithAllTags = createCaptor.getAllValues().get(0);
         Assertions.assertThat(requestWithAllTags.tags()).containsExactlyInAnyOrder(
-                Iterables.toArray(Tagging.translateTagsToSdk(TAG_SET), software.amazon.awssdk.services.rds.model.Tag.class)
+                Iterables.toArray(Tagging.translateTagsToSdk(expectedRequestTags), software.amazon.awssdk.services.rds.model.Tag.class)
         );
-        final RestoreDbInstanceFromDbSnapshotRequest requestWithSystemTags = createCaptor.getAllValues().get(1);
-        Assertions.assertThat(requestWithSystemTags.tags()).containsExactlyInAnyOrder(
-                Iterables.toArray(TAG_SET.getSystemTags(), software.amazon.awssdk.services.rds.model.Tag.class)
-        );
-
-        verify(rdsProxy.client(), times(3)).describeDBInstances(any(DescribeDbInstancesRequest.class));
-
-        ArgumentCaptor<AddTagsToResourceRequest> addTagCaptor = ArgumentCaptor.forClass(AddTagsToResourceRequest.class);
-        verify(rdsProxy.client(), times(1)).addTagsToResource(addTagCaptor.capture());
-        Assertions.assertThat(addTagCaptor.getValue().tags()).containsExactlyInAnyOrder(
-                Iterables.toArray(Tagging.translateTagsToSdk(extraTags), software.amazon.awssdk.services.rds.model.Tag.class)
-        );
-
-        verify(rdsProxy.client(), times(1)).describeDBSnapshots(any(DescribeDbSnapshotsRequest.class));
     }
 
     @Test
@@ -433,10 +419,7 @@ public class CreateHandlerTest extends AbstractHandlerTest {
                                 .awsErrorDetails(AwsErrorDetails.builder()
                                         .errorCode(ErrorCode.AccessDeniedException.toString())
                                         .build()
-                                ).build())
-                .thenReturn(CreateDbInstanceReadReplicaResponse.builder().build());
-        when(rdsProxy.client().addTagsToResource(any(AddTagsToResourceRequest.class)))
-                .thenReturn(AddTagsToResourceResponse.builder().build());
+                                ).build());
 
         final CallbackContext context = new CallbackContext();
         context.setCreated(false);
@@ -451,36 +434,15 @@ public class CreateHandlerTest extends AbstractHandlerTest {
 
         test_handleRequest_base(
                 context,
-                ResourceHandlerRequest.<ResourceModel>builder()
-                        .systemTags(Translator.translateTagsToRequest(Translator.translateTagsFromSdk(TAG_SET.getSystemTags())))
-                        .desiredResourceTags(Translator.translateTagsToRequest(Translator.translateTagsFromSdk(TAG_SET.getStackTags()))),
-                () -> DB_INSTANCE_ACTIVE,
                 null,
                 () -> RESOURCE_MODEL_READ_REPLICA.toBuilder()
                         .tags(Translator.translateTagsFromSdk(TAG_SET.getResourceTags()))
                         .build(),
-                expectSuccess()
+                expectFailed(HandlerErrorCode.AccessDenied)
         );
 
         ArgumentCaptor<CreateDbInstanceReadReplicaRequest> createCaptor = ArgumentCaptor.forClass(CreateDbInstanceReadReplicaRequest.class);
-        verify(rdsProxy.client(), times(2)).createDBInstanceReadReplica(createCaptor.capture());
-
-        final CreateDbInstanceReadReplicaRequest requestWithAllTags = createCaptor.getAllValues().get(0);
-        Assertions.assertThat(requestWithAllTags.tags()).containsExactlyInAnyOrder(
-                Iterables.toArray(Tagging.translateTagsToSdk(TAG_SET), software.amazon.awssdk.services.rds.model.Tag.class)
-        );
-        final CreateDbInstanceReadReplicaRequest requestWithSystemTags = createCaptor.getAllValues().get(1);
-        Assertions.assertThat(requestWithSystemTags.tags()).containsExactlyInAnyOrder(
-                Iterables.toArray(TAG_SET.getSystemTags(), software.amazon.awssdk.services.rds.model.Tag.class)
-        );
-
-        verify(rdsProxy.client(), times(3)).describeDBInstances(any(DescribeDbInstancesRequest.class));
-
-        ArgumentCaptor<AddTagsToResourceRequest> addTagCaptor = ArgumentCaptor.forClass(AddTagsToResourceRequest.class);
-        verify(rdsProxy.client(), times(1)).addTagsToResource(addTagCaptor.capture());
-        Assertions.assertThat(addTagCaptor.getValue().tags()).containsExactlyInAnyOrder(
-                Iterables.toArray(Tagging.translateTagsToSdk(extraTags), software.amazon.awssdk.services.rds.model.Tag.class)
-        );
+        verify(rdsProxy.client(), times(1)).createDBInstanceReadReplica(createCaptor.capture());
     }
 
     @Test
@@ -577,7 +539,7 @@ public class CreateHandlerTest extends AbstractHandlerTest {
                 expectFailed(HandlerErrorCode.AccessDenied)
         );
 
-        verify(rdsProxy.client(), times(2)).createDBInstance(any(CreateDbInstanceRequest.class));
+        verify(rdsProxy.client(), times(1)).createDBInstance(any(CreateDbInstanceRequest.class));
     }
 
     @Test
@@ -645,86 +607,49 @@ public class CreateHandlerTest extends AbstractHandlerTest {
                                 .awsErrorDetails(AwsErrorDetails.builder()
                                         .errorCode(ErrorCode.AccessDeniedException.toString())
                                         .build()
-                                ).build())
-                .thenReturn(CreateDbInstanceResponse.builder().build());
-        when(rdsProxy.client().addTagsToResource(any(AddTagsToResourceRequest.class)))
-                .thenReturn(AddTagsToResourceResponse.builder().build());
+                                ).build());
 
         final CallbackContext context = new CallbackContext();
         context.setCreated(false);
-        context.setUpdated(true);
-        context.setRebooted(true);
-        context.setUpdatedRoles(true);
-
-        final Tagging.TagSet extraTags = Tagging.TagSet.builder()
-                .stackTags(TAG_SET.getStackTags())
-                .resourceTags(TAG_SET.getResourceTags())
-                .build();
 
         test_handleRequest_base(
                 context,
-                ResourceHandlerRequest.<ResourceModel>builder()
-                        .systemTags(Translator.translateTagsToRequest(Translator.translateTagsFromSdk(TAG_SET.getSystemTags())))
-                        .desiredResourceTags(Translator.translateTagsToRequest(Translator.translateTagsFromSdk(TAG_SET.getStackTags()))),
-                () -> DB_INSTANCE_ACTIVE,
                 null,
                 () -> RESOURCE_MODEL_BLDR()
                         .tags(Translator.translateTagsFromSdk(TAG_SET.getResourceTags()))
                         .build(),
-                expectSuccess()
+                expectFailed(HandlerErrorCode.AccessDenied)
         );
-
-        ArgumentCaptor<CreateDbInstanceRequest> createCaptor = ArgumentCaptor.forClass(CreateDbInstanceRequest.class);
-        verify(rdsProxy.client(), times(2)).createDBInstance(createCaptor.capture());
-
-        final CreateDbInstanceRequest requestWithAllTags = createCaptor.getAllValues().get(0);
-        Assertions.assertThat(requestWithAllTags.tags()).containsExactlyInAnyOrder(
-                Iterables.toArray(Tagging.translateTagsToSdk(TAG_SET), software.amazon.awssdk.services.rds.model.Tag.class)
-        );
-        final CreateDbInstanceRequest requestWithSystemTags = createCaptor.getAllValues().get(1);
-        Assertions.assertThat(requestWithSystemTags.tags()).containsExactlyInAnyOrder(
-                Iterables.toArray(TAG_SET.getSystemTags(), software.amazon.awssdk.services.rds.model.Tag.class)
-        );
-
-        verify(rdsProxy.client(), times(3)).describeDBInstances(any(DescribeDbInstancesRequest.class));
-
-        ArgumentCaptor<AddTagsToResourceRequest> addTagCaptor = ArgumentCaptor.forClass(AddTagsToResourceRequest.class);
-        verify(rdsProxy.client(), times(1)).addTagsToResource(addTagCaptor.capture());
-        Assertions.assertThat(addTagCaptor.getValue().tags()).containsExactlyInAnyOrder(
-                Iterables.toArray(Tagging.translateTagsToSdk(extraTags), software.amazon.awssdk.services.rds.model.Tag.class)
-        );
+        verify(rdsProxy.client(), times(1)).createDBInstance(any(CreateDbInstanceRequest.class));
     }
 
     @Test
-    public void handleRequest_CreateDBInstance_SoftFailTagsReentrance() {
+    public void handleRequest_CreateDBInstance_FailTagsNoReentranceForSystemTagsOnly() {
         when(rdsProxy.client().createDBInstance(any(CreateDbInstanceRequest.class)))
-                .thenReturn(CreateDbInstanceResponse.builder().build());
-        when(rdsProxy.client().addTagsToResource(any(AddTagsToResourceRequest.class)))
-                .thenReturn(AddTagsToResourceResponse.builder().build());
+                .thenThrow(
+                        RdsException.builder()
+                            .message("Role not authorized to execute rds:AddTagsToResource")
+                            .awsErrorDetails(AwsErrorDetails.builder()
+                                        .errorCode(ErrorCode.AccessDeniedException.toString())
+                                        .build()
+                                ).build());
 
         final CallbackContext context = new CallbackContext();
         context.setCreated(false);
-        context.getTaggingContext().setSoftFailTags(true);
         context.setUpdated(true);
         context.setRebooted(true);
         context.setUpdatedRoles(true);
 
-        final Tagging.TagSet extraTags = Tagging.TagSet.builder()
-                .stackTags(TAG_SET.getStackTags())
-                .resourceTags(TAG_SET.getResourceTags())
-                .build();
-
         test_handleRequest_base(
                 context,
                 ResourceHandlerRequest.<ResourceModel>builder()
-                        .systemTags(Translator.translateTagsToRequest(Translator.translateTagsFromSdk(TAG_SET.getSystemTags())))
-                        .desiredResourceTags(Translator.translateTagsToRequest(Translator.translateTagsFromSdk(TAG_SET.getStackTags()))),
-                () -> DB_INSTANCE_ACTIVE,
+                        .systemTags(Translator.translateTagsToRequest(Translator.translateTagsFromSdk(TAG_SET.getSystemTags()))),
+                null,
                 null,
                 () -> RESOURCE_MODEL_BLDR()
-                        .tags(Translator.translateTagsFromSdk(TAG_SET.getResourceTags()))
+                        .tags(null)
                         .build(),
-                expectSuccess()
+                expectFailed(HandlerErrorCode.UnauthorizedTaggingOperation)
         );
 
         ArgumentCaptor<CreateDbInstanceRequest> createCaptor = ArgumentCaptor.forClass(CreateDbInstanceRequest.class);
@@ -735,13 +660,6 @@ public class CreateHandlerTest extends AbstractHandlerTest {
                 Iterables.toArray(TAG_SET.getSystemTags(), software.amazon.awssdk.services.rds.model.Tag.class)
         );
 
-        verify(rdsProxy.client(), times(3)).describeDBInstances(any(DescribeDbInstancesRequest.class));
-
-        ArgumentCaptor<AddTagsToResourceRequest> addTagCaptor = ArgumentCaptor.forClass(AddTagsToResourceRequest.class);
-        verify(rdsProxy.client(), times(1)).addTagsToResource(addTagCaptor.capture());
-        Assertions.assertThat(addTagCaptor.getValue().tags()).containsExactlyInAnyOrder(
-                Iterables.toArray(Tagging.translateTagsToSdk(extraTags), software.amazon.awssdk.services.rds.model.Tag.class)
-        );
     }
 
     @Test
@@ -1975,8 +1893,6 @@ public class CreateHandlerTest extends AbstractHandlerTest {
                                         .build()
                                 ).build())
                 .thenReturn(restoreResponse);
-        when(rdsProxy.client().addTagsToResource(any(AddTagsToResourceRequest.class)))
-                .thenReturn(AddTagsToResourceResponse.builder().build());
 
         final CallbackContext context = new CallbackContext();
         context.setCreated(false);
@@ -1984,43 +1900,27 @@ public class CreateHandlerTest extends AbstractHandlerTest {
         context.setRebooted(true);
         context.setUpdatedRoles(true);
 
-        final Tagging.TagSet extraTags = Tagging.TagSet.builder()
-                .stackTags(TAG_SET.getStackTags())
-                .resourceTags(TAG_SET.getResourceTags())
-                .build();
 
         test_handleRequest_base(
                 context,
                 ResourceHandlerRequest.<ResourceModel>builder()
                         .systemTags(Translator.translateTagsToRequest(Translator.translateTagsFromSdk(TAG_SET.getSystemTags())))
                         .desiredResourceTags(Translator.translateTagsToRequest(Translator.translateTagsFromSdk(TAG_SET.getStackTags()))),
-                () -> DB_INSTANCE_ACTIVE,
+                null,
                 null,
                 () -> RESOURCE_MODEL_RESTORING_TO_POINT_IN_TIME.toBuilder()
                         .tags(Translator.translateTagsFromSdk(TAG_SET.getResourceTags()))
                         .useLatestRestorableTime(true)
                         .build(),
-                expectSuccess()
+                expectFailed(HandlerErrorCode.AccessDenied)
         );
 
         ArgumentCaptor<RestoreDbInstanceToPointInTimeRequest> createCaptor = ArgumentCaptor.forClass(RestoreDbInstanceToPointInTimeRequest.class);
-        verify(rdsProxy.client(), times(2)).restoreDBInstanceToPointInTime(createCaptor.capture());
+        verify(rdsProxy.client(), times(1)).restoreDBInstanceToPointInTime(createCaptor.capture());
 
         final RestoreDbInstanceToPointInTimeRequest requestWithAllTags = createCaptor.getAllValues().get(0);
         Assertions.assertThat(requestWithAllTags.tags()).containsExactlyInAnyOrder(
                 Iterables.toArray(Tagging.translateTagsToSdk(TAG_SET), software.amazon.awssdk.services.rds.model.Tag.class)
-        );
-        final RestoreDbInstanceToPointInTimeRequest requestWithSystemTags = createCaptor.getAllValues().get(1);
-        Assertions.assertThat(requestWithSystemTags.tags()).containsExactlyInAnyOrder(
-                Iterables.toArray(TAG_SET.getSystemTags(), software.amazon.awssdk.services.rds.model.Tag.class)
-        );
-
-        verify(rdsProxy.client(), times(3)).describeDBInstances(any(DescribeDbInstancesRequest.class));
-
-        ArgumentCaptor<AddTagsToResourceRequest> addTagCaptor = ArgumentCaptor.forClass(AddTagsToResourceRequest.class);
-        verify(rdsProxy.client(), times(1)).addTagsToResource(addTagCaptor.capture());
-        Assertions.assertThat(addTagCaptor.getValue().tags()).containsExactlyInAnyOrder(
-                Iterables.toArray(Tagging.translateTagsToSdk(extraTags), software.amazon.awssdk.services.rds.model.Tag.class)
         );
     }
 

--- a/aws-rds-dbparametergroup/src/main/java/software/amazon/rds/dbparametergroup/BaseHandlerStd.java
+++ b/aws-rds-dbparametergroup/src/main/java/software/amazon/rds/dbparametergroup/BaseHandlerStd.java
@@ -149,11 +149,11 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
                     progress,
                     exception,
                     DEFAULT_DB_PARAMETER_GROUP_ERROR_RULE_SET.extendWith(
-                            Tagging.bestEffortErrorRuleSet(
+                            Tagging.getUpdateTagsAccessDeniedRuleSet(
                                     tagsToAdd,
                                     tagsToRemove,
-                                    Tagging.SOFT_FAIL_IN_PROGRESS_TAGGING_ERROR_RULE_SET,
-                                    Tagging.HARD_FAIL_TAG_ERROR_RULE_SET
+                                    Tagging.IGNORE_LIST_TAGS_PERMISSION_DENIED_ERROR_RULE_SET,
+                                    Tagging.RESOURCE_TAG_ERROR_RULE_SET
                             )
                     )
             );

--- a/aws-rds-dbparametergroup/src/main/java/software/amazon/rds/dbparametergroup/CreateHandler.java
+++ b/aws-rds-dbparametergroup/src/main/java/software/amazon/rds/dbparametergroup/CreateHandler.java
@@ -64,7 +64,7 @@ public class CreateHandler extends BaseHandlerStd {
             final RequestLogger logger
     ) {
         final HandlerMethod<ResourceModel, CallbackContext> createMethod = (pxy, pcl, prg, tgs) -> createDBParameterGroup(pxy, pcl, prg, tgs, logger);
-        return Tagging.createWithUnauthorizedTagging(proxy, proxyClient, createMethod, progress, allTags)
+        return Tagging.createWithTaggingFallback(proxy, proxyClient, createMethod, progress, allTags)
                 .then(p -> Commons.execOnce(p, () -> {
                     final Tagging.TagSet extraTags = Tagging.TagSet.builder()
                             .stackTags(allTags.getStackTags())

--- a/aws-rds-dbparametergroup/src/main/java/software/amazon/rds/dbparametergroup/CreateHandler.java
+++ b/aws-rds-dbparametergroup/src/main/java/software/amazon/rds/dbparametergroup/CreateHandler.java
@@ -64,7 +64,7 @@ public class CreateHandler extends BaseHandlerStd {
             final RequestLogger logger
     ) {
         final HandlerMethod<ResourceModel, CallbackContext> createMethod = (pxy, pcl, prg, tgs) -> createDBParameterGroup(pxy, pcl, prg, tgs, logger);
-        return Tagging.safeCreate(proxy, proxyClient, createMethod, progress, allTags)
+        return Tagging.createWithUnauthorizedTagging(proxy, proxyClient, createMethod, progress, allTags)
                 .then(p -> Commons.execOnce(p, () -> {
                     final Tagging.TagSet extraTags = Tagging.TagSet.builder()
                             .stackTags(allTags.getStackTags())

--- a/aws-rds-dbparametergroup/src/main/java/software/amazon/rds/dbparametergroup/ReadHandler.java
+++ b/aws-rds-dbparametergroup/src/main/java/software/amazon/rds/dbparametergroup/ReadHandler.java
@@ -103,7 +103,7 @@ public class ReadHandler extends BaseHandlerStd {
             return Commons.handleException(
                     ProgressEvent.progress(model, context),
                     exception,
-                    DEFAULT_DB_PARAMETER_GROUP_ERROR_RULE_SET.extendWith(Tagging.SOFT_FAIL_TAG_ERROR_RULE_SET)
+                    DEFAULT_DB_PARAMETER_GROUP_ERROR_RULE_SET.extendWith(Tagging.STACK_TAGS_ERROR_RULE_SET)
             );
         }
         return ProgressEvent.success(model, context);

--- a/aws-rds-dbsubnetgroup/src/main/java/software/amazon/rds/dbsubnetgroup/BaseHandlerStd.java
+++ b/aws-rds-dbsubnetgroup/src/main/java/software/amazon/rds/dbsubnetgroup/BaseHandlerStd.java
@@ -121,11 +121,11 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
                     progress,
                     exception,
                     DEFAULT_DB_SUBNET_GROUP_ERROR_RULE_SET.extendWith(
-                            Tagging.bestEffortErrorRuleSet(
+                            Tagging.getUpdateTagsAccessDeniedRuleSet(
                                     tagsToAdd,
                                     tagsToRemove,
-                                    Tagging.SOFT_FAIL_IN_PROGRESS_TAGGING_ERROR_RULE_SET,
-                                    Tagging.HARD_FAIL_TAG_ERROR_RULE_SET
+                                    Tagging.IGNORE_LIST_TAGS_PERMISSION_DENIED_ERROR_RULE_SET,
+                                    Tagging.RESOURCE_TAG_ERROR_RULE_SET
                             )
                     )
             );

--- a/aws-rds-dbsubnetgroup/src/main/java/software/amazon/rds/dbsubnetgroup/CreateHandler.java
+++ b/aws-rds-dbsubnetgroup/src/main/java/software/amazon/rds/dbsubnetgroup/CreateHandler.java
@@ -55,7 +55,7 @@ public class CreateHandler extends BaseHandlerStd {
                                                                                   final ProxyClient<RdsClient> proxyClient,
                                                                                   final ProgressEvent<ResourceModel, CallbackContext> progress,
                                                                                   final Tagging.TagSet allTags) {
-        return Tagging.createWithUnauthorizedTagging(proxy, proxyClient, this::createDbSubnetGroup, progress, allTags)
+        return Tagging.createWithTaggingFallback(proxy, proxyClient, this::createDbSubnetGroup, progress, allTags)
                 .then(p -> Commons.execOnce(p, () -> {
                     final Tagging.TagSet extraTags = Tagging.TagSet.builder()
                             .stackTags(allTags.getStackTags())

--- a/aws-rds-dbsubnetgroup/src/main/java/software/amazon/rds/dbsubnetgroup/CreateHandler.java
+++ b/aws-rds-dbsubnetgroup/src/main/java/software/amazon/rds/dbsubnetgroup/CreateHandler.java
@@ -1,6 +1,5 @@
 package software.amazon.rds.dbsubnetgroup;
 
-import java.util.Collections;
 import java.util.LinkedHashSet;
 
 import com.amazonaws.util.StringUtils;
@@ -56,7 +55,7 @@ public class CreateHandler extends BaseHandlerStd {
                                                                                   final ProxyClient<RdsClient> proxyClient,
                                                                                   final ProgressEvent<ResourceModel, CallbackContext> progress,
                                                                                   final Tagging.TagSet allTags) {
-        return Tagging.safeCreate(proxy, proxyClient, this::createDbSubnetGroup, progress, allTags)
+        return Tagging.createWithUnauthorizedTagging(proxy, proxyClient, this::createDbSubnetGroup, progress, allTags)
                 .then(p -> Commons.execOnce(p, () -> {
                     final Tagging.TagSet extraTags = Tagging.TagSet.builder()
                             .stackTags(allTags.getStackTags())

--- a/aws-rds-dbsubnetgroup/src/main/java/software/amazon/rds/dbsubnetgroup/ReadHandler.java
+++ b/aws-rds-dbsubnetgroup/src/main/java/software/amazon/rds/dbsubnetgroup/ReadHandler.java
@@ -70,7 +70,7 @@ public class ReadHandler extends BaseHandlerStd {
             return Commons.handleException(
                     ProgressEvent.progress(model, context),
                     exception,
-                    DEFAULT_DB_SUBNET_GROUP_ERROR_RULE_SET.extendWith(Tagging.SOFT_FAIL_TAG_ERROR_RULE_SET)
+                    DEFAULT_DB_SUBNET_GROUP_ERROR_RULE_SET.extendWith(Tagging.STACK_TAGS_ERROR_RULE_SET)
             );
         }
         return ProgressEvent.success(model, context);

--- a/aws-rds-eventsubscription/src/main/java/software/amazon/rds/eventsubscription/BaseHandlerStd.java
+++ b/aws-rds-eventsubscription/src/main/java/software/amazon/rds/eventsubscription/BaseHandlerStd.java
@@ -135,11 +135,11 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
                     progress,
                     exception,
                     DEFAULT_EVENT_SUBSCRIPTION_ERROR_RULE_SET.extendWith(
-                                    Tagging.bestEffortErrorRuleSet(
+                                    Tagging.getUpdateTagsAccessDeniedRuleSet(
                                             tagsToAdd,
                                             tagsToRemove,
-                                            Tagging.SOFT_FAIL_IN_PROGRESS_TAGGING_ERROR_RULE_SET,
-                                            Tagging.HARD_FAIL_TAG_ERROR_RULE_SET
+                                            Tagging.IGNORE_LIST_TAGS_PERMISSION_DENIED_ERROR_RULE_SET,
+                                            Tagging.RESOURCE_TAG_ERROR_RULE_SET
                                     )
                             )
             );

--- a/aws-rds-eventsubscription/src/main/java/software/amazon/rds/eventsubscription/CreateHandler.java
+++ b/aws-rds-eventsubscription/src/main/java/software/amazon/rds/eventsubscription/CreateHandler.java
@@ -47,7 +47,7 @@ public class CreateHandler extends BaseHandlerStd {
                                                                                       final ProxyClient<RdsClient> proxyClient,
                                                                                       final ProgressEvent<ResourceModel, CallbackContext> progress,
                                                                                       final Tagging.TagSet allTags) {
-        return Tagging.createWithUnauthorizedTagging(proxy, proxyClient, this::createEventSubscription, progress, allTags)
+        return Tagging.createWithTaggingFallback(proxy, proxyClient, this::createEventSubscription, progress, allTags)
                 .then(p -> Commons.execOnce(p, () -> {
                     final Tagging.TagSet extraTags = Tagging.TagSet.builder()
                             .stackTags(allTags.getStackTags())

--- a/aws-rds-eventsubscription/src/main/java/software/amazon/rds/eventsubscription/CreateHandler.java
+++ b/aws-rds-eventsubscription/src/main/java/software/amazon/rds/eventsubscription/CreateHandler.java
@@ -47,7 +47,7 @@ public class CreateHandler extends BaseHandlerStd {
                                                                                       final ProxyClient<RdsClient> proxyClient,
                                                                                       final ProgressEvent<ResourceModel, CallbackContext> progress,
                                                                                       final Tagging.TagSet allTags) {
-        return Tagging.safeCreate(proxy, proxyClient, this::createEventSubscription, progress, allTags)
+        return Tagging.createWithUnauthorizedTagging(proxy, proxyClient, this::createEventSubscription, progress, allTags)
                 .then(p -> Commons.execOnce(p, () -> {
                     final Tagging.TagSet extraTags = Tagging.TagSet.builder()
                             .stackTags(allTags.getStackTags())

--- a/aws-rds-eventsubscription/src/main/java/software/amazon/rds/eventsubscription/ReadHandler.java
+++ b/aws-rds-eventsubscription/src/main/java/software/amazon/rds/eventsubscription/ReadHandler.java
@@ -49,7 +49,7 @@ public class ReadHandler extends BaseHandlerStd {
             return Commons.handleException(
                     ProgressEvent.progress(model, context),
                     exception,
-                    DEFAULT_EVENT_SUBSCRIPTION_ERROR_RULE_SET.extendWith(Tagging.SOFT_FAIL_TAG_ERROR_RULE_SET)
+                    DEFAULT_EVENT_SUBSCRIPTION_ERROR_RULE_SET.extendWith(Tagging.STACK_TAGS_ERROR_RULE_SET)
             );
         }
         return ProgressEvent.success(model, context);

--- a/aws-rds-optiongroup/docs/tag.md
+++ b/aws-rds-optiongroup/docs/tag.md
@@ -32,9 +32,9 @@ _Required_: Yes
 
 _Type_: String
 
-_Minimum_: <code>1</code>
+_Minimum Length_: <code>1</code>
 
-_Maximum_: <code>128</code>
+_Maximum Length_: <code>128</code>
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 
@@ -46,6 +46,6 @@ _Required_: No
 
 _Type_: String
 
-_Maximum_: <code>256</code>
+_Maximum Length_: <code>256</code>
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)

--- a/aws-rds-optiongroup/src/main/java/software/amazon/rds/optiongroup/BaseHandlerStd.java
+++ b/aws-rds-optiongroup/src/main/java/software/amazon/rds/optiongroup/BaseHandlerStd.java
@@ -135,11 +135,11 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
                                 progress,
                                 exception,
                                 DEFAULT_OPTION_GROUP_ERROR_RULE_SET.extendWith(
-                                        Tagging.bestEffortErrorRuleSet(
+                                        Tagging.getUpdateTagsAccessDeniedRuleSet(
                                                 tagsToAdd,
                                                 tagsToRemove,
-                                                Tagging.SOFT_FAIL_IN_PROGRESS_TAGGING_ERROR_RULE_SET,
-                                                Tagging.HARD_FAIL_TAG_ERROR_RULE_SET
+                                                Tagging.IGNORE_LIST_TAGS_PERMISSION_DENIED_ERROR_RULE_SET,
+                                                Tagging.RESOURCE_TAG_ERROR_RULE_SET
                                         )
                                 )
                         );

--- a/aws-rds-optiongroup/src/main/java/software/amazon/rds/optiongroup/CreateHandler.java
+++ b/aws-rds-optiongroup/src/main/java/software/amazon/rds/optiongroup/CreateHandler.java
@@ -50,7 +50,7 @@ public class CreateHandler extends BaseHandlerStd {
 
         return ProgressEvent.progress(request.getDesiredResourceState(), callbackContext)
                 .then(progress -> setOptionGroupNameIfEmpty(request, progress))
-                .then(progress -> Tagging.createWithUnauthorizedTagging(proxy, proxyClient, this::createOptionGroup, progress, allTags))
+                .then(progress -> Tagging.createWithTaggingFallback(proxy, proxyClient, this::createOptionGroup, progress, allTags))
                 .then(progress -> Commons.execOnce(progress, () -> {
                         final Tagging.TagSet extraTags = Tagging.TagSet.builder()
                                 .stackTags(allTags.getStackTags())

--- a/aws-rds-optiongroup/src/main/java/software/amazon/rds/optiongroup/CreateHandler.java
+++ b/aws-rds-optiongroup/src/main/java/software/amazon/rds/optiongroup/CreateHandler.java
@@ -50,7 +50,7 @@ public class CreateHandler extends BaseHandlerStd {
 
         return ProgressEvent.progress(request.getDesiredResourceState(), callbackContext)
                 .then(progress -> setOptionGroupNameIfEmpty(request, progress))
-                .then(progress -> Tagging.safeCreate(proxy, proxyClient, this::createOptionGroup, progress, allTags))
+                .then(progress -> Tagging.createWithUnauthorizedTagging(proxy, proxyClient, this::createOptionGroup, progress, allTags))
                 .then(progress -> Commons.execOnce(progress, () -> {
                         final Tagging.TagSet extraTags = Tagging.TagSet.builder()
                                 .stackTags(allTags.getStackTags())


### PR DESCRIPTION
*Description of changes:*

In order to maintain compatibility with older versions, we used to overlook the AccessDenied exception when a customer lacked the permission to add stack level tags. This PR aims to rectify this behavior by following to the latest CloudFormation guidelines and instead throwing an `UnauthorizedTaggingOperation` error code. 

However, we still have the tagging logic in place to distinguish between access denied for resource tags and access denied for stack level tags. Once CloudFormation confirms that it is safe to convert `UnauthorizedTaggingOperation` to the regular `AccessDenied` error code, we can safely remove all the logic related to tag error management and the `safeCreate` mechanism.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
