### PR TITLE
Add iam CreateServiceLinkedRole permissions

### DIFF
--- a/aws-rds-dbcluster/aws-rds-dbcluster.json
+++ b/aws-rds-dbcluster/aws-rds-dbcluster.json
@@ -462,6 +462,7 @@
   "handlers": {
     "create": {
       "permissions": [
+        "iam:CreateServiceLinkedRole",
         "iam:PassRole",
         "rds:AddRoleToDBCluster",
         "rds:AddTagsToResource",

--- a/aws-rds-dbcluster/resource-role.yaml
+++ b/aws-rds-dbcluster/resource-role.yaml
@@ -31,6 +31,7 @@ Resources:
               - Effect: Allow
                 Action:
                 - "ec2:DescribeSecurityGroups"
+                - "iam:CreateServiceLinkedRole"
                 - "iam:PassRole"
                 - "rds:AddRoleToDBCluster"
                 - "rds:AddTagsToResource"

--- a/aws-rds-dbclusterparametergroup/aws-rds-dbclusterparametergroup.json
+++ b/aws-rds-dbclusterparametergroup/aws-rds-dbclusterparametergroup.json
@@ -73,6 +73,7 @@
   "handlers": {
     "create": {
       "permissions": [
+        "iam:CreateServiceLinkedRole",
         "rds:AddTagsToResource",
         "rds:CreateDBClusterParameterGroup",
         "rds:DescribeDBClusterParameterGroups",

--- a/aws-rds-dbclusterparametergroup/resource-role.yaml
+++ b/aws-rds-dbclusterparametergroup/resource-role.yaml
@@ -30,6 +30,7 @@ Resources:
             Statement:
               - Effect: Allow
                 Action:
+                - "iam:CreateServiceLinkedRole"
                 - "rds:AddTagsToResource"
                 - "rds:CreateDBClusterParameterGroup"
                 - "rds:DeleteDBClusterParameterGroup"

--- a/aws-rds-dbparametergroup/aws-rds-dbparametergroup.json
+++ b/aws-rds-dbparametergroup/aws-rds-dbparametergroup.json
@@ -74,6 +74,7 @@
   "handlers": {
     "create": {
       "permissions": [
+        "iam:CreateServiceLinkedRole",
         "rds:AddTagsToResource",
         "rds:CreateDBParameterGroup",
         "rds:DescribeDBParameterGroups",

--- a/aws-rds-dbparametergroup/resource-role.yaml
+++ b/aws-rds-dbparametergroup/resource-role.yaml
@@ -30,6 +30,7 @@ Resources:
             Statement:
               - Effect: Allow
                 Action:
+                - "iam:CreateServiceLinkedRole"
                 - "rds:AddTagsToResource"
                 - "rds:CreateDBParameterGroup"
                 - "rds:DeleteDBParameterGroup"

--- a/aws-rds-dbsubnetgroup/aws-rds-dbsubnetgroup.json
+++ b/aws-rds-dbsubnetgroup/aws-rds-dbsubnetgroup.json
@@ -72,6 +72,7 @@
   "handlers": {
     "create": {
       "permissions": [
+        "iam:CreateServiceLinkedRole",
         "rds:CreateDBSubnetGroup",
         "rds:DescribeDBSubnetGroups",
         "rds:AddTagsToResource",

--- a/aws-rds-dbsubnetgroup/resource-role.yaml
+++ b/aws-rds-dbsubnetgroup/resource-role.yaml
@@ -30,6 +30,7 @@ Resources:
             Statement:
               - Effect: Allow
                 Action:
+                - "iam:CreateServiceLinkedRole"
                 - "rds:AddTagsToResource"
                 - "rds:CreateDBSubnetGroup"
                 - "rds:DeleteDBSubnetGroup"

--- a/aws-rds-eventsubscription/aws-rds-eventsubscription.json
+++ b/aws-rds-eventsubscription/aws-rds-eventsubscription.json
@@ -90,6 +90,7 @@
   "handlers": {
     "create": {
       "permissions": [
+        "iam:CreateServiceLinkedRole",
         "rds:CreateEventSubscription",
         "rds:DescribeEventSubscriptions",
         "rds:ListTagsForResource",

--- a/aws-rds-eventsubscription/resource-role.yaml
+++ b/aws-rds-eventsubscription/resource-role.yaml
@@ -30,6 +30,7 @@ Resources:
             Statement:
               - Effect: Allow
                 Action:
+                - "iam:CreateServiceLinkedRole"
                 - "rds:AddSourceIdentifierToSubscription"
                 - "rds:AddTagsToResource"
                 - "rds:CreateEventSubscription"

--- a/aws-rds-optiongroup/aws-rds-optiongroup.json
+++ b/aws-rds-optiongroup/aws-rds-optiongroup.json
@@ -145,6 +145,7 @@
   "handlers": {
     "create": {
       "permissions": [
+        "iam:CreateServiceLinkedRole",
         "rds:AddTagsToResource",
         "rds:CreateOptionGroup",
         "rds:DescribeOptionGroups",

--- a/aws-rds-optiongroup/resource-role.yaml
+++ b/aws-rds-optiongroup/resource-role.yaml
@@ -30,6 +30,7 @@ Resources:
             Statement:
               - Effect: Allow
                 Action:
+                - "iam:CreateServiceLinkedRole"
                 - "rds:AddTagsToResource"
                 - "rds:CreateOptionGroup"
                 - "rds:DeleteOptionGroup"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Cloudformation handlers need to specify which permissions are required to perform the operations requested by customers. This CR adds CreateServiceLinkedRole on create for other resources similar to what is being done for DbInstance


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
