### PR TITLE
[Common][All] Fix List Tags Soft Failure Parity in Read Handlers 

### DIFF
--- a/aws-rds-cfn-common/src/main/java/software/amazon/rds/common/handler/Tagging.java
+++ b/aws-rds-cfn-common/src/main/java/software/amazon/rds/common/handler/Tagging.java
@@ -22,7 +22,6 @@ import software.amazon.awssdk.services.rds.model.RemoveTagsFromResourceRequest;
 import software.amazon.awssdk.services.rds.model.Tag;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.HandlerErrorCode;
-import software.amazon.cloudformation.proxy.OperationStatus;
 import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.rds.common.error.ErrorCode;
@@ -32,7 +31,7 @@ import software.amazon.rds.common.error.ErrorStatus;
 public final class Tagging {
     public static final ErrorRuleSet IGNORE_LIST_TAGS_PERMISSION_DENIED_ERROR_RULE_SET = ErrorRuleSet
             .extend(ErrorRuleSet.EMPTY_RULE_SET)
-            .withErrorCodes(ErrorStatus.ignore(OperationStatus.IN_PROGRESS),
+            .withErrorCodes(ErrorStatus.ignore(),
                     ErrorCode.AccessDenied,
                     ErrorCode.AccessDeniedException)
             .build();

--- a/aws-rds-customdbengineversion/src/main/java/software/amazon/rds/customdbengineversion/BaseHandlerStd.java
+++ b/aws-rds-customdbengineversion/src/main/java/software/amazon/rds/customdbengineversion/BaseHandlerStd.java
@@ -187,9 +187,7 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
                 DEFAULT_CUSTOM_DB_ENGINE_VERSION_ERROR_RULE_SET.extendWith(
                         Tagging.getUpdateTagsAccessDeniedRuleSet(
                                 tagsToAdd,
-                                tagsToRemove,
-                                Tagging.IGNORE_LIST_TAGS_PERMISSION_DENIED_ERROR_RULE_SET,
-                                Tagging.RESOURCE_TAG_ERROR_RULE_SET
+                                tagsToRemove
                         )
                 )
         );

--- a/aws-rds-customdbengineversion/src/test/java/software/amazon/rds/customdbengineversion/UpdateHandlerTest.java
+++ b/aws-rds-customdbengineversion/src/test/java/software/amazon/rds/customdbengineversion/UpdateHandlerTest.java
@@ -215,7 +215,9 @@ public class UpdateHandlerTest extends AbstractHandlerTest {
     }
 
     @Test
-    public void handleRequest_SoftFailingTaggingOnRemoveTags() {
+    public void handleRequest_HardFailWithUnauthorizedTagsOnRemove() {
+        when(rdsProxy.client().modifyCustomDBEngineVersion(any(ModifyCustomDbEngineVersionRequest.class)))
+                .thenReturn(ModifyCustomDbEngineVersionResponse.builder().build());
         when(rdsProxy.client().removeTagsFromResource(any(RemoveTagsFromResourceRequest.class)))
                 .thenThrow(
                         RdsException.builder().awsErrorDetails(AwsErrorDetails.builder()
@@ -226,19 +228,22 @@ public class UpdateHandlerTest extends AbstractHandlerTest {
         test_handleRequest_base(
                 context,
                 ResourceHandlerRequest.<ResourceModel>builder()
-                        .previousSystemTags(Translator.translateTagsToRequest(TAG_LIST))
-                        .systemTags(Translator.translateTagsToRequest(TAG_LIST_EMPTY)),
+                        .previousResourceTags(Translator.translateTagsToRequest(TAG_LIST))
+                        .desiredResourceTags(Translator.translateTagsToRequest(TAG_LIST_EMPTY)),
                 () -> DB_ENGINE_VERSION_AVAILABLE,
                 () -> RESOURCE_MODEL_BUILDER().build(),
-                () -> RESOURCE_MODEL_BUILDER().build(),
-                expectSuccess()
+                () -> RESOURCE_MODEL_BUILDER().status("inactive").build(),
+                expectFailed(HandlerErrorCode.UnauthorizedTaggingOperation)
         );
 
+        verify(rdsProxy.client(), times(1)).modifyCustomDBEngineVersion(any(ModifyCustomDbEngineVersionRequest.class));
         verify(rdsProxy.client(), times(1)).removeTagsFromResource(any(RemoveTagsFromResourceRequest.class));
     }
 
     @Test
-    public void handleRequest_SoftFailingTaggingOnAddTags() {
+    public void handleRequest_HardFailWithUnauthorizedTagsOnAdd() {
+        when(rdsProxy.client().modifyCustomDBEngineVersion(any(ModifyCustomDbEngineVersionRequest.class)))
+                .thenReturn(ModifyCustomDbEngineVersionResponse.builder().build());
         when(rdsProxy.client().addTagsToResource(any(AddTagsToResourceRequest.class)))
                 .thenThrow(
                         RdsException.builder().awsErrorDetails(AwsErrorDetails.builder()
@@ -253,10 +258,11 @@ public class UpdateHandlerTest extends AbstractHandlerTest {
                         .systemTags(Translator.translateTagsToRequest(TAG_LIST)),
                 () -> DB_ENGINE_VERSION_AVAILABLE,
                 () -> RESOURCE_MODEL_BUILDER().build(),
-                () -> RESOURCE_MODEL_BUILDER().build(),
-                expectSuccess()
+                () -> RESOURCE_MODEL_BUILDER().status("inactive").build(),
+                expectFailed(HandlerErrorCode.UnauthorizedTaggingOperation)
         );
 
+        verify(rdsProxy.client(), times(1)).modifyCustomDBEngineVersion(any(ModifyCustomDbEngineVersionRequest.class));
         verify(rdsProxy.client(), times(1)).addTagsToResource(any(AddTagsToResourceRequest.class));
     }
 }

--- a/aws-rds-dbclusterendpoint/src/main/java/software/amazon/rds/dbclusterendpoint/ReadHandler.java
+++ b/aws-rds-dbclusterendpoint/src/main/java/software/amazon/rds/dbclusterendpoint/ReadHandler.java
@@ -1,5 +1,8 @@
 package software.amazon.rds.dbclusterendpoint;
 
+import java.util.Optional;
+import java.util.Set;
+
 import software.amazon.awssdk.services.rds.RdsClient;
 import software.amazon.awssdk.services.rds.model.DBClusterEndpoint;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
@@ -11,9 +14,6 @@ import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 import software.amazon.rds.common.handler.Commons;
 import software.amazon.rds.common.handler.HandlerConfig;
 import software.amazon.rds.common.handler.Tagging;
-
-import java.util.Optional;
-import java.util.Set;
 
 public class ReadHandler extends BaseHandlerStd {
 
@@ -73,7 +73,7 @@ public class ReadHandler extends BaseHandlerStd {
             return Commons.handleException(
                     ProgressEvent.progress(model, context),
                     exception,
-                    DEFAULT_DB_CLUSTER_ENDPOINT_ERROR_RULE_SET.extendWith(Tagging.STACK_TAGS_ERROR_RULE_SET)
+                    DEFAULT_DB_CLUSTER_ENDPOINT_ERROR_RULE_SET.extendWith(Tagging.IGNORE_LIST_TAGS_PERMISSION_DENIED_ERROR_RULE_SET)
             );
         }
         return ProgressEvent.success(model, context);

--- a/aws-rds-dbclusterparametergroup/src/main/java/software/amazon/rds/dbclusterparametergroup/BaseHandlerStd.java
+++ b/aws-rds-dbclusterparametergroup/src/main/java/software/amazon/rds/dbclusterparametergroup/BaseHandlerStd.java
@@ -1,8 +1,6 @@
 package software.amazon.rds.dbclusterparametergroup;
 
 import java.time.Duration;
-import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -178,9 +176,7 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
                     DEFAULT_DB_CLUSTER_PARAMETER_GROUP_ERROR_RULE_SET.extendWith(
                             Tagging.getUpdateTagsAccessDeniedRuleSet(
                                     tagsToAdd,
-                                    tagsToRemove,
-                                    Tagging.IGNORE_LIST_TAGS_PERMISSION_DENIED_ERROR_RULE_SET,
-                                    Tagging.RESOURCE_TAG_ERROR_RULE_SET
+                                    tagsToRemove
                             )
                     )
             );

--- a/aws-rds-dbclusterparametergroup/src/main/java/software/amazon/rds/dbclusterparametergroup/ReadHandler.java
+++ b/aws-rds-dbclusterparametergroup/src/main/java/software/amazon/rds/dbclusterparametergroup/ReadHandler.java
@@ -89,7 +89,7 @@ public class ReadHandler extends BaseHandlerStd {
             return Commons.handleException(
                     ProgressEvent.progress(model, context),
                     exception,
-                    DEFAULT_DB_CLUSTER_PARAMETER_GROUP_ERROR_RULE_SET.extendWith(Tagging.STACK_TAGS_ERROR_RULE_SET)
+                    DEFAULT_DB_CLUSTER_PARAMETER_GROUP_ERROR_RULE_SET.extendWith(Tagging.IGNORE_LIST_TAGS_PERMISSION_DENIED_ERROR_RULE_SET)
             );
         }
         return ProgressEvent.success(model, context);

--- a/aws-rds-dbparametergroup/src/main/java/software/amazon/rds/dbparametergroup/BaseHandlerStd.java
+++ b/aws-rds-dbparametergroup/src/main/java/software/amazon/rds/dbparametergroup/BaseHandlerStd.java
@@ -151,9 +151,7 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
                     DEFAULT_DB_PARAMETER_GROUP_ERROR_RULE_SET.extendWith(
                             Tagging.getUpdateTagsAccessDeniedRuleSet(
                                     tagsToAdd,
-                                    tagsToRemove,
-                                    Tagging.IGNORE_LIST_TAGS_PERMISSION_DENIED_ERROR_RULE_SET,
-                                    Tagging.RESOURCE_TAG_ERROR_RULE_SET
+                                    tagsToRemove
                             )
                     )
             );

--- a/aws-rds-dbparametergroup/src/main/java/software/amazon/rds/dbparametergroup/ReadHandler.java
+++ b/aws-rds-dbparametergroup/src/main/java/software/amazon/rds/dbparametergroup/ReadHandler.java
@@ -103,7 +103,7 @@ public class ReadHandler extends BaseHandlerStd {
             return Commons.handleException(
                     ProgressEvent.progress(model, context),
                     exception,
-                    DEFAULT_DB_PARAMETER_GROUP_ERROR_RULE_SET.extendWith(Tagging.STACK_TAGS_ERROR_RULE_SET)
+                    DEFAULT_DB_PARAMETER_GROUP_ERROR_RULE_SET.extendWith(Tagging.IGNORE_LIST_TAGS_PERMISSION_DENIED_ERROR_RULE_SET)
             );
         }
         return ProgressEvent.success(model, context);

--- a/aws-rds-dbsubnetgroup/src/main/java/software/amazon/rds/dbsubnetgroup/BaseHandlerStd.java
+++ b/aws-rds-dbsubnetgroup/src/main/java/software/amazon/rds/dbsubnetgroup/BaseHandlerStd.java
@@ -123,9 +123,7 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
                     DEFAULT_DB_SUBNET_GROUP_ERROR_RULE_SET.extendWith(
                             Tagging.getUpdateTagsAccessDeniedRuleSet(
                                     tagsToAdd,
-                                    tagsToRemove,
-                                    Tagging.IGNORE_LIST_TAGS_PERMISSION_DENIED_ERROR_RULE_SET,
-                                    Tagging.RESOURCE_TAG_ERROR_RULE_SET
+                                    tagsToRemove
                             )
                     )
             );

--- a/aws-rds-dbsubnetgroup/src/main/java/software/amazon/rds/dbsubnetgroup/ReadHandler.java
+++ b/aws-rds-dbsubnetgroup/src/main/java/software/amazon/rds/dbsubnetgroup/ReadHandler.java
@@ -70,7 +70,7 @@ public class ReadHandler extends BaseHandlerStd {
             return Commons.handleException(
                     ProgressEvent.progress(model, context),
                     exception,
-                    DEFAULT_DB_SUBNET_GROUP_ERROR_RULE_SET.extendWith(Tagging.STACK_TAGS_ERROR_RULE_SET)
+                    DEFAULT_DB_SUBNET_GROUP_ERROR_RULE_SET.extendWith(Tagging.IGNORE_LIST_TAGS_PERMISSION_DENIED_ERROR_RULE_SET)
             );
         }
         return ProgressEvent.success(model, context);

--- a/aws-rds-eventsubscription/src/main/java/software/amazon/rds/eventsubscription/BaseHandlerStd.java
+++ b/aws-rds-eventsubscription/src/main/java/software/amazon/rds/eventsubscription/BaseHandlerStd.java
@@ -137,9 +137,7 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
                     DEFAULT_EVENT_SUBSCRIPTION_ERROR_RULE_SET.extendWith(
                                     Tagging.getUpdateTagsAccessDeniedRuleSet(
                                             tagsToAdd,
-                                            tagsToRemove,
-                                            Tagging.IGNORE_LIST_TAGS_PERMISSION_DENIED_ERROR_RULE_SET,
-                                            Tagging.RESOURCE_TAG_ERROR_RULE_SET
+                                            tagsToRemove
                                     )
                             )
             );

--- a/aws-rds-eventsubscription/src/main/java/software/amazon/rds/eventsubscription/ReadHandler.java
+++ b/aws-rds-eventsubscription/src/main/java/software/amazon/rds/eventsubscription/ReadHandler.java
@@ -49,7 +49,7 @@ public class ReadHandler extends BaseHandlerStd {
             return Commons.handleException(
                     ProgressEvent.progress(model, context),
                     exception,
-                    DEFAULT_EVENT_SUBSCRIPTION_ERROR_RULE_SET.extendWith(Tagging.STACK_TAGS_ERROR_RULE_SET)
+                    DEFAULT_EVENT_SUBSCRIPTION_ERROR_RULE_SET.extendWith(Tagging.IGNORE_LIST_TAGS_PERMISSION_DENIED_ERROR_RULE_SET)
             );
         }
         return ProgressEvent.success(model, context);

--- a/aws-rds-optiongroup/src/main/java/software/amazon/rds/optiongroup/BaseHandlerStd.java
+++ b/aws-rds-optiongroup/src/main/java/software/amazon/rds/optiongroup/BaseHandlerStd.java
@@ -137,9 +137,7 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
                                 DEFAULT_OPTION_GROUP_ERROR_RULE_SET.extendWith(
                                         Tagging.getUpdateTagsAccessDeniedRuleSet(
                                                 tagsToAdd,
-                                                tagsToRemove,
-                                                Tagging.IGNORE_LIST_TAGS_PERMISSION_DENIED_ERROR_RULE_SET,
-                                                Tagging.RESOURCE_TAG_ERROR_RULE_SET
+                                                tagsToRemove
                                         )
                                 )
                         );

--- a/aws-rds-optiongroup/src/main/java/software/amazon/rds/optiongroup/CallbackContext.java
+++ b/aws-rds-optiongroup/src/main/java/software/amazon/rds/optiongroup/CallbackContext.java
@@ -9,6 +9,7 @@ import software.amazon.rds.common.handler.TaggingContext;
 @lombok.EqualsAndHashCode(callSuper = true)
 public class CallbackContext extends StdCallbackContext implements TaggingContext.Provider {
     private TaggingContext taggingContext;
+    private String optionGroupGroupArn;
 
     public CallbackContext() {
         super();


### PR DESCRIPTION
*Description of changes:*

Due to the absence of the tags attribute in the response of many Describe calls, only resources such as DBInstance, DBCluster, and CustomDBEngineVersion include tags in their describe call. For other resources, it is necessary to make a separate ListTagsForResource call to retrieve tags. In order to avoid inconveniencing customers who do not have List permission, this call is handled with soft failure, ensuring that they are not penalized for lacking the necessary permission.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
