### PR TITLE
[CustomDBEngineVersion] Add support for RAC rolling OS patching

### DIFF
--- a/aws-rds-customdbengineversion/aws-rds-customdbengineversion.json
+++ b/aws-rds-customdbengineversion/aws-rds-customdbengineversion.json
@@ -76,6 +76,18 @@
       "type": "string",
       "description": "The ARN of the custom engine version."
     },
+    "SourceCustomDBEngineVersionIdentifier": {
+      "type": "string",
+      "description": "The identifier of the source custom engine version."
+    },
+    "UseAwsProvidedLatestImage": {
+      "type": "boolean",
+      "description": "A value that indicates whether AWS provided latest image is applied automatically to the Custom Engine Version. By default, AWS provided latest image is applied automatically. This value is only applied on create."
+    },
+    "ImageId": {
+      "type": "string",
+      "description": "The identifier of Amazon Machine Image (AMI) used for CEV."
+    },
     "Status": {
       "type": "string",
       "description": "The availability status to be assigned to the CEV.",
@@ -103,12 +115,13 @@
     "/properties/KMSKeyId": "$join([\"arn:(aws)[-]{0,1}[a-z]{0,2}[-]{0,1}[a-z]{0,3}:kms:[a-z]{2}[-]{1}[a-z]{3,10}[-]{0,1}[a-z]{0,10}[-]{1}[1-3]{1}:[0-9]{12}[:]{1}key\\/\", KMSKeyId])"
   },
   "required": [
-    "DatabaseInstallationFilesS3BucketName",
     "Engine",
     "EngineVersion"
   ],
   "writeOnlyProperties": [
-    "/properties/Manifest"
+    "/properties/Manifest",
+    "/properties/SourceCustomDbEngineVersionIdentifier",
+    "/properties/UseAwsProvidedLatestImage"
   ],
   "readOnlyProperties": [
     "/properties/DBEngineVersionArn"
@@ -122,14 +135,23 @@
     "/properties/EngineVersion",
     "/properties/DatabaseInstallationFilesS3BucketName",
     "/properties/DatabaseInstallationFilesS3Prefix",
+    "/properties/ImageId",
     "/properties/KMSKeyId",
-    "/properties/Manifest"
+    "/properties/Manifest",
+    "/properties/SourceCustomDbEngineVersionIdentifier",
+    "/properties/UseAwsProvidedLatestImage"
   ],
   "handlers": {
     "create": {
       "permissions": [
+        "ec2:CopySnapshot",
+        "ec2:DeleteSnapshot",
+        "ec2:DescribeSnapshots",
         "kms:CreateGrant",
+        "kms:Decrypt",
         "kms:DescribeKey",
+        "kms:GenerateDataKey",
+        "kms:ReEncrypt",
         "mediaimport:CreateDatabaseBinarySnapshot",
         "rds:AddTagsToResource",
         "rds:CreateCustomDBEngineVersion",

--- a/aws-rds-customdbengineversion/docs/README.md
+++ b/aws-rds-customdbengineversion/docs/README.md
@@ -19,6 +19,9 @@ To declare this entity in your AWS CloudFormation template, use the following sy
         "<a href="#engineversion" title="EngineVersion">EngineVersion</a>" : <i>String</i>,
         "<a href="#kmskeyid" title="KMSKeyId">KMSKeyId</a>" : <i>String</i>,
         "<a href="#manifest" title="Manifest">Manifest</a>" : <i>String</i>,
+        "<a href="#sourcecustomdbengineversionidentifier" title="SourceCustomDBEngineVersionIdentifier">SourceCustomDBEngineVersionIdentifier</a>" : <i>String</i>,
+        "<a href="#useawsprovidedlatestimage" title="UseAwsProvidedLatestImage">UseAwsProvidedLatestImage</a>" : <i>Boolean</i>,
+        "<a href="#imageid" title="ImageId">ImageId</a>" : <i>String</i>,
         "<a href="#status" title="Status">Status</a>" : <i>String</i>,
         "<a href="#tags" title="Tags">Tags</a>" : <i>[ <a href="tag.md">Tag</a>, ... ]</i>
     }
@@ -37,6 +40,9 @@ Properties:
     <a href="#engineversion" title="EngineVersion">EngineVersion</a>: <i>String</i>
     <a href="#kmskeyid" title="KMSKeyId">KMSKeyId</a>: <i>String</i>
     <a href="#manifest" title="Manifest">Manifest</a>: <i>String</i>
+    <a href="#sourcecustomdbengineversionidentifier" title="SourceCustomDBEngineVersionIdentifier">SourceCustomDBEngineVersionIdentifier</a>: <i>String</i>
+    <a href="#useawsprovidedlatestimage" title="UseAwsProvidedLatestImage">UseAwsProvidedLatestImage</a>: <i>Boolean</i>
+    <a href="#imageid" title="ImageId">ImageId</a>: <i>String</i>
     <a href="#status" title="Status">Status</a>: <i>String</i>
     <a href="#tags" title="Tags">Tags</a>: <i>
       - <a href="tag.md">Tag</a></i>
@@ -48,7 +54,7 @@ Properties:
 
 The name of an Amazon S3 bucket that contains database installation files for your CEV. For example, a valid bucket name is `my-custom-installation-files`.
 
-_Required_: Yes
+_Required_: No
 
 _Type_: String
 
@@ -139,6 +145,36 @@ _Type_: String
 _Minimum Length_: <code>1</code>
 
 _Maximum Length_: <code>51000</code>
+
+_Update requires_: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
+
+#### SourceCustomDBEngineVersionIdentifier
+
+The identifier of the source custom engine version.
+
+_Required_: No
+
+_Type_: String
+
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+
+#### UseAwsProvidedLatestImage
+
+A value that indicates whether AWS provided latest image is applied automatically to the Custom Engine Version. By default, AWS provided latest image is applied automatically.
+
+_Required_: No
+
+_Type_: Boolean
+
+_Update requires_: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
+
+#### ImageId
+
+The identifier of Amazon Machine Image (AMI) used for CEV.
+
+_Required_: No
+
+_Type_: String
 
 _Update requires_: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
 

--- a/aws-rds-customdbengineversion/pom.xml
+++ b/aws-rds-customdbengineversion/pom.xml
@@ -50,6 +50,12 @@
             <version>1.18.22</version>
             <scope>provided</scope>
         </dependency>
+        <!-- https://mvnrepository.com/artifact/software.amazon.awssdk/aws-query-protocol -->
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>aws-query-protocol</artifactId>
+            <version>2.20.138</version>
+        </dependency>
         <!-- https://mvnrepository.com/artifact/org.assertj/assertj-core -->
         <dependency>
             <groupId>org.assertj</groupId>

--- a/aws-rds-customdbengineversion/resource-role.yaml
+++ b/aws-rds-customdbengineversion/resource-role.yaml
@@ -30,8 +30,14 @@ Resources:
             Statement:
               - Effect: Allow
                 Action:
+                - "ec2:CopySnapshot"
+                - "ec2:DeleteSnapshot"
+                - "ec2:DescribeSnapshots"
                 - "kms:CreateGrant"
+                - "kms:Decrypt"
                 - "kms:DescribeKey"
+                - "kms:GenerateDataKey"
+                - "kms:ReEncrypt"
                 - "mediaimport:CreateDatabaseBinarySnapshot"
                 - "rds:AddTagsToResource"
                 - "rds:CreateCustomDBEngineVersion"

--- a/aws-rds-customdbengineversion/src/main/java/software/amazon/rds/customdbengineversion/Translator.java
+++ b/aws-rds-customdbengineversion/src/main/java/software/amazon/rds/customdbengineversion/Translator.java
@@ -31,9 +31,12 @@ public class Translator {
                 .description(model.getDescription())
                 .engine(model.getEngine())
                 .engineVersion(model.getEngineVersion())
+                .imageId(model.getImageId())
                 .kmsKeyId(model.getKMSKeyId())
                 .manifest(model.getManifest())
+                .sourceCustomDbEngineVersionIdentifier(model.getSourceCustomDBEngineVersionIdentifier())
                 .tags(Tagging.translateTagsToSdk(tags))
+                .useAwsProvidedLatestImage(model.getUseAwsProvidedLatestImage())
                 .build();
     }
 
@@ -108,6 +111,7 @@ public class Translator {
                 .description(engineVersion.dbEngineVersionDescription())
                 .engine(engineVersion.engine())
                 .engineVersion(engineVersion.engineVersion())
+                .imageId(engineVersion.image() != null ? engineVersion.image().imageId() : null)
                 .kMSKeyId(engineVersion.kmsKeyId())
                 .status(engineVersion.status())
                 .tags(translateTagsFromSdk(engineVersion.tagList()))

--- a/pom.xml
+++ b/pom.xml
@@ -11,6 +11,7 @@
     <modules>
         <module>aws-rds-cfn-test-common</module>
         <module>aws-rds-cfn-common</module>
+        <module>aws-rds-customdbengineversion</module>
         <module>aws-rds-dbcluster</module>
         <module>aws-rds-dbclusterendpoint</module>
         <module>aws-rds-dbclusterparametergroup</module>
@@ -20,7 +21,6 @@
         <module>aws-rds-eventsubscription</module>
         <module>aws-rds-globalcluster</module>
         <module>aws-rds-integration</module>
-        <module>aws-rds-customdbengineversion</module>
         <module>aws-rds-optiongroup</module>
     </modules>
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This code change introduces three new parameters for CustomDBEngineVersion resource.
This code change will enable customers to opt into Oracle RAC Rolling OS Patching feature and also use Custom SQLServer with Cloudformation handlers.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
