### PR TITLE
[DBClusterParameterGroup] Conditionally reset parameters

### DIFF
--- a/aws-rds-dbclusterparametergroup/src/main/java/software/amazon/rds/dbclusterparametergroup/CreateHandler.java
+++ b/aws-rds-dbclusterparametergroup/src/main/java/software/amazon/rds/dbclusterparametergroup/CreateHandler.java
@@ -1,9 +1,12 @@
 package software.amazon.rds.dbclusterparametergroup;
 
+import java.util.ArrayList;
 import java.util.Map;
 
 import com.amazonaws.util.StringUtils;
+import com.google.common.collect.Maps;
 import software.amazon.awssdk.services.rds.RdsClient;
+import software.amazon.awssdk.services.rds.model.Parameter;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ProxyClient;
@@ -45,6 +48,7 @@ public class CreateHandler extends BaseHandlerStd {
                 .build();
 
         final Map<String, Object> desiredParams = request.getDesiredResourceState().getParameters();
+        final Map<String, Parameter> currentClusterParameters = Maps.newHashMap();
 
         return ProgressEvent.progress(request.getDesiredResourceState(), callbackContext)
                 .then(progress -> setDbClusterParameterGroupNameIfMissing(request, progress))
@@ -56,7 +60,10 @@ public class CreateHandler extends BaseHandlerStd {
                             .build();
                     return updateTags(proxy, proxyClient, progress, Tagging.TagSet.emptySet(), extraTags);
                 }, CallbackContext::isAddTagsComplete, CallbackContext::setAddTagsComplete))
-                .then(progress -> Commons.execOnce(progress, () -> applyParameters(proxy, proxyClient, progress, desiredParams, logger),
+                .then(progress -> Commons.execOnce(progress, () ->
+                                describeCurrentDBClusterParameters(proxy, proxyClient, progress, new ArrayList<>(desiredParams.keySet()), currentClusterParameters, logger)
+                                        .then(p -> applyParameters(proxy, proxyClient, progress, currentClusterParameters, logger)
+                        ),
                         CallbackContext::isParametersApplied, CallbackContext::setParametersApplied))
                 .then(progress -> new ReadHandler().handleRequest(proxy, request, callbackContext, proxyClient, logger));
     }

--- a/aws-rds-dbclusterparametergroup/src/main/java/software/amazon/rds/dbclusterparametergroup/Translator.java
+++ b/aws-rds-dbclusterparametergroup/src/main/java/software/amazon/rds/dbclusterparametergroup/Translator.java
@@ -110,10 +110,12 @@ public class Translator {
                 .build();
     }
 
-    public static ResetDbClusterParameterGroupRequest resetDbClusterParameterGroupRequest(final ResourceModel model) {
+    public static ResetDbClusterParameterGroupRequest resetDbClusterParameterGroupRequest(final ResourceModel model,
+                                                                                          final Map<String, Parameter> parametersToReset) {
+
         return ResetDbClusterParameterGroupRequest.builder()
+                .parameters(parametersToReset.values())
                 .dbClusterParameterGroupName(model.getDBClusterParameterGroupName())
-                .resetAllParameters(true)
                 .build();
     }
 


### PR DESCRIPTION
This PR changes ResetParameter logic to only reset changed parameters in DBClusterParameterGroup. This allows us to avoid unnecessary reboots caused by resetting parameters with `pending-reboot` apply method even when unchanged. It also allows to avoid update failures when attempting to reset parameters such as `lower_case_table_names` - which are not safe to reset.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
