### PR TITLE
Adding resource stabilization time and improved UnexpectedErrorStatus

### DIFF
--- a/aws-rds-cfn-common/src/main/java/software/amazon/rds/common/handler/TimestampContext.java
+++ b/aws-rds-cfn-common/src/main/java/software/amazon/rds/common/handler/TimestampContext.java
@@ -15,5 +15,7 @@ public class TimestampContext {
         void timestampOnce(final String label, final Instant instant);
 
         Instant getTimestamp(final String label);
+
+        void calculateTimeDeltaInMinutes(final String label, final Instant currentTime, final Instant startTime);
     }
 }

--- a/aws-rds-customdbengineversion/src/main/java/software/amazon/rds/customdbengineversion/CallbackContext.java
+++ b/aws-rds-customdbengineversion/src/main/java/software/amazon/rds/customdbengineversion/CallbackContext.java
@@ -2,6 +2,7 @@ package software.amazon.rds.customdbengineversion;
 
 import software.amazon.cloudformation.proxy.StdCallbackContext;
 import software.amazon.rds.common.handler.TaggingContext;
+import software.amazon.rds.common.handler.TimestampContext;
 
 import java.time.Duration;
 import java.time.Instant;
@@ -12,7 +13,7 @@ import java.util.Map;
 @lombok.Setter
 @lombok.ToString
 @lombok.EqualsAndHashCode(callSuper = true)
-public class CallbackContext extends StdCallbackContext implements TaggingContext.Provider {
+public class CallbackContext extends StdCallbackContext implements TaggingContext.Provider, TimestampContext.Provider {
     private boolean modified;
     private TaggingContext taggingContext;
     private Map<String, Long> timestamps;
@@ -38,14 +39,17 @@ public class CallbackContext extends StdCallbackContext implements TaggingContex
         this.taggingContext.setAddTagsComplete(addTagsComplete);
     }
 
+    @Override
     public void timestamp(final String label, final Instant instant) {
         timestamps.put(label, instant.getEpochSecond());
     }
 
+    @Override
     public void timestampOnce(final String label, final Instant instant) {
         timestamps.computeIfAbsent(label, s -> instant.getEpochSecond());
     }
 
+    @Override
     public Instant getTimestamp(final String label) {
         if (timestamps.containsKey(label)) {
             return Instant.ofEpochSecond(timestamps.get(label));
@@ -53,6 +57,7 @@ public class CallbackContext extends StdCallbackContext implements TaggingContex
         return null;
     }
 
+    @Override
     public void calculateTimeDeltaInMinutes(final String label, final Instant currentTime, final Instant startTime){
         double delta = Duration.between(currentTime, startTime).toMinutes();
         timeDelta.put(label, delta);

--- a/aws-rds-customdbengineversion/src/main/java/software/amazon/rds/customdbengineversion/CallbackContext.java
+++ b/aws-rds-customdbengineversion/src/main/java/software/amazon/rds/customdbengineversion/CallbackContext.java
@@ -3,18 +3,26 @@ package software.amazon.rds.customdbengineversion;
 import software.amazon.cloudformation.proxy.StdCallbackContext;
 import software.amazon.rds.common.handler.TaggingContext;
 
+import java.time.Duration;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+
 @lombok.Getter
 @lombok.Setter
 @lombok.ToString
 @lombok.EqualsAndHashCode(callSuper = true)
 public class CallbackContext extends StdCallbackContext implements TaggingContext.Provider {
     private boolean modified;
-
     private TaggingContext taggingContext;
+    private Map<String, Long> timestamps;
+    private Map<String, Double> timeDelta;
 
     public CallbackContext() {
         super();
         this.taggingContext = new TaggingContext();
+        this.timestamps = new HashMap<>();
+        this.timeDelta = new HashMap<>();
     }
 
     @Override
@@ -28,5 +36,25 @@ public class CallbackContext extends StdCallbackContext implements TaggingContex
 
     public void setAddTagsComplete(final boolean addTagsComplete) {
         this.taggingContext.setAddTagsComplete(addTagsComplete);
+    }
+
+    public void timestamp(final String label, final Instant instant) {
+        timestamps.put(label, instant.getEpochSecond());
+    }
+
+    public void timestampOnce(final String label, final Instant instant) {
+        timestamps.computeIfAbsent(label, s -> instant.getEpochSecond());
+    }
+
+    public Instant getTimestamp(final String label) {
+        if (timestamps.containsKey(label)) {
+            return Instant.ofEpochSecond(timestamps.get(label));
+        }
+        return null;
+    }
+
+    public void calculateTimeDeltaInMinutes(final String label, final Instant currentTime, final Instant startTime){
+        double delta = Duration.between(currentTime, startTime).toMinutes();
+        timeDelta.put(label, delta);
     }
 }

--- a/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/BaseHandlerStd.java
+++ b/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/BaseHandlerStd.java
@@ -4,6 +4,7 @@ import static software.amazon.rds.dbcluster.Translator.addRoleToDbClusterRequest
 import static software.amazon.rds.dbcluster.Translator.removeRoleFromDbClusterRequest;
 
 import java.time.Duration;
+import java.time.Instant;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashSet;
@@ -92,6 +93,9 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
     public static final String RESOURCE_IDENTIFIER = "dbcluster";
     public static final String ENGINE_AURORA_POSTGRESQL = "aurora-postgresql";
     private static final String MASTER_USER_SECRET_ACTIVE = "active";
+    protected static final String DB_CLUSTER_REQUEST_STARTED_AT = "dbcluster-request-started-at";
+    protected static final String DB_CLUSTER_REQUEST_IN_PROGRESS_AT = "dbcluster-request-in-progress-at";
+    protected static final String DB_CLUSTER_STABILIZATION_TIME = "dbcluster-stabilization-time";
     public static final String STACK_NAME = "rds";
     protected static final int RESOURCE_ID_MAX_LENGTH = 63;
 
@@ -210,6 +214,7 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
             final RequestLogger requestLogger
     ) {
         this.requestLogger = requestLogger;
+        resourceStabilizationTime(callbackContext);
         try {
             validateRequest(request);
         } catch (RequestValidationException exception) {
@@ -339,6 +344,12 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
         return isDBClusterStabilizedResult && isNoPendingChangesResult && isMasterUserSecretStabilizedResult && isGlobalWriteForwardingStabilizedResult;
     }
 
+    private void resourceStabilizationTime(final CallbackContext context) {
+        context.timestampOnce(DB_CLUSTER_REQUEST_STARTED_AT, Instant.now());
+        context.timestamp(DB_CLUSTER_REQUEST_IN_PROGRESS_AT, Instant.now());
+        context.calculateTimeDeltaInMinutes(DB_CLUSTER_STABILIZATION_TIME, context.getTimestamp(DB_CLUSTER_REQUEST_IN_PROGRESS_AT), context.getTimestamp(DB_CLUSTER_REQUEST_STARTED_AT));
+    }
+
     protected static boolean isMasterUserSecretStabilized(DBCluster dbCluster) {
         if (dbCluster.masterUserSecret() == null ||
                 CollectionUtils.isEmpty(dbCluster.dbClusterMembers())) {
@@ -351,7 +362,7 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
         return BooleanUtils.isNotTrue(dbCluster.globalWriteForwardingRequested()) ||
                 // Even if GWF is requested the WF will not start until a replica is created by customers
                 (dbCluster.globalWriteForwardingStatus() != WriteForwardingStatus.ENABLING &&
-                dbCluster.globalWriteForwardingStatus() != WriteForwardingStatus.DISABLING);
+                        dbCluster.globalWriteForwardingStatus() != WriteForwardingStatus.DISABLING);
     }
 
     protected boolean isClusterRemovedFromGlobalCluster(
@@ -492,22 +503,22 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
         final String dbClusterArn = fetchDBCluster(proxyClient, model).dbClusterArn();
 
         return proxy.initiate("rds::enable-http-endpoint-v2", proxyClient, model, callbackContext)
-                    .translateToServiceRequest(modelRequest -> Translator.enableHttpEndpointRequest(dbClusterArn))
-                    .backoffDelay(config.getBackoff())
-                    .makeServiceCall((enableRequest, proxyInvocation) -> proxyInvocation.injectCredentialsAndInvokeV2(
-                            enableRequest,
-                            proxyInvocation.client()::enableHttpEndpoint
-                    ))
-                    .stabilize((enableHttpRequest, enableHttpResponse, client, resourceModel, context) ->
-                            isHttpEndpointV2Set(client, resourceModel, true)
-                    )
-                    .handleError((enableHttpRequest, exception, client, resourceModel, callbackCtxt) -> Commons.handleException(
-                            ProgressEvent.progress(resourceModel, callbackCtxt),
-                            exception,
-                            DEFAULT_DB_CLUSTER_ERROR_RULE_SET,
-                            requestLogger
-                    ))
-                    .progress();
+                .translateToServiceRequest(modelRequest -> Translator.enableHttpEndpointRequest(dbClusterArn))
+                .backoffDelay(config.getBackoff())
+                .makeServiceCall((enableRequest, proxyInvocation) -> proxyInvocation.injectCredentialsAndInvokeV2(
+                        enableRequest,
+                        proxyInvocation.client()::enableHttpEndpoint
+                ))
+                .stabilize((enableHttpRequest, enableHttpResponse, client, resourceModel, context) ->
+                        isHttpEndpointV2Set(client, resourceModel, true)
+                )
+                .handleError((enableHttpRequest, exception, client, resourceModel, callbackCtxt) -> Commons.handleException(
+                        ProgressEvent.progress(resourceModel, callbackCtxt),
+                        exception,
+                        DEFAULT_DB_CLUSTER_ERROR_RULE_SET,
+                        requestLogger
+                ))
+                .progress();
     }
 
     protected ProgressEvent<ResourceModel, CallbackContext> disableHttpEndpointV2(

--- a/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/CallbackContext.java
+++ b/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/CallbackContext.java
@@ -8,12 +8,13 @@ import java.util.Map;
 import software.amazon.cloudformation.proxy.StdCallbackContext;
 import software.amazon.rds.common.handler.ProbingContext;
 import software.amazon.rds.common.handler.TaggingContext;
+import software.amazon.rds.common.handler.TimestampContext;
 
 @lombok.Getter
 @lombok.Setter
 @lombok.ToString
 @lombok.EqualsAndHashCode(callSuper = true)
-public class CallbackContext extends StdCallbackContext implements TaggingContext.Provider, ProbingContext.Provider {
+public class CallbackContext extends StdCallbackContext implements TaggingContext.Provider, ProbingContext.Provider, TimestampContext.Provider {
     private boolean modified;
     private boolean rebooted;
     private boolean deleting;
@@ -50,20 +51,25 @@ public class CallbackContext extends StdCallbackContext implements TaggingContex
         return probingContext;
     }
 
+    @Override
+    public void timestamp(final String label, final Instant instant) {
+        timestamps.put(label, instant.getEpochSecond());
+    }
+
+    @Override
     public void timestampOnce(final String label, final Instant instant) {
         timestamps.computeIfAbsent(label, s -> instant.getEpochSecond());
     }
 
+    @Override
     public Instant getTimestamp(final String label) {
         if (timestamps.containsKey(label)) {
             return Instant.ofEpochSecond(timestamps.get(label));
         }
         return null;
     }
-    public void timestamp(final String label, final Instant instant) {
-        timestamps.put(label, instant.getEpochSecond());
-    }
 
+    @Override
     public void calculateTimeDeltaInMinutes(final String label, final Instant currentTime, final Instant startTime){
         double delta = Duration.between(currentTime, startTime).toMinutes();
         timeDelta.put(label, delta);

--- a/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/CallbackContext.java
+++ b/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/CallbackContext.java
@@ -1,5 +1,6 @@
 package software.amazon.rds.dbcluster;
 
+import java.time.Duration;
 import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
@@ -18,6 +19,7 @@ public class CallbackContext extends StdCallbackContext implements TaggingContex
     private boolean deleting;
 
     private Map<String, Long> timestamps;
+    private Map<String, Double> timeDelta;
 
     private TaggingContext taggingContext;
     private ProbingContext probingContext;
@@ -27,6 +29,7 @@ public class CallbackContext extends StdCallbackContext implements TaggingContex
         this.taggingContext = new TaggingContext();
         this.probingContext = new ProbingContext();
         this.timestamps = new HashMap<>();
+        this.timeDelta = new HashMap<>();
     }
 
     @Override
@@ -56,5 +59,13 @@ public class CallbackContext extends StdCallbackContext implements TaggingContex
             return Instant.ofEpochSecond(timestamps.get(label));
         }
         return null;
+    }
+    public void timestamp(final String label, final Instant instant) {
+        timestamps.put(label, instant.getEpochSecond());
+    }
+
+    public void calculateTimeDeltaInMinutes(final String label, final Instant currentTime, final Instant startTime){
+        double delta = Duration.between(currentTime, startTime).toMinutes();
+        timeDelta.put(label, delta);
     }
 }

--- a/aws-rds-dbclusterendpoint/src/main/java/software/amazon/rds/dbclusterendpoint/BaseHandlerStd.java
+++ b/aws-rds-dbclusterendpoint/src/main/java/software/amazon/rds/dbclusterendpoint/BaseHandlerStd.java
@@ -3,6 +3,7 @@ package software.amazon.rds.dbclusterendpoint;
 import java.time.Duration;
 import java.util.Collection;
 import java.util.Optional;
+import java.time.Instant;
 
 import software.amazon.awssdk.services.rds.RdsClient;
 import software.amazon.awssdk.services.rds.model.DBClusterEndpoint;
@@ -33,6 +34,9 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
     protected static final String DEFAULT_STACK_NAME = "rds";
     protected static final String DB_CLUSTER_ENDPOINT_AVAILABLE = "available";
     protected static final String CUSTOM_ENDPOINT = "CUSTOM";
+    protected static final String DB_CLUSTER_ENDPOINT_REQUEST_STARTED_AT = "dbclusterendpoint-request-started-at";
+    protected static final String DB_CLUSTER_ENDPOINT_REQUEST_IN_PROGRESS_AT = "dbclusterendpoint-request-in-progress-at";
+    protected static final String DB_CLUSTER_ENDPOINT_STABILIZATION_TIME = "dbclusterendpoint-stabilization-time";
 
     protected static final Constant BACKOFF_DELAY = Constant.of()
             .timeout(Duration.ofSeconds(180L))
@@ -96,12 +100,19 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
             final RequestLogger requestLogger
     ){
         this.requestLogger = requestLogger;
+        resourceStabilizationTime(callbackContext);
         return handleRequest(proxy, proxyClient, request, callbackContext);
     }
 
     protected boolean isStabilized(final ResourceModel model, final ProxyClient<RdsClient> proxyClient) {
         final DBClusterEndpoint endpoint = fetchDBClusterEndpoint(model, proxyClient);
         return DB_CLUSTER_ENDPOINT_AVAILABLE.equals(endpoint.status());
+    }
+
+    private void resourceStabilizationTime(final CallbackContext callbackContext) {
+        callbackContext.timestampOnce(DB_CLUSTER_ENDPOINT_REQUEST_STARTED_AT, Instant.now());
+        callbackContext.timestamp(DB_CLUSTER_ENDPOINT_REQUEST_IN_PROGRESS_AT, Instant.now());
+        callbackContext.calculateTimeDeltaInMinutes(DB_CLUSTER_ENDPOINT_STABILIZATION_TIME, callbackContext.getTimestamp(DB_CLUSTER_ENDPOINT_REQUEST_IN_PROGRESS_AT), callbackContext.getTimestamp(DB_CLUSTER_ENDPOINT_REQUEST_STARTED_AT));
     }
 
     protected ProgressEvent<ResourceModel, CallbackContext> updateTags(

--- a/aws-rds-dbclusterendpoint/src/main/java/software/amazon/rds/dbclusterendpoint/CallbackContext.java
+++ b/aws-rds-dbclusterendpoint/src/main/java/software/amazon/rds/dbclusterendpoint/CallbackContext.java
@@ -2,6 +2,7 @@ package software.amazon.rds.dbclusterendpoint;
 
 import software.amazon.cloudformation.proxy.StdCallbackContext;
 import software.amazon.rds.common.handler.TaggingContext;
+import software.amazon.rds.common.handler.TimestampContext;
 
 import java.time.Duration;
 import java.time.Instant;
@@ -12,7 +13,7 @@ import java.util.Map;
 @lombok.Setter
 @lombok.ToString
 @lombok.EqualsAndHashCode(callSuper = true)
-public class CallbackContext extends StdCallbackContext implements TaggingContext.Provider {
+public class CallbackContext extends StdCallbackContext implements TaggingContext.Provider, TimestampContext.Provider {
     private TaggingContext taggingContext;
     private Map<String, Long> timestamps;
     private Map<String, Double> timeDelta;
@@ -37,14 +38,17 @@ public class CallbackContext extends StdCallbackContext implements TaggingContex
         this.taggingContext.setAddTagsComplete(addTagsComplete);
     }
 
+    @Override
     public void timestamp(final String label, final Instant instant) {
         timestamps.put(label, instant.getEpochSecond());
     }
 
+    @Override
     public void timestampOnce(final String label, final Instant instant) {
         timestamps.computeIfAbsent(label, s -> instant.getEpochSecond());
     }
 
+    @Override
     public Instant getTimestamp(final String label) {
         if (timestamps.containsKey(label)) {
             return Instant.ofEpochSecond(timestamps.get(label));
@@ -52,6 +56,7 @@ public class CallbackContext extends StdCallbackContext implements TaggingContex
         return null;
     }
 
+    @Override
     public void calculateTimeDeltaInMinutes(final String label, final Instant currentTime, final Instant startTime){
         double delta = Duration.between(currentTime, startTime).toMinutes();
         timeDelta.put(label, delta);

--- a/aws-rds-dbclusterendpoint/src/main/java/software/amazon/rds/dbclusterendpoint/CallbackContext.java
+++ b/aws-rds-dbclusterendpoint/src/main/java/software/amazon/rds/dbclusterendpoint/CallbackContext.java
@@ -3,16 +3,25 @@ package software.amazon.rds.dbclusterendpoint;
 import software.amazon.cloudformation.proxy.StdCallbackContext;
 import software.amazon.rds.common.handler.TaggingContext;
 
+import java.time.Duration;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+
 @lombok.Getter
 @lombok.Setter
 @lombok.ToString
 @lombok.EqualsAndHashCode(callSuper = true)
 public class CallbackContext extends StdCallbackContext implements TaggingContext.Provider {
     private TaggingContext taggingContext;
+    private Map<String, Long> timestamps;
+    private Map<String, Double> timeDelta;
 
     public CallbackContext() {
         super();
         this.taggingContext = new TaggingContext();
+        this.timestamps = new HashMap<>();
+        this.timeDelta = new HashMap<>();
     }
 
     @Override
@@ -26,5 +35,25 @@ public class CallbackContext extends StdCallbackContext implements TaggingContex
 
     public void setAddTagsComplete(final boolean addTagsComplete) {
         this.taggingContext.setAddTagsComplete(addTagsComplete);
+    }
+
+    public void timestamp(final String label, final Instant instant) {
+        timestamps.put(label, instant.getEpochSecond());
+    }
+
+    public void timestampOnce(final String label, final Instant instant) {
+        timestamps.computeIfAbsent(label, s -> instant.getEpochSecond());
+    }
+
+    public Instant getTimestamp(final String label) {
+        if (timestamps.containsKey(label)) {
+            return Instant.ofEpochSecond(timestamps.get(label));
+        }
+        return null;
+    }
+
+    public void calculateTimeDeltaInMinutes(final String label, final Instant currentTime, final Instant startTime){
+        double delta = Duration.between(currentTime, startTime).toMinutes();
+        timeDelta.put(label, delta);
     }
 }

--- a/aws-rds-dbclusterparametergroup/src/main/java/software/amazon/rds/dbclusterparametergroup/CallbackContext.java
+++ b/aws-rds-dbclusterparametergroup/src/main/java/software/amazon/rds/dbclusterparametergroup/CallbackContext.java
@@ -4,6 +4,11 @@ import software.amazon.cloudformation.proxy.StdCallbackContext;
 import software.amazon.rds.common.handler.ProbingContext;
 import software.amazon.rds.common.handler.TaggingContext;
 
+import java.time.Duration;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+
 
 @lombok.Getter
 @lombok.Setter
@@ -20,10 +25,15 @@ public class CallbackContext extends StdCallbackContext implements TaggingContex
     private TaggingContext taggingContext;
     private ProbingContext probingContext;
 
+    private Map<String, Long> timestamps;
+    private Map<String, Double> timeDelta;
+
     public CallbackContext() {
         super();
         this.taggingContext = new TaggingContext();
         this.probingContext = new ProbingContext();
+        this.timestamps = new HashMap<>();
+        this.timeDelta = new HashMap<>();
     }
 
     @Override
@@ -40,5 +50,25 @@ public class CallbackContext extends StdCallbackContext implements TaggingContex
 
     public void setAddTagsComplete(final boolean addTagsComplete) {
         this.taggingContext.setAddTagsComplete(addTagsComplete);
+    }
+
+    public void timestamp(final String label, final Instant instant) {
+        timestamps.put(label, instant.getEpochSecond());
+    }
+
+    public void timestampOnce(final String label, final Instant instant) {
+        timestamps.computeIfAbsent(label, s -> instant.getEpochSecond());
+    }
+
+    public Instant getTimestamp(final String label) {
+        if (timestamps.containsKey(label)) {
+            return Instant.ofEpochSecond(timestamps.get(label));
+        }
+        return null;
+    }
+
+    public void calculateTimeDeltaInMinutes(final String label, final Instant currentTime, final Instant startTime){
+        double delta = Duration.between(currentTime, startTime).toMinutes();
+        timeDelta.put(label, delta);
     }
 }

--- a/aws-rds-dbclusterparametergroup/src/main/java/software/amazon/rds/dbclusterparametergroup/CallbackContext.java
+++ b/aws-rds-dbclusterparametergroup/src/main/java/software/amazon/rds/dbclusterparametergroup/CallbackContext.java
@@ -3,6 +3,7 @@ package software.amazon.rds.dbclusterparametergroup;
 import software.amazon.cloudformation.proxy.StdCallbackContext;
 import software.amazon.rds.common.handler.ProbingContext;
 import software.amazon.rds.common.handler.TaggingContext;
+import software.amazon.rds.common.handler.TimestampContext;
 
 import java.time.Duration;
 import java.time.Instant;
@@ -14,7 +15,7 @@ import java.util.Map;
 @lombok.Setter
 @lombok.ToString
 @lombok.EqualsAndHashCode(callSuper = true)
-public class CallbackContext extends StdCallbackContext implements TaggingContext.Provider, ProbingContext.Provider {
+public class CallbackContext extends StdCallbackContext implements TaggingContext.Provider, ProbingContext.Provider, TimestampContext.Provider {
     private String marker;
     private String dbClusterParameterGroupArn;
 
@@ -52,14 +53,17 @@ public class CallbackContext extends StdCallbackContext implements TaggingContex
         this.taggingContext.setAddTagsComplete(addTagsComplete);
     }
 
+    @Override
     public void timestamp(final String label, final Instant instant) {
         timestamps.put(label, instant.getEpochSecond());
     }
 
+    @Override
     public void timestampOnce(final String label, final Instant instant) {
         timestamps.computeIfAbsent(label, s -> instant.getEpochSecond());
     }
 
+    @Override
     public Instant getTimestamp(final String label) {
         if (timestamps.containsKey(label)) {
             return Instant.ofEpochSecond(timestamps.get(label));
@@ -67,6 +71,7 @@ public class CallbackContext extends StdCallbackContext implements TaggingContex
         return null;
     }
 
+    @Override
     public void calculateTimeDeltaInMinutes(final String label, final Instant currentTime, final Instant startTime){
         double delta = Duration.between(currentTime, startTime).toMinutes();
         timeDelta.put(label, delta);

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/BaseHandlerStd.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/BaseHandlerStd.java
@@ -1,6 +1,7 @@
 package software.amazon.rds.dbinstance;
 
 import java.time.Duration;
+import java.time.Instant;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashSet;
@@ -153,6 +154,12 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
     protected static final String UNKNOWN_SOURCE_REGION_ERROR = "Unknown source region";
 
     protected static final String RESOURCE_UPDATED_AT = "resource-updated-at";
+
+    protected static final String DB_INSTANCE_REQUEST_STARTED_AT = "dbinstance-request-started-at";
+
+    protected static final String DB_INSTANCE_REQUEST_IN_PROGRESS_AT = "dbinstance-request-in-progress-at";
+
+    protected static final String DB_INSTANCE_STABILIZATION_TIME = "dbinstance-stabilization-time";
 
     protected final HandlerConfig config;
 
@@ -396,6 +403,7 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
             final RequestLogger requestLogger
     ) {
         this.requestLogger = requestLogger;
+        resourceStabilizationTime(context);
         try {
             validateRequest(request);
         } catch (RequestValidationException exception) {
@@ -695,6 +703,12 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
                         " process will continue until all included flags are true."));
 
         return isDBInstanceStabilizedAfterMutateResult;
+    }
+
+    private void resourceStabilizationTime(final CallbackContext context) {
+        context.timestampOnce(DB_INSTANCE_REQUEST_STARTED_AT, Instant.now());
+        context.timestamp(DB_INSTANCE_REQUEST_IN_PROGRESS_AT, Instant.now());
+        context.calculateTimeDeltaInMinutes(DB_INSTANCE_STABILIZATION_TIME, context.getTimestamp(DB_INSTANCE_REQUEST_IN_PROGRESS_AT), context.getTimestamp(DB_INSTANCE_REQUEST_STARTED_AT));
     }
 
     protected boolean isInstanceStabilizedAfterReplicationStop(final ProxyClient<RdsClient> rdsProxyClient,

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/CallbackContext.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/CallbackContext.java
@@ -1,5 +1,6 @@
 package software.amazon.rds.dbinstance;
 
+import java.time.Duration;
 import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
@@ -28,11 +29,13 @@ public class CallbackContext extends StdCallbackContext implements TaggingContex
 
     private TaggingContext taggingContext;
     private Map<String, Long> timestamps;
+    private Map<String, Double> timeDelta;
 
     public CallbackContext() {
         super();
         this.taggingContext = new TaggingContext();
         this.timestamps = new HashMap<>();
+        this.timeDelta = new HashMap<>();
     }
 
     @Override
@@ -61,5 +64,10 @@ public class CallbackContext extends StdCallbackContext implements TaggingContex
             return Instant.ofEpochSecond(timestamps.get(label));
         }
         return null;
+    }
+
+    public void calculateTimeDeltaInMinutes(final String label, final Instant currentTime, final Instant startTime){
+        double delta = Duration.between(currentTime, startTime).toMinutes();
+        timeDelta.put(label, delta);
     }
 }

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/CallbackContext.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/CallbackContext.java
@@ -52,14 +52,17 @@ public class CallbackContext extends StdCallbackContext implements TaggingContex
         taggingContext.setAddTagsComplete(addTagsComplete);
     }
 
+    @Override
     public void timestamp(final String label, final Instant instant) {
         timestamps.put(label, instant.getEpochSecond());
     }
 
+    @Override
     public void timestampOnce(final String label, final Instant instant) {
         timestamps.computeIfAbsent(label, s -> instant.getEpochSecond());
     }
 
+    @Override
     public Instant getTimestamp(final String label) {
         if (timestamps.containsKey(label)) {
             return Instant.ofEpochSecond(timestamps.get(label));
@@ -67,6 +70,7 @@ public class CallbackContext extends StdCallbackContext implements TaggingContex
         return null;
     }
 
+    @Override
     public void calculateTimeDeltaInMinutes(final String label, final Instant currentTime, final Instant startTime){
         double delta = Duration.between(currentTime, startTime).toMinutes();
         timeDelta.put(label, delta);

--- a/aws-rds-dbparametergroup/src/main/java/software/amazon/rds/dbparametergroup/CallbackContext.java
+++ b/aws-rds-dbparametergroup/src/main/java/software/amazon/rds/dbparametergroup/CallbackContext.java
@@ -2,6 +2,7 @@ package software.amazon.rds.dbparametergroup;
 
 import software.amazon.cloudformation.proxy.StdCallbackContext;
 import software.amazon.rds.common.handler.TaggingContext;
+import software.amazon.rds.common.handler.TimestampContext;
 
 import java.time.Duration;
 import java.time.Instant;
@@ -12,7 +13,7 @@ import java.util.Map;
 @lombok.Setter
 @lombok.ToString
 @lombok.EqualsAndHashCode(callSuper = true)
-public class CallbackContext extends StdCallbackContext implements TaggingContext.Provider {
+public class CallbackContext extends StdCallbackContext implements TaggingContext.Provider, TimestampContext.Provider {
     private boolean parametersApplied;
     private String dbParameterGroupArn;
 
@@ -41,21 +42,25 @@ public class CallbackContext extends StdCallbackContext implements TaggingContex
         taggingContext.setAddTagsComplete(addTagsComplete);
     }
 
+    @Override
     public void timestamp(final String label, final Instant instant) {
         timestamps.put(label, instant.getEpochSecond());
     }
 
+    @Override
     public void timestampOnce(final String label, final Instant instant) {
         timestamps.computeIfAbsent(label, s -> instant.getEpochSecond());
     }
 
+    @Override
     public Instant getTimestamp(final String label) {
-        if (timestamps.containsKey(label) && label != null) {
+        if (timestamps.containsKey(label)) {
             return Instant.ofEpochSecond(timestamps.get(label));
         }
         return null;
     }
 
+    @Override
     public void calculateTimeDeltaInMinutes(final String label, final Instant currentTime, final Instant startTime){
         double delta = Duration.between(currentTime, startTime).toMinutes();
         timeDelta.put(label, delta);

--- a/aws-rds-dbparametergroup/src/main/java/software/amazon/rds/dbparametergroup/CallbackContext.java
+++ b/aws-rds-dbparametergroup/src/main/java/software/amazon/rds/dbparametergroup/CallbackContext.java
@@ -3,6 +3,11 @@ package software.amazon.rds.dbparametergroup;
 import software.amazon.cloudformation.proxy.StdCallbackContext;
 import software.amazon.rds.common.handler.TaggingContext;
 
+import java.time.Duration;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+
 @lombok.Getter
 @lombok.Setter
 @lombok.ToString
@@ -11,11 +16,16 @@ public class CallbackContext extends StdCallbackContext implements TaggingContex
     private boolean parametersApplied;
     private String dbParameterGroupArn;
 
+    private Map<String, Long> timestamps;
+    private Map<String, Double> timeDelta;
+
     private TaggingContext taggingContext;
 
     public CallbackContext() {
         super();
         this.taggingContext = new TaggingContext();
+        this.timestamps = new HashMap<>();
+        this.timeDelta = new HashMap<>();
     }
 
     @Override
@@ -29,5 +39,25 @@ public class CallbackContext extends StdCallbackContext implements TaggingContex
 
     public void setAddTagsComplete(final boolean addTagsComplete) {
         taggingContext.setAddTagsComplete(addTagsComplete);
+    }
+
+    public void timestamp(final String label, final Instant instant) {
+        timestamps.put(label, instant.getEpochSecond());
+    }
+
+    public void timestampOnce(final String label, final Instant instant) {
+        timestamps.computeIfAbsent(label, s -> instant.getEpochSecond());
+    }
+
+    public Instant getTimestamp(final String label) {
+        if (timestamps.containsKey(label) && label != null) {
+            return Instant.ofEpochSecond(timestamps.get(label));
+        }
+        return null;
+    }
+
+    public void calculateTimeDeltaInMinutes(final String label, final Instant currentTime, final Instant startTime){
+        double delta = Duration.between(currentTime, startTime).toMinutes();
+        timeDelta.put(label, delta);
     }
 }

--- a/aws-rds-dbsubnetgroup/src/main/java/software/amazon/rds/dbsubnetgroup/CallbackContext.java
+++ b/aws-rds-dbsubnetgroup/src/main/java/software/amazon/rds/dbsubnetgroup/CallbackContext.java
@@ -3,6 +3,11 @@ package software.amazon.rds.dbsubnetgroup;
 import software.amazon.cloudformation.proxy.StdCallbackContext;
 import software.amazon.rds.common.handler.TaggingContext;
 
+import java.time.Duration;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+
 @lombok.Getter
 @lombok.Setter
 @lombok.ToString
@@ -10,11 +15,16 @@ import software.amazon.rds.common.handler.TaggingContext;
 public class CallbackContext extends StdCallbackContext implements TaggingContext.Provider {
     private String dbSubnetGroupArn;
 
+    private Map<String, Long> timestamps;
+    private Map<String, Double> timeDelta;
+
     private TaggingContext taggingContext;
 
     public CallbackContext() {
         super();
         this.taggingContext = new TaggingContext();
+        this.timestamps = new HashMap<>();
+        this.timeDelta = new HashMap<>();
     }
 
     @Override
@@ -28,5 +38,25 @@ public class CallbackContext extends StdCallbackContext implements TaggingContex
 
     public void setAddTagsComplete(final boolean addTagsComplete) {
         taggingContext.setAddTagsComplete(addTagsComplete);
+    }
+
+    public void timestamp(final String label, final Instant instant) {
+        timestamps.put(label, instant.getEpochSecond());
+    }
+
+    public void timestampOnce(final String label, final Instant instant) {
+        timestamps.computeIfAbsent(label, s -> instant.getEpochSecond());
+    }
+
+    public Instant getTimestamp(final String label) {
+        if (timestamps.containsKey(label)) {
+            return Instant.ofEpochSecond(timestamps.get(label));
+        }
+        return null;
+    }
+
+    public void calculateTimeDeltaInMinutes(final String label, final Instant currentTime, final Instant startTime){
+        double delta = Duration.between(currentTime, startTime).toMinutes();
+        timeDelta.put(label, delta);
     }
 }

--- a/aws-rds-dbsubnetgroup/src/main/java/software/amazon/rds/dbsubnetgroup/CallbackContext.java
+++ b/aws-rds-dbsubnetgroup/src/main/java/software/amazon/rds/dbsubnetgroup/CallbackContext.java
@@ -2,6 +2,7 @@ package software.amazon.rds.dbsubnetgroup;
 
 import software.amazon.cloudformation.proxy.StdCallbackContext;
 import software.amazon.rds.common.handler.TaggingContext;
+import software.amazon.rds.common.handler.TimestampContext;
 
 import java.time.Duration;
 import java.time.Instant;
@@ -12,7 +13,7 @@ import java.util.Map;
 @lombok.Setter
 @lombok.ToString
 @lombok.EqualsAndHashCode(callSuper = true)
-public class CallbackContext extends StdCallbackContext implements TaggingContext.Provider {
+public class CallbackContext extends StdCallbackContext implements TaggingContext.Provider, TimestampContext.Provider {
     private String dbSubnetGroupArn;
 
     private Map<String, Long> timestamps;
@@ -40,14 +41,17 @@ public class CallbackContext extends StdCallbackContext implements TaggingContex
         taggingContext.setAddTagsComplete(addTagsComplete);
     }
 
+    @Override
     public void timestamp(final String label, final Instant instant) {
         timestamps.put(label, instant.getEpochSecond());
     }
 
+    @Override
     public void timestampOnce(final String label, final Instant instant) {
         timestamps.computeIfAbsent(label, s -> instant.getEpochSecond());
     }
 
+    @Override
     public Instant getTimestamp(final String label) {
         if (timestamps.containsKey(label)) {
             return Instant.ofEpochSecond(timestamps.get(label));
@@ -55,6 +59,7 @@ public class CallbackContext extends StdCallbackContext implements TaggingContex
         return null;
     }
 
+    @Override
     public void calculateTimeDeltaInMinutes(final String label, final Instant currentTime, final Instant startTime){
         double delta = Duration.between(currentTime, startTime).toMinutes();
         timeDelta.put(label, delta);

--- a/aws-rds-dbsubnetgroup/src/test/java/software/amazon/rds/dbsubnetgroup/CreateHandlerTest.java
+++ b/aws-rds-dbsubnetgroup/src/test/java/software/amazon/rds/dbsubnetgroup/CreateHandlerTest.java
@@ -196,7 +196,7 @@ public class CreateHandlerTest extends AbstractTestBase {
                 InvalidParameterException.class
         );
 
-        Mockito.doNothing().when(requestLogger).log(any(String.class));
+        Mockito.doNothing().when(requestLogger).log(any(String.class), any(String.class));
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
                 .desiredResourceState(RESOURCE_MODEL)
                 .desiredResourceTags(translateTagsToMap(TAG_SET))

--- a/aws-rds-eventsubscription/src/main/java/software/amazon/rds/eventsubscription/CallbackContext.java
+++ b/aws-rds-eventsubscription/src/main/java/software/amazon/rds/eventsubscription/CallbackContext.java
@@ -3,6 +3,11 @@ package software.amazon.rds.eventsubscription;
 import software.amazon.cloudformation.proxy.StdCallbackContext;
 import software.amazon.rds.common.handler.TaggingContext;
 
+import java.time.Duration;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+
 @lombok.Getter
 @lombok.Setter
 @lombok.ToString
@@ -10,11 +15,16 @@ import software.amazon.rds.common.handler.TaggingContext;
 public class CallbackContext extends StdCallbackContext implements TaggingContext.Provider {
     private String eventSubscriptionArn;
 
+    private Map<String, Long> timestamps;
+    private Map<String, Double> timeDelta;
+
     private TaggingContext taggingContext;
 
     public CallbackContext() {
         super();
         this.taggingContext = new TaggingContext();
+        this.timestamps = new HashMap<>();
+        this.timeDelta = new HashMap<>();
     }
 
     @Override
@@ -28,5 +38,25 @@ public class CallbackContext extends StdCallbackContext implements TaggingContex
 
     public void setAddTagsComplete(final boolean addTagsComplete) {
         taggingContext.setAddTagsComplete(addTagsComplete);
+    }
+
+    public void timestamp(final String label, final Instant instant) {
+        timestamps.put(label, instant.getEpochSecond());
+    }
+
+    public void timestampOnce(final String label, final Instant instant) {
+        timestamps.computeIfAbsent(label, s -> instant.getEpochSecond());
+    }
+
+    public Instant getTimestamp(final String label) {
+        if (timestamps.containsKey(label)) {
+            return Instant.ofEpochSecond(timestamps.get(label));
+        }
+        return null;
+    }
+
+    public void calculateTimeDeltaInMinutes(final String label, final Instant currentTime, final Instant startTime){
+        double delta = Duration.between(currentTime, startTime).toMinutes();
+        timeDelta.put(label, delta);
     }
 }

--- a/aws-rds-eventsubscription/src/main/java/software/amazon/rds/eventsubscription/CallbackContext.java
+++ b/aws-rds-eventsubscription/src/main/java/software/amazon/rds/eventsubscription/CallbackContext.java
@@ -2,6 +2,7 @@ package software.amazon.rds.eventsubscription;
 
 import software.amazon.cloudformation.proxy.StdCallbackContext;
 import software.amazon.rds.common.handler.TaggingContext;
+import software.amazon.rds.common.handler.TimestampContext;
 
 import java.time.Duration;
 import java.time.Instant;
@@ -12,7 +13,7 @@ import java.util.Map;
 @lombok.Setter
 @lombok.ToString
 @lombok.EqualsAndHashCode(callSuper = true)
-public class CallbackContext extends StdCallbackContext implements TaggingContext.Provider {
+public class CallbackContext extends StdCallbackContext implements TaggingContext.Provider, TimestampContext.Provider {
     private String eventSubscriptionArn;
 
     private Map<String, Long> timestamps;
@@ -40,14 +41,17 @@ public class CallbackContext extends StdCallbackContext implements TaggingContex
         taggingContext.setAddTagsComplete(addTagsComplete);
     }
 
+    @Override
     public void timestamp(final String label, final Instant instant) {
         timestamps.put(label, instant.getEpochSecond());
     }
 
+    @Override
     public void timestampOnce(final String label, final Instant instant) {
         timestamps.computeIfAbsent(label, s -> instant.getEpochSecond());
     }
 
+    @Override
     public Instant getTimestamp(final String label) {
         if (timestamps.containsKey(label)) {
             return Instant.ofEpochSecond(timestamps.get(label));
@@ -55,6 +59,7 @@ public class CallbackContext extends StdCallbackContext implements TaggingContex
         return null;
     }
 
+    @Override
     public void calculateTimeDeltaInMinutes(final String label, final Instant currentTime, final Instant startTime){
         double delta = Duration.between(currentTime, startTime).toMinutes();
         timeDelta.put(label, delta);

--- a/aws-rds-optiongroup/src/main/java/software/amazon/rds/optiongroup/BaseHandlerStd.java
+++ b/aws-rds-optiongroup/src/main/java/software/amazon/rds/optiongroup/BaseHandlerStd.java
@@ -1,6 +1,7 @@
 package software.amazon.rds.optiongroup;
 
 import java.time.Duration;
+import java.time.Instant;
 import java.util.Collection;
 
 import software.amazon.awssdk.services.rds.RdsClient;
@@ -29,6 +30,9 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
 
     protected static final String STACK_NAME = "rds";
     protected static final String RESOURCE_IDENTIFIER = "optiongroup";
+    protected static final String OPTION_GROUP_REQUEST_STARTED_AT = "optiongroup-request-started-at";
+    protected static final String OPTION_GROUP_REQUEST_IN_PROGRESS_AT = "optiongroup-request-in-progress-at";
+    protected static final String OPTION_GROUP_STABILIZATION_TIME = "optiongroup-stabilization-time";
     protected static final int RESOURCE_ID_MAX_LENGTH = 255;
 
     protected static final Constant BACKOFF_DELAY = Constant.of()
@@ -89,6 +93,7 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
             final RequestLogger requestLogger
     ) {
         this.requestLogger = requestLogger;
+        resourceStabilizationTime(callbackContext);
         return handleRequest(proxy, proxyClient, request, callbackContext);
     };
 
@@ -109,6 +114,14 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
                         requestLogger
                 ))
                 .progress();
+    }
+
+    private void resourceStabilizationTime(final CallbackContext callbackContext) {
+        callbackContext.timestampOnce(OPTION_GROUP_REQUEST_STARTED_AT, Instant.now());
+        callbackContext.timestamp(OPTION_GROUP_REQUEST_IN_PROGRESS_AT, Instant.now());
+        callbackContext.calculateTimeDeltaInMinutes(OPTION_GROUP_STABILIZATION_TIME,
+                callbackContext.getTimestamp(OPTION_GROUP_REQUEST_IN_PROGRESS_AT),
+                callbackContext.getTimestamp(OPTION_GROUP_REQUEST_STARTED_AT));
     }
 
     protected ProgressEvent<ResourceModel, CallbackContext> updateTags(

--- a/aws-rds-optiongroup/src/main/java/software/amazon/rds/optiongroup/CallbackContext.java
+++ b/aws-rds-optiongroup/src/main/java/software/amazon/rds/optiongroup/CallbackContext.java
@@ -3,6 +3,11 @@ package software.amazon.rds.optiongroup;
 import software.amazon.cloudformation.proxy.StdCallbackContext;
 import software.amazon.rds.common.handler.TaggingContext;
 
+import java.time.Duration;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+
 @lombok.Getter
 @lombok.Setter
 @lombok.ToString
@@ -11,9 +16,14 @@ public class CallbackContext extends StdCallbackContext implements TaggingContex
     private TaggingContext taggingContext;
     private String optionGroupGroupArn;
 
+    private Map<String, Long> timestamps;
+    private Map<String, Double> timeDelta;
+
     public CallbackContext() {
         super();
         this.taggingContext = new TaggingContext();
+        this.timestamps = new HashMap<>();
+        this.timeDelta = new HashMap<>();
     }
 
     @Override
@@ -27,5 +37,25 @@ public class CallbackContext extends StdCallbackContext implements TaggingContex
 
     public void setAddTagsComplete(final boolean addTagsComplete) {
         this.taggingContext.setAddTagsComplete(addTagsComplete);
+    }
+
+    public void timestamp(final String label, final Instant instant) {
+        timestamps.put(label, instant.getEpochSecond());
+    }
+
+    public void timestampOnce(final String label, final Instant instant) {
+        timestamps.computeIfAbsent(label, s -> instant.getEpochSecond());
+    }
+
+    public Instant getTimestamp(final String label) {
+        if (timestamps.containsKey(label)) {
+            return Instant.ofEpochSecond(timestamps.get(label));
+        }
+        return null;
+    }
+
+    public void calculateTimeDeltaInMinutes(final String label, final Instant currentTime, final Instant startTime){
+        double delta = Duration.between(currentTime, startTime).toMinutes();
+        timeDelta.put(label, delta);
     }
 }

--- a/aws-rds-optiongroup/src/main/java/software/amazon/rds/optiongroup/CallbackContext.java
+++ b/aws-rds-optiongroup/src/main/java/software/amazon/rds/optiongroup/CallbackContext.java
@@ -2,6 +2,7 @@ package software.amazon.rds.optiongroup;
 
 import software.amazon.cloudformation.proxy.StdCallbackContext;
 import software.amazon.rds.common.handler.TaggingContext;
+import software.amazon.rds.common.handler.TimestampContext;
 
 import java.time.Duration;
 import java.time.Instant;
@@ -12,7 +13,7 @@ import java.util.Map;
 @lombok.Setter
 @lombok.ToString
 @lombok.EqualsAndHashCode(callSuper = true)
-public class CallbackContext extends StdCallbackContext implements TaggingContext.Provider {
+public class CallbackContext extends StdCallbackContext implements TaggingContext.Provider, TimestampContext.Provider {
     private TaggingContext taggingContext;
     private String optionGroupGroupArn;
 
@@ -39,14 +40,17 @@ public class CallbackContext extends StdCallbackContext implements TaggingContex
         this.taggingContext.setAddTagsComplete(addTagsComplete);
     }
 
+    @Override
     public void timestamp(final String label, final Instant instant) {
         timestamps.put(label, instant.getEpochSecond());
     }
 
+    @Override
     public void timestampOnce(final String label, final Instant instant) {
         timestamps.computeIfAbsent(label, s -> instant.getEpochSecond());
     }
 
+    @Override
     public Instant getTimestamp(final String label) {
         if (timestamps.containsKey(label)) {
             return Instant.ofEpochSecond(timestamps.get(label));
@@ -54,6 +58,7 @@ public class CallbackContext extends StdCallbackContext implements TaggingContex
         return null;
     }
 
+    @Override
     public void calculateTimeDeltaInMinutes(final String label, final Instant currentTime, final Instant startTime){
         double delta = Duration.between(currentTime, startTime).toMinutes();
         timeDelta.put(label, delta);


### PR DESCRIPTION
### Adding resource stabilization time and enhancing UnexpectedErrorStatus message

_- Resource stabilization time is a time-delta that resolves the duration
  of a resource to reach a stable state after a stack creation or update._

- This was achieved by timestamping the request-start-time once and
dynamically update the request-in-progress timestamp. The delta will
be resolved every time when a stack operation is invoked.

- Added UnexpectedErrorStatus StackTrace to better identify root causes
  of such errors.

- Adapted unit tests to accept the new changes.

- Added unit test to ensure the stack trace is logged accordingly.

- Added unit test to increase test coverage.

- Testing was done in local account.