### PR TITLE
[DBInstance] Add AllowMajorUpgrade on ModifyAfterCreate

### DIFF
--- a/aws-rds-dbinstance/pom.xml
+++ b/aws-rds-dbinstance/pom.xml
@@ -52,7 +52,12 @@
             <version>1.18.22</version>
             <scope>provided</scope>
         </dependency>
-
+       <!-- https://mvnrepository.com/artifact/software.amazon.awssdk/aws-query-protocol -->
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>aws-query-protocol</artifactId>
+            <version>2.20.138</version>
+        </dependency>
         <!-- https://mvnrepository.com/artifact/org.assertj/assertj-core -->
         <dependency>
             <groupId>org.assertj</groupId>

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/Translator.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/Translator.java
@@ -588,6 +588,7 @@ public class Translator {
 
     public static ModifyDbInstanceRequest modifyDbInstanceAfterCreateRequest(final ResourceModel model) {
         final ModifyDbInstanceRequest.Builder builder = ModifyDbInstanceRequest.builder()
+                .allowMajorVersionUpgrade(model.getAllowMajorVersionUpgrade())
                 .applyImmediately(Boolean.TRUE)
                 .backupRetentionPeriod(model.getBackupRetentionPeriod())
                 .caCertificateIdentifier(model.getCACertificateIdentifier())

--- a/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/TranslatorTest.java
+++ b/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/TranslatorTest.java
@@ -730,6 +730,17 @@ class TranslatorTest extends AbstractHandlerTest {
     }
 
     @Test
+    public void test_createDbInstanceRequest_AllowMajorVersionUpgrade() {
+        ResourceModel model = ResourceModel.builder()
+                .allowMajorVersionUpgrade(true)
+                .build();
+        final ModifyDbInstanceRequest modifyAfterCreateRequest = Translator.modifyDbInstanceAfterCreateRequest(
+                model
+        );
+        assertThat(modifyAfterCreateRequest.allowMajorVersionUpgrade()).isTrue();
+    }
+
+    @Test
     public void test_createDbInstanceRequest_SetPerformanceInsightsKMSKeyIdIfEnabled() {
         final String kmsKeyId = "test-kms-key-id";
         final CreateDbInstanceRequest request = Translator.createDbInstanceRequest(


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Adds missing flag AllowMajorUpgrade to modify call  made during create for DBInstance.
- Adds unit test to ensure parameter is present


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
