### PR TITLE
[DBInstance] Send EnablePerformanceInsights when changing Performance…

### DIFF
--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/Translator.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/Translator.java
@@ -473,7 +473,6 @@ public class Translator {
                 .multiAZ(diff(previousModel.getMultiAZ(), desiredModel.getMultiAZ()))
                 .networkType(diff(previousModel.getNetworkType(), desiredModel.getNetworkType()))
                 .optionGroupName(diff(previousModel.getOptionGroupName(), desiredModel.getOptionGroupName()))
-                .performanceInsightsRetentionPeriod(diff(previousModel.getPerformanceInsightsRetentionPeriod(), desiredModel.getPerformanceInsightsRetentionPeriod()))
                 .preferredBackupWindow(diff(previousModel.getPreferredBackupWindow(), desiredModel.getPreferredBackupWindow()))
                 .preferredMaintenanceWindow(diff(previousModel.getPreferredMaintenanceWindow(), desiredModel.getPreferredMaintenanceWindow()))
                 .promotionTier(desiredModel.getPromotionTier()) // promotion tier is set unconditionally
@@ -514,13 +513,15 @@ public class Translator {
             builder.useDefaultProcessorFeatures(desiredModel.getUseDefaultProcessorFeatures());
         }
 
-        // EnablePerformanceInsights (EPI) and PerformanceInsightsKMSKeyId (PKI) are coupled parameters.
-        // The following logic stands:
+        // EnablePerformanceInsights (EPI), PerformanceInsightsKMSKeyId (PKI) and PerformanceInsightsRetentionPeriod (PIP)
+        // are coupled parameters. The following logic stands:
         // 0. If EPI or PKI are changed, provide the diff unconditionally.
         // 1. if EPI is true, provide the desired PKI unconditionally.
         // 2. if PKI is changed, provide the desired EPI unconditionally.
+        // 3. if PIP is changed, provide the desired EPI unconditionally.
         final Boolean enablePerformanceInsightsDiff = diff(previousModel.getEnablePerformanceInsights(), desiredModel.getEnablePerformanceInsights());
         final String performanceInsightsKMSKeyIdDiff = diff(previousModel.getPerformanceInsightsKMSKeyId(), desiredModel.getPerformanceInsightsKMSKeyId());
+        final Integer performanceInsightsRetentionPeriodDiff = diff(previousModel.getPerformanceInsightsRetentionPeriod(), desiredModel.getPerformanceInsightsRetentionPeriod());
 
         if (enablePerformanceInsightsDiff != null || performanceInsightsKMSKeyIdDiff != null) {
             builder.enablePerformanceInsights(enablePerformanceInsightsDiff);
@@ -531,6 +532,11 @@ public class Translator {
             if (performanceInsightsKMSKeyIdDiff != null) {
                 builder.enablePerformanceInsights(desiredModel.getEnablePerformanceInsights());
             }
+        }
+
+        if (performanceInsightsRetentionPeriodDiff != null) {
+            builder.performanceInsightsRetentionPeriod(performanceInsightsRetentionPeriodDiff);
+            builder.enablePerformanceInsights(desiredModel.getEnablePerformanceInsights());
         }
 
         if (BooleanUtils.isTrue(desiredModel.getManageMasterUserPassword())) {
@@ -617,6 +623,7 @@ public class Translator {
                 .maxAllocatedStorage(model.getMaxAllocatedStorage())
                 .monitoringInterval(model.getMonitoringInterval())
                 .monitoringRoleArn(model.getMonitoringRoleArn())
+                .performanceInsightsRetentionPeriod(model.getPerformanceInsightsRetentionPeriod())
                 .performanceInsightsKMSKeyId(model.getPerformanceInsightsKMSKeyId())
                 .preferredBackupWindow(model.getPreferredBackupWindow())
                 .preferredMaintenanceWindow(model.getPreferredMaintenanceWindow());

--- a/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/TranslatorTest.java
+++ b/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/TranslatorTest.java
@@ -817,6 +817,38 @@ class TranslatorTest extends AbstractHandlerTest {
     }
 
     @Test
+    public void test_modifyDbInstanceRequest_PerformanceInsightsChangeRetentionPeriod() {
+        final int NEW_RETENTION_PERIOD = 31;
+        final ResourceModel previousModel = ResourceModel.builder()
+                .enablePerformanceInsights(true)
+                .performanceInsightsRetentionPeriod(7)
+                .build();
+        final ResourceModel desiredModel = ResourceModel.builder()
+                .enablePerformanceInsights(true)
+                .performanceInsightsRetentionPeriod(NEW_RETENTION_PERIOD)
+                .build();
+        final ModifyDbInstanceRequest request = Translator.modifyDbInstanceRequest(previousModel, desiredModel, false);
+        assertThat(request.enablePerformanceInsights()).isTrue();
+        assertThat(request.performanceInsightsRetentionPeriod()).isEqualTo(NEW_RETENTION_PERIOD);
+    }
+
+    @Test
+    public void test_modifyDbInstanceRequest_NoPerformanceInsightsChangeRetentionPeriod() {
+        final int NEW_RETENTION_PERIOD = 31;
+        final ResourceModel previousModel = ResourceModel.builder()
+                .enablePerformanceInsights(false)
+                .performanceInsightsRetentionPeriod(7)
+                .build();
+        final ResourceModel desiredModel = ResourceModel.builder()
+                .enablePerformanceInsights(false)
+                .performanceInsightsRetentionPeriod(NEW_RETENTION_PERIOD)
+                .build();
+        final ModifyDbInstanceRequest request = Translator.modifyDbInstanceRequest(previousModel, desiredModel, false);
+        assertThat(request.enablePerformanceInsights()).isFalse();
+        assertThat(request.performanceInsightsRetentionPeriod()).isEqualTo(NEW_RETENTION_PERIOD);
+    }
+
+    @Test
     public void test_modifyDbInstanceRequest_PerformanceInsightsEnabledChangeKMSKeyId() {
         final String kmsKeyId1 = "test-kms-key-id-1";
         final String kmsKeyId2 = "test-kms-key-id-2";
@@ -1095,6 +1127,18 @@ class TranslatorTest extends AbstractHandlerTest {
                 .build();
         final ModifyDbInstanceRequest request = Translator.modifyDbInstanceAfterCreateRequest(model);
         assertThat(request.enablePerformanceInsights()).isTrue();
+    }
+
+    @Test
+    public void test_modifyAfterCreate_shouldSetEnablePerformanceInsightsRetentionPeriod() {
+        final int PI_RETENTION_PERIOD = 31;
+        final ResourceModel model = RESOURCE_MODEL_BLDR()
+                .enablePerformanceInsights(true)
+                .performanceInsightsRetentionPeriod(PI_RETENTION_PERIOD)
+                .build();
+        final ModifyDbInstanceRequest request = Translator.modifyDbInstanceAfterCreateRequest(model);
+        assertThat(request.enablePerformanceInsights()).isTrue();
+        assertThat(request.performanceInsightsRetentionPeriod()).isEqualTo(PI_RETENTION_PERIOD);
     }
 
     @Test


### PR DESCRIPTION
…InsightsRetentionPeriod

*Issue #, if available:*

*Description of changes:*
This PR introduces two changes for PerformanceInsights request parameters handling. First it will always send `enablePerformanceInsights` flag when changing `performanceInsightsRetentionPeriod`. This is to ensure that when the retention period changes, if the feature is disabled in the instance for any reason but enabled in the model, it will update the instance to reflect the model. Second, it adds `performanceInsightsRetentionPeriod` field to the modify-after-create call to ensure APIs that do not take this parameter will not cause drift as the parameter is set via ModifyDBInstance during the stack creation.

Both of these changes are covered by unit tests added in the same code change.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
