### PR TITLE
Only include diff of ServerlessV2ScalingConfiguration in ModifyDBCluster Call

### DIFF
--- a/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/Translator.java
+++ b/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/Translator.java
@@ -281,7 +281,12 @@ public class Translator {
                 .preferredBackupWindow(diff(previousModel.getPreferredBackupWindow(), desiredModel.getPreferredBackupWindow()))
                 .preferredMaintenanceWindow(diff(previousModel.getPreferredMaintenanceWindow(), desiredModel.getPreferredMaintenanceWindow()))
                 .scalingConfiguration(translateScalingConfigurationToSdk(desiredModel.getScalingConfiguration()))
-                .serverlessV2ScalingConfiguration(translateServerlessV2ScalingConfiguration(desiredModel.getServerlessV2ScalingConfiguration()))
+                .serverlessV2ScalingConfiguration(
+                        diff(
+                                translateServerlessV2ScalingConfiguration(previousModel.getServerlessV2ScalingConfiguration()),
+                                translateServerlessV2ScalingConfiguration(desiredModel.getServerlessV2ScalingConfiguration())
+                        )
+                )
                 .storageType(desiredModel.getStorageType());
 
         if (!(isRollback || Objects.equals(previousModel.getEngineVersion(), desiredModel.getEngineVersion()))) {

--- a/aws-rds-dbcluster/src/test/java/software/amazon/rds/dbcluster/TranslatorTest.java
+++ b/aws-rds-dbcluster/src/test/java/software/amazon/rds/dbcluster/TranslatorTest.java
@@ -10,8 +10,8 @@ import org.junit.jupiter.api.Test;
 import com.google.common.collect.ImmutableList;
 import software.amazon.awssdk.services.ec2.Ec2Client;
 import software.amazon.awssdk.services.rds.RdsClient;
-import software.amazon.awssdk.services.rds.model.DBCluster;
 import software.amazon.awssdk.services.rds.model.CreateDbClusterRequest;
+import software.amazon.awssdk.services.rds.model.DBCluster;
 import software.amazon.awssdk.services.rds.model.DomainMembership;
 import software.amazon.awssdk.services.rds.model.ModifyDbClusterRequest;
 import software.amazon.awssdk.services.rds.model.RestoreDbClusterFromSnapshotRequest;
@@ -176,12 +176,63 @@ public class TranslatorTest extends AbstractHandlerTest {
                 .storageType(STORAGE_TYPE_GP3)
                 .iops(100)
                 .allocatedStorage(300)
-        .build();
+                .build();
 
         final ModifyDbClusterRequest request = Translator.modifyDbClusterRequest(previousModel, desiredModel, IS_NOT_ROLLBACK);
         assertThat(request.storageType()).isEqualTo(STORAGE_TYPE_GP3);
         assertThat(request.iops()).isEqualTo(100);
         assertThat(request.allocatedStorage()).isEqualTo(300);
+    }
+
+    @Test
+    public void modifyDbClusterRequest_setServerlessV2ScalingConfiguration() {
+        Double previousMax = 10.0;
+        Double desiredMax = 20.0;
+        Double previousMin = 1.0;
+        Double desiredMin = 2.0;
+
+        final ResourceModel previousModel = RESOURCE_MODEL.toBuilder().serverlessV2ScalingConfiguration(
+                ServerlessV2ScalingConfiguration.builder()
+                        .maxCapacity(previousMax)
+                        .minCapacity(previousMin)
+                        .build()
+        ).build();
+
+        final ResourceModel desiredModel = RESOURCE_MODEL.toBuilder().serverlessV2ScalingConfiguration(
+                ServerlessV2ScalingConfiguration.builder()
+                        .maxCapacity(desiredMax)
+                        .minCapacity(desiredMin)
+                        .build()
+        ).build();
+
+        final ModifyDbClusterRequest request = Translator.modifyDbClusterRequest(previousModel, desiredModel, IS_NOT_ROLLBACK);
+        assertThat(request.serverlessV2ScalingConfiguration().minCapacity()).isEqualTo(desiredMin);
+        assertThat(request.serverlessV2ScalingConfiguration().maxCapacity()).isEqualTo(desiredMax);
+    }
+
+    @Test
+    public void modifyDbClusterRequest_sameServerlessV2ScalingConfiguration() {
+        Double previousMax = 10.0;
+        Double desiredMax = 10.0;
+        Double previousMin = 1.0;
+        Double desiredMin = 1.0;
+
+        final ResourceModel previousModel = RESOURCE_MODEL.toBuilder().serverlessV2ScalingConfiguration(
+                ServerlessV2ScalingConfiguration.builder()
+                        .maxCapacity(previousMax)
+                        .minCapacity(previousMin)
+                        .build()
+        ).build();
+
+        final ResourceModel desiredModel = RESOURCE_MODEL.toBuilder().serverlessV2ScalingConfiguration(
+                ServerlessV2ScalingConfiguration.builder()
+                        .maxCapacity(desiredMax)
+                        .minCapacity(desiredMin)
+                        .build()
+        ).build();
+
+        final ModifyDbClusterRequest request = Translator.modifyDbClusterRequest(previousModel, desiredModel, IS_NOT_ROLLBACK);
+        assertThat(request.serverlessV2ScalingConfiguration()).isEqualTo(null);
     }
 
     @Test


### PR DESCRIPTION
*Description of changes:*
Include only diff of ServerlessV2ScalingConfiguration in the ModifyDBCluster that used in update handler for better consistency.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
