### PR TITLE
[DBInstance] Support automatic replication region for encrypted storages

### DIFF
--- a/aws-rds-dbinstance/aws-rds-dbinstance.json
+++ b/aws-rds-dbinstance/aws-rds-dbinstance.json
@@ -134,6 +134,10 @@
       "type": "string",
       "description": "Enables replication of automated backups to a different Amazon Web Services Region."
     },
+    "AutomaticBackupReplicationKmsKeyId": {
+      "type": "string",
+      "description": "The Amazon Web Services KMS key identifier for encryption of the replicated automated backups. The KMS key ID is the Amazon Resource Name (ARN) for the KMS encryption key in the destination Amazon Web Services Region, for example, `arn:aws:kms:us-east-1:123456789012:key/AKIAIOSFODNN7EXAMPLE` ."
+    },
     "AvailabilityZone": {
       "type": "string",
       "description": "The Availability Zone (AZ) where the database will be created. For information on AWS Regions and Availability Zones."
@@ -527,6 +531,7 @@
   ],
   "writeOnlyProperties": [
     "/properties/AllowMajorVersionUpgrade",
+    "/properties/AutomaticBackupReplicationKmsKeyId",
     "/properties/CertificateRotationRestart",
     "/properties/DBSnapshotIdentifier",
     "/properties/DeleteAutomatedBackups",

--- a/aws-rds-dbinstance/docs/README.md
+++ b/aws-rds-dbinstance/docs/README.md
@@ -17,6 +17,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
         "<a href="#associatedroles" title="AssociatedRoles">AssociatedRoles</a>" : <i>[ <a href="dbinstancerole.md">DBInstanceRole</a>, ... ]</i>,
         "<a href="#autominorversionupgrade" title="AutoMinorVersionUpgrade">AutoMinorVersionUpgrade</a>" : <i>Boolean</i>,
         "<a href="#automaticbackupreplicationregion" title="AutomaticBackupReplicationRegion">AutomaticBackupReplicationRegion</a>" : <i>String</i>,
+        "<a href="#automaticbackupreplicationkmskeyid" title="AutomaticBackupReplicationKmsKeyId">AutomaticBackupReplicationKmsKeyId</a>" : <i>String</i>,
         "<a href="#availabilityzone" title="AvailabilityZone">AvailabilityZone</a>" : <i>String</i>,
         "<a href="#backupretentionperiod" title="BackupRetentionPeriod">BackupRetentionPeriod</a>" : <i>Integer</i>,
         "<a href="#cacertificateidentifier" title="CACertificateIdentifier">CACertificateIdentifier</a>" : <i>String</i>,
@@ -103,6 +104,7 @@ Properties:
       - <a href="dbinstancerole.md">DBInstanceRole</a></i>
     <a href="#autominorversionupgrade" title="AutoMinorVersionUpgrade">AutoMinorVersionUpgrade</a>: <i>Boolean</i>
     <a href="#automaticbackupreplicationregion" title="AutomaticBackupReplicationRegion">AutomaticBackupReplicationRegion</a>: <i>String</i>
+    <a href="#automaticbackupreplicationkmskeyid" title="AutomaticBackupReplicationKmsKeyId">AutomaticBackupReplicationKmsKeyId</a>: <i>String</i>
     <a href="#availabilityzone" title="AvailabilityZone">AvailabilityZone</a>: <i>String</i>
     <a href="#backupretentionperiod" title="BackupRetentionPeriod">BackupRetentionPeriod</a>: <i>Integer</i>
     <a href="#cacertificateidentifier" title="CACertificateIdentifier">CACertificateIdentifier</a>: <i>String</i>
@@ -229,6 +231,16 @@ _Update requires_: [Some interruptions](https://docs.aws.amazon.com/AWSCloudForm
 #### AutomaticBackupReplicationRegion
 
 Enables replication of automated backups to a different Amazon Web Services Region.
+
+_Required_: No
+
+_Type_: String
+
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+
+#### AutomaticBackupReplicationKmsKeyId
+
+The Amazon Web Services KMS key identifier for encryption of the replicated automated backups. The KMS key ID is the Amazon Resource Name (ARN) for the KMS encryption key in the destination Amazon Web Services Region, for example, `arn:aws:kms:us-east-1:123456789012:key/AKIAIOSFODNN7EXAMPLE` .
 
 _Required_: No
 

--- a/aws-rds-dbinstance/pom.xml
+++ b/aws-rds-dbinstance/pom.xml
@@ -17,6 +17,7 @@
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <org.projectlombok.version>1.18.30</org.projectlombok.version>
     </properties>
 
     <dependencies>
@@ -50,7 +51,7 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.22</version>
+            <version>${org.projectlombok.version}</version>
             <scope>provided</scope>
         </dependency>
        <!-- https://mvnrepository.com/artifact/software.amazon.awssdk/aws-query-protocol -->
@@ -102,6 +103,15 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.12.1</version>
                 <configuration>
+                    <source>${java.version}</source>
+                    <target>${java.version}</target>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                            <version>${org.projectlombok.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
                     <compilerArgs>
                         <arg>-Xlint:all,-options,-processing</arg>
                         <arg>-Werror</arg>
@@ -111,7 +121,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>2.3</version>
+                <version>3.2.4</version>
                 <configuration>
                     <createDependencyReducedPom>false</createDependencyReducedPom>
                 </configuration>

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/BaseHandlerStd.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/BaseHandlerStd.java
@@ -1132,15 +1132,18 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
 
     protected ProgressEvent<ResourceModel, CallbackContext> startAutomaticBackupReplicationInRegion(
             final String dbInstanceArn,
+            final String kmsKeyId,
             final AmazonWebServicesClientProxy proxy,
             final ProgressEvent<ResourceModel, CallbackContext> progress,
             final ProxyClient<RdsClient> sourceRegionClient,
             final String region
     ) {
         final ProxyClient<RdsClient> rdsClient = new LoggingProxyClient<>(requestLogger, proxy.newProxy(() -> new RdsClientProvider().getClientForRegion(region)));
+        final String AUTOMATIC_REPLICATION_KMS_KEY_ERROR = "Encrypted instances require a valid KMS key ID";
+        final String AUTOMATIC_REPLICATION_KMS_KEY_EVENT_MESSAGE = "Provide a valid value for the AutomaticBackupReplicationKmsKeyId property.";
 
         return proxy.initiate("rds::start-db-instance-automatic-backup-replication", rdsClient, progress.getResourceModel(), progress.getCallbackContext())
-                .translateToServiceRequest(resourceModel -> Translator.startDbInstanceAutomatedBackupsReplicationRequest(dbInstanceArn))
+                .translateToServiceRequest(resourceModel -> Translator.startDbInstanceAutomatedBackupsReplicationRequest(dbInstanceArn, kmsKeyId))
                 .backoffDelay(config.getBackoff())
                 .makeServiceCall((request, client) -> rdsClient.injectCredentialsAndInvokeV2(
                         request,
@@ -1148,12 +1151,19 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
                 ))
                 .stabilize((request, response, proxyInvocation, model, context) ->
                         isInstanceStabilizedAfterReplicationStart(sourceRegionClient, model))
-                .handleError((request, exception, client, model, context) -> Commons.handleException(
-                        ProgressEvent.progress(model, context),
-                        exception,
-                        MODIFY_DB_INSTANCE_AUTOMATIC_BACKUP_REPLICATION_ERROR_RULE_SET,
-                        requestLogger
-                ))
+                .handleError((request, exception, client, model, context) -> {
+                    ProgressEvent<ResourceModel, CallbackContext> progressEvent = Commons.handleException(
+                            ProgressEvent.progress(model, context),
+                            exception,
+                            MODIFY_DB_INSTANCE_AUTOMATIC_BACKUP_REPLICATION_ERROR_RULE_SET,
+                            requestLogger
+                    );
+                    if (exception.getMessage().contains(AUTOMATIC_REPLICATION_KMS_KEY_ERROR)) {
+                        progressEvent.setMessage(StringUtils.trimToEmpty(progressEvent.getMessage())
+                                .concat(" " + AUTOMATIC_REPLICATION_KMS_KEY_EVENT_MESSAGE));
+                    }
+                    return progressEvent;
+                })
                 .progress();
     }
 }

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/CallbackContext.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/CallbackContext.java
@@ -25,6 +25,7 @@ public class CallbackContext extends StdCallbackContext implements TaggingContex
     private boolean automaticBackupReplicationStarted;
     private String dbInstanceArn;
     private String currentRegion;
+    private String kmsKeyId;
 
     private TaggingContext taggingContext;
     private Map<String, Long> timestamps;

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/Translator.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/Translator.java
@@ -748,10 +748,12 @@ public class Translator {
     }
 
     public static StartDbInstanceAutomatedBackupsReplicationRequest startDbInstanceAutomatedBackupsReplicationRequest(
-            final String dbInstanceArn
+            final String dbInstanceArn,
+            final String kmsKeyId
     ) {
         return StartDbInstanceAutomatedBackupsReplicationRequest.builder()
                 .sourceDBInstanceArn(dbInstanceArn)
+                .kmsKeyId(kmsKeyId)
                 .build();
     }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This code change adds a new parameter `AutomaticBackupReplicationKmsKeyId` to the CloudFormation DBInstance template with supporting logic to provide this parameter when enabling `AutomatedBackupsReplication`. When customers with DBInstances that have enabled `StorageEncryption` wishes to start `AutomatedBackupsReplication` in a region, they must provide a valid KMS Key in the replication region. Currently there is no way customers can provide this KMS Key via CloudFormation. 

Known limitations of the AutomatedBackupsReplication: 
- When customers have retained backups in a region they must provide the same KMS key used to encrypt those backups. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
