### PR TITLE
[Integration] Correct the maximum name length for Integration

### DIFF
--- a/aws-rds-integration/src/main/java/software/amazon/rds/integration/BaseHandlerStd.java
+++ b/aws-rds-integration/src/main/java/software/amazon/rds/integration/BaseHandlerStd.java
@@ -29,7 +29,7 @@ import java.util.Collection;
 public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
     protected static final String STACK_NAME = "rds";
     protected static final String RESOURCE_IDENTIFIER = "integration";
-    protected static final int MAX_LENGTH_INTEGRATION = 64;
+    protected static final int MAX_LENGTH_INTEGRATION = 63;
 
     protected static final ErrorRuleSet DEFAULT_INTEGRATION_ERROR_RULE_SET = ErrorRuleSet
             .extend(Commons.DEFAULT_ERROR_RULE_SET)


### PR DESCRIPTION
https://github.com/aws-cloudformation/aws-cloudformation-resource-providers-rds/issues/499

*Issue #, if available:* #499

*Description of changes:* https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_CreateIntegration.html

The maximum length for the integration is 63, not 64.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice. - YES
