### PR TITLE
[CustomDBEngineVersion] Update ListHandler logic to return only created custom

### DIFF
--- a/aws-rds-customdbengineversion/src/main/java/software/amazon/rds/customdbengineversion/ListHandler.java
+++ b/aws-rds-customdbengineversion/src/main/java/software/amazon/rds/customdbengineversion/ListHandler.java
@@ -1,7 +1,11 @@
 package software.amazon.rds.customdbengineversion;
 
+import java.util.Collection;
 import java.util.List;
 
+import org.apache.commons.lang3.StringUtils;
+
+import com.google.common.collect.ImmutableList;
 import software.amazon.awssdk.services.rds.RdsClient;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.Logger;
@@ -12,6 +16,14 @@ import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 import software.amazon.rds.common.handler.HandlerConfig;
 
 public class ListHandler extends BaseHandlerStd {
+
+    final static Collection<String> CUSTOM_ENGINES = ImmutableList.of(
+            "custom-oracle-ee",
+            "custom-oracle-ee-cdb",
+            "custom-sqlserver-ee",
+            "custom-sqlserver-se",
+            "custom-sqlserver-web"
+    );
 
     public ListHandler() {
         this(CUSTOM_ENGINE_VERSION_HANDLER_CONFIG_10H);
@@ -28,13 +40,14 @@ public class ListHandler extends BaseHandlerStd {
                                                                           final ProxyClient<RdsClient> proxyClient,
                                                                           final Logger logger) {
         return proxy.initiate("rds::list-db-engine-versions", proxyClient, request.getDesiredResourceState(), callbackContext)
-                .translateToServiceRequest(resourceModel -> Translator.describeDbEngineVersionsRequest(resourceModel, request.getNextToken()))
+                .translateToServiceRequest(resourceModel -> Translator.describeDbEngineVersionsRequest(resourceModel, CUSTOM_ENGINES, request.getNextToken()))
                 .backoffDelay(config.getBackoff())
                 .makeServiceCall((describeRequest, proxyInvocation) -> proxyInvocation.injectCredentialsAndInvokeV2(
                         describeRequest,
                         proxyInvocation.client()::describeDBEngineVersions
                 )).done((describeRequest, describeResponse, proxyInvocation, resourceModel, context) -> {
-                    final List<ResourceModel> resourceModels = Translator.translateFromSdk(describeResponse.dbEngineVersions().stream());
+                    final List<ResourceModel> resourceModels = Translator.translateFromSdk(describeResponse.dbEngineVersions().stream()
+                            .filter(dbEngineVersion -> StringUtils.isNotBlank(dbEngineVersion.dbEngineVersionArn())));
                     return ProgressEvent.<ResourceModel, CallbackContext>builder()
                             .callbackContext(callbackContext)
                             .resourceModels(resourceModels)

--- a/aws-rds-customdbengineversion/src/main/java/software/amazon/rds/customdbengineversion/Translator.java
+++ b/aws-rds-customdbengineversion/src/main/java/software/amazon/rds/customdbengineversion/Translator.java
@@ -12,11 +12,15 @@ import software.amazon.awssdk.services.rds.model.CreateCustomDbEngineVersionRequ
 import software.amazon.awssdk.services.rds.model.DBEngineVersion;
 import software.amazon.awssdk.services.rds.model.DeleteCustomDbEngineVersionRequest;
 import software.amazon.awssdk.services.rds.model.DescribeDbEngineVersionsRequest;
+import software.amazon.awssdk.services.rds.model.Filter;
 import software.amazon.awssdk.services.rds.model.ModifyCustomDbEngineVersionRequest;
 import software.amazon.rds.common.handler.Tagging;
 import software.amazon.rds.common.util.DifferenceUtils;
 
 public class Translator {
+
+    public static final String ENGINE_FILTER_NAME = "engine";
+
     public static CreateCustomDbEngineVersionRequest createCustomDbEngineVersionRequest(
             final ResourceModel model,
             final Tagging.TagSet tags
@@ -110,13 +114,17 @@ public class Translator {
                 .build();
     }
 
-    public static DescribeDbEngineVersionsRequest describeDbEngineVersionsRequest(final ResourceModel model,
+    public static DescribeDbEngineVersionsRequest describeDbEngineVersionsRequest(final ResourceModel model, final Collection<String> engines,
                                                                                   final String nextToken) {
         return DescribeDbEngineVersionsRequest.builder()
                 .engine(model.getEngine())
                 .engineVersion(model.getEngineVersion())
-                .marker(nextToken)
+                .filters(Filter.builder()
+                        .name(ENGINE_FILTER_NAME)
+                        .values(engines)
+                        .build())
                 .includeAll(true)
+                .marker(nextToken)
                 .build();
     }
 


### PR DESCRIPTION
*Description of changes:*
In this code modification, I have adjusted the behavior to only return the custom engine versions that have been created, rather than returning all engine versions present in RDS.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
