### PR TITLE
[Common][All] remove silent failure mechanism and throw unauthorized tagging exception

### DIFF
--- a/aws-rds-cfn-common/src/main/java/software/amazon/rds/common/handler/Tagging.java
+++ b/aws-rds-cfn-common/src/main/java/software/amazon/rds/common/handler/Tagging.java
@@ -22,7 +22,6 @@ import software.amazon.awssdk.services.rds.model.RemoveTagsFromResourceRequest;
 import software.amazon.awssdk.services.rds.model.Tag;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.HandlerErrorCode;
-import software.amazon.cloudformation.proxy.OperationStatus;
 import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.rds.common.error.ErrorCode;
@@ -30,26 +29,27 @@ import software.amazon.rds.common.error.ErrorRuleSet;
 import software.amazon.rds.common.error.ErrorStatus;
 
 public final class Tagging {
-    public static final ErrorRuleSet SOFT_FAIL_IN_PROGRESS_TAGGING_ERROR_RULE_SET = ErrorRuleSet
+    public static final ErrorRuleSet IGNORE_LIST_TAGS_PERMISSION_DENIED_ERROR_RULE_SET = ErrorRuleSet
             .extend(ErrorRuleSet.EMPTY_RULE_SET)
-            .withErrorCodes(ErrorStatus.ignore(OperationStatus.IN_PROGRESS),
+            .withErrorCodes(ErrorStatus.ignore(),
                     ErrorCode.AccessDenied,
                     ErrorCode.AccessDeniedException)
             .build();
 
-    public static final ErrorRuleSet SOFT_FAIL_TAG_ERROR_RULE_SET = ErrorRuleSet
+    public static final ErrorRuleSet STACK_TAGS_ERROR_RULE_SET = ErrorRuleSet
             .extend(ErrorRuleSet.EMPTY_RULE_SET)
-            .withErrorCodes(ErrorStatus.ignore(),
+            .withErrorCodes(ErrorStatus.failWith(HandlerErrorCode.UnauthorizedTaggingOperation),
                     ErrorCode.AccessDenied,
                     ErrorCode.AccessDeniedException
             ).build();
 
-    public static final ErrorRuleSet HARD_FAIL_TAG_ERROR_RULE_SET = ErrorRuleSet
+    public static final ErrorRuleSet RESOURCE_TAG_ERROR_RULE_SET = ErrorRuleSet
             .extend(ErrorRuleSet.EMPTY_RULE_SET)
             .withErrorCodes(ErrorStatus.failWith(HandlerErrorCode.AccessDenied),
                     ErrorCode.AccessDenied,
                     ErrorCode.AccessDeniedException
             ).build();
+    public static final String RDS_ADD_TAGS_TO_RESOURCE_ACTION = "rds:AddTagsToResource";
 
     public static TagSet exclude(final TagSet from, final TagSet what) {
         final Set<Tag> systemTags = new LinkedHashSet<>(from.getSystemTags());
@@ -194,56 +194,52 @@ public final class Tagging {
                 .build();
     }
 
-    public static ErrorRuleSet bestEffortErrorRuleSet(
+    public static ErrorRuleSet getUpdateTagsAccessDeniedRuleSet(
             final TagSet tagsToAdd,
             final TagSet tagsToRemove
     ) {
-        return bestEffortErrorRuleSet(tagsToAdd, tagsToRemove, SOFT_FAIL_TAG_ERROR_RULE_SET, HARD_FAIL_TAG_ERROR_RULE_SET);
+        return getUpdateTagsAccessDeniedRuleSet(tagsToAdd, tagsToRemove, STACK_TAGS_ERROR_RULE_SET, RESOURCE_TAG_ERROR_RULE_SET);
     }
 
-    public static ErrorRuleSet bestEffortErrorRuleSet(
+    public static ErrorRuleSet getUpdateTagsAccessDeniedRuleSet(
             final TagSet tagsToAdd,
             final TagSet tagsToRemove,
-            final ErrorRuleSet softFailErrorRuleSet,
-            final ErrorRuleSet hardFailErrorRuleSet
+            final ErrorRuleSet stackTagsErrorRuleSet,
+            final ErrorRuleSet resourceTagsErrorRuleSet
     ) {
-        // Only soft fail if the customer provided no resource-level tags
+        /* If the tagging operation comes across an AccessDenied error, we will throw an UnauthorizedTaggingOperation
+        errorCode for stack level tags. For Resource tags, if they are included, we will throw an AccessDenied error.
+        This is done to ensure backward compatibility. */
         if (tagsToAdd.getResourceTags().isEmpty() && tagsToRemove.getResourceTags().isEmpty()) {
-            return softFailErrorRuleSet;
+            return stackTagsErrorRuleSet;
         }
-        return hardFailErrorRuleSet;
+        return resourceTagsErrorRuleSet;
     }
 
-    public static <M, C extends TaggingContext.Provider> ProgressEvent<M, C> safeCreate(
+    public static <M, C extends TaggingContext.Provider> ProgressEvent<M, C> createWithTaggingFallback(
             final AmazonWebServicesClientProxy proxy,
             final ProxyClient<RdsClient> rdsProxyClient,
             final HandlerMethod<M, C> handlerMethod,
             final ProgressEvent<M, C> progress,
             final Tagging.TagSet allTags
     ) {
-        return progress.then(p -> {
-            final C context = p.getCallbackContext();
-            if (context.getTaggingContext().isSoftFailTags()) {
-                return p;
+        final ProgressEvent<M, C> allTagsResult = handlerMethod.invoke(proxy, rdsProxyClient, progress, allTags);
+        if (allTagsResult.isFailed()) {
+            if (isUnauthorizedTaggingFailure(allTagsResult, allTags)) {
+                allTagsResult.setErrorCode(HandlerErrorCode.UnauthorizedTaggingOperation);
             }
-            final ProgressEvent<M, C> allTagsResult = handlerMethod.invoke(proxy, rdsProxyClient, p, allTags);
-            if (allTagsResult.isFailed()) {
-                if (HandlerErrorCode.AccessDenied.equals(allTagsResult.getErrorCode())) {
-                    context.getTaggingContext().setSoftFailTags(true);
-                    return ProgressEvent.progress(allTagsResult.getResourceModel(), context);
-                }
-                return allTagsResult;
-            }
-            allTagsResult.getCallbackContext().getTaggingContext().setAddTagsComplete(true);
             return allTagsResult;
-        }).then(p -> {
-            final C context = p.getCallbackContext();
-            if (!context.getTaggingContext().isSoftFailTags()) {
-                return p;
-            }
-            final Tagging.TagSet systemTags = Tagging.TagSet.builder().systemTags(allTags.getSystemTags()).build();
-            return handlerMethod.invoke(proxy, rdsProxyClient, p, systemTags);
-        });
+        }
+        allTagsResult.getCallbackContext().getTaggingContext().setAddTagsComplete(true);
+        return allTagsResult;
+    }
+
+    private static <M, C extends TaggingContext.Provider> boolean isUnauthorizedTaggingFailure(final ProgressEvent<M, C> allTagsResult,
+                                                                                               final TagSet allTags) {
+        return HandlerErrorCode.AccessDenied.equals(allTagsResult.getErrorCode()) &&
+                        allTags.getResourceTags().isEmpty() &&
+                        allTagsResult.getMessage() != null &&
+                        allTagsResult.getMessage().contains(RDS_ADD_TAGS_TO_RESOURCE_ACTION);
     }
 
     private static void addToMapIfAbsent(Map<String, Tag> allTags, Collection<Tag> tags) {

--- a/aws-rds-cfn-common/src/main/java/software/amazon/rds/common/handler/TaggingContext.java
+++ b/aws-rds-cfn-common/src/main/java/software/amazon/rds/common/handler/TaggingContext.java
@@ -5,7 +5,6 @@ package software.amazon.rds.common.handler;
 @lombok.ToString
 @lombok.EqualsAndHashCode
 public class TaggingContext {
-    private boolean softFailTags;
     private boolean addTagsComplete;
 
     public interface Provider {

--- a/aws-rds-customdbengineversion/src/main/java/software/amazon/rds/customdbengineversion/BaseHandlerStd.java
+++ b/aws-rds-customdbengineversion/src/main/java/software/amazon/rds/customdbengineversion/BaseHandlerStd.java
@@ -185,11 +185,9 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
                 progress,
                 exception,
                 DEFAULT_CUSTOM_DB_ENGINE_VERSION_ERROR_RULE_SET.extendWith(
-                        Tagging.bestEffortErrorRuleSet(
+                        Tagging.getUpdateTagsAccessDeniedRuleSet(
                                 tagsToAdd,
-                                tagsToRemove,
-                                Tagging.SOFT_FAIL_IN_PROGRESS_TAGGING_ERROR_RULE_SET,
-                                Tagging.HARD_FAIL_TAG_ERROR_RULE_SET
+                                tagsToRemove
                         )
                 )
         );

--- a/aws-rds-customdbengineversion/src/main/java/software/amazon/rds/customdbengineversion/CreateHandler.java
+++ b/aws-rds-customdbengineversion/src/main/java/software/amazon/rds/customdbengineversion/CreateHandler.java
@@ -74,7 +74,7 @@ public class CreateHandler extends BaseHandlerStd {
                                                                                         final ProxyClient<RdsClient> proxyClient,
                                                                                         final ProgressEvent<ResourceModel, CallbackContext> progress,
                                                                                         final Tagging.TagSet allTags) {
-        return Tagging.safeCreate(proxy, proxyClient, this::createCustomEngineVersion, progress, allTags)
+        return Tagging.createWithTaggingFallback(proxy, proxyClient, this::createCustomEngineVersion, progress, allTags)
                 .then(p -> Commons.execOnce(p, () -> {
                     final Tagging.TagSet extraTags = Tagging.TagSet.builder()
                             .stackTags(allTags.getStackTags())

--- a/aws-rds-customdbengineversion/src/test/java/software/amazon/rds/customdbengineversion/CreateHandlerTest.java
+++ b/aws-rds-customdbengineversion/src/test/java/software/amazon/rds/customdbengineversion/CreateHandlerTest.java
@@ -1,6 +1,7 @@
 package software.amazon.rds.customdbengineversion;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -9,6 +10,7 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import java.time.Duration;
+import java.util.Objects;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.assertj.core.api.Assertions;
@@ -16,6 +18,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.platform.commons.util.StringUtils;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -177,80 +180,14 @@ public class CreateHandlerTest extends AbstractHandlerTest {
                                 .awsErrorDetails(AwsErrorDetails.builder()
                                         .errorCode(ErrorCode.AccessDeniedException.toString())
                                         .build()
-                                ).build())
-                .thenReturn(CreateCustomDbEngineVersionResponse.builder().build());
-        when(rdsProxy.client().addTagsToResource(any(AddTagsToResourceRequest.class)))
-                .thenReturn(AddTagsToResourceResponse.builder().build());
-
-        final Tagging.TagSet extraTags = Tagging.TagSet.builder()
-                .stackTags(TAG_SET.getStackTags())
-                .resourceTags(TAG_SET.getResourceTags())
-                .build();
+                                ).build());
 
         final ProgressEvent<ResourceModel, CallbackContext> progress = test_handleRequest_base(
                 new CallbackContext(),
                 ResourceHandlerRequest.<ResourceModel>builder()
                         .systemTags(Translator.translateTagsToRequest(Translator.translateTagsFromSdk(TAG_SET.getSystemTags())))
                         .desiredResourceTags(Translator.translateTagsToRequest(Translator.translateTagsFromSdk(TAG_SET.getStackTags()))),
-                () -> DB_ENGINE_VERSION_AVAILABLE,
                 null,
-                () -> RESOURCE_MODEL.toBuilder()
-                        .tags(Translator.translateTagsFromSdk(TAG_SET.getResourceTags()))
-                        .build(),
-                expectSuccess()
-        );
-
-        Assertions.assertThat(progress.getCallbackContext().isAddTagsComplete()).isTrue();
-        Assertions.assertThat(progress.getCallbackContext().getTaggingContext().isSoftFailTags()).isTrue();
-
-        ArgumentCaptor<CreateCustomDbEngineVersionRequest> createCaptor = ArgumentCaptor.forClass(CreateCustomDbEngineVersionRequest.class);
-        verify(rdsProxy.client(), times(2)).createCustomDBEngineVersion(createCaptor.capture());
-        final CreateCustomDbEngineVersionRequest requestWithAllTags = createCaptor.getAllValues().get(0);
-        final CreateCustomDbEngineVersionRequest requestWithSystemTags = createCaptor.getAllValues().get(1);
-        Assertions.assertThat(requestWithAllTags.tags()).containsExactlyInAnyOrder(
-                Iterables.toArray(Tagging.translateTagsToSdk(TAG_SET), software.amazon.awssdk.services.rds.model.Tag.class));
-        Assertions.assertThat(requestWithSystemTags.tags()).containsExactlyInAnyOrder(
-                Iterables.toArray(TAG_SET.getSystemTags(), software.amazon.awssdk.services.rds.model.Tag.class));
-
-        verify(rdsProxy.client(), times(3)).describeDBEngineVersions(any(DescribeDbEngineVersionsRequest.class));
-
-        ArgumentCaptor<AddTagsToResourceRequest> addTagsCaptor = ArgumentCaptor.forClass(AddTagsToResourceRequest.class);
-        verify(rdsProxy.client(), times(1)).addTagsToResource(addTagsCaptor.capture());
-        Assertions.assertThat(addTagsCaptor.getValue().tags()).containsExactlyInAnyOrder(
-                Iterables.toArray(Tagging.translateTagsToSdk(extraTags), software.amazon.awssdk.services.rds.model.Tag.class));
-    }
-
-
-    @Test
-    public void handleRequest_HardFailTagging() {
-        when(rdsProxy.client().createCustomDBEngineVersion(any(CreateCustomDbEngineVersionRequest.class)))
-                .thenThrow(
-                        RdsException.builder()
-                                .awsErrorDetails(AwsErrorDetails.builder()
-                                        .errorCode(ErrorCode.AccessDeniedException.toString())
-                                        .build()
-                                ).build())
-                .thenReturn(CreateCustomDbEngineVersionResponse.builder().build());
-
-        when(rdsProxy.client().addTagsToResource(any(AddTagsToResourceRequest.class)))
-                .thenThrow(
-                        RdsException.builder()
-                                .awsErrorDetails(AwsErrorDetails.builder()
-                                        .errorCode(ErrorCode.AccessDeniedException.toString())
-                                        .build()
-                                ).build());
-
-        final Tagging.TagSet extraTags = Tagging.TagSet.builder()
-                .stackTags(TAG_SET.getStackTags())
-                .resourceTags(TAG_SET.getResourceTags())
-                .build();
-
-        test_handleRequest_base(
-                new CallbackContext(),
-                ResourceHandlerRequest.<ResourceModel>builder()
-                        .systemTags(Translator.translateTagsToRequest(Translator.translateTagsFromSdk(TAG_SET.getSystemTags())))
-                        .desiredResourceTags(Translator.translateTagsToRequest(Translator.translateTagsFromSdk(TAG_SET.getStackTags()))),
-                () -> DB_ENGINE_VERSION_AVAILABLE,
                 null,
                 () -> RESOURCE_MODEL.toBuilder()
                         .tags(Translator.translateTagsFromSdk(TAG_SET.getResourceTags()))
@@ -259,19 +196,45 @@ public class CreateHandlerTest extends AbstractHandlerTest {
         );
 
         ArgumentCaptor<CreateCustomDbEngineVersionRequest> createCaptor = ArgumentCaptor.forClass(CreateCustomDbEngineVersionRequest.class);
-        verify(rdsProxy.client(), times(2)).createCustomDBEngineVersion(createCaptor.capture());
+        verify(rdsProxy.client(), times(1)).createCustomDBEngineVersion(createCaptor.capture());
         final CreateCustomDbEngineVersionRequest requestWithAllTags = createCaptor.getAllValues().get(0);
-        final CreateCustomDbEngineVersionRequest requestWithSystemTags = createCaptor.getAllValues().get(1);
         Assertions.assertThat(requestWithAllTags.tags()).containsExactlyInAnyOrder(
                 Iterables.toArray(Tagging.translateTagsToSdk(TAG_SET), software.amazon.awssdk.services.rds.model.Tag.class));
-        Assertions.assertThat(requestWithSystemTags.tags()).containsExactlyInAnyOrder(
-                Iterables.toArray(TAG_SET.getSystemTags(), software.amazon.awssdk.services.rds.model.Tag.class));
+    }
 
-        verify(rdsProxy.client(), times(2)).describeDBEngineVersions(any(DescribeDbEngineVersionsRequest.class));
 
-        ArgumentCaptor<AddTagsToResourceRequest> addTagsCaptor = ArgumentCaptor.forClass(AddTagsToResourceRequest.class);
-        verify(rdsProxy.client(), times(1)).addTagsToResource(addTagsCaptor.capture());
-        Assertions.assertThat(addTagsCaptor.getValue().tags()).containsExactlyInAnyOrder(
-                Iterables.toArray(Tagging.translateTagsToSdk(extraTags), software.amazon.awssdk.services.rds.model.Tag.class));
+    @Test
+    public void handleRequest_HardFailTagging() {
+        when(rdsProxy.client().createCustomDBEngineVersion(any(CreateCustomDbEngineVersionRequest.class)))
+                .thenThrow(
+                        RdsException.builder()
+                                .message("Role not authorized to execute rds:AddTagsToResource")
+                                .awsErrorDetails(AwsErrorDetails.builder()
+                                        .errorCode(ErrorCode.AccessDeniedException.toString())
+                                        .build()
+                                ).build());
+
+        test_handleRequest_base(
+                new CallbackContext(),
+                ResourceHandlerRequest.<ResourceModel>builder()
+                        .systemTags(Translator.translateTagsToRequest(Translator.translateTagsFromSdk(TAG_SET.getSystemTags())))
+                        .desiredResourceTags(Translator.translateTagsToRequest(Translator.translateTagsFromSdk(TAG_SET.getStackTags()))),
+                null,
+                null,
+                () -> RESOURCE_MODEL.toBuilder()
+                        .tags(null)
+                        .build(),
+                expectFailed(HandlerErrorCode.UnauthorizedTaggingOperation)
+        );
+
+        final Tagging.TagSet expectedRequestTags = Tagging.TagSet.builder()
+                .stackTags(TAG_SET.getStackTags())
+                .systemTags(TAG_SET.getSystemTags())
+                .build();
+        ArgumentCaptor<CreateCustomDbEngineVersionRequest> createCaptor = ArgumentCaptor.forClass(CreateCustomDbEngineVersionRequest.class);
+        verify(rdsProxy.client(), times(1)).createCustomDBEngineVersion(createCaptor.capture());
+        final CreateCustomDbEngineVersionRequest requestWithAllTags = createCaptor.getAllValues().get(0);
+        Assertions.assertThat(requestWithAllTags.tags()).containsExactlyInAnyOrder(
+                Iterables.toArray(Tagging.translateTagsToSdk(expectedRequestTags), software.amazon.awssdk.services.rds.model.Tag.class));
     }
 }

--- a/aws-rds-customdbengineversion/src/test/java/software/amazon/rds/customdbengineversion/UpdateHandlerTest.java
+++ b/aws-rds-customdbengineversion/src/test/java/software/amazon/rds/customdbengineversion/UpdateHandlerTest.java
@@ -215,7 +215,9 @@ public class UpdateHandlerTest extends AbstractHandlerTest {
     }
 
     @Test
-    public void handleRequest_SoftFailingTaggingOnRemoveTags() {
+    public void handleRequest_HardFailWithUnauthorizedTagsOnRemove() {
+        when(rdsProxy.client().modifyCustomDBEngineVersion(any(ModifyCustomDbEngineVersionRequest.class)))
+                .thenReturn(ModifyCustomDbEngineVersionResponse.builder().build());
         when(rdsProxy.client().removeTagsFromResource(any(RemoveTagsFromResourceRequest.class)))
                 .thenThrow(
                         RdsException.builder().awsErrorDetails(AwsErrorDetails.builder()
@@ -226,19 +228,22 @@ public class UpdateHandlerTest extends AbstractHandlerTest {
         test_handleRequest_base(
                 context,
                 ResourceHandlerRequest.<ResourceModel>builder()
-                        .previousSystemTags(Translator.translateTagsToRequest(TAG_LIST))
-                        .systemTags(Translator.translateTagsToRequest(TAG_LIST_EMPTY)),
+                        .previousResourceTags(Translator.translateTagsToRequest(TAG_LIST))
+                        .desiredResourceTags(Translator.translateTagsToRequest(TAG_LIST_EMPTY)),
                 () -> DB_ENGINE_VERSION_AVAILABLE,
                 () -> RESOURCE_MODEL_BUILDER().build(),
-                () -> RESOURCE_MODEL_BUILDER().build(),
-                expectSuccess()
+                () -> RESOURCE_MODEL_BUILDER().status("inactive").build(),
+                expectFailed(HandlerErrorCode.UnauthorizedTaggingOperation)
         );
 
+        verify(rdsProxy.client(), times(1)).modifyCustomDBEngineVersion(any(ModifyCustomDbEngineVersionRequest.class));
         verify(rdsProxy.client(), times(1)).removeTagsFromResource(any(RemoveTagsFromResourceRequest.class));
     }
 
     @Test
-    public void handleRequest_SoftFailingTaggingOnAddTags() {
+    public void handleRequest_HardFailWithUnauthorizedTagsOnAdd() {
+        when(rdsProxy.client().modifyCustomDBEngineVersion(any(ModifyCustomDbEngineVersionRequest.class)))
+                .thenReturn(ModifyCustomDbEngineVersionResponse.builder().build());
         when(rdsProxy.client().addTagsToResource(any(AddTagsToResourceRequest.class)))
                 .thenThrow(
                         RdsException.builder().awsErrorDetails(AwsErrorDetails.builder()
@@ -253,10 +258,11 @@ public class UpdateHandlerTest extends AbstractHandlerTest {
                         .systemTags(Translator.translateTagsToRequest(TAG_LIST)),
                 () -> DB_ENGINE_VERSION_AVAILABLE,
                 () -> RESOURCE_MODEL_BUILDER().build(),
-                () -> RESOURCE_MODEL_BUILDER().build(),
-                expectSuccess()
+                () -> RESOURCE_MODEL_BUILDER().status("inactive").build(),
+                expectFailed(HandlerErrorCode.UnauthorizedTaggingOperation)
         );
 
+        verify(rdsProxy.client(), times(1)).modifyCustomDBEngineVersion(any(ModifyCustomDbEngineVersionRequest.class));
         verify(rdsProxy.client(), times(1)).addTagsToResource(any(AddTagsToResourceRequest.class));
     }
 }

--- a/aws-rds-dbcluster/docs/README.md
+++ b/aws-rds-dbcluster/docs/README.md
@@ -32,6 +32,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
         "<a href="#domain" title="Domain">Domain</a>" : <i>String</i>,
         "<a href="#domainiamrolename" title="DomainIAMRoleName">DomainIAMRoleName</a>" : <i>String</i>,
         "<a href="#enablecloudwatchlogsexports" title="EnableCloudwatchLogsExports">EnableCloudwatchLogsExports</a>" : <i>[ String, ... ]</i>,
+        "<a href="#enableglobalwriteforwarding" title="EnableGlobalWriteForwarding">EnableGlobalWriteForwarding</a>" : <i>Boolean</i>,
         "<a href="#enablehttpendpoint" title="EnableHttpEndpoint">EnableHttpEndpoint</a>" : <i>Boolean</i>,
         "<a href="#enableiamdatabaseauthentication" title="EnableIAMDatabaseAuthentication">EnableIAMDatabaseAuthentication</a>" : <i>Boolean</i>,
         "<a href="#engine" title="Engine">Engine</a>" : <i>String</i>,
@@ -98,6 +99,7 @@ Properties:
     <a href="#domainiamrolename" title="DomainIAMRoleName">DomainIAMRoleName</a>: <i>String</i>
     <a href="#enablecloudwatchlogsexports" title="EnableCloudwatchLogsExports">EnableCloudwatchLogsExports</a>: <i>
       - String</i>
+    <a href="#enableglobalwriteforwarding" title="EnableGlobalWriteForwarding">EnableGlobalWriteForwarding</a>: <i>Boolean</i>
     <a href="#enablehttpendpoint" title="EnableHttpEndpoint">EnableHttpEndpoint</a>: <i>Boolean</i>
     <a href="#enableiamdatabaseauthentication" title="EnableIAMDatabaseAuthentication">EnableIAMDatabaseAuthentication</a>: <i>Boolean</i>
     <a href="#engine" title="Engine">Engine</a>: <i>String</i>
@@ -345,6 +347,16 @@ The list of log types that need to be enabled for exporting to CloudWatch Logs. 
 _Required_: No
 
 _Type_: List of String
+
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+
+#### EnableGlobalWriteForwarding
+
+Specifies whether to enable this DB cluster to forward write operations to the primary cluster of a global cluster (Aurora global database). By default, write operations are not allowed on Aurora DB clusters that are secondary clusters in an Aurora global database.
+
+_Required_: No
+
+_Type_: Boolean
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 

--- a/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/BaseHandlerStd.java
+++ b/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/BaseHandlerStd.java
@@ -518,7 +518,7 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
             return Commons.handleException(
                     progress,
                     exception,
-                    DEFAULT_DB_CLUSTER_ERROR_RULE_SET.extendWith(Tagging.bestEffortErrorRuleSet(rulesetTagsToAdd, rulesetTagsToRemove))
+                    DEFAULT_DB_CLUSTER_ERROR_RULE_SET.extendWith(Tagging.getUpdateTagsAccessDeniedRuleSet(rulesetTagsToAdd, rulesetTagsToRemove))
             );
         }
 

--- a/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/CreateHandler.java
+++ b/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/CreateHandler.java
@@ -71,11 +71,11 @@ public class CreateHandler extends BaseHandlerStd {
         return ProgressEvent.progress(model, callbackContext)
                 .then(progress -> {
                     if (isRestoreToPointInTime(model)) {
-                        return Tagging.safeCreate(proxy, rdsProxyClient, this::restoreDbClusterToPointInTime, progress, allTags);
+                        return Tagging.createWithTaggingFallback(proxy, rdsProxyClient, this::restoreDbClusterToPointInTime, progress, allTags);
                     } else if (isRestoreFromSnapshot(model)) {
-                        return Tagging.safeCreate(proxy, rdsProxyClient, this::restoreDbClusterFromSnapshot, progress, allTags);
+                        return Tagging.createWithTaggingFallback(proxy, rdsProxyClient, this::restoreDbClusterFromSnapshot, progress, allTags);
                     }
-                    return Tagging.safeCreate(proxy, rdsProxyClient, this::createDbCluster, progress, allTags);
+                    return Tagging.createWithTaggingFallback(proxy, rdsProxyClient, this::createDbCluster, progress, allTags);
                 })
                 .then(progress -> Commons.execOnce(progress, () -> {
                     final Tagging.TagSet extraTags = Tagging.TagSet.builder()

--- a/aws-rds-dbcluster/src/test/java/software/amazon/rds/dbcluster/CreateHandlerTest.java
+++ b/aws-rds-dbcluster/src/test/java/software/amazon/rds/dbcluster/CreateHandlerTest.java
@@ -169,55 +169,39 @@ public class CreateHandlerTest extends AbstractHandlerTest {
     }
 
     @Test
-    public void handleRequest_CreateDbCluster_AccessDeniedTagging() {
+    public void handleRequest_CreateDbCluster_UnauthorizedTaggingOperation() {
         when(rdsProxy.client().createDBCluster(any(CreateDbClusterRequest.class)))
                 .thenThrow(
                         RdsException.builder()
+                                .message("Role not authorized to execute rds:AddTagsToResource")
                                 .awsErrorDetails(AwsErrorDetails.builder()
                                         .errorCode(ErrorCode.AccessDeniedException.toString())
                                         .build()
-                                ).build())
-                .thenReturn(CreateDbClusterResponse.builder().build());
-        when(rdsProxy.client().addRoleToDBCluster(any(AddRoleToDbClusterRequest.class)))
-                .thenReturn(AddRoleToDbClusterResponse.builder().build());
-        when(rdsProxy.client().addTagsToResource(any(AddTagsToResourceRequest.class)))
-                .thenReturn(AddTagsToResourceResponse.builder().build());
-
-        final Tagging.TagSet extraTags = Tagging.TagSet.builder()
-                .stackTags(TAG_SET.getStackTags())
-                .resourceTags(TAG_SET.getResourceTags())
-                .build();
+                                ).build());
 
         test_handleRequest_base(
                 new CallbackContext(),
                 ResourceHandlerRequest.<ResourceModel>builder()
                         .systemTags(Translator.translateTagsToRequest(Translator.translateTagsFromSdk(TAG_SET.getSystemTags())))
                         .desiredResourceTags(Translator.translateTagsToRequest(Translator.translateTagsFromSdk(TAG_SET.getStackTags()))),
-                () -> DBCLUSTER_ACTIVE,
+                null,
                 null,
                 () -> RESOURCE_MODEL.toBuilder()
                         .associatedRoles(ImmutableList.of(ROLE))
-                        .tags(Translator.translateTagsFromSdk(TAG_SET.getResourceTags()))
+                        .tags(null)
                         .build(),
-                expectSuccess()
+                expectFailed(HandlerErrorCode.UnauthorizedTaggingOperation)
         );
 
+        final Tagging.TagSet expectedRequestTags = Tagging.TagSet.builder()
+                .stackTags(TAG_SET.getStackTags())
+                .systemTags(TAG_SET.getSystemTags())
+                .build();
         ArgumentCaptor<CreateDbClusterRequest> createCaptor = ArgumentCaptor.forClass(CreateDbClusterRequest.class);
-        verify(rdsProxy.client(), times(2)).createDBCluster(createCaptor.capture());
+        verify(rdsProxy.client(), times(1)).createDBCluster(createCaptor.capture());
         final CreateDbClusterRequest requestWithAllTags = createCaptor.getAllValues().get(0);
-        final CreateDbClusterRequest requestWithSystemTags = createCaptor.getAllValues().get(1);
         Assertions.assertThat(requestWithAllTags.tags()).containsExactlyInAnyOrder(
-                Iterables.toArray(Tagging.translateTagsToSdk(TAG_SET), software.amazon.awssdk.services.rds.model.Tag.class));
-        Assertions.assertThat(requestWithSystemTags.tags()).containsExactlyInAnyOrder(
-                Iterables.toArray(TAG_SET.getSystemTags(), software.amazon.awssdk.services.rds.model.Tag.class));
-
-        verify(rdsProxy.client(), times(1)).addRoleToDBCluster(any(AddRoleToDbClusterRequest.class));
-        verify(rdsProxy.client(), times(4)).describeDBClusters(any(DescribeDbClustersRequest.class));
-
-        ArgumentCaptor<AddTagsToResourceRequest> addTagsCaptor = ArgumentCaptor.forClass(AddTagsToResourceRequest.class);
-        verify(rdsProxy.client(), times(1)).addTagsToResource(addTagsCaptor.capture());
-        Assertions.assertThat(addTagsCaptor.getValue().tags()).containsExactlyInAnyOrder(
-                Iterables.toArray(Tagging.translateTagsToSdk(extraTags), software.amazon.awssdk.services.rds.model.Tag.class));
+                Iterables.toArray(Tagging.translateTagsToSdk(expectedRequestTags), software.amazon.awssdk.services.rds.model.Tag.class));
     }
 
     @Test
@@ -352,51 +336,28 @@ public class CreateHandlerTest extends AbstractHandlerTest {
                                 .awsErrorDetails(AwsErrorDetails.builder()
                                         .errorCode(ErrorCode.AccessDeniedException.toString())
                                         .build()
-                                ).build())
-                .thenReturn(RestoreDbClusterFromSnapshotResponse.builder().build());
-        when(rdsProxy.client().modifyDBCluster(any(ModifyDbClusterRequest.class)))
-                .thenReturn(ModifyDbClusterResponse.builder().build());
-        when(rdsProxy.client().addTagsToResource(any(AddTagsToResourceRequest.class)))
-                .thenReturn(AddTagsToResourceResponse.builder().build());
-        when(rdsProxy.client().describeEvents(any(DescribeEventsRequest.class)))
-                .thenReturn(DescribeEventsResponse.builder().build());
-
-        final Tagging.TagSet extraTags = Tagging.TagSet.builder()
-                .stackTags(TAG_SET.getStackTags())
-                .resourceTags(TAG_SET.getResourceTags())
-                .build();
+                                ).build());
 
         test_handleRequest_base(
                 new CallbackContext(),
                 ResourceHandlerRequest.<ResourceModel>builder()
                         .systemTags(Translator.translateTagsToRequest(Translator.translateTagsFromSdk(TAG_SET.getSystemTags())))
                         .desiredResourceTags(Translator.translateTagsToRequest(Translator.translateTagsFromSdk(TAG_SET.getStackTags()))),
-                () -> DBCLUSTER_ACTIVE,
+                null,
                 null,
                 () -> RESOURCE_MODEL_ON_RESTORE.toBuilder()
                         .tags(Translator.translateTagsFromSdk(TAG_SET.getResourceTags()))
                         .build(),
-                expectSuccess()
+                expectFailed(HandlerErrorCode.AccessDenied)
         );
 
         ArgumentCaptor<RestoreDbClusterFromSnapshotRequest> createCaptor = ArgumentCaptor.forClass(RestoreDbClusterFromSnapshotRequest.class);
-        verify(rdsProxy.client(), times(2)).restoreDBClusterFromSnapshot(createCaptor.capture());
-        verify(rdsProxy.client(), times(1)).describeEvents(any(DescribeEventsRequest.class));
+        verify(rdsProxy.client(), times(1)).restoreDBClusterFromSnapshot(createCaptor.capture());
 
         final RestoreDbClusterFromSnapshotRequest requestWithAllTags = createCaptor.getAllValues().get(0);
-        final RestoreDbClusterFromSnapshotRequest requestWithSystemTags = createCaptor.getAllValues().get(1);
         Assertions.assertThat(requestWithAllTags.tags()).containsExactlyInAnyOrder(
                 Iterables.toArray(Tagging.translateTagsToSdk(TAG_SET), software.amazon.awssdk.services.rds.model.Tag.class));
-        Assertions.assertThat(requestWithSystemTags.tags()).containsExactlyInAnyOrder(
-                Iterables.toArray(TAG_SET.getSystemTags(), software.amazon.awssdk.services.rds.model.Tag.class));
 
-        verify(rdsProxy.client(), times(4)).describeDBClusters(any(DescribeDbClustersRequest.class));
-        verify(rdsProxy.client(), times(1)).modifyDBCluster(any(ModifyDbClusterRequest.class));
-
-        ArgumentCaptor<AddTagsToResourceRequest> addTagsCaptor = ArgumentCaptor.forClass(AddTagsToResourceRequest.class);
-        verify(rdsProxy.client(), times(1)).addTagsToResource(addTagsCaptor.capture());
-        Assertions.assertThat(addTagsCaptor.getValue().tags()).containsExactlyInAnyOrder(
-                Iterables.toArray(Tagging.translateTagsToSdk(extraTags), software.amazon.awssdk.services.rds.model.Tag.class));
     }
 
     @Test
@@ -567,14 +528,7 @@ public class CreateHandlerTest extends AbstractHandlerTest {
                                 .awsErrorDetails(AwsErrorDetails.builder()
                                         .errorCode(ErrorCode.AccessDeniedException.toString())
                                         .build()
-                                ).build())
-                .thenReturn(RestoreDbClusterToPointInTimeResponse.builder().build());
-        when(rdsProxy.client().addTagsToResource(any(AddTagsToResourceRequest.class)))
-                .thenReturn(AddTagsToResourceResponse.builder().build());
-        when(rdsProxy.client().modifyDBCluster(any(ModifyDbClusterRequest.class)))
-                .thenReturn(ModifyDbClusterResponse.builder().build());
-        when(rdsProxy.client().describeEvents(any(DescribeEventsRequest.class)))
-                .thenReturn(DescribeEventsResponse.builder().build());
+                                ).build());
 
         final Tagging.TagSet extraTags = Tagging.TagSet.builder()
                 .stackTags(TAG_SET.getStackTags())
@@ -586,30 +540,20 @@ public class CreateHandlerTest extends AbstractHandlerTest {
                 ResourceHandlerRequest.<ResourceModel>builder()
                         .systemTags(Translator.translateTagsToRequest(Translator.translateTagsFromSdk(TAG_SET.getSystemTags())))
                         .desiredResourceTags(Translator.translateTagsToRequest(Translator.translateTagsFromSdk(TAG_SET.getStackTags()))),
-                () -> DBCLUSTER_ACTIVE,
+                null,
                 null,
                 () -> RESOURCE_MODEL_ON_RESTORE_IN_TIME.toBuilder()
                         .tags(Translator.translateTagsFromSdk(TAG_SET.getResourceTags()))
                         .build(),
-                expectSuccess()
+                expectFailed(HandlerErrorCode.AccessDenied)
         );
 
         ArgumentCaptor<RestoreDbClusterToPointInTimeRequest> createCaptor = ArgumentCaptor.forClass(RestoreDbClusterToPointInTimeRequest.class);
-        verify(rdsProxy.client(), times(2)).restoreDBClusterToPointInTime(createCaptor.capture());
+        verify(rdsProxy.client(), times(1)).restoreDBClusterToPointInTime(createCaptor.capture());
 
         final RestoreDbClusterToPointInTimeRequest requestWithAllTags = createCaptor.getAllValues().get(0);
-        final RestoreDbClusterToPointInTimeRequest requestWithSystemTags = createCaptor.getAllValues().get(1);
         Assertions.assertThat(requestWithAllTags.tags()).containsExactlyInAnyOrder(
                 Iterables.toArray(Tagging.translateTagsToSdk(TAG_SET), software.amazon.awssdk.services.rds.model.Tag.class));
-        Assertions.assertThat(requestWithSystemTags.tags()).containsExactlyInAnyOrder(
-                Iterables.toArray(TAG_SET.getSystemTags(), software.amazon.awssdk.services.rds.model.Tag.class));
-
-        verify(rdsProxy.client(), times(4)).describeDBClusters(any(DescribeDbClustersRequest.class));
-
-        ArgumentCaptor<AddTagsToResourceRequest> addTagsCaptor = ArgumentCaptor.forClass(AddTagsToResourceRequest.class);
-        verify(rdsProxy.client(), times(1)).addTagsToResource(addTagsCaptor.capture());
-        Assertions.assertThat(addTagsCaptor.getValue().tags()).containsExactlyInAnyOrder(
-                Iterables.toArray(Tagging.translateTagsToSdk(extraTags), software.amazon.awssdk.services.rds.model.Tag.class));
     }
 
     @Test

--- a/aws-rds-dbclusterendpoint/src/main/java/software/amazon/rds/dbclusterendpoint/BaseHandlerStd.java
+++ b/aws-rds-dbclusterendpoint/src/main/java/software/amazon/rds/dbclusterendpoint/BaseHandlerStd.java
@@ -119,7 +119,7 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
             return Commons.handleException(
                     progress,
                     exception,
-                    DEFAULT_DB_CLUSTER_ENDPOINT_ERROR_RULE_SET.extendWith(Tagging.bestEffortErrorRuleSet(rulesetTagsToAdd, rulesetTagsToRemove))
+                    DEFAULT_DB_CLUSTER_ENDPOINT_ERROR_RULE_SET.extendWith(Tagging.getUpdateTagsAccessDeniedRuleSet(rulesetTagsToAdd, rulesetTagsToRemove))
             );
         }
         return progress;

--- a/aws-rds-dbclusterendpoint/src/main/java/software/amazon/rds/dbclusterendpoint/CreateHandler.java
+++ b/aws-rds-dbclusterendpoint/src/main/java/software/amazon/rds/dbclusterendpoint/CreateHandler.java
@@ -54,7 +54,7 @@ public class CreateHandler extends BaseHandlerStd {
                     .toString());
         }
         return ProgressEvent.progress(model, callbackContext)
-                .then(progress -> Tagging.safeCreate(proxy, proxyClient, this::createDbClusterEndpoint, progress, allTags))
+                .then(progress -> Tagging.createWithTaggingFallback(proxy, proxyClient, this::createDbClusterEndpoint, progress, allTags))
                 .then(progress -> Commons.execOnce(progress, () -> {
                             final Tagging.TagSet extraTags = Tagging.TagSet.builder()
                                     .stackTags(Tagging.translateTagsToSdk(request.getDesiredResourceTags()))

--- a/aws-rds-dbclusterendpoint/src/main/java/software/amazon/rds/dbclusterendpoint/ReadHandler.java
+++ b/aws-rds-dbclusterendpoint/src/main/java/software/amazon/rds/dbclusterendpoint/ReadHandler.java
@@ -73,7 +73,7 @@ public class ReadHandler extends BaseHandlerStd {
             return Commons.handleException(
                     ProgressEvent.progress(model, context),
                     exception,
-                    DEFAULT_DB_CLUSTER_ENDPOINT_ERROR_RULE_SET.extendWith(Tagging.SOFT_FAIL_TAG_ERROR_RULE_SET)
+                    DEFAULT_DB_CLUSTER_ENDPOINT_ERROR_RULE_SET.extendWith(Tagging.IGNORE_LIST_TAGS_PERMISSION_DENIED_ERROR_RULE_SET)
             );
         }
         return ProgressEvent.success(model, context);

--- a/aws-rds-dbclusterendpoint/src/test/java/software/amazon/rds/dbclusterendpoint/UpdateHandlerTest.java
+++ b/aws-rds-dbclusterendpoint/src/test/java/software/amazon/rds/dbclusterendpoint/UpdateHandlerTest.java
@@ -265,7 +265,7 @@ null,
                 () -> DB_CLUSTER_ENDPOINT_AVAILABLE,
                 () -> RESOURCE_MODEL_BUILDER().build(),
                 () -> RESOURCE_MODEL_BUILDER().build(),
-                expectSuccess()
+                expectFailed(HandlerErrorCode.UnauthorizedTaggingOperation)
         );
 
         verify(rdsProxy.client(), times(1)).modifyDBClusterEndpoint(any(ModifyDbClusterEndpointRequest.class));
@@ -292,7 +292,7 @@ null,
                 () -> DB_CLUSTER_ENDPOINT_AVAILABLE,
                 () -> RESOURCE_MODEL_BUILDER().build(),
                 () -> RESOURCE_MODEL_BUILDER().build(),
-                expectSuccess()
+                expectFailed(HandlerErrorCode.UnauthorizedTaggingOperation)
         );
 
         verify(rdsProxy.client(), times(1)).modifyDBClusterEndpoint(any(ModifyDbClusterEndpointRequest.class));

--- a/aws-rds-dbclusterparametergroup/src/main/java/software/amazon/rds/dbclusterparametergroup/BaseHandlerStd.java
+++ b/aws-rds-dbclusterparametergroup/src/main/java/software/amazon/rds/dbclusterparametergroup/BaseHandlerStd.java
@@ -182,11 +182,9 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
                     progress,
                     exception,
                     DEFAULT_DB_CLUSTER_PARAMETER_GROUP_ERROR_RULE_SET.extendWith(
-                            Tagging.bestEffortErrorRuleSet(
+                            Tagging.getUpdateTagsAccessDeniedRuleSet(
                                     rulesetTagsToAdd,
-                                    rulesetTagsToRemove,
-                                    Tagging.SOFT_FAIL_IN_PROGRESS_TAGGING_ERROR_RULE_SET,
-                                    Tagging.HARD_FAIL_TAG_ERROR_RULE_SET
+                                    rulesetTagsToRemove
                             )
                     )
             );

--- a/aws-rds-dbclusterparametergroup/src/main/java/software/amazon/rds/dbclusterparametergroup/CreateHandler.java
+++ b/aws-rds-dbclusterparametergroup/src/main/java/software/amazon/rds/dbclusterparametergroup/CreateHandler.java
@@ -52,7 +52,7 @@ public class CreateHandler extends BaseHandlerStd {
 
         return ProgressEvent.progress(request.getDesiredResourceState(), callbackContext)
                 .then(progress -> setDbClusterParameterGroupNameIfMissing(request, progress))
-                .then(progress -> Tagging.safeCreate(proxy, proxyClient, this::createDbClusterParameterGroup, progress, allTags))
+                .then(progress -> Tagging.createWithTaggingFallback(proxy, proxyClient, this::createDbClusterParameterGroup, progress, allTags))
                 .then(progress -> Commons.execOnce(progress, () -> {
                     final Tagging.TagSet extraTags = Tagging.TagSet.builder()
                             .stackTags(allTags.getStackTags())

--- a/aws-rds-dbclusterparametergroup/src/main/java/software/amazon/rds/dbclusterparametergroup/ReadHandler.java
+++ b/aws-rds-dbclusterparametergroup/src/main/java/software/amazon/rds/dbclusterparametergroup/ReadHandler.java
@@ -89,7 +89,7 @@ public class ReadHandler extends BaseHandlerStd {
             return Commons.handleException(
                     ProgressEvent.progress(model, context),
                     exception,
-                    DEFAULT_DB_CLUSTER_PARAMETER_GROUP_ERROR_RULE_SET.extendWith(Tagging.SOFT_FAIL_TAG_ERROR_RULE_SET)
+                    DEFAULT_DB_CLUSTER_PARAMETER_GROUP_ERROR_RULE_SET.extendWith(Tagging.IGNORE_LIST_TAGS_PERMISSION_DENIED_ERROR_RULE_SET)
             );
         }
         return ProgressEvent.success(model, context);

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/BaseHandlerStd.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/BaseHandlerStd.java
@@ -1071,7 +1071,7 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
             return Commons.handleException(
                     progress,
                     exception,
-                    DEFAULT_DB_INSTANCE_ERROR_RULE_SET.extendWith(Tagging.bestEffortErrorRuleSet(rulesetTagsToAdd, rulesetTagsToRemove))
+                    DEFAULT_DB_INSTANCE_ERROR_RULE_SET.extendWith(Tagging.getUpdateTagsAccessDeniedRuleSet(rulesetTagsToAdd, rulesetTagsToRemove))
             );
         }
 

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/CreateHandler.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/CreateHandler.java
@@ -201,7 +201,7 @@ public class CreateHandler extends BaseHandlerStd {
     }
 
     private HandlerMethod<ResourceModel, CallbackContext> safeAddTags(final HandlerMethod<ResourceModel, CallbackContext> handlerMethod) {
-        return (proxy, rdsProxyClient, progress, tagSet) -> progress.then(p -> Tagging.safeCreate(proxy, rdsProxyClient, handlerMethod, progress, tagSet));
+        return (proxy, rdsProxyClient, progress, tagSet) -> progress.then(p -> Tagging.createWithTaggingFallback(proxy, rdsProxyClient, handlerMethod, progress, tagSet));
     }
 
     private String fetchEngine(final ProxyClient<RdsClient> client,

--- a/aws-rds-dbparametergroup/src/main/java/software/amazon/rds/dbparametergroup/BaseHandlerStd.java
+++ b/aws-rds-dbparametergroup/src/main/java/software/amazon/rds/dbparametergroup/BaseHandlerStd.java
@@ -157,11 +157,9 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
                     progress,
                     exception,
                     DEFAULT_DB_PARAMETER_GROUP_ERROR_RULE_SET.extendWith(
-                            Tagging.bestEffortErrorRuleSet(
-                                    rulesetTagsToAdd,
-                                    rulesetTagsToRemove,
-                                    Tagging.SOFT_FAIL_IN_PROGRESS_TAGGING_ERROR_RULE_SET,
-                                    Tagging.HARD_FAIL_TAG_ERROR_RULE_SET
+                            Tagging.getUpdateTagsAccessDeniedRuleSet(
+                                rulesetTagsToAdd,
+                                rulesetTagsToRemove
                             )
                     )
             );

--- a/aws-rds-dbparametergroup/src/main/java/software/amazon/rds/dbparametergroup/CreateHandler.java
+++ b/aws-rds-dbparametergroup/src/main/java/software/amazon/rds/dbparametergroup/CreateHandler.java
@@ -64,7 +64,7 @@ public class CreateHandler extends BaseHandlerStd {
             final RequestLogger logger
     ) {
         final HandlerMethod<ResourceModel, CallbackContext> createMethod = (pxy, pcl, prg, tgs) -> createDBParameterGroup(pxy, pcl, prg, tgs, logger);
-        return Tagging.safeCreate(proxy, proxyClient, createMethod, progress, allTags)
+        return Tagging.createWithTaggingFallback(proxy, proxyClient, createMethod, progress, allTags)
                 .then(p -> Commons.execOnce(p, () -> {
                     final Tagging.TagSet extraTags = Tagging.TagSet.builder()
                             .stackTags(allTags.getStackTags())

--- a/aws-rds-dbparametergroup/src/main/java/software/amazon/rds/dbparametergroup/ReadHandler.java
+++ b/aws-rds-dbparametergroup/src/main/java/software/amazon/rds/dbparametergroup/ReadHandler.java
@@ -103,7 +103,7 @@ public class ReadHandler extends BaseHandlerStd {
             return Commons.handleException(
                     ProgressEvent.progress(model, context),
                     exception,
-                    DEFAULT_DB_PARAMETER_GROUP_ERROR_RULE_SET.extendWith(Tagging.SOFT_FAIL_TAG_ERROR_RULE_SET)
+                    DEFAULT_DB_PARAMETER_GROUP_ERROR_RULE_SET.extendWith(Tagging.IGNORE_LIST_TAGS_PERMISSION_DENIED_ERROR_RULE_SET)
             );
         }
         return ProgressEvent.success(model, context);

--- a/aws-rds-dbsubnetgroup/src/main/java/software/amazon/rds/dbsubnetgroup/BaseHandlerStd.java
+++ b/aws-rds-dbsubnetgroup/src/main/java/software/amazon/rds/dbsubnetgroup/BaseHandlerStd.java
@@ -134,11 +134,9 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
                     progress,
                     exception,
                     DEFAULT_DB_SUBNET_GROUP_ERROR_RULE_SET.extendWith(
-                            Tagging.bestEffortErrorRuleSet(
+                            Tagging.getUpdateTagsAccessDeniedRuleSet(
                                     rulesetTagsToAdd,
-                                    rulesetTagsToRemove,
-                                    Tagging.SOFT_FAIL_IN_PROGRESS_TAGGING_ERROR_RULE_SET,
-                                    Tagging.HARD_FAIL_TAG_ERROR_RULE_SET
+                                    rulesetTagsToRemove
                             )
                     )
             );

--- a/aws-rds-dbsubnetgroup/src/main/java/software/amazon/rds/dbsubnetgroup/CreateHandler.java
+++ b/aws-rds-dbsubnetgroup/src/main/java/software/amazon/rds/dbsubnetgroup/CreateHandler.java
@@ -55,7 +55,7 @@ public class CreateHandler extends BaseHandlerStd {
                                                                                   final ProxyClient<RdsClient> proxyClient,
                                                                                   final ProgressEvent<ResourceModel, CallbackContext> progress,
                                                                                   final Tagging.TagSet allTags) {
-        return Tagging.safeCreate(proxy, proxyClient, this::createDbSubnetGroup, progress, allTags)
+        return Tagging.createWithTaggingFallback(proxy, proxyClient, this::createDbSubnetGroup, progress, allTags)
                 .then(p -> Commons.execOnce(p, () -> {
                     final Tagging.TagSet extraTags = Tagging.TagSet.builder()
                             .stackTags(allTags.getStackTags())

--- a/aws-rds-dbsubnetgroup/src/main/java/software/amazon/rds/dbsubnetgroup/ReadHandler.java
+++ b/aws-rds-dbsubnetgroup/src/main/java/software/amazon/rds/dbsubnetgroup/ReadHandler.java
@@ -70,7 +70,7 @@ public class ReadHandler extends BaseHandlerStd {
             return Commons.handleException(
                     ProgressEvent.progress(model, context),
                     exception,
-                    DEFAULT_DB_SUBNET_GROUP_ERROR_RULE_SET.extendWith(Tagging.SOFT_FAIL_TAG_ERROR_RULE_SET)
+                    DEFAULT_DB_SUBNET_GROUP_ERROR_RULE_SET.extendWith(Tagging.IGNORE_LIST_TAGS_PERMISSION_DENIED_ERROR_RULE_SET)
             );
         }
         return ProgressEvent.success(model, context);

--- a/aws-rds-eventsubscription/src/main/java/software/amazon/rds/eventsubscription/BaseHandlerStd.java
+++ b/aws-rds-eventsubscription/src/main/java/software/amazon/rds/eventsubscription/BaseHandlerStd.java
@@ -143,11 +143,9 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
                     progress,
                     exception,
                     DEFAULT_EVENT_SUBSCRIPTION_ERROR_RULE_SET.extendWith(
-                                    Tagging.bestEffortErrorRuleSet(
+                                    Tagging.getUpdateTagsAccessDeniedRuleSet(
                                             rulesetTagsToAdd,
-                                            rulesetTagsToRemove,
-                                            Tagging.SOFT_FAIL_IN_PROGRESS_TAGGING_ERROR_RULE_SET,
-                                            Tagging.HARD_FAIL_TAG_ERROR_RULE_SET
+                                            rulesetTagsToRemove
                                     )
                             )
             );

--- a/aws-rds-eventsubscription/src/main/java/software/amazon/rds/eventsubscription/CreateHandler.java
+++ b/aws-rds-eventsubscription/src/main/java/software/amazon/rds/eventsubscription/CreateHandler.java
@@ -47,7 +47,7 @@ public class CreateHandler extends BaseHandlerStd {
                                                                                       final ProxyClient<RdsClient> proxyClient,
                                                                                       final ProgressEvent<ResourceModel, CallbackContext> progress,
                                                                                       final Tagging.TagSet allTags) {
-        return Tagging.safeCreate(proxy, proxyClient, this::createEventSubscription, progress, allTags)
+        return Tagging.createWithTaggingFallback(proxy, proxyClient, this::createEventSubscription, progress, allTags)
                 .then(p -> Commons.execOnce(p, () -> {
                     final Tagging.TagSet extraTags = Tagging.TagSet.builder()
                             .stackTags(allTags.getStackTags())

--- a/aws-rds-eventsubscription/src/main/java/software/amazon/rds/eventsubscription/ReadHandler.java
+++ b/aws-rds-eventsubscription/src/main/java/software/amazon/rds/eventsubscription/ReadHandler.java
@@ -49,7 +49,7 @@ public class ReadHandler extends BaseHandlerStd {
             return Commons.handleException(
                     ProgressEvent.progress(model, context),
                     exception,
-                    DEFAULT_EVENT_SUBSCRIPTION_ERROR_RULE_SET.extendWith(Tagging.SOFT_FAIL_TAG_ERROR_RULE_SET)
+                    DEFAULT_EVENT_SUBSCRIPTION_ERROR_RULE_SET.extendWith(Tagging.IGNORE_LIST_TAGS_PERMISSION_DENIED_ERROR_RULE_SET)
             );
         }
         return ProgressEvent.success(model, context);

--- a/aws-rds-optiongroup/src/main/java/software/amazon/rds/optiongroup/BaseHandlerStd.java
+++ b/aws-rds-optiongroup/src/main/java/software/amazon/rds/optiongroup/BaseHandlerStd.java
@@ -142,11 +142,9 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
                                 progress,
                                 exception,
                                 DEFAULT_OPTION_GROUP_ERROR_RULE_SET.extendWith(
-                                        Tagging.bestEffortErrorRuleSet(
+                                        Tagging.getUpdateTagsAccessDeniedRuleSet(
                                                 rulesetTagsToAdd,
-                                                rulesetTagsToRemove,
-                                                Tagging.SOFT_FAIL_IN_PROGRESS_TAGGING_ERROR_RULE_SET,
-                                                Tagging.HARD_FAIL_TAG_ERROR_RULE_SET
+                                                rulesetTagsToRemove
                                         )
                                 )
                         );

--- a/aws-rds-optiongroup/src/main/java/software/amazon/rds/optiongroup/CreateHandler.java
+++ b/aws-rds-optiongroup/src/main/java/software/amazon/rds/optiongroup/CreateHandler.java
@@ -50,7 +50,7 @@ public class CreateHandler extends BaseHandlerStd {
 
         return ProgressEvent.progress(request.getDesiredResourceState(), callbackContext)
                 .then(progress -> setOptionGroupNameIfEmpty(request, progress))
-                .then(progress -> Tagging.safeCreate(proxy, proxyClient, this::createOptionGroup, progress, allTags))
+                .then(progress -> Tagging.createWithTaggingFallback(proxy, proxyClient, this::createOptionGroup, progress, allTags))
                 .then(progress -> Commons.execOnce(progress, () -> {
                         final Tagging.TagSet extraTags = Tagging.TagSet.builder()
                                 .stackTags(allTags.getStackTags())

--- a/aws-rds-optiongroup/src/main/java/software/amazon/rds/optiongroup/ReadHandler.java
+++ b/aws-rds-optiongroup/src/main/java/software/amazon/rds/optiongroup/ReadHandler.java
@@ -75,7 +75,7 @@ public class ReadHandler extends BaseHandlerStd {
             return Commons.handleException(
                     ProgressEvent.progress(model, context),
                     exception,
-                    DEFAULT_OPTION_GROUP_ERROR_RULE_SET.extendWith(Tagging.SOFT_FAIL_TAG_ERROR_RULE_SET)
+                    DEFAULT_OPTION_GROUP_ERROR_RULE_SET.extendWith(Tagging.IGNORE_LIST_TAGS_PERMISSION_DENIED_ERROR_RULE_SET)
             );
         }
         return ProgressEvent.success(model, context);

--- a/aws-rds-optiongroup/src/test/java/software/amazon/rds/optiongroup/CreateHandlerTest.java
+++ b/aws-rds-optiongroup/src/test/java/software/amazon/rds/optiongroup/CreateHandlerTest.java
@@ -11,9 +11,11 @@ import static org.mockito.Mockito.when;
 
 import java.time.Duration;
 
+import com.google.common.collect.Iterables;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -21,7 +23,6 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import com.google.common.collect.Iterables;
 import lombok.Getter;
 import software.amazon.awssdk.awscore.exception.AwsErrorDetails;
 import software.amazon.awssdk.services.rds.RdsClient;
@@ -38,10 +39,10 @@ import software.amazon.awssdk.services.rds.model.OptionGroupAlreadyExistsExcepti
 import software.amazon.awssdk.services.rds.model.RdsException;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.HandlerErrorCode;
-import software.amazon.cloudformation.proxy.OperationStatus;
 import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
+import software.amazon.cloudformation.proxy.OperationStatus;
 import software.amazon.rds.common.error.ErrorCode;
 import software.amazon.rds.common.handler.HandlerConfig;
 import software.amazon.rds.common.handler.Tagging;
@@ -215,26 +216,11 @@ public class CreateHandlerTest extends AbstractTestBase {
         when(proxyClient.client().createOptionGroup(any(CreateOptionGroupRequest.class)))
                 .thenThrow(
                         RdsException.builder()
-                                .awsErrorDetails(AwsErrorDetails.builder()
-                                        .errorCode(ErrorCode.AccessDeniedException.toString())
-                                        .build()
-                                ).build())
-                .thenReturn(CreateOptionGroupResponse.builder().build());
-
-        final DescribeOptionGroupsResponse describeDbClusterParameterGroupsResponse = DescribeOptionGroupsResponse.builder()
-                .optionGroupsList(OPTION_GROUP_ACTIVE).build();
-        when(proxyClient.client().describeOptionGroups(any(DescribeOptionGroupsRequest.class))).thenReturn(describeDbClusterParameterGroupsResponse);
-
-        when(proxyClient.client().addTagsToResource(any(AddTagsToResourceRequest.class)))
-                .thenThrow(
-                        RdsException.builder()
+                                .message("Role not authorized to execute rds:AddTagsToResource")
                                 .awsErrorDetails(AwsErrorDetails.builder()
                                         .errorCode(ErrorCode.AccessDeniedException.toString())
                                         .build()
                                 ).build());
-
-        when(proxyClient.client().listTagsForResource(any(ListTagsForResourceRequest.class)))
-                .thenReturn(ListTagsForResourceResponse.builder().build());
 
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
                 .clientRequestToken(TestUtils.randomString(32, TestUtils.ALPHA))
@@ -247,33 +233,18 @@ public class CreateHandlerTest extends AbstractTestBase {
         final ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);
 
 
-        assertThat(response).isNotNull();
-        assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
-        assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
-        assertThat(response.getResourceModels()).isNull();
-        assertThat(response.getMessage()).isNull();
-        assertThat(response.getErrorCode()).isNull();
-
-        verify(proxyClient.client(), times(1)).addTagsToResource(any(AddTagsToResourceRequest.class));
-        verify(proxyClient.client(), times(2)).describeOptionGroups(any(DescribeOptionGroupsRequest.class));
-        verify(proxyClient.client(), times(1)).listTagsForResource(any(ListTagsForResourceRequest.class));
+        Assertions.assertThat(response).isNotNull();
+        Assertions.assertThat(response.getStatus()).isEqualTo(OperationStatus.FAILED);
+        Assertions.assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
+        Assertions.assertThat(response.getMessage()).isNotNull();
+        Assertions.assertThat(response.getErrorCode()).isEqualTo(HandlerErrorCode.UnauthorizedTaggingOperation);
+        Assertions.assertThat(response.getResourceModels()).isNull();
 
         ArgumentCaptor<CreateOptionGroupRequest> createOptionGroupCaptor = ArgumentCaptor.forClass(CreateOptionGroupRequest.class);
-        verify(proxyClient.client(), times(2)).createOptionGroup(createOptionGroupCaptor.capture());
+        verify(proxyClient.client(), times(1)).createOptionGroup(createOptionGroupCaptor.capture());
         final CreateOptionGroupRequest createOptionGroupWithAllTags = createOptionGroupCaptor.getAllValues().get(0);
         Assertions.assertThat(createOptionGroupWithAllTags.tags()).containsExactlyInAnyOrder(
                 Iterables.toArray(Tagging.translateTagsToSdk(desiredTags), software.amazon.awssdk.services.rds.model.Tag.class)
-        );
-        final CreateOptionGroupRequest createOptionGroupWithSystemTags = createOptionGroupCaptor.getAllValues().get(1);
-        Assertions.assertThat(createOptionGroupWithSystemTags.tags()).containsExactlyInAnyOrder(
-                Iterables.toArray(desiredTags.getSystemTags(), software.amazon.awssdk.services.rds.model.Tag.class)
-        );
-
-        ArgumentCaptor<AddTagsToResourceRequest> addTagsCaptor = ArgumentCaptor.forClass(AddTagsToResourceRequest.class);
-        verify(proxyClient.client(), times(1)).addTagsToResource(addTagsCaptor.capture());
-        final AddTagsToResourceRequest requestWithStackTags = addTagsCaptor.getAllValues().get(0);
-        Assertions.assertThat(requestWithStackTags.tags()).containsExactlyInAnyOrder(
-                Iterables.toArray(desiredTags.getStackTags(), software.amazon.awssdk.services.rds.model.Tag.class)
         );
     }
 
@@ -287,19 +258,6 @@ public class CreateHandlerTest extends AbstractTestBase {
                 .build();
 
         when(proxyClient.client().createOptionGroup(any(CreateOptionGroupRequest.class)))
-                .thenThrow(
-                        RdsException.builder()
-                                .awsErrorDetails(AwsErrorDetails.builder()
-                                        .errorCode(ErrorCode.AccessDeniedException.toString())
-                                        .build()
-                                ).build())
-                .thenReturn(CreateOptionGroupResponse.builder().build());
-
-        final DescribeOptionGroupsResponse describeDbClusterParameterGroupsResponse = DescribeOptionGroupsResponse.builder()
-                .optionGroupsList(OPTION_GROUP_ACTIVE).build();
-        when(proxyClient.client().describeOptionGroups(any(DescribeOptionGroupsRequest.class))).thenReturn(describeDbClusterParameterGroupsResponse);
-
-        when(proxyClient.client().addTagsToResource(any(AddTagsToResourceRequest.class)))
                 .thenThrow(
                         RdsException.builder()
                                 .awsErrorDetails(AwsErrorDetails.builder()
@@ -323,25 +281,11 @@ public class CreateHandlerTest extends AbstractTestBase {
         Assertions.assertThat(response.getErrorCode()).isEqualTo(HandlerErrorCode.AccessDenied);
         Assertions.assertThat(response.getResourceModels()).isNull();
 
-        verify(proxyClient.client(), times(1)).addTagsToResource(any(AddTagsToResourceRequest.class));
-        verify(proxyClient.client(), times(1)).describeOptionGroups(any(DescribeOptionGroupsRequest.class));
-
         ArgumentCaptor<CreateOptionGroupRequest> createOptionGroupCaptor = ArgumentCaptor.forClass(CreateOptionGroupRequest.class);
-        verify(proxyClient.client(), times(2)).createOptionGroup(createOptionGroupCaptor.capture());
+        verify(proxyClient.client(), times(1)).createOptionGroup(createOptionGroupCaptor.capture());
         final CreateOptionGroupRequest createOptionGroupWithAllTags = createOptionGroupCaptor.getAllValues().get(0);
         Assertions.assertThat(createOptionGroupWithAllTags.tags()).containsExactlyInAnyOrder(
                 Iterables.toArray(Tagging.translateTagsToSdk(desiredTags), software.amazon.awssdk.services.rds.model.Tag.class)
-        );
-        final CreateOptionGroupRequest createOptionGroupWithSystemTags = createOptionGroupCaptor.getAllValues().get(1);
-        Assertions.assertThat(createOptionGroupWithSystemTags.tags()).containsExactlyInAnyOrder(
-                Iterables.toArray(desiredTags.getSystemTags(), software.amazon.awssdk.services.rds.model.Tag.class)
-        );
-
-        ArgumentCaptor<AddTagsToResourceRequest> addTagsCaptor = ArgumentCaptor.forClass(AddTagsToResourceRequest.class);
-        verify(proxyClient.client(), times(1)).addTagsToResource(addTagsCaptor.capture());
-        final AddTagsToResourceRequest requestWithResourceTags = addTagsCaptor.getAllValues().get(0);
-        Assertions.assertThat(requestWithResourceTags.tags()).containsExactlyInAnyOrder(
-                Iterables.toArray(desiredTags.getResourceTags(), software.amazon.awssdk.services.rds.model.Tag.class)
         );
     }
 

--- a/aws-rds-optiongroup/src/test/java/software/amazon/rds/optiongroup/UpdateHandlerTest.java
+++ b/aws-rds-optiongroup/src/test/java/software/amazon/rds/optiongroup/UpdateHandlerTest.java
@@ -243,8 +243,6 @@ public class UpdateHandlerTest extends AbstractTestBase {
                 )
         );
 
-        when(proxyClient.client().listTagsForResource(any(ListTagsForResourceRequest.class)))
-                .thenReturn(ListTagsForResourceResponse.builder().build());
         final DescribeOptionGroupsResponse describeDbClusterParameterGroupsResponse = DescribeOptionGroupsResponse.builder()
                 .optionGroupsList(OPTION_GROUP_ACTIVE).build();
         when(proxyClient.client().describeOptionGroups(any(DescribeOptionGroupsRequest.class)))
@@ -269,15 +267,14 @@ public class UpdateHandlerTest extends AbstractTestBase {
         final ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);
 
         assertThat(response).isNotNull();
-        assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.FAILED);
         assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
+        assertThat(response.getMessage()).isNotNull();
+        assertThat(response.getErrorCode()).isEqualTo(HandlerErrorCode.UnauthorizedTaggingOperation);
         assertThat(response.getResourceModels()).isNull();
-        assertThat(response.getMessage()).isNull();
-        assertThat(response.getErrorCode()).isNull();
 
         verify(proxyClient.client(), times(1)).removeTagsFromResource(any(RemoveTagsFromResourceRequest.class));
-        verify(proxyClient.client(), times(2)).describeOptionGroups(any(DescribeOptionGroupsRequest.class));
-        verify(proxyClient.client(), times(1)).listTagsForResource(any(ListTagsForResourceRequest.class));
+        verify(proxyClient.client(), times(1)).describeOptionGroups(any(DescribeOptionGroupsRequest.class));
     }
 
     @Test


### PR DESCRIPTION
*Description of changes:*
To ensure compatibility with older versions, we previously ignored the AccessDenied exception when a customer did not have permission to add stack level tags. This PR addresses this issue by aligning with the latest CloudFormation guidelines and instead throwing an UnauthorizedTaggingOperation error code.

However, we have retained the already exist tagging logic to differentiate between access denied for resource tags and access denied for stack level tags. Once CloudFormation confirms that it is safe to convert UnauthorizedTaggingOperation to the regular AccessDenied error code, we can safely remove all the logic related to tag error management and the safeCreate mechanism.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
