### PR TITLE
[DBSubnetGroup] Remove validation on DBSubnetGroupName

### DIFF
--- a/aws-rds-dbsubnetgroup/aws-rds-dbsubnetgroup.json
+++ b/aws-rds-dbsubnetgroup/aws-rds-dbsubnetgroup.json
@@ -7,8 +7,7 @@
       "type": "string"
     },
     "DBSubnetGroupName": {
-      "type": "string",
-      "pattern": "^(?!default$)[a-zA-Z]{1}[a-zA-Z0-9-_\\.\\s]{0,254}$"
+      "type": "string"
     },
     "SubnetIds": {
       "type": "array",

--- a/aws-rds-dbsubnetgroup/docs/README.md
+++ b/aws-rds-dbsubnetgroup/docs/README.md
@@ -49,8 +49,6 @@ _Required_: No
 
 _Type_: String
 
-_Pattern_: <code>^(?!default$)[a-zA-Z]{1}[a-zA-Z0-9-_\.\s]{0,254}$</code>
-
 _Update requires_: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
 
 #### SubnetIds


### PR DESCRIPTION
*Description of changes:*

DBSubnetGroupName validation removed to rely on RDS validation, the DBSubnetGroupName schema was also too restrictive

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
