### PR TITLE
[DBCluster] Stabilization for pending AllocatedStorage and Iops

### DIFF
--- a/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/BaseHandlerStd.java
+++ b/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/BaseHandlerStd.java
@@ -310,7 +310,9 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
                 modifiedValues.masterUserPassword() == null &&
                         modifiedValues.iamDatabaseAuthenticationEnabled() == null &&
                         modifiedValues.engineVersion() == null &&
-                        modifiedValues.storageType() == null);
+                        modifiedValues.storageType() == null &&
+                        modifiedValues.allocatedStorage() == null &&
+                        modifiedValues.iops() == null);
     }
 
     protected boolean isDBClusterStabilized(
@@ -326,7 +328,7 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
         final boolean isMasterUserSecretStabilizedResult = isMasterUserSecretStabilized(dbCluster);
         final boolean isGlobalWriteForwardingStabilizedResult = isGlobalWriteForwardingStabilized(dbCluster);
 
-        requestLogger.log(String.format("isDbClusterStabilized: $b", isDBClusterStabilizedResult),
+        requestLogger.log(String.format("isDbClusterStabilized: %b", isDBClusterStabilizedResult),
                 ImmutableMap.of("isDbClusterAvailable", isDBClusterStabilizedResult,
                         "isNoPendingChanges", isNoPendingChangesResult,
                         "isMasterUserSecretStabilized", isMasterUserSecretStabilizedResult,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This change includes stabilization logic for DBCluster resources for `allocatedStorage` and `iops` pending modified values. Stabilization logic will wait for these values to be applied to the DBCluster before considering the resource stabilized.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
