### PR TITLE
Adding resource stabilization time and UnexpectedErrorStatus StackTrace.

### DIFF
--- a/aws-rds-cfn-common/src/main/java/software/amazon/rds/common/handler/Commons.java
+++ b/aws-rds-cfn-common/src/main/java/software/amazon/rds/common/handler/Commons.java
@@ -2,7 +2,6 @@ package software.amazon.rds.common.handler;
 
 import java.time.Instant;
 import java.time.ZonedDateTime;
-import java.util.Arrays;
 import java.util.Map;
 import java.util.function.Function;
 
@@ -72,8 +71,9 @@ public final class Commons {
         final M model = progress.getResourceModel();
         final C context = progress.getCallbackContext();
         final ErrorStatus errorStatus = errorRuleSet.handle(exception);
-        final Throwable rootCause = ExceptionUtils.getRootCause(exception);
+        final String exceptionMessage = getRootCauseExceptionMessage(exception);
         final String exceptionClass = exception.getClass().getCanonicalName();
+        final StringBuilder messageBuilder = new StringBuilder();
 
         if (errorStatus instanceof IgnoreErrorStatus) {
             switch (((IgnoreErrorStatus) errorStatus).getStatus()) {
@@ -95,7 +95,10 @@ public final class Commons {
             }
             return ProgressEvent.failed(model, context, handlerErrorStatus.getHandlerErrorCode(), exception.getMessage());
         } if (errorStatus instanceof UnexpectedErrorStatus && requestLogger != null) {
-            requestLogger.log("UnexpectedErrorStatus: " + getRootCauseExceptionMessage(rootCause) + " " + exceptionClass);
+            messageBuilder.append(exceptionClass).append("\n")
+                    .append(exceptionMessage).append("\n")
+                    .append(ExceptionUtils.getStackTrace(exception));
+            requestLogger.log("UnexpectedErrorStatus", messageBuilder.toString());
         }
         return ProgressEvent.failed(model, context, HandlerErrorCode.InternalFailure, exception.getMessage());
     }

--- a/aws-rds-cfn-common/src/test/java/software/amazon/rds/common/handler/CommonsTest.java
+++ b/aws-rds-cfn-common/src/test/java/software/amazon/rds/common/handler/CommonsTest.java
@@ -157,22 +157,52 @@ class CommonsTest {
     {
         final ProgressEvent<Void, Void> progressEvent = new ProgressEvent<>();
         final Exception ex = new RuntimeException();
-        final Throwable exRootCause = ExceptionUtils.getRootCause(ex);
+        final String rootCauseExceptionMessage = getRootCauseExceptionMessage(ex);
         final String exceptionClass = ex.getClass().getCanonicalName();
         final ErrorRuleSet ruleSet = ErrorRuleSet.extend(ErrorRuleSet.EMPTY_RULE_SET).build();
+        final StringBuilder test_messageBuilder = new StringBuilder();
         Mockito.doAnswer(invocationOnMock
                 ->{Object arg0 = invocationOnMock.getArgument(0);
-        return null;}).when(requestLogger).log(any(String.class));
+        return null;}).when(requestLogger).log(any(String.class),any(String.class));
 
         final ProgressEvent <Void, Void> resultEvent = Commons.handleException(progressEvent, ex, ruleSet, requestLogger);
 
         ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
-        verify(requestLogger).log(captor.capture());
+        verify(requestLogger).log(captor.capture(), captor.capture());
+
+        test_messageBuilder.append(exceptionClass).append("\n")
+                .append(rootCauseExceptionMessage).append("\n")
+                .append(ExceptionUtils.getStackTrace(ex));
 
         final String logLine = captor.getValue();
         assertThat(resultEvent).isNotNull();
         assertThat(resultEvent.isFailed()).isTrue();
-        assertThat(logLine).contains("UnexpectedErrorStatus: " + getRootCauseExceptionMessage(exRootCause) + " " + exceptionClass);
+        assertThat(logLine).contains("UnexpectedErrorStatus", test_messageBuilder.toString());
+    }
+
+    @Test
+    void test_RootCauseMessage_UnexpectedErrorStatus_With_text()
+    {
+        final ProgressEvent<Void, Void> progressEvent = new ProgressEvent<>();
+        final Exception ex = new RuntimeException("Runtime exception test");
+        final String exceptionClass = ex.getClass().getCanonicalName();
+        final String rootCauseExceptionMessage = getRootCauseExceptionMessage(ex);
+        final StringBuilder test_messageBuilder = new StringBuilder();
+        final ErrorRuleSet ruleSet = ErrorRuleSet.extend(ErrorRuleSet.EMPTY_RULE_SET).build();
+        Mockito.doNothing().when(requestLogger).log(any(String.class), any((String.class)));
+        final ProgressEvent <Void, Void> resultEvent = Commons.handleException(progressEvent, ex, ruleSet, requestLogger);
+
+        ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
+        verify(requestLogger).log(captor.capture(), captor.capture());
+
+        test_messageBuilder.append(exceptionClass).append("\n")
+                .append(rootCauseExceptionMessage).append("\n")
+                .append(ExceptionUtils.getStackTrace(ex));
+
+        final String logLine = captor.getValue();
+        assertThat(resultEvent).isNotNull();
+        assertThat(resultEvent.isFailed()).isTrue();
+        assertThat(logLine).contains("UnexpectedErrorStatus",test_messageBuilder.toString());
     }
 
     @Test
@@ -184,26 +214,6 @@ class CommonsTest {
         final ProgressEvent <Void, Void> resultEvent = Commons.handleException(progressEvent, ex, ruleSet, null);
         assertThat(resultEvent).isNotNull();
         assertThat(resultEvent.isFailed()).isTrue();
-    }
-
-    @Test
-    void test_RootCauseMessage_UnexpectedErrorStatus_With_text()
-    {
-        final ProgressEvent<Void, Void> progressEvent = new ProgressEvent<>();
-        final Exception ex = new RuntimeException("Runtime exception test");
-        final String exceptionClass = ex.getClass().getCanonicalName();
-        final ErrorRuleSet ruleSet = ErrorRuleSet.extend(ErrorRuleSet.EMPTY_RULE_SET).build();
-        Mockito.doNothing().when(requestLogger).log(any(String.class));
-        final ProgressEvent <Void, Void> resultEvent = Commons.handleException(progressEvent, ex, ruleSet, requestLogger);
-
-        ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
-        verify(requestLogger).log(captor.capture());
-
-        final String logLine = captor.getValue();
-        assertThat(resultEvent).isNotNull();
-        assertThat(resultEvent.isFailed()).isTrue();
-
-        assertThat(logLine).contains("UnexpectedErrorStatus: Runtime exception test" + " " + exceptionClass);
     }
 
     @Test
@@ -231,6 +241,30 @@ class CommonsTest {
         assertThat(resultEvent).isNotNull();
         assertThat(resultEvent.isFailed()).isTrue();
         assertThat(resultEvent.getErrorCode()).isEqualTo(HandlerErrorCode.InternalFailure);
+    }
+
+    @Test
+    void test_handleException_UnexpectedErrorStatus_getStackTrace(){
+        final ProgressEvent<Void, Void> progressEvent = new ProgressEvent<>();
+        final Exception ex = new RuntimeException("Runtime exception test");
+        final String exRootCause = getRootCauseExceptionMessage(ex);
+        final String exceptionClass = ex.getClass().getCanonicalName();
+        final String exceptionStackTrace = ExceptionUtils.getStackTrace(ex);
+        final ErrorRuleSet ruleSet = ErrorRuleSet.extend(ErrorRuleSet.EMPTY_RULE_SET).build();
+        final StringBuilder test_messageBuilder = new StringBuilder();
+        test_messageBuilder.append(exceptionClass).append("\n")
+                .append(exRootCause).append("\n")
+                .append(exceptionStackTrace);
+
+        Mockito.doNothing().when(requestLogger).log(any(String.class), any((String.class)));
+        final ProgressEvent <Void, Void> resultEvent = Commons.handleException(progressEvent, ex, ruleSet, requestLogger);
+        ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
+        verify(requestLogger).log(captor.capture(), captor.capture());
+
+        final String logLine = captor.getValue();
+        assertThat(resultEvent).isNotNull();
+        assertThat(resultEvent.isFailed()).isTrue();
+        assertThat(logLine).contains("UnexpectedErrorStatus",test_messageBuilder.toString());
     }
 
     @Test

--- a/aws-rds-customdbengineversion/src/main/java/software/amazon/rds/customdbengineversion/BaseHandlerStd.java
+++ b/aws-rds-customdbengineversion/src/main/java/software/amazon/rds/customdbengineversion/BaseHandlerStd.java
@@ -1,6 +1,7 @@
 package software.amazon.rds.customdbengineversion;
 
 import java.time.Duration;
+import java.time.Instant;
 import java.util.Optional;
 import java.util.function.BiFunction;
 import java.util.function.Function;
@@ -39,6 +40,9 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
 
     protected static final String STACK_NAME = "rds";
     protected static final String RESOURCE_IDENTIFIER = "customdbengineversion";
+    protected static final String REQUEST_STARTED_AT = "customdbengineversion-request-started-at";
+    protected static final String REQUEST_IN_PROGRESS_AT = "customdbengineversion-request-in-progress-at";
+    protected static final String RESOURCE_STABILIZATION_TIME = "customdbengineversion-stabilization-time";
     protected static final int RESOURCE_ID_MAX_LENGTH = 50;
     protected static final String IS_ALREADY_BEING_DELETED_ERROR_FRAGMENT = "is already being deleted";
     protected static final String SQL_SERVER_ENGINES = "custom-sqlserver";
@@ -123,6 +127,7 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
             final RequestLogger requestLogger)
     {
         this.requestLogger = requestLogger;
+        resourceStabilizationTime(callbackContext);
         return handleRequest(proxy, request, callbackContext, proxyClient);
     }
 
@@ -146,6 +151,12 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
         if (status != null && status.isTerminal()) {
             throw new CfnNotStabilizedException(new Exception("Custom DB Engine Version is in state: " + source + ""));
         }
+    }
+
+    private void resourceStabilizationTime(final CallbackContext callbackContext) {
+        callbackContext.timestampOnce(REQUEST_STARTED_AT, Instant.now());
+        callbackContext.timestamp(REQUEST_IN_PROGRESS_AT, Instant.now());
+        callbackContext.calculateTimeDelta(RESOURCE_STABILIZATION_TIME, callbackContext.getTimestamp(REQUEST_STARTED_AT), callbackContext.getTimestamp(REQUEST_IN_PROGRESS_AT));
     }
 
     protected DBEngineVersion fetchDBEngineVersion(final ResourceModel model,

--- a/aws-rds-customdbengineversion/src/main/java/software/amazon/rds/customdbengineversion/BaseHandlerStd.java
+++ b/aws-rds-customdbengineversion/src/main/java/software/amazon/rds/customdbengineversion/BaseHandlerStd.java
@@ -40,9 +40,9 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
 
     protected static final String STACK_NAME = "rds";
     protected static final String RESOURCE_IDENTIFIER = "customdbengineversion";
-    protected static final String REQUEST_STARTED_AT = "customdbengineversion-request-started-at";
-    protected static final String REQUEST_IN_PROGRESS_AT = "customdbengineversion-request-in-progress-at";
-    protected static final String RESOURCE_STABILIZATION_TIME = "customdbengineversion-stabilization-time";
+    protected static final String CUSTOM_DB_ENGINE_VERSION_REQUEST_STARTED_AT = "customdbengineversion-request-started-at";
+    protected static final String CUSTOM_DB_ENGINE_VERSION_REQUEST_IN_PROGRESS_AT = "customdbengineversion-request-in-progress-at";
+    protected static final String CUSTOM_DB_ENGINE_VERSION_RESOURCE_STABILIZATION_TIME = "customdbengineversion-stabilization-time";
     protected static final int RESOURCE_ID_MAX_LENGTH = 50;
     protected static final String IS_ALREADY_BEING_DELETED_ERROR_FRAGMENT = "is already being deleted";
     protected static final String SQL_SERVER_ENGINES = "custom-sqlserver";
@@ -154,9 +154,15 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
     }
 
     private void resourceStabilizationTime(final CallbackContext callbackContext) {
+<<<<<<< HEAD
         callbackContext.timestampOnce(REQUEST_STARTED_AT, Instant.now());
         callbackContext.timestamp(REQUEST_IN_PROGRESS_AT, Instant.now());
         callbackContext.calculateTimeDeltaInMinutes(RESOURCE_STABILIZATION_TIME, callbackContext.getTimestamp(REQUEST_STARTED_AT), callbackContext.getTimestamp(REQUEST_IN_PROGRESS_AT));
+=======
+        callbackContext.timestampOnce(CUSTOM_DB_ENGINE_VERSION_REQUEST_STARTED_AT, Instant.now());
+        callbackContext.timestamp(CUSTOM_DB_ENGINE_VERSION_REQUEST_IN_PROGRESS_AT, Instant.now());
+        callbackContext.calculateTimeDeltaInMinutes(CUSTOM_DB_ENGINE_VERSION_RESOURCE_STABILIZATION_TIME, callbackContext.getTimestamp(CUSTOM_DB_ENGINE_VERSION_REQUEST_IN_PROGRESS_AT), callbackContext.getTimestamp(CUSTOM_DB_ENGINE_VERSION_REQUEST_STARTED_AT));
+>>>>>>> 60e25ea (Adding resource stabilization time and enhancing UnexpectedErrorStatus)
     }
 
     protected DBEngineVersion fetchDBEngineVersion(final ResourceModel model,

--- a/aws-rds-customdbengineversion/src/main/java/software/amazon/rds/customdbengineversion/BaseHandlerStd.java
+++ b/aws-rds-customdbengineversion/src/main/java/software/amazon/rds/customdbengineversion/BaseHandlerStd.java
@@ -156,7 +156,7 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
     private void resourceStabilizationTime(final CallbackContext callbackContext) {
         callbackContext.timestampOnce(REQUEST_STARTED_AT, Instant.now());
         callbackContext.timestamp(REQUEST_IN_PROGRESS_AT, Instant.now());
-        callbackContext.calculateTimeDelta(RESOURCE_STABILIZATION_TIME, callbackContext.getTimestamp(REQUEST_STARTED_AT), callbackContext.getTimestamp(REQUEST_IN_PROGRESS_AT));
+        callbackContext.calculateTimeDeltaInMinutes(RESOURCE_STABILIZATION_TIME, callbackContext.getTimestamp(REQUEST_STARTED_AT), callbackContext.getTimestamp(REQUEST_IN_PROGRESS_AT));
     }
 
     protected DBEngineVersion fetchDBEngineVersion(final ResourceModel model,

--- a/aws-rds-customdbengineversion/src/main/java/software/amazon/rds/customdbengineversion/BaseHandlerStd.java
+++ b/aws-rds-customdbengineversion/src/main/java/software/amazon/rds/customdbengineversion/BaseHandlerStd.java
@@ -154,15 +154,9 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
     }
 
     private void resourceStabilizationTime(final CallbackContext callbackContext) {
-<<<<<<< HEAD
-        callbackContext.timestampOnce(REQUEST_STARTED_AT, Instant.now());
-        callbackContext.timestamp(REQUEST_IN_PROGRESS_AT, Instant.now());
-        callbackContext.calculateTimeDeltaInMinutes(RESOURCE_STABILIZATION_TIME, callbackContext.getTimestamp(REQUEST_STARTED_AT), callbackContext.getTimestamp(REQUEST_IN_PROGRESS_AT));
-=======
         callbackContext.timestampOnce(CUSTOM_DB_ENGINE_VERSION_REQUEST_STARTED_AT, Instant.now());
         callbackContext.timestamp(CUSTOM_DB_ENGINE_VERSION_REQUEST_IN_PROGRESS_AT, Instant.now());
         callbackContext.calculateTimeDeltaInMinutes(CUSTOM_DB_ENGINE_VERSION_RESOURCE_STABILIZATION_TIME, callbackContext.getTimestamp(CUSTOM_DB_ENGINE_VERSION_REQUEST_IN_PROGRESS_AT), callbackContext.getTimestamp(CUSTOM_DB_ENGINE_VERSION_REQUEST_STARTED_AT));
->>>>>>> 60e25ea (Adding resource stabilization time and enhancing UnexpectedErrorStatus)
     }
 
     protected DBEngineVersion fetchDBEngineVersion(final ResourceModel model,

--- a/aws-rds-customdbengineversion/src/main/java/software/amazon/rds/customdbengineversion/CallbackContext.java
+++ b/aws-rds-customdbengineversion/src/main/java/software/amazon/rds/customdbengineversion/CallbackContext.java
@@ -53,8 +53,8 @@ public class CallbackContext extends StdCallbackContext implements TaggingContex
         return null;
     }
 
-    public void calculateTimeDelta(final String label, final Instant currentTime, final Instant startTime){
-        double delta = Duration.between(currentTime, startTime).toHours();
+    public void calculateTimeDeltaInMinutes(final String label, final Instant currentTime, final Instant startTime){
+        double delta = Duration.between(currentTime, startTime).toMinutes();
         timeDelta.put(label, delta);
     }
 }

--- a/aws-rds-customdbengineversion/src/main/java/software/amazon/rds/customdbengineversion/CallbackContext.java
+++ b/aws-rds-customdbengineversion/src/main/java/software/amazon/rds/customdbengineversion/CallbackContext.java
@@ -3,18 +3,26 @@ package software.amazon.rds.customdbengineversion;
 import software.amazon.cloudformation.proxy.StdCallbackContext;
 import software.amazon.rds.common.handler.TaggingContext;
 
+import java.time.Duration;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+
 @lombok.Getter
 @lombok.Setter
 @lombok.ToString
 @lombok.EqualsAndHashCode(callSuper = true)
 public class CallbackContext extends StdCallbackContext implements TaggingContext.Provider {
     private boolean modified;
-
     private TaggingContext taggingContext;
+    private Map<String, Long> timestamps;
+    private Map<String, Double> timeDelta;
 
     public CallbackContext() {
         super();
         this.taggingContext = new TaggingContext();
+        this.timestamps = new HashMap<>();
+        this.timeDelta = new HashMap<>();
     }
 
     @Override
@@ -28,5 +36,25 @@ public class CallbackContext extends StdCallbackContext implements TaggingContex
 
     public void setAddTagsComplete(final boolean addTagsComplete) {
         this.taggingContext.setAddTagsComplete(addTagsComplete);
+    }
+
+    public void timestamp(final String label, final Instant instant) {
+        timestamps.put(label, instant.getEpochSecond());
+    }
+
+    public void timestampOnce(final String label, final Instant instant) {
+        timestamps.computeIfAbsent(label, s -> instant.getEpochSecond());
+    }
+
+    public Instant getTimestamp(final String label) {
+        if (timestamps.containsKey(label)) {
+            return Instant.ofEpochSecond(timestamps.get(label));
+        }
+        return null;
+    }
+
+    public void calculateTimeDelta(final String label, final Instant currentTime, final Instant startTime){
+        double delta = Duration.between(currentTime, startTime).toHours();
+        timeDelta.put(label, delta);
     }
 }

--- a/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/BaseHandlerStd.java
+++ b/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/BaseHandlerStd.java
@@ -347,7 +347,7 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
     private void resourceStabilizationTime(final CallbackContext context) {
         context.timestampOnce(DB_CLUSTER_REQUEST_STARTED_AT, Instant.now());
         context.timestamp(DB_CLUSTER_REQUEST_IN_PROGRESS_AT, Instant.now());
-        context.calculateTimeDelta(DB_CLUSTER_STABILIZATION_TIME, context.getTimestamp(DB_CLUSTER_REQUEST_STARTED_AT), context.getTimestamp(DB_CLUSTER_REQUEST_IN_PROGRESS_AT));
+        context.calculateTimeDeltaInMinutes(DB_CLUSTER_STABILIZATION_TIME, context.getTimestamp(DB_CLUSTER_REQUEST_STARTED_AT), context.getTimestamp(DB_CLUSTER_REQUEST_IN_PROGRESS_AT));
     }
 
     protected static boolean isMasterUserSecretStabilized(DBCluster dbCluster) {

--- a/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/BaseHandlerStd.java
+++ b/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/BaseHandlerStd.java
@@ -347,7 +347,7 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
     private void resourceStabilizationTime(final CallbackContext context) {
         context.timestampOnce(DB_CLUSTER_REQUEST_STARTED_AT, Instant.now());
         context.timestamp(DB_CLUSTER_REQUEST_IN_PROGRESS_AT, Instant.now());
-        context.calculateTimeDeltaInMinutes(DB_CLUSTER_STABILIZATION_TIME, context.getTimestamp(DB_CLUSTER_REQUEST_STARTED_AT), context.getTimestamp(DB_CLUSTER_REQUEST_IN_PROGRESS_AT));
+        context.calculateTimeDeltaInMinutes(DB_CLUSTER_STABILIZATION_TIME, context.getTimestamp(DB_CLUSTER_REQUEST_IN_PROGRESS_AT), context.getTimestamp(DB_CLUSTER_REQUEST_STARTED_AT));
     }
 
     protected static boolean isMasterUserSecretStabilized(DBCluster dbCluster) {

--- a/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/CallbackContext.java
+++ b/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/CallbackContext.java
@@ -1,5 +1,6 @@
 package software.amazon.rds.dbcluster;
 
+import java.time.Duration;
 import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
@@ -18,6 +19,7 @@ public class CallbackContext extends StdCallbackContext implements TaggingContex
     private boolean deleting;
 
     private Map<String, Long> timestamps;
+    private Map<String, Double> timeDelta;
 
     private TaggingContext taggingContext;
     private ProbingContext probingContext;
@@ -27,6 +29,7 @@ public class CallbackContext extends StdCallbackContext implements TaggingContex
         this.taggingContext = new TaggingContext();
         this.probingContext = new ProbingContext();
         this.timestamps = new HashMap<>();
+        this.timeDelta = new HashMap<>();
     }
 
     @Override
@@ -56,5 +59,13 @@ public class CallbackContext extends StdCallbackContext implements TaggingContex
             return Instant.ofEpochSecond(timestamps.get(label));
         }
         return null;
+    }
+    public void timestamp(final String label, final Instant instant) {
+        timestamps.put(label, instant.getEpochSecond());
+    }
+
+    public void calculateTimeDelta(final String label, final Instant currentTime, final Instant startTime){
+        double delta = Duration.between(currentTime, startTime).toHours();
+        timeDelta.put(label, delta);
     }
 }

--- a/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/CallbackContext.java
+++ b/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/CallbackContext.java
@@ -64,8 +64,8 @@ public class CallbackContext extends StdCallbackContext implements TaggingContex
         timestamps.put(label, instant.getEpochSecond());
     }
 
-    public void calculateTimeDelta(final String label, final Instant currentTime, final Instant startTime){
-        double delta = Duration.between(currentTime, startTime).toHours();
+    public void calculateTimeDeltaInMinutes(final String label, final Instant currentTime, final Instant startTime){
+        double delta = Duration.between(currentTime, startTime).toMinutes();
         timeDelta.put(label, delta);
     }
 }

--- a/aws-rds-dbclusterendpoint/src/main/java/software/amazon/rds/dbclusterendpoint/BaseHandlerStd.java
+++ b/aws-rds-dbclusterendpoint/src/main/java/software/amazon/rds/dbclusterendpoint/BaseHandlerStd.java
@@ -112,7 +112,7 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
     private void resourceStabilizationTime(final CallbackContext callbackContext) {
         callbackContext.timestampOnce(DB_CLUSTER_ENDPOINT_REQUEST_STARTED_AT, Instant.now());
         callbackContext.timestamp(DB_CLUSTER_ENDPOINT_REQUEST_IN_PROGRESS_AT, Instant.now());
-        callbackContext.calculateTimeDeltaInMinutes(DB_CLUSTER_ENDPOINT_STABILIZATION_TIME, callbackContext.getTimestamp(DB_CLUSTER_ENDPOINT_REQUEST_STARTED_AT), callbackContext.getTimestamp(DB_CLUSTER_ENDPOINT_REQUEST_IN_PROGRESS_AT));
+        callbackContext.calculateTimeDeltaInMinutes(DB_CLUSTER_ENDPOINT_STABILIZATION_TIME, callbackContext.getTimestamp(DB_CLUSTER_ENDPOINT_REQUEST_IN_PROGRESS_AT), callbackContext.getTimestamp(DB_CLUSTER_ENDPOINT_REQUEST_STARTED_AT));
     }
 
     protected ProgressEvent<ResourceModel, CallbackContext> updateTags(

--- a/aws-rds-dbclusterendpoint/src/main/java/software/amazon/rds/dbclusterendpoint/BaseHandlerStd.java
+++ b/aws-rds-dbclusterendpoint/src/main/java/software/amazon/rds/dbclusterendpoint/BaseHandlerStd.java
@@ -112,7 +112,7 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
     private void resourceStabilizationTime(final CallbackContext callbackContext) {
         callbackContext.timestampOnce(DB_CLUSTER_ENDPOINT_REQUEST_STARTED_AT, Instant.now());
         callbackContext.timestamp(DB_CLUSTER_ENDPOINT_REQUEST_IN_PROGRESS_AT, Instant.now());
-        callbackContext.calculateTimeDelta(DB_CLUSTER_ENDPOINT_STABILIZATION_TIME, callbackContext.getTimestamp(DB_CLUSTER_ENDPOINT_REQUEST_STARTED_AT), callbackContext.getTimestamp(DB_CLUSTER_ENDPOINT_REQUEST_IN_PROGRESS_AT));
+        callbackContext.calculateTimeDeltaInMinutes(DB_CLUSTER_ENDPOINT_STABILIZATION_TIME, callbackContext.getTimestamp(DB_CLUSTER_ENDPOINT_REQUEST_STARTED_AT), callbackContext.getTimestamp(DB_CLUSTER_ENDPOINT_REQUEST_IN_PROGRESS_AT));
     }
 
     protected ProgressEvent<ResourceModel, CallbackContext> updateTags(

--- a/aws-rds-dbclusterendpoint/src/main/java/software/amazon/rds/dbclusterendpoint/CallbackContext.java
+++ b/aws-rds-dbclusterendpoint/src/main/java/software/amazon/rds/dbclusterendpoint/CallbackContext.java
@@ -3,16 +3,25 @@ package software.amazon.rds.dbclusterendpoint;
 import software.amazon.cloudformation.proxy.StdCallbackContext;
 import software.amazon.rds.common.handler.TaggingContext;
 
+import java.time.Duration;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+
 @lombok.Getter
 @lombok.Setter
 @lombok.ToString
 @lombok.EqualsAndHashCode(callSuper = true)
 public class CallbackContext extends StdCallbackContext implements TaggingContext.Provider {
     private TaggingContext taggingContext;
+    private Map<String, Long> timestamps;
+    private Map<String, Double> timeDelta;
 
     public CallbackContext() {
         super();
         this.taggingContext = new TaggingContext();
+        this.timestamps = new HashMap<>();
+        this.timeDelta = new HashMap<>();
     }
 
     @Override
@@ -26,5 +35,25 @@ public class CallbackContext extends StdCallbackContext implements TaggingContex
 
     public void setAddTagsComplete(final boolean addTagsComplete) {
         this.taggingContext.setAddTagsComplete(addTagsComplete);
+    }
+
+    public void timestamp(final String label, final Instant instant) {
+        timestamps.put(label, instant.getEpochSecond());
+    }
+
+    public void timestampOnce(final String label, final Instant instant) {
+        timestamps.computeIfAbsent(label, s -> instant.getEpochSecond());
+    }
+
+    public Instant getTimestamp(final String label) {
+        if (timestamps.containsKey(label)) {
+            return Instant.ofEpochSecond(timestamps.get(label));
+        }
+        return null;
+    }
+
+    public void calculateTimeDelta(final String label, final Instant currentTime, final Instant startTime){
+        double delta = Duration.between(currentTime, startTime).toHours();
+        timeDelta.put(label, delta);
     }
 }

--- a/aws-rds-dbclusterendpoint/src/main/java/software/amazon/rds/dbclusterendpoint/CallbackContext.java
+++ b/aws-rds-dbclusterendpoint/src/main/java/software/amazon/rds/dbclusterendpoint/CallbackContext.java
@@ -52,8 +52,8 @@ public class CallbackContext extends StdCallbackContext implements TaggingContex
         return null;
     }
 
-    public void calculateTimeDelta(final String label, final Instant currentTime, final Instant startTime){
-        double delta = Duration.between(currentTime, startTime).toHours();
+    public void calculateTimeDeltaInMinutes(final String label, final Instant currentTime, final Instant startTime){
+        double delta = Duration.between(currentTime, startTime).toMinutes();
         timeDelta.put(label, delta);
     }
 }

--- a/aws-rds-dbclusterparametergroup/src/main/java/software/amazon/rds/dbclusterparametergroup/BaseHandlerStd.java
+++ b/aws-rds-dbclusterparametergroup/src/main/java/software/amazon/rds/dbclusterparametergroup/BaseHandlerStd.java
@@ -550,7 +550,7 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
     private void resourceStabilizationTime(final CallbackContext callbackContext) {
         callbackContext.timestampOnce(DB_CLUSTER_PARAMETER_GROUP_REQUEST_STARTED_AT, Instant.now());
         callbackContext.timestamp(DB_CLUSTER_PARAMETER_GROUP_REQUEST_IN_PROGRESS_AT, Instant.now());
-        callbackContext.calculateTimeDeltaInMinutes(DB_CLUSTER_PARAMETER_GROUP_RESOURCE_STABILIZATION_TIME, callbackContext.getTimestamp(DB_CLUSTER_PARAMETER_GROUP_REQUEST_STARTED_AT), callbackContext.getTimestamp(DB_CLUSTER_PARAMETER_GROUP_REQUEST_IN_PROGRESS_AT));
+        callbackContext.calculateTimeDeltaInMinutes(DB_CLUSTER_PARAMETER_GROUP_RESOURCE_STABILIZATION_TIME, callbackContext.getTimestamp(DB_CLUSTER_PARAMETER_GROUP_REQUEST_IN_PROGRESS_AT), callbackContext.getTimestamp(DB_CLUSTER_PARAMETER_GROUP_REQUEST_STARTED_AT));
     }
 
     protected ProgressEvent<ResourceModel, CallbackContext> waitForDbClustersStabilization(

--- a/aws-rds-dbclusterparametergroup/src/main/java/software/amazon/rds/dbclusterparametergroup/BaseHandlerStd.java
+++ b/aws-rds-dbclusterparametergroup/src/main/java/software/amazon/rds/dbclusterparametergroup/BaseHandlerStd.java
@@ -1,6 +1,7 @@
 package software.amazon.rds.dbclusterparametergroup;
 
 import java.time.Duration;
+import java.time.Instant;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -75,6 +76,9 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
     protected static final String AVAILABLE = "available";
     protected static final String RESOURCE_IDENTIFIER = "dbclusterparametergroup";
     protected static final String STACK_NAME = "rds";
+    protected static final String DB_CLUSTER_PARAMETER_GROUP_REQUEST_STARTED_AT = "dbclusterparametergroup-request-started-at";
+    protected static final String DB_CLUSTER_PARAMETER_GROUP_REQUEST_IN_PROGRESS_AT = "dbclusterparametergroup-request-in-progress-at";
+    protected static final String DB_CLUSTER_PARAMETER_GROUP_RESOURCE_STABILIZATION_TIME = "dbclusterparametergroup-stabilization-time";
 
     protected static final int MAX_LENGTH_GROUP_NAME = 255;
     protected static final int MAX_PARAMETERS_PER_REQUEST = 20;
@@ -160,6 +164,7 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
             final RequestLogger requestLogger
     ) {
         this.requestLogger = requestLogger;
+        resourceStabilizationTime(callbackContext);
         return handleRequest(proxy, proxyClient, request, callbackContext);
     }
 
@@ -209,7 +214,7 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
             final ProxyClient<RdsClient> proxyClient,
             final ProgressEvent<ResourceModel, CallbackContext> progress,
             final Map<String, Parameter> currentClusterParameters,
-            final RequestLogger logger
+            final RequestLogger requestLogger
     ) {
         return ProgressEvent.progress(progress.getResourceModel(), progress.getCallbackContext())
                 .then(progressEvent -> validateModelParameters(progressEvent, currentClusterParameters))
@@ -540,6 +545,12 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
         } while (marker != null);
 
         return true;
+    }
+
+    private void resourceStabilizationTime(final CallbackContext callbackContext) {
+        callbackContext.timestampOnce(DB_CLUSTER_PARAMETER_GROUP_REQUEST_STARTED_AT, Instant.now());
+        callbackContext.timestamp(DB_CLUSTER_PARAMETER_GROUP_REQUEST_IN_PROGRESS_AT, Instant.now());
+        callbackContext.calculateTimeDelta(DB_CLUSTER_PARAMETER_GROUP_RESOURCE_STABILIZATION_TIME, callbackContext.getTimestamp(DB_CLUSTER_PARAMETER_GROUP_REQUEST_STARTED_AT), callbackContext.getTimestamp(DB_CLUSTER_PARAMETER_GROUP_REQUEST_IN_PROGRESS_AT));
     }
 
     protected ProgressEvent<ResourceModel, CallbackContext> waitForDbClustersStabilization(

--- a/aws-rds-dbclusterparametergroup/src/main/java/software/amazon/rds/dbclusterparametergroup/BaseHandlerStd.java
+++ b/aws-rds-dbclusterparametergroup/src/main/java/software/amazon/rds/dbclusterparametergroup/BaseHandlerStd.java
@@ -550,7 +550,7 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
     private void resourceStabilizationTime(final CallbackContext callbackContext) {
         callbackContext.timestampOnce(DB_CLUSTER_PARAMETER_GROUP_REQUEST_STARTED_AT, Instant.now());
         callbackContext.timestamp(DB_CLUSTER_PARAMETER_GROUP_REQUEST_IN_PROGRESS_AT, Instant.now());
-        callbackContext.calculateTimeDelta(DB_CLUSTER_PARAMETER_GROUP_RESOURCE_STABILIZATION_TIME, callbackContext.getTimestamp(DB_CLUSTER_PARAMETER_GROUP_REQUEST_STARTED_AT), callbackContext.getTimestamp(DB_CLUSTER_PARAMETER_GROUP_REQUEST_IN_PROGRESS_AT));
+        callbackContext.calculateTimeDeltaInMinutes(DB_CLUSTER_PARAMETER_GROUP_RESOURCE_STABILIZATION_TIME, callbackContext.getTimestamp(DB_CLUSTER_PARAMETER_GROUP_REQUEST_STARTED_AT), callbackContext.getTimestamp(DB_CLUSTER_PARAMETER_GROUP_REQUEST_IN_PROGRESS_AT));
     }
 
     protected ProgressEvent<ResourceModel, CallbackContext> waitForDbClustersStabilization(

--- a/aws-rds-dbclusterparametergroup/src/main/java/software/amazon/rds/dbclusterparametergroup/CallbackContext.java
+++ b/aws-rds-dbclusterparametergroup/src/main/java/software/amazon/rds/dbclusterparametergroup/CallbackContext.java
@@ -4,6 +4,11 @@ import software.amazon.cloudformation.proxy.StdCallbackContext;
 import software.amazon.rds.common.handler.ProbingContext;
 import software.amazon.rds.common.handler.TaggingContext;
 
+import java.time.Duration;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+
 
 @lombok.Getter
 @lombok.Setter
@@ -20,10 +25,15 @@ public class CallbackContext extends StdCallbackContext implements TaggingContex
     private TaggingContext taggingContext;
     private ProbingContext probingContext;
 
+    private Map<String, Long> timestamps;
+    private Map<String, Double> timeDelta;
+
     public CallbackContext() {
         super();
         this.taggingContext = new TaggingContext();
         this.probingContext = new ProbingContext();
+        this.timestamps = new HashMap<>();
+        this.timeDelta = new HashMap<>();
     }
 
     @Override
@@ -40,5 +50,25 @@ public class CallbackContext extends StdCallbackContext implements TaggingContex
 
     public void setAddTagsComplete(final boolean addTagsComplete) {
         this.taggingContext.setAddTagsComplete(addTagsComplete);
+    }
+
+    public void timestamp(final String label, final Instant instant) {
+        timestamps.put(label, instant.getEpochSecond());
+    }
+
+    public void timestampOnce(final String label, final Instant instant) {
+        timestamps.computeIfAbsent(label, s -> instant.getEpochSecond());
+    }
+
+    public Instant getTimestamp(final String label) {
+        if (timestamps.containsKey(label)) {
+            return Instant.ofEpochSecond(timestamps.get(label));
+        }
+        return null;
+    }
+
+    public void calculateTimeDelta(final String label, final Instant currentTime, final Instant startTime){
+        double delta = Duration.between(currentTime, startTime).toHours();
+        timeDelta.put(label, delta);
     }
 }

--- a/aws-rds-dbclusterparametergroup/src/main/java/software/amazon/rds/dbclusterparametergroup/CallbackContext.java
+++ b/aws-rds-dbclusterparametergroup/src/main/java/software/amazon/rds/dbclusterparametergroup/CallbackContext.java
@@ -67,8 +67,8 @@ public class CallbackContext extends StdCallbackContext implements TaggingContex
         return null;
     }
 
-    public void calculateTimeDelta(final String label, final Instant currentTime, final Instant startTime){
-        double delta = Duration.between(currentTime, startTime).toHours();
+    public void calculateTimeDeltaInMinutes(final String label, final Instant currentTime, final Instant startTime){
+        double delta = Duration.between(currentTime, startTime).toMinutes();
         timeDelta.put(label, delta);
     }
 }

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/BaseHandlerStd.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/BaseHandlerStd.java
@@ -403,6 +403,7 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
             final RequestLogger requestLogger
     ) {
         this.requestLogger = requestLogger;
+        resourceStabilizationTime(context);
         try {
             validateRequest(request);
         } catch (RequestValidationException exception) {
@@ -707,7 +708,7 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
     private void resourceStabilizationTime(final CallbackContext context) {
         context.timestampOnce(DB_INSTANCE_REQUEST_STARTED_AT, Instant.now());
         context.timestamp(DB_INSTANCE_REQUEST_IN_PROGRESS_AT, Instant.now());
-        context.calculateTimeDeltaInMinutes(DB_INSTANCE_STABILIZATION_TIME, context.getTimestamp(DB_INSTANCE_REQUEST_STARTED_AT), context.getTimestamp(DB_INSTANCE_REQUEST_IN_PROGRESS_AT));
+        context.calculateTimeDeltaInMinutes(DB_INSTANCE_STABILIZATION_TIME, context.getTimestamp(DB_INSTANCE_REQUEST_IN_PROGRESS_AT), context.getTimestamp(DB_INSTANCE_REQUEST_STARTED_AT));
     }
 
     protected boolean isInstanceStabilizedAfterReplicationStop(final ProxyClient<RdsClient> rdsProxyClient,

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/BaseHandlerStd.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/BaseHandlerStd.java
@@ -1,6 +1,7 @@
 package software.amazon.rds.dbinstance;
 
 import java.time.Duration;
+import java.time.Instant;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashSet;
@@ -153,6 +154,12 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
     protected static final String UNKNOWN_SOURCE_REGION_ERROR = "Unknown source region";
 
     protected static final String RESOURCE_UPDATED_AT = "resource-updated-at";
+
+    protected static final String DB_INSTANCE_REQUEST_STARTED_AT = "dbinstance-request-started-at";
+
+    protected static final String DB_INSTANCE_REQUEST_IN_PROGRESS_AT = "dbinstance-request-in-progress-at";
+
+    protected static final String DB_INSTANCE_STABILIZATION_TIME = "dbinstance-stabilization-time";
 
     protected final HandlerConfig config;
 
@@ -695,6 +702,12 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
                         " process will continue until all included flags are true."));
 
         return isDBInstanceStabilizedAfterMutateResult;
+    }
+
+    private void resourceStabilizationTime(final CallbackContext context) {
+        context.timestampOnce(DB_INSTANCE_REQUEST_STARTED_AT, Instant.now());
+        context.timestamp(DB_INSTANCE_REQUEST_IN_PROGRESS_AT, Instant.now());
+        context.calculateTimeDelta(DB_INSTANCE_STABILIZATION_TIME, context.getTimestamp(DB_INSTANCE_REQUEST_STARTED_AT), context.getTimestamp(DB_INSTANCE_REQUEST_IN_PROGRESS_AT));
     }
 
     protected boolean isInstanceStabilizedAfterReplicationStop(final ProxyClient<RdsClient> rdsProxyClient,

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/BaseHandlerStd.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/BaseHandlerStd.java
@@ -707,7 +707,7 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
     private void resourceStabilizationTime(final CallbackContext context) {
         context.timestampOnce(DB_INSTANCE_REQUEST_STARTED_AT, Instant.now());
         context.timestamp(DB_INSTANCE_REQUEST_IN_PROGRESS_AT, Instant.now());
-        context.calculateTimeDelta(DB_INSTANCE_STABILIZATION_TIME, context.getTimestamp(DB_INSTANCE_REQUEST_STARTED_AT), context.getTimestamp(DB_INSTANCE_REQUEST_IN_PROGRESS_AT));
+        context.calculateTimeDeltaInMinutes(DB_INSTANCE_STABILIZATION_TIME, context.getTimestamp(DB_INSTANCE_REQUEST_STARTED_AT), context.getTimestamp(DB_INSTANCE_REQUEST_IN_PROGRESS_AT));
     }
 
     protected boolean isInstanceStabilizedAfterReplicationStop(final ProxyClient<RdsClient> rdsProxyClient,

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/CallbackContext.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/CallbackContext.java
@@ -1,5 +1,6 @@
 package software.amazon.rds.dbinstance;
 
+import java.time.Duration;
 import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
@@ -28,11 +29,13 @@ public class CallbackContext extends StdCallbackContext implements TaggingContex
 
     private TaggingContext taggingContext;
     private Map<String, Long> timestamps;
+    private Map<String, Double> timeDelta;
 
     public CallbackContext() {
         super();
         this.taggingContext = new TaggingContext();
         this.timestamps = new HashMap<>();
+        this.timeDelta = new HashMap<>();
     }
 
     @Override
@@ -61,5 +64,10 @@ public class CallbackContext extends StdCallbackContext implements TaggingContex
             return Instant.ofEpochSecond(timestamps.get(label));
         }
         return null;
+    }
+
+    public void calculateTimeDelta(final String label, final Instant currentTime, final Instant startTime){
+        double delta = Duration.between(currentTime, startTime).toHours();
+        timeDelta.put(label, delta);
     }
 }

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/CallbackContext.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/CallbackContext.java
@@ -66,8 +66,8 @@ public class CallbackContext extends StdCallbackContext implements TaggingContex
         return null;
     }
 
-    public void calculateTimeDelta(final String label, final Instant currentTime, final Instant startTime){
-        double delta = Duration.between(currentTime, startTime).toHours();
+    public void calculateTimeDeltaInMinutes(final String label, final Instant currentTime, final Instant startTime){
+        double delta = Duration.between(currentTime, startTime).toMinutes();
         timeDelta.put(label, delta);
     }
 }

--- a/aws-rds-dbparametergroup/src/main/java/software/amazon/rds/dbparametergroup/BaseHandlerStd.java
+++ b/aws-rds-dbparametergroup/src/main/java/software/amazon/rds/dbparametergroup/BaseHandlerStd.java
@@ -440,7 +440,7 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
     private void resourceStabilizationTime(final CallbackContext callbackContext) {
         callbackContext.timestampOnce(DB_PARAMETER_GROUP_REQUEST_STARTED_AT, Instant.now());
         callbackContext.timestamp(DB_PARAMETER_GROUP_REQUEST_IN_PROGRESS_AT, Instant.now());
-        callbackContext.calculateTimeDelta(DB_PARAMETER_GROUP_STABILIZATION_TIME,
+        callbackContext.calculateTimeDeltaInMinutes(DB_PARAMETER_GROUP_STABILIZATION_TIME,
                 callbackContext.getTimestamp(DB_PARAMETER_GROUP_REQUEST_STARTED_AT),
                 callbackContext.getTimestamp(DB_PARAMETER_GROUP_REQUEST_IN_PROGRESS_AT));
     }

--- a/aws-rds-dbparametergroup/src/main/java/software/amazon/rds/dbparametergroup/BaseHandlerStd.java
+++ b/aws-rds-dbparametergroup/src/main/java/software/amazon/rds/dbparametergroup/BaseHandlerStd.java
@@ -1,5 +1,6 @@
 package software.amazon.rds.dbparametergroup;
 
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -87,6 +88,10 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
     protected static final String RESOURCE_IDENTIFIER = "dbparametergroup";
     protected static final String STACK_NAME = "rds";
 
+    protected static final String DB_PARAMETER_GROUP_REQUEST_STARTED_AT = "dbparametergroup-request-started-at";
+    protected static final String DB_PARAMETER_GROUP_REQUEST_IN_PROGRESS_AT = "dbparametergroup-request-in-progress-at";
+    protected static final String DB_PARAMETER_GROUP_STABILIZATION_TIME = "dbparametergroup-stabilization-time";
+
     protected HandlerConfig config;
     protected RequestLogger requestLogger;
 
@@ -135,6 +140,7 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
             final RequestLogger requestLogger
     ) {
         this.requestLogger = requestLogger;
+        resourceStabilizationTime(callbackContext);
         return handleRequest(proxy, proxyClient, request, callbackContext);
     };
 
@@ -431,6 +437,13 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
         return result;
     }
 
+    private void resourceStabilizationTime(final CallbackContext callbackContext) {
+        callbackContext.timestampOnce(DB_PARAMETER_GROUP_REQUEST_STARTED_AT, Instant.now());
+        callbackContext.timestamp(DB_PARAMETER_GROUP_REQUEST_IN_PROGRESS_AT, Instant.now());
+        callbackContext.calculateTimeDelta(DB_PARAMETER_GROUP_STABILIZATION_TIME,
+                callbackContext.getTimestamp(DB_PARAMETER_GROUP_REQUEST_STARTED_AT),
+                callbackContext.getTimestamp(DB_PARAMETER_GROUP_REQUEST_IN_PROGRESS_AT));
+    }
     private Iterable<Parameter> fetchDBParametersIterableWithFilters(
             final ProxyClient<RdsClient> proxyClient,
             final String dbParameterGroupName,

--- a/aws-rds-dbparametergroup/src/main/java/software/amazon/rds/dbparametergroup/BaseHandlerStd.java
+++ b/aws-rds-dbparametergroup/src/main/java/software/amazon/rds/dbparametergroup/BaseHandlerStd.java
@@ -441,8 +441,8 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
         callbackContext.timestampOnce(DB_PARAMETER_GROUP_REQUEST_STARTED_AT, Instant.now());
         callbackContext.timestamp(DB_PARAMETER_GROUP_REQUEST_IN_PROGRESS_AT, Instant.now());
         callbackContext.calculateTimeDeltaInMinutes(DB_PARAMETER_GROUP_STABILIZATION_TIME,
-                callbackContext.getTimestamp(DB_PARAMETER_GROUP_REQUEST_STARTED_AT),
-                callbackContext.getTimestamp(DB_PARAMETER_GROUP_REQUEST_IN_PROGRESS_AT));
+                callbackContext.getTimestamp(DB_PARAMETER_GROUP_REQUEST_IN_PROGRESS_AT),
+                callbackContext.getTimestamp(DB_PARAMETER_GROUP_REQUEST_STARTED_AT));
     }
     private Iterable<Parameter> fetchDBParametersIterableWithFilters(
             final ProxyClient<RdsClient> proxyClient,

--- a/aws-rds-dbparametergroup/src/main/java/software/amazon/rds/dbparametergroup/CallbackContext.java
+++ b/aws-rds-dbparametergroup/src/main/java/software/amazon/rds/dbparametergroup/CallbackContext.java
@@ -3,6 +3,11 @@ package software.amazon.rds.dbparametergroup;
 import software.amazon.cloudformation.proxy.StdCallbackContext;
 import software.amazon.rds.common.handler.TaggingContext;
 
+import java.time.Duration;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+
 @lombok.Getter
 @lombok.Setter
 @lombok.ToString
@@ -11,11 +16,16 @@ public class CallbackContext extends StdCallbackContext implements TaggingContex
     private boolean parametersApplied;
     private String dbParameterGroupArn;
 
+    private Map<String, Long> timestamps;
+    private Map<String, Double> timeDelta;
+
     private TaggingContext taggingContext;
 
     public CallbackContext() {
         super();
         this.taggingContext = new TaggingContext();
+        this.timestamps = new HashMap<>();
+        this.timeDelta = new HashMap<>();
     }
 
     @Override
@@ -29,5 +39,25 @@ public class CallbackContext extends StdCallbackContext implements TaggingContex
 
     public void setAddTagsComplete(final boolean addTagsComplete) {
         taggingContext.setAddTagsComplete(addTagsComplete);
+    }
+
+    public void timestamp(final String label, final Instant instant) {
+        timestamps.put(label, instant.getEpochSecond());
+    }
+
+    public void timestampOnce(final String label, final Instant instant) {
+        timestamps.computeIfAbsent(label, s -> instant.getEpochSecond());
+    }
+
+    public Instant getTimestamp(final String label) {
+        if (timestamps.containsKey(label)) {
+            return Instant.ofEpochSecond(timestamps.get(label));
+        }
+        return null;
+    }
+
+    public void calculateTimeDelta(final String label, final Instant currentTime, final Instant startTime){
+        double delta = Duration.between(currentTime, startTime).toHours();
+        timeDelta.put(label, delta);
     }
 }

--- a/aws-rds-dbparametergroup/src/main/java/software/amazon/rds/dbparametergroup/CallbackContext.java
+++ b/aws-rds-dbparametergroup/src/main/java/software/amazon/rds/dbparametergroup/CallbackContext.java
@@ -50,14 +50,14 @@ public class CallbackContext extends StdCallbackContext implements TaggingContex
     }
 
     public Instant getTimestamp(final String label) {
-        if (timestamps.containsKey(label)) {
+        if (timestamps.containsKey(label) && label != null) {
             return Instant.ofEpochSecond(timestamps.get(label));
         }
         return null;
     }
 
-    public void calculateTimeDelta(final String label, final Instant currentTime, final Instant startTime){
-        double delta = Duration.between(currentTime, startTime).toHours();
+    public void calculateTimeDeltaInMinutes(final String label, final Instant currentTime, final Instant startTime){
+        double delta = Duration.between(currentTime, startTime).toMinutes();
         timeDelta.put(label, delta);
     }
 }

--- a/aws-rds-dbsubnetgroup/src/main/java/software/amazon/rds/dbsubnetgroup/BaseHandlerStd.java
+++ b/aws-rds-dbsubnetgroup/src/main/java/software/amazon/rds/dbsubnetgroup/BaseHandlerStd.java
@@ -23,6 +23,7 @@ import software.amazon.rds.common.logging.LoggingProxyClient;
 import software.amazon.rds.common.logging.RequestLogger;
 import software.amazon.rds.common.printer.FilteredJsonPrinter;
 
+import java.time.Instant;
 import java.util.Collection;
 
 public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
@@ -30,6 +31,9 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
     protected static final String DB_SUBNET_GROUP_STATUS_COMPLETE = "Complete";
     protected static final String STACK_NAME = "rds";
     protected static final String RESOURCE_IDENTIFIER = "dbsubnetgroup";
+    protected static final String DB_SUBNET_GROUP_REQUEST_STARTED_AT = "dbsubnetgroup-request-started-at";
+    protected static final String DB_SUBNET_GROUP_REQUEST_IN_PROGRESS_AT = "dbsubnetgroup-request-in-progress-at";
+    protected static final String DB_SUBNET_GROUP_STABILIZATION_TIME = "dbsubnetgroup-stabilization-time";
 
     protected static final ErrorRuleSet DEFAULT_DB_SUBNET_GROUP_ERROR_RULE_SET = ErrorRuleSet
             .extend(Commons.DEFAULT_ERROR_RULE_SET)
@@ -92,6 +96,7 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
             final RequestLogger requestLogger
     ) {
         this.requestLogger = requestLogger;
+        resourceStabilizationTime(callbackContext);
         return handleRequest(proxy, request, callbackContext, proxyClient);
     }
 
@@ -101,6 +106,14 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
                         proxyClient.client()::describeDBSubnetGroups)
                 .dbSubnetGroups().stream().findFirst().get().subnetGroupStatus();
         return status.equals(DB_SUBNET_GROUP_STATUS_COMPLETE);
+    }
+
+    private void resourceStabilizationTime(final CallbackContext callbackContext) {
+        callbackContext.timestampOnce(DB_SUBNET_GROUP_REQUEST_STARTED_AT, Instant.now());
+        callbackContext.timestamp(DB_SUBNET_GROUP_REQUEST_IN_PROGRESS_AT, Instant.now());
+        callbackContext.calculateTimeDelta(DB_SUBNET_GROUP_STABILIZATION_TIME,
+                callbackContext.getTimestamp(DB_SUBNET_GROUP_REQUEST_STARTED_AT),
+                callbackContext.getTimestamp(DB_SUBNET_GROUP_REQUEST_IN_PROGRESS_AT));
     }
 
     protected boolean isDeleted(final ResourceModel model,

--- a/aws-rds-dbsubnetgroup/src/main/java/software/amazon/rds/dbsubnetgroup/BaseHandlerStd.java
+++ b/aws-rds-dbsubnetgroup/src/main/java/software/amazon/rds/dbsubnetgroup/BaseHandlerStd.java
@@ -112,8 +112,8 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
         callbackContext.timestampOnce(DB_SUBNET_GROUP_REQUEST_STARTED_AT, Instant.now());
         callbackContext.timestamp(DB_SUBNET_GROUP_REQUEST_IN_PROGRESS_AT, Instant.now());
         callbackContext.calculateTimeDeltaInMinutes(DB_SUBNET_GROUP_STABILIZATION_TIME,
-                callbackContext.getTimestamp(DB_SUBNET_GROUP_REQUEST_STARTED_AT),
-                callbackContext.getTimestamp(DB_SUBNET_GROUP_REQUEST_IN_PROGRESS_AT));
+                callbackContext.getTimestamp(DB_SUBNET_GROUP_REQUEST_IN_PROGRESS_AT),
+                callbackContext.getTimestamp(DB_SUBNET_GROUP_REQUEST_STARTED_AT));
     }
 
     protected boolean isDeleted(final ResourceModel model,

--- a/aws-rds-dbsubnetgroup/src/main/java/software/amazon/rds/dbsubnetgroup/BaseHandlerStd.java
+++ b/aws-rds-dbsubnetgroup/src/main/java/software/amazon/rds/dbsubnetgroup/BaseHandlerStd.java
@@ -111,7 +111,7 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
     private void resourceStabilizationTime(final CallbackContext callbackContext) {
         callbackContext.timestampOnce(DB_SUBNET_GROUP_REQUEST_STARTED_AT, Instant.now());
         callbackContext.timestamp(DB_SUBNET_GROUP_REQUEST_IN_PROGRESS_AT, Instant.now());
-        callbackContext.calculateTimeDelta(DB_SUBNET_GROUP_STABILIZATION_TIME,
+        callbackContext.calculateTimeDeltaInMinutes(DB_SUBNET_GROUP_STABILIZATION_TIME,
                 callbackContext.getTimestamp(DB_SUBNET_GROUP_REQUEST_STARTED_AT),
                 callbackContext.getTimestamp(DB_SUBNET_GROUP_REQUEST_IN_PROGRESS_AT));
     }

--- a/aws-rds-dbsubnetgroup/src/main/java/software/amazon/rds/dbsubnetgroup/CallbackContext.java
+++ b/aws-rds-dbsubnetgroup/src/main/java/software/amazon/rds/dbsubnetgroup/CallbackContext.java
@@ -55,8 +55,8 @@ public class CallbackContext extends StdCallbackContext implements TaggingContex
         return null;
     }
 
-    public void calculateTimeDelta(final String label, final Instant currentTime, final Instant startTime){
-        double delta = Duration.between(currentTime, startTime).toHours();
+    public void calculateTimeDeltaInMinutes(final String label, final Instant currentTime, final Instant startTime){
+        double delta = Duration.between(currentTime, startTime).toMinutes();
         timeDelta.put(label, delta);
     }
 }

--- a/aws-rds-dbsubnetgroup/src/main/java/software/amazon/rds/dbsubnetgroup/CallbackContext.java
+++ b/aws-rds-dbsubnetgroup/src/main/java/software/amazon/rds/dbsubnetgroup/CallbackContext.java
@@ -3,6 +3,11 @@ package software.amazon.rds.dbsubnetgroup;
 import software.amazon.cloudformation.proxy.StdCallbackContext;
 import software.amazon.rds.common.handler.TaggingContext;
 
+import java.time.Duration;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+
 @lombok.Getter
 @lombok.Setter
 @lombok.ToString
@@ -10,11 +15,16 @@ import software.amazon.rds.common.handler.TaggingContext;
 public class CallbackContext extends StdCallbackContext implements TaggingContext.Provider {
     private String dbSubnetGroupArn;
 
+    private Map<String, Long> timestamps;
+    private Map<String, Double> timeDelta;
+
     private TaggingContext taggingContext;
 
     public CallbackContext() {
         super();
         this.taggingContext = new TaggingContext();
+        this.timestamps = new HashMap<>();
+        this.timeDelta = new HashMap<>();
     }
 
     @Override
@@ -28,5 +38,25 @@ public class CallbackContext extends StdCallbackContext implements TaggingContex
 
     public void setAddTagsComplete(final boolean addTagsComplete) {
         taggingContext.setAddTagsComplete(addTagsComplete);
+    }
+
+    public void timestamp(final String label, final Instant instant) {
+        timestamps.put(label, instant.getEpochSecond());
+    }
+
+    public void timestampOnce(final String label, final Instant instant) {
+        timestamps.computeIfAbsent(label, s -> instant.getEpochSecond());
+    }
+
+    public Instant getTimestamp(final String label) {
+        if (timestamps.containsKey(label)) {
+            return Instant.ofEpochSecond(timestamps.get(label));
+        }
+        return null;
+    }
+
+    public void calculateTimeDelta(final String label, final Instant currentTime, final Instant startTime){
+        double delta = Duration.between(currentTime, startTime).toHours();
+        timeDelta.put(label, delta);
     }
 }

--- a/aws-rds-dbsubnetgroup/src/test/java/software/amazon/rds/dbsubnetgroup/CreateHandlerTest.java
+++ b/aws-rds-dbsubnetgroup/src/test/java/software/amazon/rds/dbsubnetgroup/CreateHandlerTest.java
@@ -196,7 +196,7 @@ public class CreateHandlerTest extends AbstractTestBase {
                 InvalidParameterException.class
         );
 
-        Mockito.doNothing().when(requestLogger).log(any(String.class));
+        Mockito.doNothing().when(requestLogger).log(any(String.class), any(String.class));
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
                 .desiredResourceState(RESOURCE_MODEL)
                 .desiredResourceTags(translateTagsToMap(TAG_SET))

--- a/aws-rds-eventsubscription/src/main/java/software/amazon/rds/eventsubscription/BaseHandlerStd.java
+++ b/aws-rds-eventsubscription/src/main/java/software/amazon/rds/eventsubscription/BaseHandlerStd.java
@@ -1,5 +1,6 @@
 package software.amazon.rds.eventsubscription;
 
+import java.time.Instant;
 import java.util.Collection;
 import java.util.function.BiFunction;
 import java.util.function.Function;
@@ -31,6 +32,9 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
 
     protected static final String STACK_NAME = "rds";
     protected static final String RESOURCE_IDENTIFIER = "eventsubscription";
+    protected static final String EVENT_SUBSCRIPTION_REQUEST_STARTED_AT = "eventsubscription-request-started-at";
+    protected static final String EVENT_SUBSCRIPTION_REQUEST_IN_PROGRESS_AT = "eventsubscription-request-in-progress-at";
+    protected static final String EVENT_SUBSCRIPTION_RESOURCE_STABILIZATION_TIME = "eventsubscription-stabilization-time";
     protected static final int MAX_LENGTH_EVENT_SUBSCRIPTION = 255;
     protected RequestLogger requestLogger;
 
@@ -83,6 +87,7 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
     )
     {
         this.requestLogger = requestLogger;
+        resourceStabilizationTime(callbackContext);
         return handleRequest(proxy, proxyClient, request, callbackContext);
     }
 
@@ -93,6 +98,14 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
                     proxyClient.client()::describeEventSubscriptions)
                 .eventSubscriptionsList().stream().findFirst().get().status();
         return status.equals("active");
+    }
+
+    private void resourceStabilizationTime(final CallbackContext callbackContext) {
+        callbackContext.timestampOnce(EVENT_SUBSCRIPTION_REQUEST_STARTED_AT, Instant.now());
+        callbackContext.timestamp(EVENT_SUBSCRIPTION_REQUEST_IN_PROGRESS_AT, Instant.now());
+        callbackContext.calculateTimeDelta(EVENT_SUBSCRIPTION_RESOURCE_STABILIZATION_TIME,
+                callbackContext.getTimestamp(EVENT_SUBSCRIPTION_REQUEST_STARTED_AT),
+                callbackContext.getTimestamp(EVENT_SUBSCRIPTION_REQUEST_IN_PROGRESS_AT));
     }
 
     protected ProgressEvent<ResourceModel, CallbackContext> setEnabledDefaultValue(

--- a/aws-rds-eventsubscription/src/main/java/software/amazon/rds/eventsubscription/BaseHandlerStd.java
+++ b/aws-rds-eventsubscription/src/main/java/software/amazon/rds/eventsubscription/BaseHandlerStd.java
@@ -103,7 +103,7 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
     private void resourceStabilizationTime(final CallbackContext callbackContext) {
         callbackContext.timestampOnce(EVENT_SUBSCRIPTION_REQUEST_STARTED_AT, Instant.now());
         callbackContext.timestamp(EVENT_SUBSCRIPTION_REQUEST_IN_PROGRESS_AT, Instant.now());
-        callbackContext.calculateTimeDelta(EVENT_SUBSCRIPTION_RESOURCE_STABILIZATION_TIME,
+        callbackContext.calculateTimeDeltaInMinutes(EVENT_SUBSCRIPTION_RESOURCE_STABILIZATION_TIME,
                 callbackContext.getTimestamp(EVENT_SUBSCRIPTION_REQUEST_STARTED_AT),
                 callbackContext.getTimestamp(EVENT_SUBSCRIPTION_REQUEST_IN_PROGRESS_AT));
     }

--- a/aws-rds-eventsubscription/src/main/java/software/amazon/rds/eventsubscription/BaseHandlerStd.java
+++ b/aws-rds-eventsubscription/src/main/java/software/amazon/rds/eventsubscription/BaseHandlerStd.java
@@ -104,8 +104,8 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
         callbackContext.timestampOnce(EVENT_SUBSCRIPTION_REQUEST_STARTED_AT, Instant.now());
         callbackContext.timestamp(EVENT_SUBSCRIPTION_REQUEST_IN_PROGRESS_AT, Instant.now());
         callbackContext.calculateTimeDeltaInMinutes(EVENT_SUBSCRIPTION_RESOURCE_STABILIZATION_TIME,
-                callbackContext.getTimestamp(EVENT_SUBSCRIPTION_REQUEST_STARTED_AT),
-                callbackContext.getTimestamp(EVENT_SUBSCRIPTION_REQUEST_IN_PROGRESS_AT));
+                callbackContext.getTimestamp(EVENT_SUBSCRIPTION_REQUEST_IN_PROGRESS_AT),
+                callbackContext.getTimestamp(EVENT_SUBSCRIPTION_REQUEST_STARTED_AT));
     }
 
     protected ProgressEvent<ResourceModel, CallbackContext> setEnabledDefaultValue(

--- a/aws-rds-eventsubscription/src/main/java/software/amazon/rds/eventsubscription/CallbackContext.java
+++ b/aws-rds-eventsubscription/src/main/java/software/amazon/rds/eventsubscription/CallbackContext.java
@@ -55,8 +55,8 @@ public class CallbackContext extends StdCallbackContext implements TaggingContex
         return null;
     }
 
-    public void calculateTimeDelta(final String label, final Instant currentTime, final Instant startTime){
-        double delta = Duration.between(currentTime, startTime).toHours();
+    public void calculateTimeDeltaInMinutes(final String label, final Instant currentTime, final Instant startTime){
+        double delta = Duration.between(currentTime, startTime).toMinutes();
         timeDelta.put(label, delta);
     }
 }

--- a/aws-rds-eventsubscription/src/main/java/software/amazon/rds/eventsubscription/CallbackContext.java
+++ b/aws-rds-eventsubscription/src/main/java/software/amazon/rds/eventsubscription/CallbackContext.java
@@ -3,6 +3,11 @@ package software.amazon.rds.eventsubscription;
 import software.amazon.cloudformation.proxy.StdCallbackContext;
 import software.amazon.rds.common.handler.TaggingContext;
 
+import java.time.Duration;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+
 @lombok.Getter
 @lombok.Setter
 @lombok.ToString
@@ -10,11 +15,16 @@ import software.amazon.rds.common.handler.TaggingContext;
 public class CallbackContext extends StdCallbackContext implements TaggingContext.Provider {
     private String eventSubscriptionArn;
 
+    private Map<String, Long> timestamps;
+    private Map<String, Double> timeDelta;
+
     private TaggingContext taggingContext;
 
     public CallbackContext() {
         super();
         this.taggingContext = new TaggingContext();
+        this.timestamps = new HashMap<>();
+        this.timeDelta = new HashMap<>();
     }
 
     @Override
@@ -28,5 +38,25 @@ public class CallbackContext extends StdCallbackContext implements TaggingContex
 
     public void setAddTagsComplete(final boolean addTagsComplete) {
         taggingContext.setAddTagsComplete(addTagsComplete);
+    }
+
+    public void timestamp(final String label, final Instant instant) {
+        timestamps.put(label, instant.getEpochSecond());
+    }
+
+    public void timestampOnce(final String label, final Instant instant) {
+        timestamps.computeIfAbsent(label, s -> instant.getEpochSecond());
+    }
+
+    public Instant getTimestamp(final String label) {
+        if (timestamps.containsKey(label)) {
+            return Instant.ofEpochSecond(timestamps.get(label));
+        }
+        return null;
+    }
+
+    public void calculateTimeDelta(final String label, final Instant currentTime, final Instant startTime){
+        double delta = Duration.between(currentTime, startTime).toHours();
+        timeDelta.put(label, delta);
     }
 }

--- a/aws-rds-optiongroup/src/main/java/software/amazon/rds/optiongroup/BaseHandlerStd.java
+++ b/aws-rds-optiongroup/src/main/java/software/amazon/rds/optiongroup/BaseHandlerStd.java
@@ -119,7 +119,7 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
     private void resourceStabilizationTime(final CallbackContext callbackContext) {
         callbackContext.timestampOnce(OPTION_GROUP_REQUEST_STARTED_AT, Instant.now());
         callbackContext.timestamp(OPTION_GROUP_REQUEST_IN_PROGRESS_AT, Instant.now());
-        callbackContext.calculateTimeDelta(OPTION_GROUP_STABILIZATION_TIME,
+        callbackContext.calculateTimeDeltaInMinutes(OPTION_GROUP_STABILIZATION_TIME,
                 callbackContext.getTimestamp(OPTION_GROUP_REQUEST_STARTED_AT),
                 callbackContext.getTimestamp(OPTION_GROUP_REQUEST_IN_PROGRESS_AT));
     }

--- a/aws-rds-optiongroup/src/main/java/software/amazon/rds/optiongroup/BaseHandlerStd.java
+++ b/aws-rds-optiongroup/src/main/java/software/amazon/rds/optiongroup/BaseHandlerStd.java
@@ -120,8 +120,8 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
         callbackContext.timestampOnce(OPTION_GROUP_REQUEST_STARTED_AT, Instant.now());
         callbackContext.timestamp(OPTION_GROUP_REQUEST_IN_PROGRESS_AT, Instant.now());
         callbackContext.calculateTimeDeltaInMinutes(OPTION_GROUP_STABILIZATION_TIME,
-                callbackContext.getTimestamp(OPTION_GROUP_REQUEST_STARTED_AT),
-                callbackContext.getTimestamp(OPTION_GROUP_REQUEST_IN_PROGRESS_AT));
+                callbackContext.getTimestamp(OPTION_GROUP_REQUEST_IN_PROGRESS_AT),
+                callbackContext.getTimestamp(OPTION_GROUP_REQUEST_STARTED_AT));
     }
 
     protected ProgressEvent<ResourceModel, CallbackContext> updateTags(

--- a/aws-rds-optiongroup/src/main/java/software/amazon/rds/optiongroup/CallbackContext.java
+++ b/aws-rds-optiongroup/src/main/java/software/amazon/rds/optiongroup/CallbackContext.java
@@ -54,8 +54,8 @@ public class CallbackContext extends StdCallbackContext implements TaggingContex
         return null;
     }
 
-    public void calculateTimeDelta(final String label, final Instant currentTime, final Instant startTime){
-        double delta = Duration.between(currentTime, startTime).toHours();
+    public void calculateTimeDeltaInMinutes(final String label, final Instant currentTime, final Instant startTime){
+        double delta = Duration.between(currentTime, startTime).toMinutes();
         timeDelta.put(label, delta);
     }
 }

--- a/aws-rds-optiongroup/src/main/java/software/amazon/rds/optiongroup/CallbackContext.java
+++ b/aws-rds-optiongroup/src/main/java/software/amazon/rds/optiongroup/CallbackContext.java
@@ -3,6 +3,11 @@ package software.amazon.rds.optiongroup;
 import software.amazon.cloudformation.proxy.StdCallbackContext;
 import software.amazon.rds.common.handler.TaggingContext;
 
+import java.time.Duration;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+
 @lombok.Getter
 @lombok.Setter
 @lombok.ToString
@@ -11,9 +16,14 @@ public class CallbackContext extends StdCallbackContext implements TaggingContex
     private TaggingContext taggingContext;
     private String optionGroupGroupArn;
 
+    private Map<String, Long> timestamps;
+    private Map<String, Double> timeDelta;
+
     public CallbackContext() {
         super();
         this.taggingContext = new TaggingContext();
+        this.timestamps = new HashMap<>();
+        this.timeDelta = new HashMap<>();
     }
 
     @Override
@@ -27,5 +37,25 @@ public class CallbackContext extends StdCallbackContext implements TaggingContex
 
     public void setAddTagsComplete(final boolean addTagsComplete) {
         this.taggingContext.setAddTagsComplete(addTagsComplete);
+    }
+
+    public void timestamp(final String label, final Instant instant) {
+        timestamps.put(label, instant.getEpochSecond());
+    }
+
+    public void timestampOnce(final String label, final Instant instant) {
+        timestamps.computeIfAbsent(label, s -> instant.getEpochSecond());
+    }
+
+    public Instant getTimestamp(final String label) {
+        if (timestamps.containsKey(label)) {
+            return Instant.ofEpochSecond(timestamps.get(label));
+        }
+        return null;
+    }
+
+    public void calculateTimeDelta(final String label, final Instant currentTime, final Instant startTime){
+        double delta = Duration.between(currentTime, startTime).toHours();
+        timeDelta.put(label, delta);
     }
 }

--- a/aws-rds-optiongroup/src/test/java/software/amazon/rds/optiongroup/CreateHandlerTest.java
+++ b/aws-rds-optiongroup/src/test/java/software/amazon/rds/optiongroup/CreateHandlerTest.java
@@ -10,6 +10,7 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import java.time.Duration;
+import java.time.Instant;
 
 import com.google.common.collect.Iterables;
 import org.assertj.core.api.Assertions;
@@ -124,6 +125,93 @@ public class CreateHandlerTest extends AbstractTestBase {
         verify(proxyClient.client(), times(1)).createOptionGroup(any(CreateOptionGroupRequest.class));
         verify(proxyClient.client(), times(1)).describeOptionGroups(any(DescribeOptionGroupsRequest.class));
         verify(proxyClient.client(), times(1)).listTagsForResource(any(ListTagsForResourceRequest.class));
+    }
+
+    @Test
+    public void handleRequest_timestamp() {
+        ResourceModel RESOURCE_MODEL = RESOURCE_MODEL_BUILDER().build();
+
+        when(proxyClient.client().createOptionGroup(any(CreateOptionGroupRequest.class)))
+                .thenReturn(CreateOptionGroupResponse.builder().build());
+
+        final DescribeOptionGroupsResponse describeDbClusterParameterGroupsResponse = DescribeOptionGroupsResponse.builder()
+                .optionGroupsList(OPTION_GROUP_ACTIVE).build();
+        when(proxyClient.client().describeOptionGroups(any(DescribeOptionGroupsRequest.class))).thenReturn(describeDbClusterParameterGroupsResponse);
+
+        when(proxyClient.client().listTagsForResource(any(ListTagsForResourceRequest.class)))
+                .thenReturn(ListTagsForResourceResponse.builder().build());
+
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+                .clientRequestToken(TestUtils.randomString(32, TestUtils.ALPHA))
+                .desiredResourceState(RESOURCE_MODEL)
+                .stackId(TestUtils.randomString(32, TestUtils.ALPHA))
+                .logicalResourceIdentifier(TestUtils.randomString(32, TestUtils.ALPHA))
+                .build();
+
+        final CallbackContext callbackContext = new CallbackContext();
+        Instant start = Instant.ofEpochSecond(0);
+        callbackContext.timestampOnce("START", start);
+        Duration timeToAdd = Duration.ofSeconds(50);
+        Instant end = Instant.ofEpochSecond(0).plus(timeToAdd);
+        callbackContext.timestamp("END", start);
+        callbackContext.timestamp("END", end);
+        
+        final ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, proxyClient, request, callbackContext);
+
+        assertThat(response).isNotNull();
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
+        assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
+        assertThat(response.getResourceModels()).isNull();
+        assertThat(response.getMessage()).isNull();
+        assertThat(response.getErrorCode()).isNull();
+
+        verify(proxyClient.client(), times(1)).createOptionGroup(any(CreateOptionGroupRequest.class));
+        verify(proxyClient.client(), times(1)).describeOptionGroups(any(DescribeOptionGroupsRequest.class));
+        verify(proxyClient.client(), times(1)).listTagsForResource(any(ListTagsForResourceRequest.class));
+        assertThat(callbackContext.getTimestamp("START").isBefore(Instant.now())).isTrue();
+        assertThat(callbackContext.getTimestamp("START")).isEqualTo(start);
+        assertThat(callbackContext.getTimestamp("END")).isEqualTo(end);
+    }
+
+    @Test
+    public void handleRequest_timeDelta() {
+        ResourceModel RESOURCE_MODEL = RESOURCE_MODEL_BUILDER().build();
+
+        when(proxyClient.client().createOptionGroup(any(CreateOptionGroupRequest.class)))
+                .thenReturn(CreateOptionGroupResponse.builder().build());
+
+        final DescribeOptionGroupsResponse describeDbClusterParameterGroupsResponse = DescribeOptionGroupsResponse.builder()
+                .optionGroupsList(OPTION_GROUP_ACTIVE).build();
+        when(proxyClient.client().describeOptionGroups(any(DescribeOptionGroupsRequest.class))).thenReturn(describeDbClusterParameterGroupsResponse);
+
+        when(proxyClient.client().listTagsForResource(any(ListTagsForResourceRequest.class)))
+                .thenReturn(ListTagsForResourceResponse.builder().build());
+
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+                .clientRequestToken(TestUtils.randomString(32, TestUtils.ALPHA))
+                .desiredResourceState(RESOURCE_MODEL)
+                .stackId(TestUtils.randomString(32, TestUtils.ALPHA))
+                .logicalResourceIdentifier(TestUtils.randomString(32, TestUtils.ALPHA))
+                .build();
+
+        final CallbackContext callbackContext = new CallbackContext();
+        callbackContext.calculateTimeDeltaInMinutes("TimeDeltaTest", Instant.ofEpochSecond(0), Instant.ofEpochSecond(60));
+
+
+        final ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, proxyClient, request, callbackContext);
+
+
+        assertThat(response).isNotNull();
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
+        assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
+        assertThat(response.getResourceModels()).isNull();
+        assertThat(response.getMessage()).isNull();
+        assertThat(response.getErrorCode()).isNull();
+
+        verify(proxyClient.client(), times(1)).createOptionGroup(any(CreateOptionGroupRequest.class));
+        verify(proxyClient.client(), times(1)).describeOptionGroups(any(DescribeOptionGroupsRequest.class));
+        verify(proxyClient.client(), times(1)).listTagsForResource(any(ListTagsForResourceRequest.class));
+        assertThat(callbackContext.getTimeDelta().get("TimeDeltaTest")).isEqualTo(1.00);
     }
 
     @Test


### PR DESCRIPTION
### Resource Stabilization Time and enhanced logging for UnexpectedErrorStatus

*Resource Stabilization Time:*
Resource Stabilization Time is a time-delta operation that resolves the duration of a resource to reach a stable state after a stack creation or update.
- This was achieved by timestamping the request-start-time once and dynamically update the request-in-progress timestamp when a new operation is invoked. Similarly, the time delta will be resolved every time when a stack operation is invoked.

*UnexpectedErrorStatus enhancements:*
- Added UnexpectedErrorStatus StackTrace into the logs to help diagnose such errors.
- Added unit test to ensure the stack trace is logged accordingly.

*Overall changes:*
- Adapted unit tests to accept the new changes.
- Testing was done in local environment.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
