### PR TITLE
 Add EngineLifecycleSupport integration to Global Clusters

### DIFF
--- a/aws-rds-cfn-common/pom.xml
+++ b/aws-rds-cfn-common/pom.xml
@@ -33,7 +33,7 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>rds</artifactId>
-            <version>2.25.12</version>
+            <version>2.25.56</version>
         </dependency>
         <dependency>
             <groupId>software.amazon.cloudformation</groupId>

--- a/aws-rds-customdbengineversion/pom.xml
+++ b/aws-rds-customdbengineversion/pom.xml
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>rds</artifactId>
-            <version>2.25.12</version>
+            <version>2.25.56</version>
         </dependency>
         <dependency>
             <groupId>software.amazon.rds.common</groupId>

--- a/aws-rds-dbcluster/pom.xml
+++ b/aws-rds-dbcluster/pom.xml
@@ -30,7 +30,7 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>rds</artifactId>
-            <version>2.25.12</version>
+            <version>2.25.56</version>
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>

--- a/aws-rds-dbclusterendpoint/pom.xml
+++ b/aws-rds-dbclusterendpoint/pom.xml
@@ -30,7 +30,7 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>rds</artifactId>
-            <version>2.25.12</version>
+            <version>2.25.56</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/software.amazon.cloudformation/aws-cloudformation-rpdk-java-plugin -->
         <dependency>

--- a/aws-rds-dbclusterparametergroup/pom.xml
+++ b/aws-rds-dbclusterparametergroup/pom.xml
@@ -30,7 +30,7 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>rds</artifactId>
-            <version>2.25.12</version>
+            <version>2.25.56</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/software.amazon.cloudformation/aws-cloudformation-rpdk-java-plugin -->
         <dependency>

--- a/aws-rds-dbinstance/pom.xml
+++ b/aws-rds-dbinstance/pom.xml
@@ -34,7 +34,7 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>rds</artifactId>
-            <version>2.25.12</version>
+            <version>2.25.56</version>
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>

--- a/aws-rds-dbparametergroup/pom.xml
+++ b/aws-rds-dbparametergroup/pom.xml
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>rds</artifactId>
-            <version>2.25.12</version>
+            <version>2.25.56</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/software.amazon.cloudformation/aws-cloudformation-rpdk-java-plugin -->
         <dependency>

--- a/aws-rds-dbsubnetgroup/pom.xml
+++ b/aws-rds-dbsubnetgroup/pom.xml
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>rds</artifactId>
-            <version>2.25.12</version>
+            <version>2.25.56</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/software.amazon.cloudformation/aws-cloudformation-rpdk-java-plugin -->
         <dependency>

--- a/aws-rds-eventsubscription/pom.xml
+++ b/aws-rds-eventsubscription/pom.xml
@@ -29,7 +29,7 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>rds</artifactId>
-            <version>2.25.12</version>
+            <version>2.25.56</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/software.amazon.cloudformation/aws-cloudformation-rpdk-java-plugin -->
         <dependency>

--- a/aws-rds-globalcluster/aws-rds-globalcluster.json
+++ b/aws-rds-globalcluster/aws-rds-globalcluster.json
@@ -12,6 +12,10 @@
         "aurora-postgresql"
       ]
     },
+    "EngineLifecycleSupport": {
+      "description": "The life cycle type of the global cluster. You can use this setting to enroll your global cluster into Amazon RDS Extended Support.",
+      "type": "string"
+    },
     "EngineVersion": {
       "description": "The version number of the database engine to use. If you specify the SourceDBClusterIdentifier property, don't specify this property. The value is inherited from the cluster.",
       "type": "string"

--- a/aws-rds-globalcluster/docs/README.md
+++ b/aws-rds-globalcluster/docs/README.md
@@ -13,6 +13,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
     "Type" : "AWS::RDS::GlobalCluster",
     "Properties" : {
         "<a href="#engine" title="Engine">Engine</a>" : <i>String</i>,
+        "<a href="#enginelifecyclesupport" title="EngineLifecycleSupport">EngineLifecycleSupport</a>" : <i>String</i>,
         "<a href="#engineversion" title="EngineVersion">EngineVersion</a>" : <i>String</i>,
         "<a href="#deletionprotection" title="DeletionProtection">DeletionProtection</a>" : <i>Boolean</i>,
         "<a href="#globalclusteridentifier" title="GlobalClusterIdentifier">GlobalClusterIdentifier</a>" : <i>String</i>,
@@ -28,6 +29,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 Type: AWS::RDS::GlobalCluster
 Properties:
     <a href="#engine" title="Engine">Engine</a>: <i>String</i>
+    <a href="#enginelifecyclesupport" title="EngineLifecycleSupport">EngineLifecycleSupport</a> : <i>String</i>,
     <a href="#engineversion" title="EngineVersion">EngineVersion</a>: <i>String</i>
     <a href="#deletionprotection" title="DeletionProtection">DeletionProtection</a>: <i>Boolean</i>
     <a href="#globalclusteridentifier" title="GlobalClusterIdentifier">GlobalClusterIdentifier</a>: <i>String</i>
@@ -49,6 +51,16 @@ _Type_: String
 _Allowed Values_: <code>aurora</code> | <code>aurora-mysql</code> | <code>aurora-postgresql</code>
 
 _Update requires_: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
+
+#### EngineLifecycleSupport
+
+The life cycle type of the global cluster. You can use this setting to enroll your global cluster into Amazon RDS Extended Support.
+
+_Required_: No
+
+_Type_: String
+
+_Update requires_: [Some interruptions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-some-interrupt)
 
 #### EngineVersion
 

--- a/aws-rds-globalcluster/pom.xml
+++ b/aws-rds-globalcluster/pom.xml
@@ -29,7 +29,7 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>rds</artifactId>
-            <version>2.25.12</version>
+            <version>2.25.56</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/software.amazon.cloudformation/aws-cloudformation-rpdk-java-plugin -->
         <dependency>

--- a/aws-rds-globalcluster/src/main/java/software/amazon/rds/globalcluster/ReadHandler.java
+++ b/aws-rds-globalcluster/src/main/java/software/amazon/rds/globalcluster/ReadHandler.java
@@ -40,6 +40,7 @@ public class ReadHandler extends BaseHandlerStd {
         builder.engineVersion(cluster.engineVersion());
         builder.storageEncrypted(cluster.storageEncrypted());
         builder.deletionProtection(cluster.deletionProtection());
+        builder.engineLifecycleSupport(cluster.engineLifecycleSupport());
 
         if (cluster.hasGlobalClusterMembers()) {
 

--- a/aws-rds-globalcluster/src/main/java/software/amazon/rds/globalcluster/Translator.java
+++ b/aws-rds-globalcluster/src/main/java/software/amazon/rds/globalcluster/Translator.java
@@ -32,6 +32,7 @@ public class Translator {
             .globalClusterIdentifier(model.getGlobalClusterIdentifier())
             .sourceDBClusterIdentifier(StringUtils.isBlank(dbClusterArn) ? model.getSourceDBClusterIdentifier() : dbClusterArn)
             .storageEncrypted(model.getStorageEncrypted())
+            .engineLifecycleSupport(model.getEngineLifecycleSupport())
             .build();
   }
 

--- a/aws-rds-integration/pom.xml
+++ b/aws-rds-integration/pom.xml
@@ -22,7 +22,7 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>rds</artifactId>
-            <version>2.25.12</version>
+            <version>2.25.56</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/software.amazon.cloudformation/aws-cloudformation-rpdk-java-plugin -->
         <dependency>

--- a/aws-rds-optiongroup/pom.xml
+++ b/aws-rds-optiongroup/pom.xml
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>rds</artifactId>
-            <version>2.25.12</version>
+            <version>2.25.56</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/software.amazon.cloudformation/aws-cloudformation-rpdk-java-plugin -->
         <dependency>


### PR DESCRIPTION
This submission adds support for EngineLifecycleSupport.

Global clusters can be created with the EngineLifecycleSupport field via CloudFormation. All subsequent updates to this field on the resource will be blocked to prevent unintended customer resource replacement. EngineLifecycleSupport is marked as "Some Interruption" causing to preserve future compatibility for when a formal modify option is available for this field.

https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/extended-support.html

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.