### PR TITLE
[All] Fix tagging when stack and resource level tags have jey collisions

### DIFF
--- a/aws-rds-cfn-common/src/main/java/software/amazon/rds/common/handler/Tagging.java
+++ b/aws-rds-cfn-common/src/main/java/software/amazon/rds/common/handler/Tagging.java
@@ -11,7 +11,6 @@ import java.util.stream.Collectors;
 
 import com.amazonaws.util.CollectionUtils;
 import com.google.common.collect.Sets;
-import javafx.util.Pair;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;

--- a/aws-rds-cfn-common/src/main/java/software/amazon/rds/common/handler/Tagging.java
+++ b/aws-rds-cfn-common/src/main/java/software/amazon/rds/common/handler/Tagging.java
@@ -11,6 +11,7 @@ import java.util.stream.Collectors;
 
 import com.amazonaws.util.CollectionUtils;
 import com.google.common.collect.Sets;
+import javafx.util.Pair;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -68,11 +69,21 @@ public final class Tagging {
                 .build();
     }
 
-    public static <K, V> Map<K, V> mergeTags(Map<K, V> tagsMap1, Map<K, V> tagsMap2) {
-        final Map<K, V> result = new LinkedHashMap<>();
-        result.putAll(Optional.ofNullable(tagsMap1).orElse(Collections.emptySortedMap()));
-        result.putAll(Optional.ofNullable(tagsMap2).orElse(Collections.emptySortedMap()));
+    public static Collection<Tag> exclude(final Collection<Tag> from, final Collection<Tag> what) {
+        final Set<Tag> result = new LinkedHashSet<>(from);
+        result.removeAll(what);
         return result;
+    }
+
+
+    public static Set<Tag> translateTagsToSdk(final Collection<Tag> tags) {
+        return Optional.ofNullable(tags).orElse(Collections.emptySet())
+                .stream()
+                .map(tag -> Tag.builder()
+                        .key(tag.key())
+                        .value(tag.value())
+                        .build())
+                .collect(Collectors.toCollection(LinkedHashSet::new));
     }
 
     public static Collection<Tag> translateTagsToSdk(final TagSet tagSet) {

--- a/aws-rds-dbclusterendpoint/docs/README.md
+++ b/aws-rds-dbclusterendpoint/docs/README.md
@@ -48,9 +48,9 @@ _Required_: Yes
 
 _Type_: String
 
-_Minimum_: <code>1</code>
+_Minimum Length_: <code>1</code>
 
-_Maximum_: <code>63</code>
+_Maximum Length_: <code>63</code>
 
 _Update requires_: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
 
@@ -62,9 +62,9 @@ _Required_: No
 
 _Type_: String
 
-_Minimum_: <code>1</code>
+_Minimum Length_: <code>1</code>
 
-_Maximum_: <code>63</code>
+_Maximum Length_: <code>63</code>
 
 _Update requires_: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
 

--- a/aws-rds-dbclusterendpoint/docs/tag.md
+++ b/aws-rds-dbclusterendpoint/docs/tag.md
@@ -32,9 +32,9 @@ _Required_: Yes
 
 _Type_: String
 
-_Minimum_: <code>1</code>
+_Minimum Length_: <code>1</code>
 
-_Maximum_: <code>128</code>
+_Maximum Length_: <code>128</code>
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 
@@ -46,6 +46,6 @@ _Required_: No
 
 _Type_: String
 
-_Maximum_: <code>256</code>
+_Maximum Length_: <code>256</code>
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)

--- a/aws-rds-dbclusterparametergroup/src/main/java/software/amazon/rds/dbclusterparametergroup/BaseHandlerStd.java
+++ b/aws-rds-dbclusterparametergroup/src/main/java/software/amazon/rds/dbclusterparametergroup/BaseHandlerStd.java
@@ -1,6 +1,7 @@
 package software.amazon.rds.dbclusterparametergroup;
 
 import java.time.Duration;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -39,6 +40,7 @@ import software.amazon.awssdk.services.rds.model.EngineDefaults;
 import software.amazon.awssdk.services.rds.model.Filter;
 import software.amazon.awssdk.services.rds.model.InvalidDbParameterGroupStateException;
 import software.amazon.awssdk.services.rds.model.Parameter;
+import software.amazon.awssdk.services.rds.model.Tag;
 import software.amazon.cloudformation.exceptions.CfnInvalidRequestException;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.CallChain.Completed;
@@ -158,12 +160,18 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
             final Tagging.TagSet previousTags,
             final Tagging.TagSet desiredTags
     ) {
-        final Tagging.TagSet tagsToAdd = Tagging.exclude(desiredTags, previousTags);
-        final Tagging.TagSet tagsToRemove = Tagging.exclude(previousTags, desiredTags);
+        final Collection<Tag> effectivePreviousTags = Tagging.translateTagsToSdk(previousTags);
+        final Collection<Tag> effectiveDesiredTags = Tagging.translateTagsToSdk(desiredTags);
+
+        final Collection<Tag> tagsToRemove = Tagging.exclude(effectivePreviousTags, effectiveDesiredTags);
+        final Collection<Tag> tagsToAdd = Tagging.exclude(effectiveDesiredTags, effectivePreviousTags);
 
         if (tagsToAdd.isEmpty() && tagsToRemove.isEmpty()) {
             return progress;
         }
+
+        final Tagging.TagSet rulesetTagsToAdd = Tagging.exclude(desiredTags, previousTags);
+        final Tagging.TagSet rulesetTagsToRemove = Tagging.exclude(previousTags, desiredTags);
 
         try {
             final String arn = progress.getCallbackContext().getDbClusterParameterGroupArn();
@@ -175,8 +183,8 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
                     exception,
                     DEFAULT_DB_CLUSTER_PARAMETER_GROUP_ERROR_RULE_SET.extendWith(
                             Tagging.bestEffortErrorRuleSet(
-                                    tagsToAdd,
-                                    tagsToRemove,
+                                    rulesetTagsToAdd,
+                                    rulesetTagsToRemove,
                                     Tagging.SOFT_FAIL_IN_PROGRESS_TAGGING_ERROR_RULE_SET,
                                     Tagging.HARD_FAIL_TAG_ERROR_RULE_SET
                             )

--- a/aws-rds-dbclusterparametergroup/src/test/java/software/amazon/rds/dbclusterparametergroup/AbstractHandlerTest.java
+++ b/aws-rds-dbclusterparametergroup/src/test/java/software/amazon/rds/dbclusterparametergroup/AbstractHandlerTest.java
@@ -58,6 +58,8 @@ public abstract class AbstractHandlerTest extends AbstractTestBase<DBClusterPara
 
     protected static final DBClusterParameterGroup DB_CLUSTER_PARAMETER_GROUP;
     protected static final List<Tag> TAG_SET;
+    protected static final List<Tag> TAG_SET_ALTER;
+
     protected static final Parameter PARAM_1, PARAM_2;
 
     protected static final String ARN = "arn";
@@ -65,6 +67,8 @@ public abstract class AbstractHandlerTest extends AbstractTestBase<DBClusterPara
     protected static final String FAMILY = "default.aurora.5";
     protected static final String TAG_KEY = "key";
     protected static final String TAG_VALUE = "value";
+    protected static final String TAG_VALUE_ALTER = "value-alter";
+
     protected static final String UPDATED_DESCRIPTION = "updated description";
 
     static {
@@ -108,6 +112,7 @@ public abstract class AbstractHandlerTest extends AbstractTestBase<DBClusterPara
                 .build();
 
         TAG_SET = Lists.newArrayList(Tag.builder().key(TAG_KEY).value(TAG_VALUE).build());
+        TAG_SET_ALTER = Lists.newArrayList(Tag.builder().key(TAG_KEY).value(TAG_VALUE_ALTER).build());
 
         DB_CLUSTER_PARAMETER_GROUP = DBClusterParameterGroup.builder()
                 .dbClusterParameterGroupArn(ARN)

--- a/aws-rds-dbclusterparametergroup/src/test/java/software/amazon/rds/dbclusterparametergroup/UpdateHandlerTest.java
+++ b/aws-rds-dbclusterparametergroup/src/test/java/software/amazon/rds/dbclusterparametergroup/UpdateHandlerTest.java
@@ -201,16 +201,16 @@ public class UpdateHandlerTest extends AbstractHandlerTest {
 
         test_handleRequest_base(
                 callbackContext,
-                ResourceHandlerRequest.<ResourceModel>builder()
-                        .desiredResourceTags(translateTagsToMap(TAG_SET)),
                 () -> DBClusterParameterGroup.builder().dbClusterParameterGroupArn(ARN).build(),
                 () -> RESOURCE_MODEL,
-                () -> RESOURCE_MODEL,
+                () -> RESOURCE_MODEL.toBuilder().tags(TAG_SET_ALTER).build(),
                 expectSuccess()
         );
 
         verify(rdsProxy.client(), times(1)).describeDBClusterParameterGroups(any(DescribeDbClusterParameterGroupsRequest.class));
         verify(rdsProxy.client(), times(1)).addTagsToResource(any(AddTagsToResourceRequest.class));
+        verify(rdsProxy.client(), times(1)).removeTagsFromResource(any(RemoveTagsFromResourceRequest.class));
+
     }
 
     @Test

--- a/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/UpdateHandlerTest.java
+++ b/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/UpdateHandlerTest.java
@@ -16,6 +16,7 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
@@ -314,6 +315,41 @@ public class UpdateHandlerTest extends AbstractHandlerTest {
     }
 
     @Test
+    public void handleRequest_ResourceTagsPrioritizedOverStackTags() {
+        final AddTagsToResourceResponse addTagsToResourceResponse = AddTagsToResourceResponse.builder().build();
+        when(rdsProxy.client().addTagsToResource(any(AddTagsToResourceRequest.class))).thenReturn(addTagsToResourceResponse);
+
+        final CallbackContext context = new CallbackContext();
+        context.setUpdated(true);
+        context.setRebooted(true);
+        context.setUpdatedRoles(true);
+        context.setStorageAllocated(true);
+
+        List<Tag> updatedTags = new ArrayList<>(TAG_LIST);
+        updatedTags.add(Tag.builder().key("tag-key").value("resource-level").build());
+
+        test_handleRequest_base(
+                context,
+                ResourceHandlerRequest.<ResourceModel>builder()
+                        .previousResourceTags(Collections.emptyMap())
+                        .desiredResourceTags(Translator.translateTagsToRequest(Collections.singleton(
+                                Tag.builder().key("tag-key").value("stack-level").build()
+                        ))),
+                () -> DB_INSTANCE_ACTIVE,
+                () -> RESOURCE_MODEL_BLDR().build(),
+                () -> RESOURCE_MODEL_BLDR().tags(updatedTags).build(),
+                expectSuccess()
+        );
+
+        final ArgumentCaptor<AddTagsToResourceRequest> captor = ArgumentCaptor.forClass(AddTagsToResourceRequest.class);
+        verify(rdsProxy.client()).addTagsToResource(captor.capture());
+        Assertions.assertThat(captor.getValue().tags())
+                .containsExactlyInAnyOrder(
+                        software.amazon.awssdk.services.rds.model.Tag .builder().key("tag-key").value("resource-level").build());
+        verify(rdsProxy.client(), times(2)).describeDBInstances(any(DescribeDbInstancesRequest.class));
+    }
+
+    @Test
     public void handleRequest_SuccessTagsRemoveOnly() {
         final RemoveTagsFromResourceResponse removeTagsFromResourceResponse = RemoveTagsFromResourceResponse.builder().build();
         when(rdsProxy.client().removeTagsFromResource(any(RemoveTagsFromResourceRequest.class))).thenReturn(removeTagsFromResourceResponse);
@@ -333,6 +369,62 @@ public class UpdateHandlerTest extends AbstractHandlerTest {
         );
 
         verify(rdsProxy.client()).removeTagsFromResource(any(RemoveTagsFromResourceRequest.class));
+        verify(rdsProxy.client(), times(2)).describeDBInstances(any(DescribeDbInstancesRequest.class));
+    }
+
+    @Test
+    public void handleRequest_StackLevelTagsRemovalDoesNotRemoveTagsIfTheyExistOnResourceLevel() {
+        final CallbackContext context = new CallbackContext();
+        context.setUpdated(true);
+        context.setRebooted(true);
+        context.setUpdatedRoles(true);
+        context.setStorageAllocated(true);
+
+        test_handleRequest_base(
+                context,
+                ResourceHandlerRequest.<ResourceModel>builder()
+                        .previousResourceTags(Translator.translateTagsToRequest(TAG_LIST))
+                        .desiredResourceTags(Collections.emptyMap()),
+                () -> DB_INSTANCE_ACTIVE,
+                () -> RESOURCE_MODEL_BLDR().build(),
+                () -> RESOURCE_MODEL_BLDR().build(),
+                expectSuccess()
+        );
+
+        verify(rdsProxy.client(), times(1)).describeDBInstances(any(DescribeDbInstancesRequest.class));
+    }
+
+    @Test
+    public void handleRequest_FallBackToStackLevelTagsIfResourceLevelWasRemoved() {
+        final AddTagsToResourceResponse addTagsToResourceResponse = AddTagsToResourceResponse.builder().build();
+        when(rdsProxy.client().addTagsToResource(any(AddTagsToResourceRequest.class))).thenReturn(addTagsToResourceResponse);
+
+        final CallbackContext context = new CallbackContext();
+        context.setUpdated(true);
+        context.setRebooted(true);
+        context.setUpdatedRoles(true);
+        context.setStorageAllocated(true);
+
+        test_handleRequest_base(
+                context,
+                ResourceHandlerRequest.<ResourceModel>builder()
+                        .previousResourceTags(Translator.translateTagsToRequest(Collections.singleton(
+                                Tag.builder().key("tag-key").value("stack-level").build())))
+                        .desiredResourceTags(Translator.translateTagsToRequest(Collections.singleton(
+                                Tag.builder().key("tag-key").value("stack-level").build()))),
+                () -> DB_INSTANCE_ACTIVE,
+                () -> RESOURCE_MODEL_BLDR().tags(Collections.singletonList(Tag.builder().key("tag-key").value("resource-level").build())).build(),
+                () -> RESOURCE_MODEL_BLDR().tags(Collections.emptyList()).build(),
+                expectSuccess()
+        );
+
+        final ArgumentCaptor<AddTagsToResourceRequest> captor = ArgumentCaptor.forClass(AddTagsToResourceRequest.class);
+        verify(rdsProxy.client()).addTagsToResource(captor.capture());
+        Assertions.assertThat(captor.getValue().tags())
+                .containsExactlyInAnyOrder(
+                        software.amazon.awssdk.services.rds.model.Tag .builder().key("tag-key").value("stack-level").build());
+        verify(rdsProxy.client()).removeTagsFromResource(any(RemoveTagsFromResourceRequest.class));
+
         verify(rdsProxy.client(), times(2)).describeDBInstances(any(DescribeDbInstancesRequest.class));
     }
 

--- a/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/UpdateHandlerTest.java
+++ b/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/UpdateHandlerTest.java
@@ -13,7 +13,10 @@ import static software.amazon.rds.dbinstance.BaseHandlerStd.RESOURCE_UPDATED_AT;
 
 import java.time.Duration;
 import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.function.Supplier;
@@ -295,14 +298,14 @@ public class UpdateHandlerTest extends AbstractHandlerTest {
         context.setUpdatedRoles(true);
         context.setStorageAllocated(true);
 
+        List<Tag> updatedTags = new ArrayList<>(TAG_LIST);
+        updatedTags.add(Tag.builder().key("updated").value("tag").build());
+
         test_handleRequest_base(
                 context,
-                ResourceHandlerRequest.<ResourceModel>builder()
-                        .previousResourceTags(Collections.emptyMap())
-                        .desiredResourceTags(Translator.translateTagsToRequest(TAG_LIST)),
                 () -> DB_INSTANCE_ACTIVE,
                 () -> RESOURCE_MODEL_BLDR().build(),
-                () -> RESOURCE_MODEL_BLDR().build(),
+                () -> RESOURCE_MODEL_BLDR().tags(updatedTags).build(),
                 expectSuccess()
         );
 
@@ -323,12 +326,9 @@ public class UpdateHandlerTest extends AbstractHandlerTest {
 
         test_handleRequest_base(
                 context,
-                ResourceHandlerRequest.<ResourceModel>builder()
-                        .previousResourceTags(Translator.translateTagsToRequest(TAG_LIST))
-                        .desiredResourceTags(Translator.translateTagsToRequest(TAG_LIST_EMPTY)),
                 () -> DB_INSTANCE_ACTIVE,
                 () -> RESOURCE_MODEL_BLDR().build(),
-                () -> RESOURCE_MODEL_BLDR().build(),
+                () -> RESOURCE_MODEL_BLDR().tags(Collections.emptyList()).build(),
                 expectSuccess()
         );
 


### PR DESCRIPTION
This PR makes sure that Resource level tags always take precedence over stack level tags. If there is a collision between stack and resource level tags, previously erroneous AddTagsToResource or RemoveTagsFromResource requests could be sent. This PR addresses this issue. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
