### PR TITLE
[DBInstance] Revert isEngineMutable check to use previous model for same engine check

### DIFF
--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/CreateHandler.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/CreateHandler.java
@@ -143,7 +143,8 @@ public class CreateHandler extends BaseHandlerStd {
                 }, CallbackContext::isAddTagsComplete, CallbackContext::setAddTagsComplete))
                 .then(progress -> ensureEngineSet(rdsProxyClient.defaultClient(), progress))
                 .then(progress -> {
-                    if (ResourceModelHelper.shouldUpdateAfterCreate(progress.getResourceModel())) {
+                    final DBInstance dbInstance = fetchDBInstance(rdsProxyClient.defaultClient(), model);
+                    if (ResourceModelHelper.shouldUpdateAfterCreate(progress.getResourceModel(), dbInstance.engine())) {
                         return Commons.execOnce(progress, () -> {
                                             progress.getCallbackContext().timestampOnce(RESOURCE_UPDATED_AT, Instant.now());
                                             return versioned(proxy, rdsProxyClient, progress, null, ImmutableMap.of(

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/Translator.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/Translator.java
@@ -229,6 +229,11 @@ public class Translator {
             builder.storageThroughput(model.getStorageThroughput());
             builder.storageType(model.getStorageType());
         }
+
+        if (ResourceModelHelper.isOracleCDBEngine(model.getEngine())) {
+            builder.engine(null);
+        }
+
         return builder.build();
     }
 
@@ -388,6 +393,11 @@ public class Translator {
             builder.storageThroughput(model.getStorageThroughput());
             builder.storageType(model.getStorageType());
         }
+
+        if (ResourceModelHelper.isOracleCDBEngine(model.getEngine())) {
+            builder.engine(null);
+        }
+
         return builder.build();
     }
 
@@ -599,7 +609,6 @@ public class Translator {
                 .engineVersion(model.getEngineVersion())
                 .manageMasterUserPassword(model.getManageMasterUserPassword())
                 .masterUserPassword(model.getMasterUserPassword())
-                .masterUserPassword(model.getMasterUserPassword())
                 .masterUserSecretKmsKeyId(model.getMasterUserSecret() != null ? model.getMasterUserSecret().getKmsKeyId() : null)
                 .maxAllocatedStorage(model.getMaxAllocatedStorage())
                 .monitoringInterval(model.getMonitoringInterval())
@@ -614,6 +623,11 @@ public class Translator {
             builder.storageThroughput(model.getStorageThroughput());
             builder.storageType(model.getStorageType());
         }
+
+        if (ResourceModelHelper.isOracleCDBEngine(model.getEngine())) {
+            builder.engine(model.getEngine());
+        }
+
         return builder.build();
     }
 

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/util/ImmutabilityHelper.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/util/ImmutabilityHelper.java
@@ -50,7 +50,7 @@ public final class ImmutabilityHelper {
     }
 
     static boolean isEngineMutable(final ResourceModel previous, final ResourceModel desired, final String currentEngine) {
-        return Objects.equal(currentEngine, desired.getEngine()) ||
+        return Objects.equal(previous.getEngine(), desired.getEngine()) ||
                 isUpgradeToAuroraMySQL(previous, desired) ||
                 isUpgradeToOracleSE2(previous, desired) ||
                 isOracleConvertToCDB(currentEngine, desired);

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/util/ResourceModelHelper.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/util/ResourceModelHelper.java
@@ -19,8 +19,11 @@ public final class ResourceModelHelper {
     private static final String SQLSERVER_ENGINE = "sqlserver";
     private static final String MYSQL_ENGINE_PREFIX = "mysql";
     private static final String ORACLE_ENGINE_PREFIX = "oracle";
+    private static final String ORACLE_SE2_CDB = "oracle-se2-cdb";
+    private static final String ORACLE_EE_CDB = "oracle-ee-cdb";
 
-    public static boolean shouldUpdateAfterCreate(final ResourceModel model) {
+    public static boolean shouldUpdateAfterCreate(final ResourceModel model,
+                                                  final String dbInstanceEngine) {
         return (isReadReplica(model) ||
                 isRestoreFromSnapshot(model) ||
                 isRestoreFromClusterSnapshot(model) ||
@@ -39,7 +42,8 @@ public final class ResourceModelHelper {
                                 (isSqlServer(model) && isStorageParametersModified(model)) ||
                                 BooleanUtils.isTrue(model.getManageMasterUserPassword()) ||
                                 BooleanUtils.isTrue(model.getDeletionProtection()) ||
-                                BooleanUtils.isTrue(model.getEnablePerformanceInsights())
+                                BooleanUtils.isTrue(model.getEnablePerformanceInsights()) ||
+                                ImmutabilityHelper.isOracleConvertToCDB(dbInstanceEngine, model)
                 );
     }
 
@@ -172,5 +176,9 @@ public final class ResourceModelHelper {
             return null;
         }
         return model.getAutomaticBackupReplicationRegion();
+    }
+
+    public static boolean isOracleCDBEngine(final String engine) {
+        return ORACLE_EE_CDB.equalsIgnoreCase(engine) || ORACLE_SE2_CDB.equalsIgnoreCase(engine);
     }
 }

--- a/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/CreateHandlerTest.java
+++ b/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/CreateHandlerTest.java
@@ -204,7 +204,7 @@ public class CreateHandlerTest extends AbstractHandlerTest {
         );
 
         verify(rdsProxy.client(), times(1)).restoreDBInstanceFromDBSnapshot(any(RestoreDbInstanceFromDbSnapshotRequest.class));
-        verify(rdsProxy.client(), times(2)).describeDBInstances(any(DescribeDbInstancesRequest.class));
+        verify(rdsProxy.client(), times(3)).describeDBInstances(any(DescribeDbInstancesRequest.class));
         verify(rdsProxy.client(), times(1)).describeDBSnapshots(any(DescribeDbSnapshotsRequest.class));
     }
 
@@ -244,7 +244,7 @@ public class CreateHandlerTest extends AbstractHandlerTest {
         ArgumentCaptor<RestoreDbInstanceFromDbSnapshotRequest> argumentCaptor = ArgumentCaptor.forClass(RestoreDbInstanceFromDbSnapshotRequest.class);
         verify(rdsProxyV12.client(), times(1)).restoreDBInstanceFromDBSnapshot(argumentCaptor.capture());
         verify(rdsProxyV12.client(), times(1)).describeDBInstances(any(DescribeDbInstancesRequest.class));
-        verify(rdsProxy.client(), times(2)).describeDBInstances(any(DescribeDbInstancesRequest.class));
+        verify(rdsProxy.client(), times(3)).describeDBInstances(any(DescribeDbInstancesRequest.class));
         verify(rdsProxy.client(), times(1)).addTagsToResource(any(AddTagsToResourceRequest.class));
         verify(rdsProxy.client(), times(1)).describeDBSnapshots(any(DescribeDbSnapshotsRequest.class));
     }
@@ -326,7 +326,7 @@ public class CreateHandlerTest extends AbstractHandlerTest {
         );
 
         verify(rdsProxy.client(), times(1)).describeDBSnapshots(any(DescribeDbSnapshotsRequest.class));
-        verify(rdsProxy.client(), times(2)).describeDBInstances(any(DescribeDbInstancesRequest.class));
+        verify(rdsProxy.client(), times(3)).describeDBInstances(any(DescribeDbInstancesRequest.class));
 
         ArgumentCaptor<RestoreDbInstanceFromDbSnapshotRequest> argument = ArgumentCaptor.forClass(RestoreDbInstanceFromDbSnapshotRequest.class);
         verify(rdsProxy.client(), times(1)).restoreDBInstanceFromDBSnapshot(argument.capture());
@@ -354,7 +354,7 @@ public class CreateHandlerTest extends AbstractHandlerTest {
                 expectSuccess()
         );
 
-        verify(rdsProxy.client(), times(2)).describeDBInstances(any(DescribeDbInstancesRequest.class));
+        verify(rdsProxy.client(), times(3)).describeDBInstances(any(DescribeDbInstancesRequest.class));
 
         ArgumentCaptor<RestoreDbInstanceFromDbSnapshotRequest> argument = ArgumentCaptor.forClass(RestoreDbInstanceFromDbSnapshotRequest.class);
         verify(rdsProxy.client(), times(1)).restoreDBInstanceFromDBSnapshot(argument.capture());
@@ -386,7 +386,7 @@ public class CreateHandlerTest extends AbstractHandlerTest {
         );
 
         verify(rdsProxy.client(), times(1)).describeDBSnapshots(any(DescribeDbSnapshotsRequest.class));
-        verify(rdsProxy.client(), times(2)).describeDBInstances(any(DescribeDbInstancesRequest.class));
+        verify(rdsProxy.client(), times(3)).describeDBInstances(any(DescribeDbInstancesRequest.class));
 
         ArgumentCaptor<RestoreDbInstanceFromDbSnapshotRequest> argument = ArgumentCaptor.forClass(RestoreDbInstanceFromDbSnapshotRequest.class);
         verify(rdsProxy.client(), times(1)).restoreDBInstanceFromDBSnapshot(argument.capture());
@@ -413,7 +413,7 @@ public class CreateHandlerTest extends AbstractHandlerTest {
         );
 
         verify(rdsProxy.client(), times(1)).createDBInstanceReadReplica(any(CreateDbInstanceReadReplicaRequest.class));
-        verify(rdsProxy.client(), times(2)).describeDBInstances(any(DescribeDbInstancesRequest.class));
+        verify(rdsProxy.client(), times(3)).describeDBInstances(any(DescribeDbInstancesRequest.class));
     }
 
     @Test
@@ -473,7 +473,7 @@ public class CreateHandlerTest extends AbstractHandlerTest {
         );
 
         verify(rdsProxy.client(), times(1)).modifyDBInstance(any(ModifyDbInstanceRequest.class));
-        verify(rdsProxy.client(), times(3)).describeDBInstances(any(DescribeDbInstancesRequest.class));
+        verify(rdsProxy.client(), times(4)).describeDBInstances(any(DescribeDbInstancesRequest.class));
         verify(rdsProxy.client(), times(1)).addTagsToResource(any(AddTagsToResourceRequest.class));
         verify(rdsProxy.client(), times(1)).describeEvents(any(DescribeEventsRequest.class));
     }
@@ -499,7 +499,7 @@ public class CreateHandlerTest extends AbstractHandlerTest {
         );
 
         verify(rdsProxy.client(), times(1)).rebootDBInstance(any(RebootDbInstanceRequest.class));
-        verify(rdsProxy.client(), times(3)).describeDBInstances(any(DescribeDbInstancesRequest.class));
+        verify(rdsProxy.client(), times(4)).describeDBInstances(any(DescribeDbInstancesRequest.class));
         verify(rdsProxy.client(), times(1)).addTagsToResource(any(AddTagsToResourceRequest.class));
     }
 
@@ -522,7 +522,7 @@ public class CreateHandlerTest extends AbstractHandlerTest {
         );
 
         verify(rdsProxy.client(), times(1)).createDBInstanceReadReplica(any(CreateDbInstanceReadReplicaRequest.class));
-        verify(rdsProxy.client(), times(2)).describeDBInstances(any(DescribeDbInstancesRequest.class));
+        verify(rdsProxy.client(), times(3)).describeDBInstances(any(DescribeDbInstancesRequest.class));
     }
 
     @Test
@@ -565,7 +565,7 @@ public class CreateHandlerTest extends AbstractHandlerTest {
                 expectSuccess()
         );
 
-        verify(rdsProxy.client(), times(2)).describeDBInstances(any(DescribeDbInstancesRequest.class));
+        verify(rdsProxy.client(), times(3)).describeDBInstances(any(DescribeDbInstancesRequest.class));
         verify(rdsProxy.client(), times(1)).addTagsToResource(any(AddTagsToResourceRequest.class));
     }
 
@@ -598,7 +598,7 @@ public class CreateHandlerTest extends AbstractHandlerTest {
         ArgumentCaptor<CreateDbInstanceRequest> argumentCaptor = ArgumentCaptor.forClass(CreateDbInstanceRequest.class);
         verify(rdsProxyV12.client(), times(1)).createDBInstance(argumentCaptor.capture());
         verify(rdsProxyV12.client(), times(1)).describeDBInstances(any(DescribeDbInstancesRequest.class));
-        verify(rdsProxy.client(), times(2)).describeDBInstances(any(DescribeDbInstancesRequest.class));
+        verify(rdsProxy.client(), times(3)).describeDBInstances(any(DescribeDbInstancesRequest.class));
         verify(rdsProxy.client(), times(1)).addTagsToResource(any(AddTagsToResourceRequest.class));
 
         Assertions.assertThat(argumentCaptor.getValue().dbSecurityGroups()).containsExactly(Iterables.toArray(DB_SECURITY_GROUPS, String.class));
@@ -680,6 +680,9 @@ public class CreateHandlerTest extends AbstractHandlerTest {
         transitions.add(DB_INSTANCE_ACTIVE.toBuilder()
                 .associatedRoles(Translator.translateAssociatedRolesToSdk(ASSOCIATED_ROLES))
                 .build());
+        transitions.add(DB_INSTANCE_ACTIVE.toBuilder()
+                .associatedRoles(Translator.translateAssociatedRolesToSdk(ASSOCIATED_ROLES))
+                .build());
 
         final CallbackContext context = new CallbackContext();
         context.setCreated(true);
@@ -694,7 +697,7 @@ public class CreateHandlerTest extends AbstractHandlerTest {
                 expectSuccess()
         );
 
-        verify(rdsProxy.client(), times(5)).describeDBInstances(any(DescribeDbInstancesRequest.class));
+        verify(rdsProxy.client(), times(6)).describeDBInstances(any(DescribeDbInstancesRequest.class));
         verify(rdsProxy.client(), times(3)).addRoleToDBInstance(any(AddRoleToDbInstanceRequest.class));
         verify(rdsProxy.client(), times(1)).addTagsToResource(any(AddTagsToResourceRequest.class));
     }
@@ -718,6 +721,9 @@ public class CreateHandlerTest extends AbstractHandlerTest {
         transitions.add(DB_INSTANCE_ACTIVE.toBuilder()
                 .associatedRoles(Translator.translateAssociatedRolesToSdk(associatedRoles))
                 .build());
+        transitions.add(DB_INSTANCE_ACTIVE.toBuilder()
+                .associatedRoles(Translator.translateAssociatedRolesToSdk(associatedRoles))
+                .build());
 
         final CallbackContext context = new CallbackContext();
         context.setCreated(true);
@@ -737,7 +743,7 @@ public class CreateHandlerTest extends AbstractHandlerTest {
                 expectSuccess()
         );
 
-        verify(rdsProxy.client(), times(3)).describeDBInstances(any(DescribeDbInstancesRequest.class));
+        verify(rdsProxy.client(), times(4)).describeDBInstances(any(DescribeDbInstancesRequest.class));
         verify(rdsProxy.client(), times(1)).addRoleToDBInstance(any(AddRoleToDbInstanceRequest.class));
         verify(rdsProxy.client(), times(1)).addTagsToResource(any(AddTagsToResourceRequest.class));
     }
@@ -758,7 +764,7 @@ public class CreateHandlerTest extends AbstractHandlerTest {
         );
 
         verify(rdsProxy.client(), times(1)).createDBInstance(any(CreateDbInstanceRequest.class));
-        verify(rdsProxy.client(), times(2)).describeDBInstances(any(DescribeDbInstancesRequest.class));
+        verify(rdsProxy.client(), times(3)).describeDBInstances(any(DescribeDbInstancesRequest.class));
     }
 
     @Test
@@ -782,7 +788,7 @@ public class CreateHandlerTest extends AbstractHandlerTest {
 
         final CreateDbInstanceRequest requestWithCertificate = createCaptor.getValue();
         Assertions.assertThat(requestWithCertificate.caCertificateIdentifier()).isEqualTo(CA_CERTIFICATE_IDENTIFIER_NON_EMPTY);
-        verify(rdsProxy.client(), times(2)).describeDBInstances(any(DescribeDbInstancesRequest.class));
+        verify(rdsProxy.client(), times(3)).describeDBInstances(any(DescribeDbInstancesRequest.class));
     }
 
     @Test
@@ -808,7 +814,7 @@ public class CreateHandlerTest extends AbstractHandlerTest {
                 expectSuccess()
         );
 
-        verify(rdsProxy.client(), times(2)).describeDBInstances(any(DescribeDbInstancesRequest.class));
+        verify(rdsProxy.client(), times(3)).describeDBInstances(any(DescribeDbInstancesRequest.class));
         verify(rdsProxy.client(), times(1)).describeEvents(any(DescribeEventsRequest.class));
 
         ArgumentCaptor<ModifyDbInstanceRequest> captor = ArgumentCaptor.forClass(ModifyDbInstanceRequest.class);
@@ -837,7 +843,7 @@ public class CreateHandlerTest extends AbstractHandlerTest {
                 expectSuccess()
         );
 
-        verify(rdsProxy.client(), times(2)).describeDBInstances(any(DescribeDbInstancesRequest.class));
+        verify(rdsProxy.client(), times(3)).describeDBInstances(any(DescribeDbInstancesRequest.class));
     }
 
     @Test
@@ -858,7 +864,7 @@ public class CreateHandlerTest extends AbstractHandlerTest {
                 expectSuccess()
         );
 
-        verify(rdsProxy.client(), times(2)).describeDBInstances(any(DescribeDbInstancesRequest.class));
+        verify(rdsProxy.client(), times(3)).describeDBInstances(any(DescribeDbInstancesRequest.class));
         verify(rdsProxy.client(), times(1)).addTagsToResource(any(AddTagsToResourceRequest.class));
     }
 
@@ -889,7 +895,7 @@ public class CreateHandlerTest extends AbstractHandlerTest {
 
         verify(rdsProxyV12.client(), times(1)).modifyDBInstance(any(ModifyDbInstanceRequest.class));
         verify(rdsProxyV12.client(), times(1)).describeDBInstances(any(DescribeDbInstancesRequest.class));
-        verify(rdsProxy.client(), times(2)).describeDBInstances(any(DescribeDbInstancesRequest.class));
+        verify(rdsProxy.client(), times(3)).describeDBInstances(any(DescribeDbInstancesRequest.class));
         verify(rdsProxy.client(), times(1)).describeEvents(any(DescribeEventsRequest.class));
     }
 
@@ -918,7 +924,7 @@ public class CreateHandlerTest extends AbstractHandlerTest {
         ArgumentCaptor<CreateDbInstanceReadReplicaRequest> captor = ArgumentCaptor.forClass(CreateDbInstanceReadReplicaRequest.class);
         verify(rdsProxy.client(), times(1)).createDBInstanceReadReplica(captor.capture());
         Assertions.assertThat(captor.getValue().allocatedStorage()).isEqualTo(ALLOCATED_STORAGE);
-        verify(rdsProxy.client(), times(2)).describeDBInstances(any(DescribeDbInstancesRequest.class));
+        verify(rdsProxy.client(), times(3)).describeDBInstances(any(DescribeDbInstancesRequest.class));
     }
 
     @Test
@@ -950,7 +956,7 @@ public class CreateHandlerTest extends AbstractHandlerTest {
         ArgumentCaptor<RestoreDbInstanceFromDbSnapshotRequest> captor = ArgumentCaptor.forClass(RestoreDbInstanceFromDbSnapshotRequest.class);
         verify(rdsProxy.client(), times(1)).restoreDBInstanceFromDBSnapshot(captor.capture());
         Assertions.assertThat(captor.getValue().allocatedStorage()).isEqualTo(ALLOCATED_STORAGE);
-        verify(rdsProxy.client(), times(2)).describeDBInstances(any(DescribeDbInstancesRequest.class));
+        verify(rdsProxy.client(), times(3)).describeDBInstances(any(DescribeDbInstancesRequest.class));
     }
 
     @Test
@@ -984,7 +990,7 @@ public class CreateHandlerTest extends AbstractHandlerTest {
         ArgumentCaptor<RestoreDbInstanceFromDbSnapshotRequest> captor = ArgumentCaptor.forClass(RestoreDbInstanceFromDbSnapshotRequest.class);
         verify(rdsProxy.client(), times(1)).restoreDBInstanceFromDBSnapshot(captor.capture());
         Assertions.assertThat(captor.getValue().allocatedStorage()).isNull();
-        verify(rdsProxy.client(), times(3)).describeDBInstances(any(DescribeDbInstancesRequest.class));
+        verify(rdsProxy.client(), times(4)).describeDBInstances(any(DescribeDbInstancesRequest.class));
         ArgumentCaptor<ModifyDbInstanceRequest> modifyCaptor = ArgumentCaptor.forClass(ModifyDbInstanceRequest.class);
         verify(rdsProxy.client(), times(1)).modifyDBInstance(modifyCaptor.capture());
         Assertions.assertThat(modifyCaptor.getValue().allocatedStorage()).isEqualTo(ALLOCATED_STORAGE);
@@ -1014,7 +1020,7 @@ public class CreateHandlerTest extends AbstractHandlerTest {
         );
 
         verify(rdsProxy.client(), times(1)).modifyDBInstance(any(ModifyDbInstanceRequest.class));
-        verify(rdsProxy.client(), times(3)).describeDBInstances(any(DescribeDbInstancesRequest.class));
+        verify(rdsProxy.client(), times(4)).describeDBInstances(any(DescribeDbInstancesRequest.class));
         verify(rdsProxy.client(), times(1)).describeEvents(any(DescribeEventsRequest.class));
     }
 
@@ -1042,7 +1048,7 @@ public class CreateHandlerTest extends AbstractHandlerTest {
         );
 
         verify(rdsProxy.client(), times(1)).modifyDBInstance(any(ModifyDbInstanceRequest.class));
-        verify(rdsProxy.client(), times(3)).describeDBInstances(any(DescribeDbInstancesRequest.class));
+        verify(rdsProxy.client(), times(4)).describeDBInstances(any(DescribeDbInstancesRequest.class));
         verify(rdsProxy.client(), times(1)).describeEvents(any(DescribeEventsRequest.class));
     }
 
@@ -1070,7 +1076,7 @@ public class CreateHandlerTest extends AbstractHandlerTest {
         );
 
         verify(rdsProxy.client(), times(1)).modifyDBInstance(any(ModifyDbInstanceRequest.class));
-        verify(rdsProxy.client(), times(3)).describeDBInstances(any(DescribeDbInstancesRequest.class));
+        verify(rdsProxy.client(), times(4)).describeDBInstances(any(DescribeDbInstancesRequest.class));
         verify(rdsProxy.client(), times(1)).describeEvents(any(DescribeEventsRequest.class));
     }
 
@@ -1098,7 +1104,7 @@ public class CreateHandlerTest extends AbstractHandlerTest {
         );
 
         verify(rdsProxy.client(), times(1)).modifyDBInstance(any(ModifyDbInstanceRequest.class));
-        verify(rdsProxy.client(), times(3)).describeDBInstances(any(DescribeDbInstancesRequest.class));
+        verify(rdsProxy.client(), times(4)).describeDBInstances(any(DescribeDbInstancesRequest.class));
         verify(rdsProxy.client(), times(1)).describeEvents(any(DescribeEventsRequest.class));
     }
 
@@ -1126,7 +1132,7 @@ public class CreateHandlerTest extends AbstractHandlerTest {
         );
 
         verify(rdsProxy.client(), times(1)).modifyDBInstance(any(ModifyDbInstanceRequest.class));
-        verify(rdsProxy.client(), times(3)).describeDBInstances(any(DescribeDbInstancesRequest.class));
+        verify(rdsProxy.client(), times(4)).describeDBInstances(any(DescribeDbInstancesRequest.class));
         verify(rdsProxy.client(), times(1)).describeEvents(any(DescribeEventsRequest.class));
     }
 
@@ -1154,7 +1160,7 @@ public class CreateHandlerTest extends AbstractHandlerTest {
         );
 
         verify(rdsProxy.client(), times(1)).modifyDBInstance(any(ModifyDbInstanceRequest.class));
-        verify(rdsProxy.client(), times(3)).describeDBInstances(any(DescribeDbInstancesRequest.class));
+        verify(rdsProxy.client(), times(4)).describeDBInstances(any(DescribeDbInstancesRequest.class));
         verify(rdsProxy.client(), times(1)).describeEvents(any(DescribeEventsRequest.class));
     }
 
@@ -1182,7 +1188,7 @@ public class CreateHandlerTest extends AbstractHandlerTest {
         );
 
         verify(rdsProxy.client(), times(1)).modifyDBInstance(any(ModifyDbInstanceRequest.class));
-        verify(rdsProxy.client(), times(3)).describeDBInstances(any(DescribeDbInstancesRequest.class));
+        verify(rdsProxy.client(), times(4)).describeDBInstances(any(DescribeDbInstancesRequest.class));
         verify(rdsProxy.client(), times(1)).describeEvents(any(DescribeEventsRequest.class));
     }
 
@@ -1210,7 +1216,7 @@ public class CreateHandlerTest extends AbstractHandlerTest {
         );
 
         verify(rdsProxy.client(), times(1)).modifyDBInstance(any(ModifyDbInstanceRequest.class));
-        verify(rdsProxy.client(), times(3)).describeDBInstances(any(DescribeDbInstancesRequest.class));
+        verify(rdsProxy.client(), times(4)).describeDBInstances(any(DescribeDbInstancesRequest.class));
         verify(rdsProxy.client(), times(1)).describeEvents(any(DescribeEventsRequest.class));
     }
 
@@ -1238,7 +1244,7 @@ public class CreateHandlerTest extends AbstractHandlerTest {
         );
 
         verify(rdsProxy.client(), times(1)).modifyDBInstance(any(ModifyDbInstanceRequest.class));
-        verify(rdsProxy.client(), times(3)).describeDBInstances(any(DescribeDbInstancesRequest.class));
+        verify(rdsProxy.client(), times(4)).describeDBInstances(any(DescribeDbInstancesRequest.class));
         verify(rdsProxy.client(), times(1)).describeEvents(any(DescribeEventsRequest.class));
     }
 
@@ -1402,7 +1408,7 @@ public class CreateHandlerTest extends AbstractHandlerTest {
                 expectSuccess()
         );
 
-        verify(rdsProxy.client(), times(2)).describeDBInstances(any(DescribeDbInstancesRequest.class));
+        verify(rdsProxy.client(), times(3)).describeDBInstances(any(DescribeDbInstancesRequest.class));
 
         ArgumentCaptor<RestoreDbInstanceFromDbSnapshotRequest> captor = ArgumentCaptor.forClass(RestoreDbInstanceFromDbSnapshotRequest.class);
         verify(rdsProxy.client(), times(1)).restoreDBInstanceFromDBSnapshot(captor.capture());
@@ -1432,7 +1438,7 @@ public class CreateHandlerTest extends AbstractHandlerTest {
                 expectSuccess()
         );
 
-        verify(rdsProxy.client(), times(2)).describeDBInstances(any(DescribeDbInstancesRequest.class));
+        verify(rdsProxy.client(), times(3)).describeDBInstances(any(DescribeDbInstancesRequest.class));
 
         ArgumentCaptor<CreateDbInstanceRequest> captor = ArgumentCaptor.forClass(CreateDbInstanceRequest.class);
         verify(rdsProxy.client(), times(1)).createDBInstance(captor.capture());
@@ -1464,7 +1470,7 @@ public class CreateHandlerTest extends AbstractHandlerTest {
                 expectSuccess()
         );
 
-        verify(rdsProxy.client(), times(2)).describeDBInstances(any(DescribeDbInstancesRequest.class));
+        verify(rdsProxy.client(), times(3)).describeDBInstances(any(DescribeDbInstancesRequest.class));
 
         ArgumentCaptor<ModifyDbInstanceRequest> captor = ArgumentCaptor.forClass(ModifyDbInstanceRequest.class);
         verify(rdsProxy.client()).modifyDBInstance(captor.capture());
@@ -1493,7 +1499,7 @@ public class CreateHandlerTest extends AbstractHandlerTest {
                 expectSuccess()
         );
 
-        verify(rdsProxy.client(), times(2)).describeDBInstances(any(DescribeDbInstancesRequest.class));
+        verify(rdsProxy.client(), times(3)).describeDBInstances(any(DescribeDbInstancesRequest.class));
 
         ArgumentCaptor<CreateDbInstanceReadReplicaRequest> captor = ArgumentCaptor.forClass(CreateDbInstanceReadReplicaRequest.class);
         verify(rdsProxy.client(), times(1)).createDBInstanceReadReplica(captor.capture());
@@ -1604,7 +1610,7 @@ public class CreateHandlerTest extends AbstractHandlerTest {
                 expectSuccess()
         );
 
-        verify(rdsProxy.client(), times(3)).describeDBInstances(any(DescribeDbInstancesRequest.class));
+        verify(rdsProxy.client(), times(4)).describeDBInstances(any(DescribeDbInstancesRequest.class));
         verify(rdsProxy.client(), times(1)).restoreDBInstanceFromDBSnapshot(any(RestoreDbInstanceFromDbSnapshotRequest.class));
 
         ArgumentCaptor<ModifyDbInstanceRequest> captor = ArgumentCaptor.forClass(ModifyDbInstanceRequest.class);
@@ -1739,7 +1745,7 @@ public class CreateHandlerTest extends AbstractHandlerTest {
         );
 
         verify(rdsProxy.client(), times(1)).restoreDBInstanceToPointInTime(any(RestoreDbInstanceToPointInTimeRequest.class));
-        verify(rdsProxy.client(), times(2)).describeDBInstances(any(DescribeDbInstancesRequest.class));
+        verify(rdsProxy.client(), times(3)).describeDBInstances(any(DescribeDbInstancesRequest.class));
     }
 
     @Test
@@ -1764,7 +1770,7 @@ public class CreateHandlerTest extends AbstractHandlerTest {
         );
 
         verify(rdsProxy.client(), times(1)).restoreDBInstanceToPointInTime(any(RestoreDbInstanceToPointInTimeRequest.class));
-        verify(rdsProxy.client(), times(2)).describeDBInstances(any(DescribeDbInstancesRequest.class));
+        verify(rdsProxy.client(), times(3)).describeDBInstances(any(DescribeDbInstancesRequest.class));
     }
 
     @Test
@@ -1791,7 +1797,7 @@ public class CreateHandlerTest extends AbstractHandlerTest {
         ArgumentCaptor<RestoreDbInstanceToPointInTimeRequest> captor = ArgumentCaptor.forClass(RestoreDbInstanceToPointInTimeRequest.class);
 
         verify(rdsProxy.client(), times(1)).restoreDBInstanceToPointInTime(captor.capture());
-        verify(rdsProxy.client(), times(2)).describeDBInstances(any(DescribeDbInstancesRequest.class));
+        verify(rdsProxy.client(), times(3)).describeDBInstances(any(DescribeDbInstancesRequest.class));
 
         // Both identifiers are passed as null. DBInstanceIdentifier will be random and the same value will be used for TargetDBInstanceIdentifier
         // All of these InstanceIdentifier tests are non-perfect since we can't tell the value of DBInstanceIdentifier. So this is only half the picture
@@ -1823,7 +1829,7 @@ public class CreateHandlerTest extends AbstractHandlerTest {
         ArgumentCaptor<RestoreDbInstanceToPointInTimeRequest> captor = ArgumentCaptor.forClass(RestoreDbInstanceToPointInTimeRequest.class);
 
         verify(rdsProxy.client(), times(1)).restoreDBInstanceToPointInTime(captor.capture());
-        verify(rdsProxy.client(), times(2)).describeDBInstances(any(DescribeDbInstancesRequest.class));
+        verify(rdsProxy.client(), times(3)).describeDBInstances(any(DescribeDbInstancesRequest.class));
 
         // Specific DBInstanceIdentifier. The same value will be used for TargetDBInstanceIdentifier
         Assertions.assertThat(captor.getValue().targetDBInstanceIdentifier()).isEqualTo(DB_INSTANCE_IDENTIFIER_NON_EMPTY);
@@ -1853,7 +1859,7 @@ public class CreateHandlerTest extends AbstractHandlerTest {
         ArgumentCaptor<RestoreDbInstanceToPointInTimeRequest> captor = ArgumentCaptor.forClass(RestoreDbInstanceToPointInTimeRequest.class);
 
         verify(rdsProxy.client(), times(1)).restoreDBInstanceToPointInTime(captor.capture());
-        verify(rdsProxy.client(), times(2)).describeDBInstances(any(DescribeDbInstancesRequest.class));
+        verify(rdsProxy.client(), times(3)).describeDBInstances(any(DescribeDbInstancesRequest.class));
 
         Assertions.assertThat(captor.getValue().restoreTime()).isEqualTo(RESTORE_TIME_UTC);
     }
@@ -1882,7 +1888,7 @@ public class CreateHandlerTest extends AbstractHandlerTest {
         ArgumentCaptor<RestoreDbInstanceToPointInTimeRequest> captor = ArgumentCaptor.forClass(RestoreDbInstanceToPointInTimeRequest.class);
 
         verify(rdsProxy.client(), times(1)).restoreDBInstanceToPointInTime(captor.capture());
-        verify(rdsProxy.client(), times(2)).describeDBInstances(any(DescribeDbInstancesRequest.class));
+        verify(rdsProxy.client(), times(3)).describeDBInstances(any(DescribeDbInstancesRequest.class));
 
         Assertions.assertThat(captor.getValue().restoreTime()).isEqualTo(RESTORE_TIME_UTC);
     }
@@ -1954,7 +1960,7 @@ public class CreateHandlerTest extends AbstractHandlerTest {
         );
 
         verify(rdsProxy.client(), times(1)).modifyDBInstance(any(ModifyDbInstanceRequest.class));
-        verify(rdsProxy.client(), times(3)).describeDBInstances(any(DescribeDbInstancesRequest.class));
+        verify(rdsProxy.client(), times(4)).describeDBInstances(any(DescribeDbInstancesRequest.class));
         verify(rdsProxy.client(), times(1)).addTagsToResource(any(AddTagsToResourceRequest.class));
         verify(rdsProxy.client(), times(1)).describeEvents(any(DescribeEventsRequest.class));
     }
@@ -1982,7 +1988,7 @@ public class CreateHandlerTest extends AbstractHandlerTest {
         );
 
         verify(rdsProxy.client(), times(1)).rebootDBInstance(any(RebootDbInstanceRequest.class));
-        verify(rdsProxy.client(), times(3)).describeDBInstances(any(DescribeDbInstancesRequest.class));
+        verify(rdsProxy.client(), times(4)).describeDBInstances(any(DescribeDbInstancesRequest.class));
         verify(rdsProxy.client(), times(1)).addTagsToResource(any(AddTagsToResourceRequest.class));
     }
 
@@ -2017,7 +2023,7 @@ public class CreateHandlerTest extends AbstractHandlerTest {
         verify(crossRegionRdsProxy.client(), times(1)).startDBInstanceAutomatedBackupsReplication(any(StartDbInstanceAutomatedBackupsReplicationRequest.class));
         verify(crossRegionRdsProxy.client(), atLeastOnce()).serviceName();
         verifyNoMoreInteractions(crossRegionRdsProxy.client());
-        verify(rdsProxy.client(), times(3)).describeDBInstances(any(DescribeDbInstancesRequest.class));
+        verify(rdsProxy.client(), times(4)).describeDBInstances(any(DescribeDbInstancesRequest.class));
     }
 
     @Test
@@ -2042,7 +2048,7 @@ public class CreateHandlerTest extends AbstractHandlerTest {
                 expectSuccess()
         );
 
-        verify(rdsProxy.client(), times(1)).describeDBInstances(any(DescribeDbInstancesRequest.class));
+        verify(rdsProxy.client(), times(2)).describeDBInstances(any(DescribeDbInstancesRequest.class));
     }
 
     @Test
@@ -2071,7 +2077,7 @@ public class CreateHandlerTest extends AbstractHandlerTest {
         ArgumentCaptor<DescribeDbSnapshotsRequest> captor = ArgumentCaptor.forClass(DescribeDbSnapshotsRequest.class);
         verify(rdsProxy.client(), times(1)).describeDBSnapshots(captor.capture());
         Assertions.assertThat(captor.getValue().dbSnapshotIdentifier()).isEqualTo("snapshot");
-        verify(rdsProxy.client(), times(1)).describeDBInstances(any(DescribeDbInstancesRequest.class));
+        verify(rdsProxy.client(), times(2)).describeDBInstances(any(DescribeDbInstancesRequest.class));
     }
 
     @Test
@@ -2100,7 +2106,7 @@ public class CreateHandlerTest extends AbstractHandlerTest {
         ArgumentCaptor<DescribeDbClusterSnapshotsRequest> captor = ArgumentCaptor.forClass(DescribeDbClusterSnapshotsRequest.class);
         verify(rdsProxy.client(), times(1)).describeDBClusterSnapshots(captor.capture());
         Assertions.assertThat(captor.getValue().dbClusterSnapshotIdentifier()).isEqualTo("cluster-snapshot");
-        verify(rdsProxy.client(), times(1)).describeDBInstances(any(DescribeDbInstancesRequest.class));
+        verify(rdsProxy.client(), times(2)).describeDBInstances(any(DescribeDbInstancesRequest.class));
     }
 
     @Test
@@ -2122,7 +2128,7 @@ public class CreateHandlerTest extends AbstractHandlerTest {
         );
 
         ArgumentCaptor<DescribeDbInstancesRequest> captor = ArgumentCaptor.forClass(DescribeDbInstancesRequest.class);
-        verify(rdsProxy.client(), times(2)).describeDBInstances(captor.capture());
+        verify(rdsProxy.client(), times(3)).describeDBInstances(captor.capture());
         Assertions.assertThat(captor.getAllValues().get(0).dbInstanceIdentifier()).isEqualTo("rr-source");
     }
 
@@ -2174,7 +2180,7 @@ public class CreateHandlerTest extends AbstractHandlerTest {
         );
 
         ArgumentCaptor<DescribeDbInstancesRequest> captor = ArgumentCaptor.forClass(DescribeDbInstancesRequest.class);
-        verify(rdsProxy.client(), times(2)).describeDBInstances(captor.capture());
+        verify(rdsProxy.client(), times(3)).describeDBInstances(captor.capture());
         Assertions.assertThat(captor.getAllValues().get(0).dbInstanceIdentifier()).isEqualTo("pitr-source");
     }
 
@@ -2198,7 +2204,7 @@ public class CreateHandlerTest extends AbstractHandlerTest {
         );
 
         ArgumentCaptor<DescribeDbInstancesRequest> captor = ArgumentCaptor.forClass(DescribeDbInstancesRequest.class);
-        verify(rdsProxy.client(), times(2)).describeDBInstances(captor.capture());
+        verify(rdsProxy.client(), times(3)).describeDBInstances(captor.capture());
         Assertions.assertThat(captor.getAllValues().get(0).filters()).hasSize(1);
 
         Assertions.assertThat(captor.getAllValues().get(0).filters().get(0).name()).isEqualTo("dbi-resource-id");

--- a/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/util/ResourceModelHelperTest.java
+++ b/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/util/ResourceModelHelperTest.java
@@ -69,7 +69,7 @@ public class ResourceModelHelperTest {
         final ResourceModel model = ResourceModel.builder()
                 .build();
 
-        assertThat(ResourceModelHelper.shouldUpdateAfterCreate(model)).isFalse();
+        assertThat(ResourceModelHelper.shouldUpdateAfterCreate(model, null)).isFalse();
     }
 
     @ParameterizedTest
@@ -80,9 +80,7 @@ public class ResourceModelHelperTest {
             "mariadb",
             "mysql",
             "oracle-ee",
-            "oracle-ee-cdb",
             "oracle-se2",
-            "oracle-se2-cdb",
             "postgres"})
     public void shouldUpdateAfterCreate_whenRestoreFromNonSqlServerSnapshotAndAllocatedStorage(final String engine) {
         final ResourceModel model = ResourceModel.builder()
@@ -91,7 +89,7 @@ public class ResourceModelHelperTest {
                 .allocatedStorage("100")
                 .build();
 
-        assertThat(ResourceModelHelper.shouldUpdateAfterCreate(model)).isFalse();
+        assertThat(ResourceModelHelper.shouldUpdateAfterCreate(model, null)).isFalse();
     }
 
 
@@ -108,7 +106,7 @@ public class ResourceModelHelperTest {
                 .allocatedStorage("100")
                 .build();
 
-        assertThat(ResourceModelHelper.shouldUpdateAfterCreate(model)).isTrue();
+        assertThat(ResourceModelHelper.shouldUpdateAfterCreate(model, null)).isTrue();
     }
 
     @Test
@@ -118,7 +116,7 @@ public class ResourceModelHelperTest {
                 .masterUserPassword("password")
                 .build();
 
-        assertThat(ResourceModelHelper.shouldUpdateAfterCreate(model)).isTrue();
+        assertThat(ResourceModelHelper.shouldUpdateAfterCreate(model, null)).isTrue();
     }
 
     @Test
@@ -128,7 +126,7 @@ public class ResourceModelHelperTest {
                 .preferredMaintenanceWindow("window")
                 .build();
 
-        assertThat(ResourceModelHelper.shouldUpdateAfterCreate(model)).isTrue();
+        assertThat(ResourceModelHelper.shouldUpdateAfterCreate(model, null)).isTrue();
     }
 
     @Test
@@ -138,7 +136,7 @@ public class ResourceModelHelperTest {
                 .maxAllocatedStorage(100)
                 .build();
 
-        assertThat(ResourceModelHelper.shouldUpdateAfterCreate(model)).isTrue();
+        assertThat(ResourceModelHelper.shouldUpdateAfterCreate(model, null)).isTrue();
     }
 
     @Test
@@ -149,7 +147,7 @@ public class ResourceModelHelperTest {
                 .dBSnapshotIdentifier("identifier")
                 .build();
 
-        assertThat(ResourceModelHelper.shouldUpdateAfterCreate(model)).isTrue();
+        assertThat(ResourceModelHelper.shouldUpdateAfterCreate(model, null)).isTrue();
     }
 
     @Test
@@ -159,7 +157,7 @@ public class ResourceModelHelperTest {
                 .storageThroughput(100)
                 .build();
 
-        assertThat(ResourceModelHelper.shouldUpdateAfterCreate(model)).isTrue();
+        assertThat(ResourceModelHelper.shouldUpdateAfterCreate(model, null)).isTrue();
     }
 
     @Test
@@ -170,7 +168,7 @@ public class ResourceModelHelperTest {
                 .engine("sqlserver")
                 .build();
 
-        assertThat(ResourceModelHelper.shouldUpdateAfterCreate(model)).isTrue();
+        assertThat(ResourceModelHelper.shouldUpdateAfterCreate(model, null)).isTrue();
     }
 
     @Test
@@ -180,7 +178,7 @@ public class ResourceModelHelperTest {
                 .manageMasterUserPassword(true)
                 .build();
 
-        assertThat(ResourceModelHelper.shouldUpdateAfterCreate(model)).isTrue();
+        assertThat(ResourceModelHelper.shouldUpdateAfterCreate(model, null)).isTrue();
     }
 
     @Test
@@ -189,7 +187,7 @@ public class ResourceModelHelperTest {
                 .sourceDBInstanceIdentifier("source-db-instance-identifier")
                 .deletionProtection(true)
                 .build();
-        assertThat(ResourceModelHelper.shouldUpdateAfterCreate(model)).isTrue();
+        assertThat(ResourceModelHelper.shouldUpdateAfterCreate(model, null)).isTrue();
     }
 
     @Test
@@ -198,7 +196,7 @@ public class ResourceModelHelperTest {
                 .dBSnapshotIdentifier("db-snapshot-identifier")
                 .enablePerformanceInsights(true)
                 .build();
-        assertThat(ResourceModelHelper.shouldUpdateAfterCreate(model)).isTrue();
+        assertThat(ResourceModelHelper.shouldUpdateAfterCreate(model, null)).isTrue();
     }
 
     @Test
@@ -207,7 +205,7 @@ public class ResourceModelHelperTest {
                 .dBSnapshotIdentifier("db-snapshot-identifier")
                 .enablePerformanceInsights(false)
                 .build();
-        assertThat(ResourceModelHelper.shouldUpdateAfterCreate(model)).isFalse();
+        assertThat(ResourceModelHelper.shouldUpdateAfterCreate(model, null)).isFalse();
     }
 
     @Test
@@ -216,7 +214,7 @@ public class ResourceModelHelperTest {
                 .dBSnapshotIdentifier("db-snapshot-identifier")
                 .enablePerformanceInsights(null)
                 .build();
-        assertThat(ResourceModelHelper.shouldUpdateAfterCreate(model)).isFalse();
+        assertThat(ResourceModelHelper.shouldUpdateAfterCreate(model, null)).isFalse();
     }
 
     @Test
@@ -225,7 +223,7 @@ public class ResourceModelHelperTest {
                 .dBSnapshotIdentifier("db-snapshot-identifier")
                 .monitoringInterval(42)
                 .build();
-        assertThat(ResourceModelHelper.shouldUpdateAfterCreate(model)).isTrue();
+        assertThat(ResourceModelHelper.shouldUpdateAfterCreate(model, null)).isTrue();
     }
 
     @Test
@@ -234,7 +232,7 @@ public class ResourceModelHelperTest {
                 .dBSnapshotIdentifier("db-snapshot-identifier")
                 .monitoringRoleArn("monitoring-role-arn")
                 .build();
-        assertThat(ResourceModelHelper.shouldUpdateAfterCreate(model)).isTrue();
+        assertThat(ResourceModelHelper.shouldUpdateAfterCreate(model, null)).isTrue();
     }
 
     @Test
@@ -244,7 +242,7 @@ public class ResourceModelHelperTest {
                 .storageType("gp2")
                 .build();
 
-        assertThat(ResourceModelHelper.shouldUpdateAfterCreate(model)).isTrue();
+        assertThat(ResourceModelHelper.shouldUpdateAfterCreate(model, null)).isTrue();
     }
 
     @Test
@@ -255,7 +253,7 @@ public class ResourceModelHelperTest {
                 .storageType("gp2")
                 .build();
 
-        assertThat(ResourceModelHelper.shouldUpdateAfterCreate(model)).isTrue();
+        assertThat(ResourceModelHelper.shouldUpdateAfterCreate(model, null)).isTrue();
     }
 
     @Test
@@ -266,7 +264,7 @@ public class ResourceModelHelperTest {
                 .storageType("gp2")
                 .build();
 
-        assertThat(ResourceModelHelper.shouldUpdateAfterCreate(model)).isFalse();
+        assertThat(ResourceModelHelper.shouldUpdateAfterCreate(model, null)).isFalse();
     }
 
     @Test
@@ -277,7 +275,27 @@ public class ResourceModelHelperTest {
                 .storageType("gp2")
                 .build();
 
-        assertThat(ResourceModelHelper.shouldUpdateAfterCreate(model)).isTrue();
+        assertThat(ResourceModelHelper.shouldUpdateAfterCreate(model, null)).isTrue();
+    }
+
+    @Test
+    public void shouldUpdateAfterCreate_whenRestoreFromOracleEESnapshotAndCDBEngineSpecified() {
+        final ResourceModel model = ResourceModel.builder()
+                .engine("oracle-ee-cdb")
+                .dBSnapshotIdentifier("snapshot")
+                .build();
+
+        assertThat(ResourceModelHelper.shouldUpdateAfterCreate(model, "oracle-ee")).isTrue();
+    }
+
+    @Test
+    public void shouldNotUpdateAfterCreate_whenRestoreFromOracleCDBEESnapshotAndCDBEngineSpecified() {
+        final ResourceModel model = ResourceModel.builder()
+                .engine("oracle-ee-cdb")
+                .dBSnapshotIdentifier("snapshot")
+                .build();
+
+        assertThat(ResourceModelHelper.shouldUpdateAfterCreate(model, "oracle-ee-cdb")).isFalse();
     }
 
     @Test


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Revert isEngineMutable check to use previous model for same engine check

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
