### PR TITLE
[DBInstance] Add support for IO2 storage

### DIFF
--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/StorageType.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/StorageType.java
@@ -4,7 +4,8 @@ public enum StorageType {
     GP2("gp2"),
     GP3("gp3"),
     IO1("io1"),
-    MAGNETIC("magnetic");
+    MAGNETIC("magnetic"),
+    IO2("io2");
 
     private final String value;
 

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/Translator.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/Translator.java
@@ -549,7 +549,7 @@ public class Translator {
     }
 
     private static Boolean isProvisionedIoStorage(final ResourceModel model) {
-        return isIo1Storage(model) || isGp3Storage(model);
+        return isIo1Storage(model) || isIo2Storage(model) || isGp3Storage(model);
     }
 
     private static Boolean isGp3Storage(final ResourceModel model) {
@@ -558,6 +558,11 @@ public class Translator {
 
     private static Boolean isIo1Storage(final ResourceModel model) {
         return StorageType.IO1.toString().equalsIgnoreCase(model.getStorageType()) ||
+                (StringUtils.isEmpty(model.getStorageType()) && model.getIops() != null);
+    }
+
+    private static Boolean isIo2Storage(final ResourceModel model) {
+        return StorageType.IO2.toString().equalsIgnoreCase(model.getStorageType()) ||
                 (StringUtils.isEmpty(model.getStorageType()) && model.getIops() != null);
     }
 

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/Translator.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/Translator.java
@@ -562,8 +562,7 @@ public class Translator {
     }
 
     private static Boolean isIo2Storage(final ResourceModel model) {
-        return StorageType.IO2.toString().equalsIgnoreCase(model.getStorageType()) ||
-                (StringUtils.isEmpty(model.getStorageType()) && model.getIops() != null);
+        return StorageType.IO2.toString().equalsIgnoreCase(model.getStorageType());
     }
 
     private static Boolean shouldDisableDomain(final ResourceModel previous, final ResourceModel desired) {

--- a/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/TranslatorTest.java
+++ b/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/TranslatorTest.java
@@ -928,6 +928,17 @@ class TranslatorTest extends AbstractHandlerTest {
     }
 
     @Test
+    public void modifyDbInstanceRequest_shouldIncludeAllocatedStorageANdIops_ifStorageTypeIsIo1_andStorageTypeChangedToIo2() {
+        final ResourceModel previous = RESOURCE_MODEL_BLDR().storageType("io1").iops(1000).allocatedStorage("100").build();
+        final ResourceModel desired = RESOURCE_MODEL_BLDR().storageType("io2").iops(1000).allocatedStorage("100").build();
+
+        final ModifyDbInstanceRequest request = Translator.modifyDbInstanceRequest(previous, desired, false);
+
+        assertThat(request.iops()).isEqualTo(1000);
+        assertThat(request.allocatedStorage()).isEqualTo(100);
+    }
+
+    @Test
     public void modifyDbInstanceRequest_shouldIncludeAllocatedStorage_ifStorageTypeIsImplicitIo1_andIopsOnlyChanged() {
         final ResourceModel previous = RESOURCE_MODEL_BLDR().storageType(null).iops(1000).build();
         final ResourceModel desired = RESOURCE_MODEL_BLDR().storageType(null).iops(1200).build();


### PR DESCRIPTION
This request adds support for IO2 storage for DBInstance

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
