### PR TITLE
[DBInstance] Ignore OptionGroup status on Delete

### DIFF
--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/BaseHandlerStd.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/BaseHandlerStd.java
@@ -609,13 +609,11 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
     ) {
         DBInstance dbInstance;
         try {
-            dbInstance = fetchDBInstance(rdsProxyClient, model);
+            fetchDBInstance(rdsProxyClient, model);
         } catch (DbInstanceNotFoundException e) {
             // the instance is gone, exactly what we need
             return true;
         }
-
-        assertNoTerminalStatusOnRdsResources(dbInstance);
 
         return false;
     }
@@ -659,13 +657,9 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
     }
 
     private void assertNoTerminalStatus(final DBInstance dbInstance) throws CfnNotStabilizedException {
-        assertNoTerminalStatusOnRdsResources(dbInstance);
-        assertNoDomainMembershipTerminalStatus(dbInstance);
-    }
-
-    private void assertNoTerminalStatusOnRdsResources(final DBInstance dbInstance) throws CfnNotStabilizedException {
         assertNoDBInstanceTerminalStatus(dbInstance);
         assertNoOptionGroupTerminalStatus(dbInstance);
+        assertNoDomainMembershipTerminalStatus(dbInstance);
     }
 
     protected boolean isDBInstanceStabilizedAfterMutate(

--- a/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/AbstractHandlerTest.java
+++ b/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/AbstractHandlerTest.java
@@ -208,6 +208,7 @@ public abstract class AbstractHandlerTest extends AbstractTestBase<DBInstance, R
     protected static final DBInstance DB_INSTANCE_ACTIVE;
     protected static final DBInstance DB_INSTANCE_SQLSERVER_ACTIVE;
     protected static final DBInstance DB_INSTANCE_DELETING;
+    protected static final DBInstance DB_INSTANCE_FAILED;
     protected static final DBInstance DB_INSTANCE_MODIFYING;
     protected static final DBInstance DB_INSTANCE_EMPTY_PORT;
     protected static final DBInstance DB_INSTANCE_STORAGE_FULL;
@@ -577,6 +578,10 @@ public abstract class AbstractHandlerTest extends AbstractTestBase<DBInstance, R
 
         DB_INSTANCE_DELETING = DB_INSTANCE_ACTIVE.toBuilder()
                 .dbInstanceStatus(DB_INSTANCE_STATUS_DELETING)
+                .build();
+
+        DB_INSTANCE_FAILED = DB_INSTANCE_ACTIVE.toBuilder()
+                .dbInstanceStatus(DB_INSTANCE_STATUS_FAILED)
                 .build();
 
         DB_INSTANCE_MODIFYING = DB_INSTANCE_ACTIVE.toBuilder()


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This change removes OptionGroup state validation on delete DBInstance handlers logic. This will allow AWS::RDS::DBInstance resource to be deleted when an OptionGroup attached to the instance is in terminal state. This change does not impact Create or Update handlers which still fail when the member OptionGroup is in terminal state.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
