### PR TITLE
[Integration] Update timeout values to work better with the service.

### DIFF
--- a/aws-rds-integration/src/main/java/software/amazon/rds/integration/BaseHandlerStd.java
+++ b/aws-rds-integration/src/main/java/software/amazon/rds/integration/BaseHandlerStd.java
@@ -15,6 +15,7 @@ import software.amazon.cloudformation.proxy.Logger;
 import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
+import software.amazon.cloudformation.proxy.delay.Constant;
 import software.amazon.rds.common.error.ErrorRuleSet;
 import software.amazon.rds.common.error.ErrorStatus;
 import software.amazon.rds.common.handler.Commons;
@@ -24,6 +25,7 @@ import software.amazon.rds.common.logging.LoggingProxyClient;
 import software.amazon.rds.common.logging.RequestLogger;
 import software.amazon.rds.common.printer.FilteredJsonPrinter;
 
+import java.time.Duration;
 import java.util.Collection;
 import java.util.Optional;
 
@@ -39,6 +41,18 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
     protected static final String RESOURCE_IDENTIFIER = "integration";
     protected static final int MAX_LENGTH_INTEGRATION = 63;
     protected static final int CALLBACK_DELAY = 6;
+
+    /** Huge database resync could potentially take a very long time. */
+    public static final Constant CREATE_UPDATE_DELAY = Constant.of()
+            .delay(Duration.ofSeconds(30))
+            .timeout(Duration.ofHours(8))
+            .build();
+
+    /** Delete shouldn't take too long. */
+    public static final Constant DELETE_DELAY = Constant.of()
+            .delay(Duration.ofSeconds(30))
+            .timeout(Duration.ofMinutes(30))
+            .build();
 
     protected static final ErrorRuleSet DEFAULT_INTEGRATION_ERROR_RULE_SET = ErrorRuleSet
             .extend(Commons.DEFAULT_ERROR_RULE_SET)

--- a/aws-rds-integration/src/main/java/software/amazon/rds/integration/CreateHandler.java
+++ b/aws-rds-integration/src/main/java/software/amazon/rds/integration/CreateHandler.java
@@ -27,6 +27,9 @@ public class CreateHandler extends BaseHandlerStd {
 
     /** Default constructor w/ default backoff */
     public CreateHandler() {
+        this(HandlerConfig.builder()
+                .backoff(CREATE_UPDATE_DELAY)
+                .build());
     }
 
     /** Default constructor w/ custom config */

--- a/aws-rds-integration/src/main/java/software/amazon/rds/integration/DeleteHandler.java
+++ b/aws-rds-integration/src/main/java/software/amazon/rds/integration/DeleteHandler.java
@@ -21,7 +21,11 @@ public class DeleteHandler extends BaseHandlerStd {
     static final int CALLBACK_DELAY = 6;
 
     /** Default constructor w/ default backoff */
-    public DeleteHandler() {}
+    public DeleteHandler() {
+        this(HandlerConfig.builder()
+                .backoff(DELETE_DELAY)
+                .build());
+    }
 
     /** Default constructor w/ custom config */
     public DeleteHandler(HandlerConfig config) {

--- a/aws-rds-integration/src/main/java/software/amazon/rds/integration/UpdateHandler.java
+++ b/aws-rds-integration/src/main/java/software/amazon/rds/integration/UpdateHandler.java
@@ -12,7 +12,11 @@ import java.util.HashSet;
 
 public class UpdateHandler extends BaseHandlerStd {
     /** Default constructor w/ default backoff */
-    public UpdateHandler() {}
+    public UpdateHandler() {
+        this(HandlerConfig.builder()
+                .backoff(CREATE_UPDATE_DELAY)
+                .build());
+    }
 
     /** Default constructor w/ custom config */
     public UpdateHandler(HandlerConfig config) {

--- a/aws-rds-integration/src/test/java/software/amazon/rds/integration/TimeoutVerificationTest.java
+++ b/aws-rds-integration/src/test/java/software/amazon/rds/integration/TimeoutVerificationTest.java
@@ -1,0 +1,37 @@
+package software.amazon.rds.integration;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import software.amazon.cloudformation.proxy.delay.Constant;
+
+import java.time.Duration;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class TimeoutVerificationTest {
+
+    @ParameterizedTest
+    @MethodSource("timeoutsAndHandlersProvider")
+    public void verifyDefaultBackoffConfig(final Duration timeout, final BaseHandlerStd handler) {
+        final Constant backoffConfig = handler.config.getBackoff();
+        Duration totalWaitTime = Duration.ZERO;
+        int attempt = 1;
+        Duration delay = backoffConfig.nextDelay(attempt);
+        while (delay != Duration.ZERO) {
+            totalWaitTime = totalWaitTime.plus(delay);
+            attempt += 1;
+            delay = backoffConfig.nextDelay(attempt);
+        }
+        assertTrue(totalWaitTime.compareTo(timeout) >= 0);
+    }
+
+    static Stream<Arguments> timeoutsAndHandlersProvider() {
+        return Stream.of(
+                Arguments.arguments(Duration.ofHours(8), new CreateHandler()),
+                Arguments.arguments(Duration.ofHours(8), new UpdateHandler()),
+                Arguments.arguments(Duration.ofMinutes(30), new DeleteHandler())
+        );
+    }
+}


### PR DESCRIPTION
Integration can take 4+ hours to create if the source database is huge. Likewise, the delete should not take more than 30 minutes, so the timeouts are being adjusted.

*Issue #, if available:* N/A

*Description of changes:*

AWS::RDS::Integration can actually take 4+ hours to create/modify if the source database is huge. Likewise, the deletion should not take more than 30 minutes (as opposed to the default 90 minutes). We are adjusting the timeout values to reflect that.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice. - YES
