### PR TITLE
[DBCluster] Removing the range validation from DBCluster  ServerlessV2ScalingConfiguration

### DIFF
--- a/aws-rds-customdbengineversion/src/main/java/software/amazon/rds/customdbengineversion/CreateHandler.java
+++ b/aws-rds-customdbengineversion/src/main/java/software/amazon/rds/customdbengineversion/CreateHandler.java
@@ -97,7 +97,8 @@ public class CreateHandler extends BaseHandlerStd {
                 .handleError((createRequest, exception, client, resourceModel, ctx) -> Commons.handleException(
                         ProgressEvent.progress(resourceModel, ctx),
                         exception,
-                        DEFAULT_CUSTOM_DB_ENGINE_VERSION_ERROR_RULE_SET, requestLogger))
+                        DEFAULT_CUSTOM_DB_ENGINE_VERSION_ERROR_RULE_SET,
+                        requestLogger))
                 .done((createRequest, createResponse, proxyInvocation, model, context) ->
                 {
                     model.setDBEngineVersionArn(createResponse.dbEngineVersionArn());

--- a/aws-rds-dbcluster/aws-rds-dbcluster.json
+++ b/aws-rds-dbcluster/aws-rds-dbcluster.json
@@ -321,15 +321,11 @@
       "properties": {
         "MinCapacity": {
           "description": "The minimum number of Aurora capacity units (ACUs) for a DB instance in an Aurora Serverless v2 cluster. You can specify ACU values in half-step increments, such as 8, 8.5, 9, and so on. The smallest value that you can use is 0.5.",
-          "type": "number",
-          "minimum": 0.5,
-          "maximum": 128
+          "type": "number"
         },
         "MaxCapacity": {
           "description": "The maximum number of Aurora capacity units (ACUs) for a DB instance in an Aurora Serverless v2 cluster. You can specify ACU values in half-step increments, such as 40, 40.5, 41, and so on. The largest value that you can use is 128.",
-          "type": "number",
-          "minimum": 0.5,
-          "maximum": 128
+          "type": "number"
         }
       }
     },

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/CreateHandler.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/CreateHandler.java
@@ -4,7 +4,6 @@ import java.time.Instant;
 import java.util.Collection;
 import java.util.Collections;
 
-import com.diffplug.spotless.maven.ArtifactResolutionException;
 import org.apache.commons.lang3.BooleanUtils;
 
 import com.amazonaws.util.StringUtils;

--- a/aws-rds-integration/docs/README.md
+++ b/aws-rds-integration/docs/README.md
@@ -1,6 +1,6 @@
 # AWS::RDS::Integration
 
-An example resource schema demonstrating some basic constructs and validation rules.
+Creates a zero-ETL integration with Amazon Redshift.
 
 ## Syntax
 


### PR DESCRIPTION
*Description of changes:*
Removing the range validation from DBCluster ServerlessV2ScalingConfiguration. RDS Webservice will handle the validation and provide a more helpful error message if there is a problem.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
