### PR TITLE
Update globalcluster lambda runtime version

### DIFF
--- a/aws-rds-globalcluster/.rpdk-config
+++ b/aws-rds-globalcluster/.rpdk-config
@@ -2,7 +2,7 @@
     "artifact_type": "RESOURCE",
     "typeName": "AWS::RDS::GlobalCluster",
     "language": "java",
-    "runtime": "java8",
+    "runtime": "java11",
     "entrypoint": "software.amazon.rds.globalcluster.HandlerWrapper::handleRequest",
     "testEntrypoint": "software.amazon.rds.globalcluster.HandlerWrapper::testEntrypoint",
     "settings": {

--- a/aws-rds-globalcluster/.rpdk-config
+++ b/aws-rds-globalcluster/.rpdk-config
@@ -2,7 +2,7 @@
     "artifact_type": "RESOURCE",
     "typeName": "AWS::RDS::GlobalCluster",
     "language": "java",
-    "runtime": "java11",
+    "runtime": "java17",
     "entrypoint": "software.amazon.rds.globalcluster.HandlerWrapper::handleRequest",
     "testEntrypoint": "software.amazon.rds.globalcluster.HandlerWrapper::testEntrypoint",
     "settings": {

--- a/aws-rds-globalcluster/pom.xml
+++ b/aws-rds-globalcluster/pom.xml
@@ -12,8 +12,9 @@
     <packaging>jar</packaging>
 
     <properties>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <java.version>17</java.version>
+        <maven.compiler.source>${java.version}</maven.compiler.source>
+        <maven.compiler.target>${java.version}</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     </properties>
@@ -117,7 +118,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.1</version>
+                <version>3.12.1</version>
                 <configuration>
                     <compilerArgs>
                         <arg>-Xlint:all,-options,-processing</arg>

--- a/aws-rds-globalcluster/template.yml
+++ b/aws-rds-globalcluster/template.yml
@@ -12,12 +12,12 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: software.amazon.rds.globalcluster.HandlerWrapper::handleRequest
-      Runtime: java8
+      Runtime: java11
       CodeUri: ./target/aws-rds-globalcluster-handler-1.0-SNAPSHOT.jar
 
   TestEntrypoint:
     Type: AWS::Serverless::Function
     Properties:
       Handler: software.amazon.rds.globalcluster.HandlerWrapper::testEntrypoint
-      Runtime: java8
+      Runtime: java11
       CodeUri: ./target/aws-rds-globalcluster-handler-1.0-SNAPSHOT.jar

--- a/aws-rds-globalcluster/template.yml
+++ b/aws-rds-globalcluster/template.yml
@@ -12,12 +12,12 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: software.amazon.rds.globalcluster.HandlerWrapper::handleRequest
-      Runtime: java11
+      Runtime: java17
       CodeUri: ./target/aws-rds-globalcluster-handler-1.0-SNAPSHOT.jar
 
   TestEntrypoint:
     Type: AWS::Serverless::Function
     Properties:
       Handler: software.amazon.rds.globalcluster.HandlerWrapper::testEntrypoint
-      Runtime: java11
+      Runtime: java17
       CodeUri: ./target/aws-rds-globalcluster-handler-1.0-SNAPSHOT.jar


### PR DESCRIPTION
*Issue #, if available:*
Follow up to https://github.com/aws-cloudformation/aws-cloudformation-resource-providers-rds/pull/495, need to update JDK version to1 7 to match the commit above

*Description of changes:*
update jdk to jdk 17

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
