### PR TITLE
[DBCluster] Support add support for StorageThroughput

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,10 @@
 aws-rds-handlers.iml
 rpdk.log
+.github
+/build/
 # for IntelliJ IDEA
 .idea/
+# Gradle
+.gradle
+/gradle/
+/wrapper/

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,10 @@
 aws-rds-handlers.iml
 rpdk.log
-.github
 /build/
+# python helper scripts
+bin/
+lib/
+env/
 # for IntelliJ IDEA
 .idea/
 # Gradle

--- a/aws-rds-cfn-common/pom.xml
+++ b/aws-rds-cfn-common/pom.xml
@@ -28,12 +28,12 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>utils</artifactId>
-            <version>2.21.17</version>
+            <version>2.24.13</version>
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>rds</artifactId>
-            <version>2.21.17</version>
+            <version>2.24.13</version>
         </dependency>
         <dependency>
             <groupId>software.amazon.cloudformation</groupId>
@@ -190,7 +190,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.4</version>
+                <version>0.8.8</version>
                 <configuration>
                     <excludes>
                     </excludes>

--- a/aws-rds-cfn-common/src/test/java/software/amazon/rds/common/handler/TaggingTest.java
+++ b/aws-rds-cfn-common/src/test/java/software/amazon/rds/common/handler/TaggingTest.java
@@ -40,6 +40,7 @@ import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 import software.amazon.rds.common.error.ErrorRuleSet;
 import software.amazon.rds.common.error.ErrorStatus;
 import software.amazon.rds.common.error.UnexpectedErrorStatus;
+import software.amazon.rds.common.handler.Tagging.TagSet;
 import software.amazon.rds.common.logging.LoggingProxyClient;
 import software.amazon.rds.common.logging.RequestLogger;
 import software.amazon.rds.common.printer.FilteredJsonPrinter;
@@ -81,6 +82,26 @@ public class TaggingTest extends ProxyClientTestBase {
         rds = mock(RdsClient.class);
         ResourceHandlerRequest<Void> request = new ResourceHandlerRequest<>();
         proxyRdsClient = new LoggingProxyClient<>(new RequestLogger(null, request, new FilteredJsonPrinter()), MOCK_PROXY(proxy, rds));
+    }
+
+    @Test
+    void tagset_emptySystemTags_notEmpty() {
+        final Set<Tag> systemTags = Collections.emptySet();
+        final Set<Tag> stackTags = STACK_TAGS;
+        final Set<Tag> resourceTags = RESOURCE_TAGS;
+
+        final TagSet tagset = new TagSet(systemTags, stackTags, resourceTags);
+        assertThat(tagset.isEmpty()).isFalse();
+    }
+
+    @Test
+    void tagset_emptyResourceTags_notEmpty() {
+        final Set<Tag> systemTags = SYSTEM_TAGS;
+        final Set<Tag> stackTags = STACK_TAGS;
+        final Set<Tag> resourceTags = Collections.emptySet();
+
+        final TagSet tagset = new TagSet(systemTags, stackTags, resourceTags);
+        assertThat(tagset.isEmpty()).isFalse();
     }
 
     @Test
@@ -184,6 +205,14 @@ public class TaggingTest extends ProxyClientTestBase {
         assertThat(allTags.containsAll(SYSTEM_TAGS)).isTrue();
         assertThat(allTags.containsAll(STACK_TAGS)).isTrue();
         assertThat(allTags.containsAll(RESOURCE_TAGS)).isTrue();
+    }
+
+    @Test
+    void test_translateTagsToSdk_from_collection() {
+        final Collection<Tag> tagSet = Collections.emptyList();
+        final Collection<Tag> allTags = Tagging.translateTagsToSdk(tagSet);
+
+        assertThat(allTags.isEmpty());
     }
 
     @Test

--- a/aws-rds-cfn-common/src/test/java/software/amazon/rds/common/logging/RequestLoggerTest.java
+++ b/aws-rds-cfn-common/src/test/java/software/amazon/rds/common/logging/RequestLoggerTest.java
@@ -83,6 +83,19 @@ public class RequestLoggerTest {
     }
 
     @Test
+    void test_log_with_exception() {
+        try{
+            ResourceHandlerRequest<Void> request = new ResourceHandlerRequest<>();
+            request.setStackId(STACK_ID);
+            RequestLogger requestLogger = new RequestLogger(logger, request, null);
+            requestLogger.log(SIMPLE_LOG, request);
+        } catch (Throwable throwable) {
+            verify(logger, atLeast(1)).log(captor.capture());
+            assertThat(captor.getValue().contains(STACK_ID)).isTrue();
+        }
+    }
+
+    @Test
     void test_log_and_throw() {
         Throwable throwable = new Throwable("This is Exception");
         ResourceHandlerRequest<Void> request = new ResourceHandlerRequest<>();

--- a/aws-rds-cfn-test-common/pom.xml
+++ b/aws-rds-cfn-test-common/pom.xml
@@ -141,7 +141,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.4</version>
+                <version>0.8.8</version>
                 <configuration>
                     <excludes>
                     </excludes>

--- a/aws-rds-customdbengineversion/pom.xml
+++ b/aws-rds-customdbengineversion/pom.xml
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>rds</artifactId>
-            <version>2.21.17</version>
+            <version>2.24.13</version>
         </dependency>
         <dependency>
             <groupId>software.amazon.rds.common</groupId>
@@ -159,7 +159,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.4</version>
+                <version>0.8.8</version>
                 <configuration>
                     <excludes>
                         <exclude>**/BaseConfiguration*</exclude>

--- a/aws-rds-dbcluster/aws-rds-dbcluster.json
+++ b/aws-rds-dbcluster/aws-rds-dbcluster.json
@@ -244,6 +244,10 @@
       "description": "Indicates whether the DB instance is encrypted.\nIf you specify the DBClusterIdentifier, SnapshotIdentifier, or SourceDBInstanceIdentifier property, don't specify this property. The value is inherited from the cluster, snapshot, or source DB instance.",
       "type": "boolean"
     },
+    "StorageThroughput": {
+      "description": "Specifies the storage throughput value for the DB cluster. This setting applies only to the gp3 storage type. ",
+      "type": "integer"
+    },
     "StorageType": {
       "description": "Specifies the storage type to be associated with the DB cluster.",
       "type": "string"
@@ -422,7 +426,8 @@
     "/properties/Endpoint/Port",
     "/properties/ReadEndpoint/Port",
     "/properties/ReadEndpoint/Address",
-    "/properties/MasterUserSecret/SecretArn"
+    "/properties/MasterUserSecret/SecretArn",
+    "/properties/StorageThroughput"
   ],
   "createOnlyProperties": [
     "/properties/AvailabilityZones",

--- a/aws-rds-dbcluster/aws-rds-dbcluster.json
+++ b/aws-rds-dbcluster/aws-rds-dbcluster.json
@@ -245,7 +245,7 @@
       "type": "boolean"
     },
     "StorageThroughput": {
-      "description": "Specifies the storage throughput value for the DB cluster. This setting applies only to the gp3 storage type. ",
+      "description": "Specifies the storage throughput value for the DB cluster. This setting applies only to the gp3 storage type.",
       "type": "integer"
     },
     "StorageType": {

--- a/aws-rds-dbcluster/pom.xml
+++ b/aws-rds-dbcluster/pom.xml
@@ -30,7 +30,7 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>rds</artifactId>
-            <version>2.22.12</version>
+            <version>2.24.13</version>
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
@@ -178,7 +178,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.4</version>
+                <version>0.8.8</version>
                 <configuration>
                     <excludes>
                         <exclude>**/BaseConfiguration*</exclude>

--- a/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/BaseHandlerStd.java
+++ b/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/BaseHandlerStd.java
@@ -44,6 +44,7 @@ import software.amazon.awssdk.services.rds.model.DomainNotFoundException;
 import software.amazon.awssdk.services.rds.model.Event;
 import software.amazon.awssdk.services.rds.model.GlobalCluster;
 import software.amazon.awssdk.services.rds.model.GlobalClusterNotFoundException;
+import software.amazon.awssdk.services.rds.model.InsufficientDbInstanceCapacityException;
 import software.amazon.awssdk.services.rds.model.InsufficientStorageClusterCapacityException;
 import software.amazon.awssdk.services.rds.model.InvalidDbClusterSnapshotStateException;
 import software.amazon.awssdk.services.rds.model.InvalidDbClusterStateException;
@@ -136,6 +137,7 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
             .withErrorClasses(ErrorStatus.failWith(HandlerErrorCode.ServiceLimitExceeded),
                     DbClusterQuotaExceededException.class,
                     InsufficientStorageClusterCapacityException.class,
+                    InsufficientDbInstanceCapacityException.class,
                     StorageQuotaExceededException.class,
                     SnapshotQuotaExceededException.class)
             .withErrorClasses(ErrorStatus.failWith(HandlerErrorCode.ResourceConflict),

--- a/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/Translator.java
+++ b/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/Translator.java
@@ -567,6 +567,7 @@ public class Translator {
                 .serverlessV2ScalingConfiguration(translateServerlessV2ScalingConfigurationFromSdk(dbCluster.serverlessV2ScalingConfiguration()))
                 .scalingConfiguration(translateScalingConfigurationFromSdk(dbCluster.scalingConfigurationInfo()))
                 .storageEncrypted(dbCluster.storageEncrypted())
+                .storageThroughput(dbCluster.storageThroughput())
                 .storageType(Optional.ofNullable(dbCluster.storageType()).orElse(STORAGE_TYPE_AURORA))
                 .tags(translateTagsFromSdk(dbCluster.tagList()))
                 .vpcSecurityGroupIds(

--- a/aws-rds-dbclusterendpoint/pom.xml
+++ b/aws-rds-dbclusterendpoint/pom.xml
@@ -30,7 +30,7 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>rds</artifactId>
-            <version>2.21.17</version>
+            <version>2.24.13</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/software.amazon.cloudformation/aws-cloudformation-rpdk-java-plugin -->
         <dependency>
@@ -167,7 +167,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.4</version>
+                <version>0.8.8</version>
                 <configuration>
                     <excludes>
                         <exclude>**/BaseConfiguration*</exclude>

--- a/aws-rds-dbclusterparametergroup/pom.xml
+++ b/aws-rds-dbclusterparametergroup/pom.xml
@@ -30,7 +30,7 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>rds</artifactId>
-            <version>2.21.17</version>
+            <version>2.24.13</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/software.amazon.cloudformation/aws-cloudformation-rpdk-java-plugin -->
         <dependency>
@@ -167,7 +167,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.4</version>
+                <version>0.8.8</version>
                 <configuration>
                     <excludes>
                         <exclude>**/BaseConfiguration*</exclude>

--- a/aws-rds-dbinstance/pom.xml
+++ b/aws-rds-dbinstance/pom.xml
@@ -33,7 +33,7 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>rds</artifactId>
-            <version>2.21.17</version>
+            <version>2.24.13</version>
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
@@ -175,7 +175,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.4</version>
+                <version>0.8.8</version>
                 <configuration>
                     <excludes>
                         <exclude>**/BaseConfiguration*</exclude>

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/BaseHandlerStd.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/BaseHandlerStd.java
@@ -772,22 +772,23 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
         final PendingModifiedValues pending = dbInstance.pendingModifiedValues();
         return (pending == null) || (pending.dbInstanceClass() == null &&
                 pending.allocatedStorage() == null &&
-                pending.masterUserPassword() == null &&
-                pending.port() == null &&
-                pending.backupRetentionPeriod() == null &&
-                pending.multiAZ() == null &&
-                pending.engineVersion() == null &&
-                pending.engine() == null &&
-                pending.iops() == null &&
-                pending.dbInstanceIdentifier() == null &&
-                pending.licenseModel() == null &&
-                pending.storageType() == null &&
-                pending.dbSubnetGroupName() == null &&
-                pending.pendingCloudwatchLogsExports() == null &&
-                CollectionUtils.isNullOrEmpty(pending.processorFeatures()) &&
-                pending.iamDatabaseAuthenticationEnabled() == null &&
                 pending.automationMode() == null &&
-                pending.resumeFullAutomationModeTime() == null
+                pending.backupRetentionPeriod() == null &&
+                pending.dbInstanceIdentifier() == null &&
+                pending.dbSubnetGroupName() == null &&
+                pending.engine() == null &&
+                pending.engineVersion() == null &&
+                pending.iamDatabaseAuthenticationEnabled() == null &&
+                pending.iops() == null &&
+                pending.licenseModel() == null &&
+                pending.masterUserPassword() == null &&
+                pending.multiAZ() == null &&
+                pending.pendingCloudwatchLogsExports() == null &&
+                pending.port() == null &&
+                CollectionUtils.isNullOrEmpty(pending.processorFeatures()) &&
+                pending.resumeFullAutomationModeTime() == null &&
+                pending.storageThroughput() == null &&
+                pending.storageType() == null
         );
     }
 

--- a/aws-rds-dbparametergroup/pom.xml
+++ b/aws-rds-dbparametergroup/pom.xml
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>rds</artifactId>
-            <version>2.21.17</version>
+            <version>2.24.13</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/software.amazon.cloudformation/aws-cloudformation-rpdk-java-plugin -->
         <dependency>
@@ -160,7 +160,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.4</version>
+                <version>0.8.8</version>
                 <configuration>
                     <excludes>
                         <exclude>**/BaseConfiguration*</exclude>

--- a/aws-rds-dbsubnetgroup/pom.xml
+++ b/aws-rds-dbsubnetgroup/pom.xml
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>rds</artifactId>
-            <version>2.21.17</version>
+            <version>2.24.13</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/software.amazon.cloudformation/aws-cloudformation-rpdk-java-plugin -->
         <dependency>
@@ -160,7 +160,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.4</version>
+                <version>0.8.8</version>
                 <configuration>
                     <excludes>
                         <exclude>**/BaseConfiguration*</exclude>

--- a/aws-rds-eventsubscription/pom.xml
+++ b/aws-rds-eventsubscription/pom.xml
@@ -29,7 +29,7 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>rds</artifactId>
-            <version>2.21.17</version>
+            <version>2.24.13</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/software.amazon.cloudformation/aws-cloudformation-rpdk-java-plugin -->
         <dependency>
@@ -160,7 +160,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.4</version>
+                <version>0.8.8</version>
                 <configuration>
                     <excludes>
                         <exclude>**/BaseConfiguration*</exclude>

--- a/aws-rds-globalcluster/pom.xml
+++ b/aws-rds-globalcluster/pom.xml
@@ -28,7 +28,7 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>rds</artifactId>
-            <version>2.21.17</version>
+            <version>2.24.13</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/software.amazon.cloudformation/aws-cloudformation-rpdk-java-plugin -->
         <dependency>
@@ -153,7 +153,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.4</version>
+                <version>0.8.8</version>
                 <configuration>
                     <excludes>
                         <exclude>**/BaseConfiguration*</exclude>

--- a/aws-rds-integration/pom.xml
+++ b/aws-rds-integration/pom.xml
@@ -22,7 +22,7 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>rds</artifactId>
-            <version>2.21.17</version>
+            <version>2.24.13</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/software.amazon.cloudformation/aws-cloudformation-rpdk-java-plugin -->
         <dependency>
@@ -159,7 +159,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.4</version>
+                <version>0.8.8</version>
                 <configuration>
                     <excludes>
                         <exclude>**/BaseConfiguration*</exclude>

--- a/aws-rds-optiongroup/pom.xml
+++ b/aws-rds-optiongroup/pom.xml
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>rds</artifactId>
-            <version>2.21.17</version>
+            <version>2.24.13</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/software.amazon.cloudformation/aws-cloudformation-rpdk-java-plugin -->
         <dependency>
@@ -160,7 +160,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.4</version>
+                <version>0.8.8</version>
                 <configuration>
                     <excludes>
                         <exclude>**/BaseConfiguration*</exclude>


### PR DESCRIPTION
This code change introduces support for GP3 storage type for Aurora engines. With the the storage types supported on Aurora engines, the database will now return a new StorageThroughput as a read-only parameter which will be set automatically by the backend. For more information, check the public documentation related to this feature:

https://aws.amazon.com/about-aws/whats-new/2022/11/amazon-rds-general-purpose-gp3-storage-volumes/

*Issue #, if available:*

*Description of changes:*
- Adds StorageThroughput as a read-only parameter.
- Adds and refactors unit tests for DBCluster related to StorageThroughput and Iops
- Includes missing stabilization on StorageThroughput for DBInstance resource which is already rolled-out.
- Bumps RDS SDK version to 2.24.13

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
