### PR TITLE
[CustomDBEngineVersion] Fix SourceCustomDbEngineVersionIdentifier casing

### DIFF
--- a/aws-rds-customdbengineversion/aws-rds-customdbengineversion.json
+++ b/aws-rds-customdbengineversion/aws-rds-customdbengineversion.json
@@ -76,7 +76,7 @@
       "type": "string",
       "description": "The ARN of the custom engine version."
     },
-    "SourceCustomDBEngineVersionIdentifier": {
+    "SourceCustomDbEngineVersionIdentifier": {
       "type": "string",
       "description": "The identifier of the source custom engine version."
     },

--- a/aws-rds-customdbengineversion/docs/README.md
+++ b/aws-rds-customdbengineversion/docs/README.md
@@ -19,7 +19,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
         "<a href="#engineversion" title="EngineVersion">EngineVersion</a>" : <i>String</i>,
         "<a href="#kmskeyid" title="KMSKeyId">KMSKeyId</a>" : <i>String</i>,
         "<a href="#manifest" title="Manifest">Manifest</a>" : <i>String</i>,
-        "<a href="#sourcecustomdbengineversionidentifier" title="SourceCustomDBEngineVersionIdentifier">SourceCustomDBEngineVersionIdentifier</a>" : <i>String</i>,
+        "<a href="#sourcecustomdbengineversionidentifier" title="SourceCustomDbEngineVersionIdentifier">SourceCustomDbEngineVersionIdentifier</a>" : <i>String</i>,
         "<a href="#useawsprovidedlatestimage" title="UseAwsProvidedLatestImage">UseAwsProvidedLatestImage</a>" : <i>Boolean</i>,
         "<a href="#imageid" title="ImageId">ImageId</a>" : <i>String</i>,
         "<a href="#status" title="Status">Status</a>" : <i>String</i>,
@@ -40,7 +40,7 @@ Properties:
     <a href="#engineversion" title="EngineVersion">EngineVersion</a>: <i>String</i>
     <a href="#kmskeyid" title="KMSKeyId">KMSKeyId</a>: <i>String</i>
     <a href="#manifest" title="Manifest">Manifest</a>: <i>String</i>
-    <a href="#sourcecustomdbengineversionidentifier" title="SourceCustomDBEngineVersionIdentifier">SourceCustomDBEngineVersionIdentifier</a>: <i>String</i>
+    <a href="#sourcecustomdbengineversionidentifier" title="SourceCustomDbEngineVersionIdentifier">SourceCustomDbEngineVersionIdentifier</a>: <i>String</i>
     <a href="#useawsprovidedlatestimage" title="UseAwsProvidedLatestImage">UseAwsProvidedLatestImage</a>: <i>Boolean</i>
     <a href="#imageid" title="ImageId">ImageId</a>: <i>String</i>
     <a href="#status" title="Status">Status</a>: <i>String</i>
@@ -148,7 +148,7 @@ _Maximum Length_: <code>51000</code>
 
 _Update requires_: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
 
-#### SourceCustomDBEngineVersionIdentifier
+#### SourceCustomDbEngineVersionIdentifier
 
 The identifier of the source custom engine version.
 
@@ -156,7 +156,7 @@ _Required_: No
 
 _Type_: String
 
-_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+_Update requires_: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
 
 #### UseAwsProvidedLatestImage
 

--- a/aws-rds-customdbengineversion/src/main/java/software/amazon/rds/customdbengineversion/Translator.java
+++ b/aws-rds-customdbengineversion/src/main/java/software/amazon/rds/customdbengineversion/Translator.java
@@ -34,7 +34,7 @@ public class Translator {
                 .imageId(model.getImageId())
                 .kmsKeyId(model.getKMSKeyId())
                 .manifest(model.getManifest())
-                .sourceCustomDbEngineVersionIdentifier(model.getSourceCustomDBEngineVersionIdentifier())
+                .sourceCustomDbEngineVersionIdentifier(model.getSourceCustomDbEngineVersionIdentifier())
                 .tags(Tagging.translateTagsToSdk(tags))
                 .useAwsProvidedLatestImage(model.getUseAwsProvidedLatestImage())
                 .build();


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Previous code change introduced SourceCustomDBEngineVersionIdentifier parameter with capital `B` in DB. This change refactors the parameter casing to match the public RDS documentation with lowercase `b`.

https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_CreateCustomDBEngineVersion.html 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
