### PR TITLE
[DBCluster] Support EnableHttpEndpoint for Aurora Postgres engine to support Data Api V2.

### DIFF
--- a/aws-rds-dbcluster/aws-rds-dbcluster.json
+++ b/aws-rds-dbcluster/aws-rds-dbcluster.json
@@ -121,7 +121,7 @@
       "type": "boolean"
     },
     "EnableHttpEndpoint": {
-      "description": "A value that indicates whether to enable the HTTP endpoint for an Aurora Serverless DB cluster. By default, the HTTP endpoint is disabled.",
+      "description": "A value that indicates whether to enable the HTTP endpoint for DB cluster. By default, the HTTP endpoint is disabled.",
       "type": "boolean"
     },
     "EnableIAMDatabaseAuthentication": {
@@ -406,7 +406,7 @@
     "/properties/DBClusterIdentifier": "$lowercase(DBClusterIdentifier)",
     "/properties/DBClusterParameterGroupName": "$lowercase(DBClusterParameterGroupName)",
     "/properties/DBSubnetGroupName": "$lowercase(DBSubnetGroupName)",
-    "/properties/EnableHttpEndpoint": "$lowercase($string(EngineMode)) = 'serverless' ? EnableHttpEndpoint : false",
+    "/properties/EnableHttpEndpoint": "$lowercase($string(EngineMode)) = 'serverless' ? EnableHttpEndpoint : ($lowercase($string(Engine)) = 'aurora-postgresql' ? EnableHttpEndpoint : false )",
     "/properties/Engine": "$lowercase(Engine)",
     "/properties/EngineVersion": "$join([$string(EngineVersion), \".*\"])",
     "/properties/KmsKeyId": "$join([\"arn:(aws)[-]{0,1}[a-z]{0,2}[-]{0,1}[a-z]{0,3}:kms:[a-z]{2}[-]{1}[a-z]{3,10}[-]{0,1}[a-z]{0,10}[-]{1}[1-3]{1}:[0-9]{12}[:]{1}key\\/\", KmsKeyId])",
@@ -474,6 +474,7 @@
         "rds:CreateDBInstance",
         "rds:DescribeDBClusters",
         "rds:DescribeEvents",
+        "rds:EnableHttpEndpoint",
         "rds:ModifyDBCluster",
         "rds:RestoreDBClusterFromSnapshot",
         "rds:RestoreDBClusterToPointInTime",
@@ -497,6 +498,8 @@
         "rds:DescribeDBSubnetGroups",
         "rds:DescribeEvents",
         "rds:DescribeGlobalClusters",
+        "rds:DisableHttpEndpoint",
+        "rds:EnableHttpEndpoint",
         "rds:ModifyDBCluster",
         "rds:ModifyDBInstance",
         "rds:RemoveFromGlobalCluster",

--- a/aws-rds-dbcluster/docs/README.md
+++ b/aws-rds-dbcluster/docs/README.md
@@ -362,7 +362,7 @@ _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormati
 
 #### EnableHttpEndpoint
 
-A value that indicates whether to enable the HTTP endpoint for an Aurora Serverless DB cluster. By default, the HTTP endpoint is disabled.
+A value that indicates whether to enable the HTTP endpoint for DB cluster. By default, the HTTP endpoint is disabled.
 
 _Required_: No
 

--- a/aws-rds-dbcluster/pom.xml
+++ b/aws-rds-dbcluster/pom.xml
@@ -29,12 +29,18 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>rds</artifactId>
-            <version>2.21.17</version>
+            <version>2.22.12</version>
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>ec2</artifactId>
-            <version>2.21.17</version>
+            <version>2.22.12</version>
+        </dependency>
+        <!-- https://mvnrepository.com/artifact/software.amazon.awssdk/aws-query-protocol -->
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>aws-query-protocol</artifactId>
+            <version>2.20.138</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/software.amazon.cloudformation/aws-cloudformation-rpdk-java-plugin -->
         <dependency>

--- a/aws-rds-dbcluster/resource-role.yaml
+++ b/aws-rds-dbcluster/resource-role.yaml
@@ -44,6 +44,8 @@ Resources:
                 - "rds:DescribeDBSubnetGroups"
                 - "rds:DescribeEvents"
                 - "rds:DescribeGlobalClusters"
+                - "rds:DisableHttpEndpoint"
+                - "rds:EnableHttpEndpoint"
                 - "rds:ModifyDBCluster"
                 - "rds:ModifyDBInstance"
                 - "rds:RemoveFromGlobalCluster"

--- a/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/Translator.java
+++ b/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/Translator.java
@@ -28,6 +28,8 @@ import software.amazon.awssdk.services.rds.model.DescribeDbClustersRequest;
 import software.amazon.awssdk.services.rds.model.DescribeDbInstancesRequest;
 import software.amazon.awssdk.services.rds.model.DescribeDbSubnetGroupsRequest;
 import software.amazon.awssdk.services.rds.model.DescribeGlobalClustersRequest;
+import software.amazon.awssdk.services.rds.model.DisableHttpEndpointRequest;
+import software.amazon.awssdk.services.rds.model.EnableHttpEndpointRequest;
 import software.amazon.awssdk.services.rds.model.ModifyDbClusterRequest;
 import software.amazon.awssdk.services.rds.model.RebootDbInstanceRequest;
 import software.amazon.awssdk.services.rds.model.RemoveFromGlobalClusterRequest;
@@ -214,7 +216,6 @@ public class Translator {
                 .domain(desiredModel.getDomain())
                 .domainIAMRoleName(desiredModel.getDomainIAMRoleName())
                 .enableGlobalWriteForwarding(desiredModel.getEnableGlobalWriteForwarding())
-                .enableHttpEndpoint(desiredModel.getEnableHttpEndpoint())
                 .enablePerformanceInsights(desiredModel.getPerformanceInsightsEnabled())
                 .iops(desiredModel.getIops())
                 .masterUserPassword(desiredModel.getMasterUserPassword())
@@ -232,6 +233,8 @@ public class Translator {
                     .backtrackWindow(castToLong(desiredModel.getBacktrackWindow()))
                     .enableIAMDatabaseAuthentication(desiredModel.getEnableIAMDatabaseAuthentication())
                     .preferredBackupWindow(desiredModel.getPreferredBackupWindow());
+        } else {
+            builder.enableHttpEndpoint(desiredModel.getEnableHttpEndpoint());
         }
 
         if (BooleanUtils.isTrue(desiredModel.getManageMasterUserPassword())) {
@@ -265,7 +268,6 @@ public class Translator {
                 .domain(desiredModel.getDomain())
                 .domainIAMRoleName(desiredModel.getDomainIAMRoleName())
                 .enableGlobalWriteForwarding(desiredModel.getEnableGlobalWriteForwarding())
-                .enableHttpEndpoint(desiredModel.getEnableHttpEndpoint())
                 .enableIAMDatabaseAuthentication(diff(previousModel.getEnableIAMDatabaseAuthentication(), desiredModel.getEnableIAMDatabaseAuthentication()))
                 .enablePerformanceInsights(desiredModel.getPerformanceInsightsEnabled())
                 .iops(desiredModel.getIops())
@@ -301,6 +303,10 @@ public class Translator {
             builder.masterUserSecretKmsKeyId(desiredModel.getMasterUserSecret() != null ? desiredModel.getMasterUserSecret().getKmsKeyId() : null);
         } else {
             builder.manageMasterUserPassword(getManageMasterUserPassword(previousModel, desiredModel));
+        }
+
+        if (EngineMode.fromString(desiredModel.getEngineMode()) == EngineMode.Serverless) {
+            builder.enableHttpEndpoint(desiredModel.getEnableHttpEndpoint());
         }
 
         return builder.build();
@@ -375,6 +381,22 @@ public class Translator {
     ) {
         return DescribeDbClustersRequest.builder()
                 .marker(nextToken)
+                .build();
+    }
+
+    static EnableHttpEndpointRequest enableHttpEndpointRequest(
+            final String clusterArn
+    ) {
+        return EnableHttpEndpointRequest.builder()
+                .resourceArn(clusterArn)
+                .build();
+    }
+
+    static DisableHttpEndpointRequest disableHttpEndpointRequest(
+            final String clusterArn
+    ) {
+        return DisableHttpEndpointRequest.builder()
+                .resourceArn(clusterArn)
                 .build();
     }
 

--- a/aws-rds-dbcluster/src/test/java/software/amazon/rds/dbcluster/BaseHandlerStdTest.java
+++ b/aws-rds-dbcluster/src/test/java/software/amazon/rds/dbcluster/BaseHandlerStdTest.java
@@ -1,13 +1,9 @@
 package software.amazon.rds.dbcluster;
 
-import java.time.Instant;
-import java.util.Collections;
-
+import org.apache.commons.collections.CollectionUtils;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-
-import org.apache.commons.collections.CollectionUtils;
 
 import software.amazon.awssdk.services.ec2.Ec2Client;
 import software.amazon.awssdk.services.rds.RdsClient;
@@ -53,7 +49,7 @@ class BaseHandlerStdTest {
 
     @Test
     void isMasterUserSecretStabilized_masterUserSecretIsNull() {
-        Assertions.assertThat(handler.isMasterUserSecretStabilized(
+        Assertions.assertThat(BaseHandlerStd.isMasterUserSecretStabilized(
                 DBCluster.builder()
                         .build()
         )).isTrue();
@@ -61,7 +57,7 @@ class BaseHandlerStdTest {
 
     @Test
     void isMasterUserSecretStabilized_masterUserSecretStatusActive() {
-        Assertions.assertThat(handler.isMasterUserSecretStabilized(
+        Assertions.assertThat(BaseHandlerStd.isMasterUserSecretStabilized(
                 DBCluster.builder()
                         .masterUserSecret(MasterUserSecret.builder()
                                 .secretStatus("Active")
@@ -78,12 +74,12 @@ class BaseHandlerStdTest {
                         .build())
                 .build();
         Assertions.assertThat(CollectionUtils.isEmpty(dbCluster.dbClusterMembers()));
-        Assertions.assertThat(handler.isMasterUserSecretStabilized(dbCluster)).isTrue();
+        Assertions.assertThat(BaseHandlerStd.isMasterUserSecretStabilized(dbCluster)).isTrue();
     }
 
     @Test
     void isGlobalWriteForwardingStabilized_globalWriteForwardingNotRequested() {
-        Assertions.assertThat(handler.isGlobalWriteForwardingStabilized(
+        Assertions.assertThat(BaseHandlerStd.isGlobalWriteForwardingStabilized(
                 DBCluster.builder()
                         .build()
         )).isTrue();
@@ -91,7 +87,7 @@ class BaseHandlerStdTest {
 
     @Test
     void isGlobalWriteForwardingStabilized_globalWriteForwardingRequested() {
-        Assertions.assertThat(handler.isGlobalWriteForwardingStabilized(
+        Assertions.assertThat(BaseHandlerStd.isGlobalWriteForwardingStabilized(
                 DBCluster.builder()
                         .globalWriteForwardingRequested(true)
                         .build()
@@ -100,7 +96,7 @@ class BaseHandlerStdTest {
 
     @Test
     void isGlobalWriteForwardingStabilized_globalWriteForwardingEnabled() {
-        Assertions.assertThat(handler.isGlobalWriteForwardingStabilized(
+        Assertions.assertThat(BaseHandlerStd.isGlobalWriteForwardingStabilized(
                 DBCluster.builder()
                         .globalWriteForwardingRequested(true)
                         .globalWriteForwardingStatus(WriteForwardingStatus.ENABLED)
@@ -110,7 +106,7 @@ class BaseHandlerStdTest {
 
     @Test
     void isGlobalWriteForwardingStabilized_globalWriteForwardingEnabling() {
-        Assertions.assertThat(handler.isGlobalWriteForwardingStabilized(
+        Assertions.assertThat(BaseHandlerStd.isGlobalWriteForwardingStabilized(
                 DBCluster.builder()
                         .globalWriteForwardingRequested(true)
                         .globalWriteForwardingStatus(WriteForwardingStatus.ENABLING)
@@ -123,7 +119,7 @@ class BaseHandlerStdTest {
         // GlobalWriteForwarding status will not enable until a replica is requested by customer
         // This prevents customers from creating a stack with only primary and setting the property
         // As WS does not validate this parameter the stack will wait on stabilization until timeout.
-        Assertions.assertThat(handler.isGlobalWriteForwardingStabilized(
+        Assertions.assertThat(BaseHandlerStd.isGlobalWriteForwardingStabilized(
                 DBCluster.builder()
                         .globalWriteForwardingRequested(true)
                         .globalWriteForwardingStatus(WriteForwardingStatus.DISABLED)
@@ -133,7 +129,7 @@ class BaseHandlerStdTest {
 
     @Test
     void isGlobalWriteForwardingStabilized_globalWriteForwardingDisabling() {
-        Assertions.assertThat(handler.isGlobalWriteForwardingStabilized(
+        Assertions.assertThat(BaseHandlerStd.isGlobalWriteForwardingStabilized(
                 DBCluster.builder()
                         .globalWriteForwardingRequested(true)
                         .globalWriteForwardingStatus(WriteForwardingStatus.DISABLING)

--- a/aws-rds-dbcluster/src/test/java/software/amazon/rds/dbcluster/SchemaTest.java
+++ b/aws-rds-dbcluster/src/test/java/software/amazon/rds/dbcluster/SchemaTest.java
@@ -141,6 +141,21 @@ class SchemaTest {
     }
 
     @Test
+    void testDrift_EnableHttpEndpoint_Aurora_Postgresql_Drifted() {
+        final ResourceModel input = ResourceModel.builder()
+                .enableHttpEndpoint(true)
+                .engine("aurora-postgresql")
+                .build();
+        final ResourceModel output = ResourceModel.builder()
+                .enableHttpEndpoint(false)
+                .engine("aurora-postgresql")
+                .build();
+        Assertions.assertThatThrownBy(() -> {
+            assertResourceNotDrifted(input, output, resourceSchema);
+        }).isInstanceOf(AssertionError.class);
+    }
+
+    @Test
     void testDrift_EnableHttpEndpoint_Provisioned() {
         final ResourceModel input = ResourceModel.builder()
                 .enableHttpEndpoint(true)


### PR DESCRIPTION
*Description of changes:*
Onboarding DBCluster to Data API version 2 feature, In the create scenario, We can enable it directly by including it in the createDBCluster API call. However, it is not supported in the RestoreDbClusterToPointInTime, RestoreDbClusterFromSnapshot, and ModifyDbCluster operations. Therefore, an additional call is necessary to enable or disable the HTTP endpoint.

Previously, the RDS webservice would disregard the false flag in the HttpEndpoint for engines that do not support the HTTP endpoint. As a result, we now ignore the unsupported fault when disabling the HTTP endpoint for the sake of backward compatibility.
  
Ref: https://aws.amazon.com/blogs/database/introducing-the-data-api-for-amazon-aurora-serverless-v2-and-amazon-aurora-provisioned-clusters/

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
