### PR TITLE
Add EngineLifecycleSupport integration for instances and clusters 

### DIFF
--- a/aws-rds-cfn-common/pom.xml
+++ b/aws-rds-cfn-common/pom.xml
@@ -33,7 +33,7 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>rds</artifactId>
-            <version>2.25.12</version>
+            <version>2.25.56</version>
         </dependency>
         <dependency>
             <groupId>software.amazon.cloudformation</groupId>

--- a/aws-rds-customdbengineversion/pom.xml
+++ b/aws-rds-customdbengineversion/pom.xml
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>rds</artifactId>
-            <version>2.25.12</version>
+            <version>2.25.56</version>
         </dependency>
         <dependency>
             <groupId>software.amazon.rds.common</groupId>

--- a/aws-rds-dbcluster/aws-rds-dbcluster.json
+++ b/aws-rds-dbcluster/aws-rds-dbcluster.json
@@ -132,6 +132,10 @@
       "description": "The name of the database engine to be used for this DB cluster. Valid Values: aurora (for MySQL 5.6-compatible Aurora), aurora-mysql (for MySQL 5.7-compatible Aurora), and aurora-postgresql",
       "type": "string"
     },
+    "EngineLifecycleSupport": {
+      "description": "The life cycle type of the DB cluster. You can use this setting to enroll your DB cluster into Amazon RDS Extended Support.",
+      "type": "string"
+    },
     "EngineMode": {
       "description": "The DB engine mode of the DB cluster, either provisioned, serverless, parallelquery, global, or multimaster.",
       "type": "string"

--- a/aws-rds-dbcluster/docs/README.md
+++ b/aws-rds-dbcluster/docs/README.md
@@ -36,6 +36,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
         "<a href="#enablehttpendpoint" title="EnableHttpEndpoint">EnableHttpEndpoint</a>" : <i>Boolean</i>,
         "<a href="#enableiamdatabaseauthentication" title="EnableIAMDatabaseAuthentication">EnableIAMDatabaseAuthentication</a>" : <i>Boolean</i>,
         "<a href="#engine" title="Engine">Engine</a>" : <i>String</i>,
+        "<a href="#enginelifecyclesupport" title="EngineLifecycleSupport">EngineLifecycleSupport</a>" : <i>String</i>,
         "<a href="#enginemode" title="EngineMode">EngineMode</a>" : <i>String</i>,
         "<a href="#engineversion" title="EngineVersion">EngineVersion</a>" : <i>String</i>,
         "<a href="#managemasteruserpassword" title="ManageMasterUserPassword">ManageMasterUserPassword</a>" : <i>Boolean</i>,
@@ -103,6 +104,7 @@ Properties:
     <a href="#enablehttpendpoint" title="EnableHttpEndpoint">EnableHttpEndpoint</a>: <i>Boolean</i>
     <a href="#enableiamdatabaseauthentication" title="EnableIAMDatabaseAuthentication">EnableIAMDatabaseAuthentication</a>: <i>Boolean</i>
     <a href="#engine" title="Engine">Engine</a>: <i>String</i>
+    <a href="#enginelifecyclesupport" title="EngineLifecycleSupport">EngineLifecycleSupport</a>: <i>String</i>
     <a href="#enginemode" title="EngineMode">EngineMode</a>: <i>String</i>
     <a href="#engineversion" title="EngineVersion">EngineVersion</a>: <i>String</i>
     <a href="#managemasteruserpassword" title="ManageMasterUserPassword">ManageMasterUserPassword</a>: <i>Boolean</i>
@@ -383,6 +385,16 @@ _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormati
 #### Engine
 
 The name of the database engine to be used for this DB cluster. Valid Values: aurora (for MySQL 5.6-compatible Aurora), aurora-mysql (for MySQL 5.7-compatible Aurora), and aurora-postgresql
+
+_Required_: No
+
+_Type_: String
+
+_Update requires_: [Some interruptions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-some-interrupt)
+
+#### EngineLifecycleSupport
+
+The life cycle type of the DB cluster. You can use this setting to enroll your DB cluster into Amazon RDS Extended Support.
 
 _Required_: No
 

--- a/aws-rds-dbcluster/pom.xml
+++ b/aws-rds-dbcluster/pom.xml
@@ -30,7 +30,7 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>rds</artifactId>
-            <version>2.25.12</version>
+            <version>2.25.56</version>
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>

--- a/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/BaseHandlerStd.java
+++ b/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/BaseHandlerStd.java
@@ -63,6 +63,7 @@ import software.amazon.awssdk.services.rds.model.StorageTypeNotSupportedExceptio
 import software.amazon.awssdk.services.rds.model.Tag;
 import software.amazon.awssdk.services.rds.model.WriteForwardingStatus;
 import software.amazon.awssdk.utils.StringUtils;
+import software.amazon.cloudformation.exceptions.CfnInvalidRequestException;
 import software.amazon.cloudformation.exceptions.CfnNotStabilizedException;
 import software.amazon.cloudformation.exceptions.ResourceNotFoundException;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
@@ -158,7 +159,8 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
                     KmsKeyNotAccessibleException.class,
                     StorageTypeNotAvailableException.class,
                     StorageTypeNotSupportedException.class,
-                    NetworkTypeNotSupportedException.class)
+                    NetworkTypeNotSupportedException.class,
+                    CfnInvalidRequestException.class)
             .build();
 
     protected static final ErrorRuleSet ADD_ASSOC_ROLES_SOFTFAIL_ERROR_RULE_SET = ErrorRuleSet

--- a/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/Translator.java
+++ b/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/Translator.java
@@ -96,6 +96,7 @@ public class Translator {
                 .storageType(model.getStorageType())
                 .tags(Tagging.translateTagsToSdk(tagSet))
                 .vpcSecurityGroupIds(model.getVpcSecurityGroupIds())
+                .engineLifecycleSupport(model.getEngineLifecycleSupport())
                 .build();
     }
 
@@ -123,7 +124,8 @@ public class Translator {
                 .restoreType(model.getRestoreType())
                 .tags(Tagging.translateTagsToSdk(tagSet))
                 .useLatestRestorableTime(model.getUseLatestRestorableTime())
-                .vpcSecurityGroupIds(model.getVpcSecurityGroupIds());
+                .vpcSecurityGroupIds(model.getVpcSecurityGroupIds())
+                .engineLifecycleSupport(model.getEngineLifecycleSupport());
 
         if (StringUtils.hasValue(model.getRestoreToTime())
                 && BooleanUtils.isNotTrue(model.getUseLatestRestorableTime())) {
@@ -165,6 +167,7 @@ public class Translator {
                 .storageType(model.getStorageType())
                 .tags(Tagging.translateTagsToSdk(tagSet))
                 .vpcSecurityGroupIds(model.getVpcSecurityGroupIds())
+                .engineLifecycleSupport(model.getEngineLifecycleSupport())
                 .build();
     }
 
@@ -546,6 +549,7 @@ public class Translator {
                                 .build()
                 )
                 .engine(dbCluster.engine())
+                .engineLifecycleSupport(dbCluster.engineLifecycleSupport())
                 .engineMode(dbCluster.engineMode())
                 .engineVersion(dbCluster.engineVersion())
                 .manageMasterUserPassword(dbCluster.masterUserSecret() != null)

--- a/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/UpdateHandler.java
+++ b/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/UpdateHandler.java
@@ -4,6 +4,7 @@ import static software.amazon.rds.dbcluster.ModelAdapter.setDefaults;
 
 import java.time.Instant;
 import java.util.HashSet;
+import java.util.Objects;
 
 import org.apache.commons.lang3.BooleanUtils;
 
@@ -11,6 +12,7 @@ import com.amazonaws.util.StringUtils;
 import software.amazon.awssdk.services.ec2.Ec2Client;
 import software.amazon.awssdk.services.rds.RdsClient;
 import software.amazon.awssdk.services.rds.model.SourceType;
+import software.amazon.cloudformation.exceptions.CfnInvalidRequestException;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.HandlerErrorCode;
 import software.amazon.cloudformation.proxy.ProgressEvent;
@@ -65,6 +67,18 @@ public class UpdateHandler extends BaseHandlerStd {
             );
         }
         return ProgressEvent.progress(desiredResourceState, callbackContext)
+                .then(progress -> {
+                    try {
+                        if(!Objects.equals(request.getDesiredResourceState().getEngineLifecycleSupport(),
+                                request.getPreviousResourceState().getEngineLifecycleSupport()) &&
+                                !request.getRollback()) {
+                            throw new CfnInvalidRequestException("EngineLifecycleSupport cannot be modified.");
+                        }
+                    } catch (CfnInvalidRequestException e) {
+                        return Commons.handleException(progress, e, DEFAULT_DB_CLUSTER_ERROR_RULE_SET, requestLogger);
+                    }
+                    return progress;
+                })
                 .then(progress -> {
                     if (shouldRemoveFromGlobalCluster(request.getPreviousResourceState(), request.getDesiredResourceState())) {
                         progress.getCallbackContext().timestampOnce(RESOURCE_UPDATED_AT, Instant.now());

--- a/aws-rds-dbcluster/src/test/java/software/amazon/rds/dbcluster/UpdateHandlerTest.java
+++ b/aws-rds-dbcluster/src/test/java/software/amazon/rds/dbcluster/UpdateHandlerTest.java
@@ -995,4 +995,17 @@ public class UpdateHandlerTest extends AbstractHandlerTest {
                 expectResponseCode
         );
     }
+
+    @Test
+    public void handleRequest_EngineLifecycleSupportShouldFail() {
+        expectServiceInvocation = false;
+        test_handleRequest_base(
+                new CallbackContext(),
+                ResourceHandlerRequest.<ResourceModel>builder().rollback(false),
+                null,
+                () -> RESOURCE_MODEL.toBuilder().engineLifecycleSupport("open-source-rds-extended-support").build(),
+                () -> RESOURCE_MODEL.toBuilder().engineLifecycleSupport("open-source-rds-extended-support-disabled").build(),
+                expectFailed(HandlerErrorCode.InvalidRequest)
+        );
+    }
 }

--- a/aws-rds-dbclusterendpoint/pom.xml
+++ b/aws-rds-dbclusterendpoint/pom.xml
@@ -30,7 +30,7 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>rds</artifactId>
-            <version>2.25.12</version>
+            <version>2.25.56</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/software.amazon.cloudformation/aws-cloudformation-rpdk-java-plugin -->
         <dependency>

--- a/aws-rds-dbclusterparametergroup/pom.xml
+++ b/aws-rds-dbclusterparametergroup/pom.xml
@@ -30,7 +30,7 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>rds</artifactId>
-            <version>2.25.12</version>
+            <version>2.25.56</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/software.amazon.cloudformation/aws-cloudformation-rpdk-java-plugin -->
         <dependency>

--- a/aws-rds-dbinstance/aws-rds-dbinstance.json
+++ b/aws-rds-dbinstance/aws-rds-dbinstance.json
@@ -289,6 +289,10 @@
       "type": "string",
       "description": "The name of the database engine that you want to use for this DB instance."
     },
+    "EngineLifecycleSupport": {
+      "type": "string",
+      "description": "The life cycle type of the DB instance. You can use this setting to enroll your DB instance into Amazon RDS Extended Support."
+    },
     "EngineVersion": {
       "type": "string",
       "description": "The version number of the database engine to use."

--- a/aws-rds-dbinstance/docs/README.md
+++ b/aws-rds-dbinstance/docs/README.md
@@ -49,6 +49,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
         "<a href="#enableperformanceinsights" title="EnablePerformanceInsights">EnablePerformanceInsights</a>" : <i>Boolean</i>,
         "<a href="#endpoint" title="Endpoint">Endpoint</a>" : <i><a href="endpoint.md">Endpoint</a></i>,
         "<a href="#engine" title="Engine">Engine</a>" : <i>String</i>,
+        "<a href="#enginelifecyclesupport" title="EngineLifecycleSupport">EngineLifecycleSupport</a>" : <i>String</i>,
         "<a href="#engineversion" title="EngineVersion">EngineVersion</a>" : <i>String</i>,
         "<a href="#managemasteruserpassword" title="ManageMasterUserPassword">ManageMasterUserPassword</a>" : <i>Boolean</i>,
         "<a href="#iops" title="Iops">Iops</a>" : <i>Integer</i>,
@@ -139,6 +140,7 @@ Properties:
     <a href="#enableperformanceinsights" title="EnablePerformanceInsights">EnablePerformanceInsights</a>: <i>Boolean</i>
     <a href="#endpoint" title="Endpoint">Endpoint</a>: <i><a href="endpoint.md">Endpoint</a></i>
     <a href="#engine" title="Engine">Engine</a>: <i>String</i>
+    <a href="#enginelifecyclesupport" title="EngineLifecycleSupport">EngineLifecycleSupport</a>: <i>String</i>
     <a href="#engineversion" title="EngineVersion">EngineVersion</a>: <i>String</i>
     <a href="#managemasteruserpassword" title="ManageMasterUserPassword">ManageMasterUserPassword</a>: <i>Boolean</i>
     <a href="#iops" title="Iops">Iops</a>: <i>Integer</i>
@@ -570,6 +572,16 @@ _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormati
 #### Engine
 
 The name of the database engine that you want to use for this DB instance.
+
+_Required_: No
+
+_Type_: String
+
+_Update requires_: [Some interruptions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-some-interrupt)
+
+#### EngineLifecycleSupport
+
+The life cycle type of the DB instance. You can use this setting to enroll your DB instance into Amazon RDS Extended Support.
 
 _Required_: No
 

--- a/aws-rds-dbinstance/pom.xml
+++ b/aws-rds-dbinstance/pom.xml
@@ -34,7 +34,7 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>rds</artifactId>
-            <version>2.25.12</version>
+            <version>2.25.56</version>
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/BaseHandlerStd.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/BaseHandlerStd.java
@@ -327,6 +327,7 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
             .withErrorClasses(ErrorStatus.failWith(HandlerErrorCode.NotFound),
                     DbInstanceNotFoundException.class)
             .withErrorClasses(ErrorStatus.failWith(HandlerErrorCode.InvalidRequest),
+                    CfnInvalidRequestException.class,
                     InvalidDbSecurityGroupStateException.class)
             .build();
 

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/Translator.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/Translator.java
@@ -222,7 +222,8 @@ public class Translator {
                 .tdeCredentialArn(model.getTdeCredentialArn())
                 .tdeCredentialPassword(model.getTdeCredentialPassword())
                 .useDefaultProcessorFeatures(model.getUseDefaultProcessorFeatures())
-                .vpcSecurityGroupIds(CollectionUtils.isNotEmpty(model.getVPCSecurityGroups()) ? model.getVPCSecurityGroups() : null);
+                .vpcSecurityGroupIds(CollectionUtils.isNotEmpty(model.getVPCSecurityGroups()) ? model.getVPCSecurityGroups() : null)
+                .engineLifecycleSupport(model.getEngineLifecycleSupport());
         if (!ResourceModelHelper.isSqlServer(model)) {
             builder.allocatedStorage(getAllocatedStorage(model));
             builder.iops(model.getIops());
@@ -329,7 +330,8 @@ public class Translator {
                 .tdeCredentialArn(model.getTdeCredentialArn())
                 .tdeCredentialPassword(model.getTdeCredentialPassword())
                 .timezone(model.getTimezone())
-                .vpcSecurityGroupIds(CollectionUtils.isNotEmpty(model.getVPCSecurityGroups()) ? model.getVPCSecurityGroups() : null);
+                .vpcSecurityGroupIds(CollectionUtils.isNotEmpty(model.getVPCSecurityGroups()) ? model.getVPCSecurityGroups() : null)
+                .engineLifecycleSupport(model.getEngineLifecycleSupport());
 
         // Set PerformanceInsightsKMSKeyId only if EnablePerformanceInsights is true.
         // The point is that it is a completely legitimate create from the CFN perspective and
@@ -386,7 +388,8 @@ public class Translator {
                 .tdeCredentialPassword(model.getTdeCredentialPassword())
                 .useDefaultProcessorFeatures(model.getUseDefaultProcessorFeatures())
                 .useLatestRestorableTime(model.getUseLatestRestorableTime())
-                .vpcSecurityGroupIds(CollectionUtils.isNotEmpty(model.getVPCSecurityGroups()) ? model.getVPCSecurityGroups() : null);
+                .vpcSecurityGroupIds(CollectionUtils.isNotEmpty(model.getVPCSecurityGroups()) ? model.getVPCSecurityGroups() : null)
+                .engineLifecycleSupport(model.getEngineLifecycleSupport());
         if (!ResourceModelHelper.isSqlServer(model)) {
             builder.allocatedStorage(getAllocatedStorage(model));
             builder.iops(model.getIops());
@@ -866,6 +869,7 @@ public class Translator {
                 .enablePerformanceInsights(dbInstance.performanceInsightsEnabled())
                 .endpoint(endpoint)
                 .engine(dbInstance.engine())
+                .engineLifecycleSupport(dbInstance.engineLifecycleSupport())
                 .engineVersion(dbInstance.engineVersion())
                 .iops(dbInstance.iops())
                 .kmsKeyId(dbInstance.kmsKeyId())

--- a/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/UpdateHandlerTest.java
+++ b/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/UpdateHandlerTest.java
@@ -1860,4 +1860,27 @@ public class UpdateHandlerTest extends AbstractHandlerTest {
 
         verify(rdsProxy.client(), times(1)).describeEvents(any(DescribeEventsRequest.class));
     }
+
+    @Test
+    public void handleRequest_EngineLifecycleSupportShouldFail() {
+        expectServiceInvocation = false;
+        final ResourceModel desiredModel = RESOURCE_MODEL_BLDR()
+                .engineLifecycleSupport("open-source-rds-extended-support")
+                .build();
+
+        final ResourceModel previousModel = RESOURCE_MODEL_BLDR()
+                .engineLifecycleSupport("open-source-rds-extended-support-disabled")
+                .build();
+
+        final CallbackContext context = new CallbackContext();
+
+        test_handleRequest_base(
+                context,
+                ResourceHandlerRequest.<ResourceModel>builder().rollback(false),
+                null,
+                () -> previousModel,
+                () -> desiredModel,
+                expectFailed(HandlerErrorCode.InvalidRequest)
+        );
+    }
 }

--- a/aws-rds-dbparametergroup/pom.xml
+++ b/aws-rds-dbparametergroup/pom.xml
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>rds</artifactId>
-            <version>2.25.12</version>
+            <version>2.25.56</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/software.amazon.cloudformation/aws-cloudformation-rpdk-java-plugin -->
         <dependency>

--- a/aws-rds-dbsubnetgroup/pom.xml
+++ b/aws-rds-dbsubnetgroup/pom.xml
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>rds</artifactId>
-            <version>2.25.12</version>
+            <version>2.25.56</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/software.amazon.cloudformation/aws-cloudformation-rpdk-java-plugin -->
         <dependency>

--- a/aws-rds-eventsubscription/pom.xml
+++ b/aws-rds-eventsubscription/pom.xml
@@ -29,7 +29,7 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>rds</artifactId>
-            <version>2.25.12</version>
+            <version>2.25.56</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/software.amazon.cloudformation/aws-cloudformation-rpdk-java-plugin -->
         <dependency>

--- a/aws-rds-globalcluster/pom.xml
+++ b/aws-rds-globalcluster/pom.xml
@@ -29,7 +29,7 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>rds</artifactId>
-            <version>2.25.12</version>
+            <version>2.25.56</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/software.amazon.cloudformation/aws-cloudformation-rpdk-java-plugin -->
         <dependency>

--- a/aws-rds-integration/pom.xml
+++ b/aws-rds-integration/pom.xml
@@ -22,7 +22,7 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>rds</artifactId>
-            <version>2.25.12</version>
+            <version>2.25.56</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/software.amazon.cloudformation/aws-cloudformation-rpdk-java-plugin -->
         <dependency>

--- a/aws-rds-optiongroup/pom.xml
+++ b/aws-rds-optiongroup/pom.xml
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>rds</artifactId>
-            <version>2.25.12</version>
+            <version>2.25.56</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/software.amazon.cloudformation/aws-cloudformation-rpdk-java-plugin -->
         <dependency>


### PR DESCRIPTION
This submission adds support for EngineLifecycleSupport.

DB instances and clusters can be created and restored with the EngineLifecycleSupport field via CloudFormation. All subsequent updates to this field on the resource will be blocked to prevent unintended customer resource replacement. EngineLifecycleSupport is marked as "Some Interruption" causing to preserve future compatibility for when a formal modify option is available for this field.

https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/extended-support.html

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
