### PR TITLE
Robustness improvements for AWS::RDS::Integration

### DIFF
--- a/aws-rds-cfn-common/src/main/java/software/amazon/rds/common/error/ErrorStatus.java
+++ b/aws-rds-cfn-common/src/main/java/software/amazon/rds/common/error/ErrorStatus.java
@@ -19,6 +19,10 @@ public interface ErrorStatus {
         return new IgnoreErrorStatus(status);
     }
 
+    static ErrorStatus retry(final int callbackDelay) {
+        return new RetryErrorStatus(OperationStatus.IN_PROGRESS, callbackDelay);
+    }
+
     static ErrorStatus conditional(Function<Exception, ErrorStatus> condition) {
         return new ConditionalErrorStatus(condition);
     }

--- a/aws-rds-cfn-common/src/main/java/software/amazon/rds/common/error/RetryErrorStatus.java
+++ b/aws-rds-cfn-common/src/main/java/software/amazon/rds/common/error/RetryErrorStatus.java
@@ -1,0 +1,17 @@
+package software.amazon.rds.common.error;
+
+import lombok.Getter;
+import software.amazon.cloudformation.proxy.OperationStatus;
+
+public class RetryErrorStatus implements ErrorStatus {
+    @Getter
+    private final OperationStatus status;
+
+    @Getter
+    private final int callbackDelay;
+
+    public RetryErrorStatus(final OperationStatus status, int callbackDelay) {
+        this.status = status;
+        this.callbackDelay = callbackDelay;
+    }
+}

--- a/aws-rds-cfn-common/src/main/java/software/amazon/rds/common/handler/Commons.java
+++ b/aws-rds-cfn-common/src/main/java/software/amazon/rds/common/handler/Commons.java
@@ -18,6 +18,7 @@ import software.amazon.rds.common.error.ErrorRuleSet;
 import software.amazon.rds.common.error.ErrorStatus;
 import software.amazon.rds.common.error.ErrorCode;
 import software.amazon.rds.common.error.IgnoreErrorStatus;
+import software.amazon.rds.common.error.RetryErrorStatus;
 import software.amazon.rds.common.error.UnexpectedErrorStatus;
 import software.amazon.rds.common.error.HandlerErrorStatus;
 import software.amazon.rds.common.logging.RequestLogger;
@@ -81,6 +82,9 @@ public final class Commons {
                 default:
                     return ProgressEvent.success(model, context);
             }
+        } else if (errorStatus instanceof RetryErrorStatus) {
+            RetryErrorStatus retryErrorStatus = (RetryErrorStatus) errorStatus;
+            return ProgressEvent.defaultInProgressHandler(context, retryErrorStatus.getCallbackDelay(), model);
         } else if (errorStatus instanceof HandlerErrorStatus) {
             final HandlerErrorStatus handlerErrorStatus = (HandlerErrorStatus) errorStatus;
             // We need to set model and context to null in case of AlreadyExists errors

--- a/aws-rds-cfn-common/src/test/java/software/amazon/rds/common/error/ErrorStatusTest.java
+++ b/aws-rds-cfn-common/src/test/java/software/amazon/rds/common/error/ErrorStatusTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Test;
 
 import software.amazon.awssdk.awscore.exception.AwsServiceException;
 import software.amazon.cloudformation.proxy.HandlerErrorCode;
+import software.amazon.cloudformation.proxy.OperationStatus;
 
 class ErrorStatusTest {
 
@@ -22,6 +23,15 @@ class ErrorStatusTest {
         final ErrorStatus errorStatus = ErrorStatus.ignore();
         assertThat(errorStatus).isInstanceOf(IgnoreErrorStatus.class);
     }
+
+    @Test
+    void retry() {
+        final ErrorStatus errorStatus = ErrorStatus.retry(3);
+        assertThat(errorStatus).isInstanceOf(RetryErrorStatus.class);
+        assertThat(((RetryErrorStatus)errorStatus).getCallbackDelay()).isEqualTo(3);
+        assertThat(((RetryErrorStatus)errorStatus).getStatus()).isEqualTo(OperationStatus.IN_PROGRESS);
+    }
+
 
     @Test
     void conditional() {

--- a/aws-rds-integration/src/main/java/software/amazon/rds/integration/BaseHandlerStd.java
+++ b/aws-rds-integration/src/main/java/software/amazon/rds/integration/BaseHandlerStd.java
@@ -25,11 +25,20 @@ import software.amazon.rds.common.logging.RequestLogger;
 import software.amazon.rds.common.printer.FilteredJsonPrinter;
 
 import java.util.Collection;
+import java.util.Optional;
 
 public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
+    protected final static String INTEGRATION_NAME_CONFLICT_ERROR_MESSAGE = "Integration names must be unique within an account";
+    /** If this message is given with IntegrationConflictOperationFault, then it is a retriable error.
+     * This is thrown when the underlying Redshift cluster is busy with other operations, but they are always
+     * transient, unless something is really wrong. */
+    protected final static String INTEGRATION_RETRIABLE_CONFLICT_MESSAGE = "because another operation is in progress for the " +
+            "Amazon Redshift data warehouse specified by the Amazon Resource Name (ARN). " +
+            "Try again after the current operation completes.";
     protected static final String STACK_NAME = "rds";
     protected static final String RESOURCE_IDENTIFIER = "integration";
     protected static final int MAX_LENGTH_INTEGRATION = 63;
+    protected static final int CALLBACK_DELAY = 6;
 
     protected static final ErrorRuleSet DEFAULT_INTEGRATION_ERROR_RULE_SET = ErrorRuleSet
             .extend(Commons.DEFAULT_ERROR_RULE_SET)
@@ -37,6 +46,22 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
                     IntegrationAlreadyExistsException.class)
             .withErrorClasses(ErrorStatus.failWith(HandlerErrorCode.NotFound),
                     IntegrationNotFoundException.class)
+            .withErrorClasses(ErrorStatus.conditional((e) -> {
+                // this condition happens on create-integration.
+                // it's a little strange that IntegrationConflictOperationException is thrown instead of AlreadyExists exception
+                // we need to override the default error handling because in this case we need to tell CFN that it's an AlreadyExists.
+                // otherwise,
+                String nonNullErrorMessage = Optional.ofNullable(e.getMessage()).orElse("");
+                if (nonNullErrorMessage.contains(INTEGRATION_NAME_CONFLICT_ERROR_MESSAGE)) {
+                    return ErrorStatus.failWith(HandlerErrorCode.AlreadyExists);
+                } else if (nonNullErrorMessage.contains(INTEGRATION_RETRIABLE_CONFLICT_MESSAGE)) {
+                    // this tells the cfn framework to come back in a bit.
+                    return ErrorStatus.retry(CALLBACK_DELAY);
+                } else {
+                    // this shouldn't happen but it's a good fallback.
+                    return ErrorStatus.failWith(HandlerErrorCode.ResourceConflict);
+                }
+            }), IntegrationConflictOperationException.class)
             .withErrorClasses(ErrorStatus.failWith(HandlerErrorCode.ResourceConflict),
                     IntegrationConflictOperationException.class)
             .withErrorClasses(ErrorStatus.failWith(HandlerErrorCode.ServiceLimitExceeded),

--- a/aws-rds-integration/src/test/java/software/amazon/rds/integration/CreateHandlerTest.java
+++ b/aws-rds-integration/src/test/java/software/amazon/rds/integration/CreateHandlerTest.java
@@ -83,6 +83,7 @@ public class CreateHandlerTest extends AbstractHandlerTest {
     public void handleRequest_CreateIntegration_withAllFields_success() {
         when(rdsProxy.client().createIntegration(any(CreateIntegrationRequest.class)))
                 .thenReturn(CreateIntegrationResponse.builder()
+                        .integrationArn(INTEGRATION_CREATING.integrationArn())
                         .build());
 
 
@@ -119,6 +120,7 @@ public class CreateHandlerTest extends AbstractHandlerTest {
     public void handleRequest_CreateIntegration_withNoName_shouldGenerateName() {
         when(rdsProxy.client().createIntegration(any(CreateIntegrationRequest.class)))
                 .thenReturn(CreateIntegrationResponse.builder()
+                        .integrationArn(INTEGRATION_CREATING.integrationArn())
                         .build());
 
         // Integration goes from CREATING -> ACTIVE, when everything is normal
@@ -151,6 +153,7 @@ public class CreateHandlerTest extends AbstractHandlerTest {
     public void handleRequest_CreateIntegration_withTerminalFailureState_returnFailure() {
         when(rdsProxy.client().createIntegration(any(CreateIntegrationRequest.class)))
                 .thenReturn(CreateIntegrationResponse.builder()
+                        .integrationArn(INTEGRATION_CREATING.integrationArn())
                         .build());
 
         // Integration goes from CREATING -> ACTIVE, when everything is normal

--- a/pom.xml
+++ b/pom.xml
@@ -12,6 +12,7 @@
         <module>aws-rds-cfn-test-common</module>
         <module>aws-rds-cfn-common</module>
         <module>aws-rds-dbcluster</module>
+        <module>aws-rds-dbclusterendpoint</module>
         <module>aws-rds-dbclusterparametergroup</module>
         <module>aws-rds-dbinstance</module>
         <module>aws-rds-dbparametergroup</module>
@@ -21,7 +22,6 @@
         <module>aws-rds-integration</module>
         <module>aws-rds-customdbengineversion</module>
         <module>aws-rds-optiongroup</module>
-        <module>aws-rds-dbclusterendpoint</module>
     </modules>
 
     <build>


### PR DESCRIPTION
Retry on IntegrationConflictOperation

*Issue #, if available:* N/A

*Description of changes:* The resource is too  sensitive to transient errors such as IntegrationConflictOperationException which is retriable. This PR corrects those flaky behaviours. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice. - YES