### PR TITLE
[All] Update AWS SDK version to 2.21.17

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 aws-rds-handlers.iml
 rpdk.log
+# for IntelliJ IDEA
+.idea/

--- a/aws-rds-cfn-common/pom.xml
+++ b/aws-rds-cfn-common/pom.xml
@@ -27,12 +27,12 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>utils</artifactId>
-            <version>2.21.6</version>
+            <version>2.21.17</version>
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>rds</artifactId>
-            <version>2.21.6</version>
+            <version>2.21.17</version>
         </dependency>
         <dependency>
             <groupId>software.amazon.cloudformation</groupId>

--- a/aws-rds-customdbengineversion/pom.xml
+++ b/aws-rds-customdbengineversion/pom.xml
@@ -22,7 +22,7 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>rds</artifactId>
-            <version>2.21.6</version>
+            <version>2.21.17</version>
         </dependency>
         <dependency>
             <groupId>software.amazon.rds.common</groupId>

--- a/aws-rds-dbcluster/pom.xml
+++ b/aws-rds-dbcluster/pom.xml
@@ -29,12 +29,12 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>rds</artifactId>
-            <version>2.21.6</version>
+            <version>2.21.17</version>
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>ec2</artifactId>
-            <version>2.21.6</version>
+            <version>2.21.17</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/software.amazon.cloudformation/aws-cloudformation-rpdk-java-plugin -->
         <dependency>

--- a/aws-rds-dbclusterendpoint/pom.xml
+++ b/aws-rds-dbclusterendpoint/pom.xml
@@ -29,7 +29,7 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>rds</artifactId>
-            <version>2.21.6</version>
+            <version>2.21.17</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/software.amazon.cloudformation/aws-cloudformation-rpdk-java-plugin -->
         <dependency>

--- a/aws-rds-dbclusterparametergroup/pom.xml
+++ b/aws-rds-dbclusterparametergroup/pom.xml
@@ -29,7 +29,7 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>rds</artifactId>
-            <version>2.21.6</version>
+            <version>2.21.17</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/software.amazon.cloudformation/aws-cloudformation-rpdk-java-plugin -->
         <dependency>

--- a/aws-rds-dbinstance/docs/README.md
+++ b/aws-rds-dbinstance/docs/README.md
@@ -385,8 +385,6 @@ _Required_: No
 
 _Type_: String
 
-_Pattern_: <code>^$|^[_a-zA-Z][a-zA-Z0-9_]{0,63}$</code>
-
 _Update requires_: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
 
 #### DBParameterGroupName

--- a/aws-rds-dbinstance/pom.xml
+++ b/aws-rds-dbinstance/pom.xml
@@ -32,12 +32,12 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>rds</artifactId>
-            <version>2.21.6</version>
+            <version>2.21.17</version>
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>ec2</artifactId>
-            <version>2.21.6</version>
+            <version>2.21.17</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/software.amazon.cloudformation/aws-cloudformation-rpdk-java-plugin -->
         <dependency>

--- a/aws-rds-dbparametergroup/pom.xml
+++ b/aws-rds-dbparametergroup/pom.xml
@@ -22,7 +22,7 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>rds</artifactId>
-            <version>2.21.6</version>
+            <version>2.21.17</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/software.amazon.cloudformation/aws-cloudformation-rpdk-java-plugin -->
         <dependency>

--- a/aws-rds-dbsubnetgroup/pom.xml
+++ b/aws-rds-dbsubnetgroup/pom.xml
@@ -22,7 +22,7 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>rds</artifactId>
-            <version>2.21.6</version>
+            <version>2.21.17</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/software.amazon.cloudformation/aws-cloudformation-rpdk-java-plugin -->
         <dependency>

--- a/aws-rds-eventsubscription/pom.xml
+++ b/aws-rds-eventsubscription/pom.xml
@@ -28,7 +28,7 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>rds</artifactId>
-            <version>2.21.6</version>
+            <version>2.21.17</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/software.amazon.cloudformation/aws-cloudformation-rpdk-java-plugin -->
         <dependency>

--- a/aws-rds-globalcluster/pom.xml
+++ b/aws-rds-globalcluster/pom.xml
@@ -28,7 +28,7 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>rds</artifactId>
-            <version>2.21.6</version>
+            <version>2.21.17</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/software.amazon.cloudformation/aws-cloudformation-rpdk-java-plugin -->
         <dependency>

--- a/aws-rds-optiongroup/pom.xml
+++ b/aws-rds-optiongroup/pom.xml
@@ -22,7 +22,7 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>rds</artifactId>
-            <version>2.21.6</version>
+            <version>2.21.17</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/software.amazon.cloudformation/aws-cloudformation-rpdk-java-plugin -->
         <dependency>


### PR DESCRIPTION
This enables the resource to access the upcoming Integration resource.

*Issue #, if available:* https://github.com/aws-cloudformation/aws-cloudformation-resource-providers-rds/issues/485

*Description of changes:* 

- Updating the AWS SDK version to 2.21.17 which exposes the Zero ETL API
- All other changes are due to the SDK version changes (documentation generator changes)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
