### PR TITLE
[DBInstance][DBCluster] Add more terminal states

### DIFF
--- a/aws-rds-cfn-common/src/main/java/software/amazon/rds/common/status/TerminableStatus.java
+++ b/aws-rds-cfn-common/src/main/java/software/amazon/rds/common/status/TerminableStatus.java
@@ -1,5 +1,14 @@
 package software.amazon.rds.common.status;
 
+/**
+ * Represents a status that could be considered "terminal" for a resource.
+ * Terminal states cause resource stabilization to fail immediately. If a
+ * resource enters a terminal state following a mutation, the operation fails
+ * with a {@link software.amazon.cloudformation.exceptions.CfnNotStabilizedException}.
+ */
 public interface TerminableStatus extends Status {
+    /**
+     * Returns true if the status is terminal.
+     */
     boolean isTerminal();
 }

--- a/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/DBClusterStatus.java
+++ b/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/DBClusterStatus.java
@@ -7,9 +7,13 @@ public enum DBClusterStatus implements TerminableStatus {
     Creating("creating"),
     Deleted("deleted"),
     InaccessibleEncryptionCredentials("inaccessible-encryption-credentials", true),
+    InaccessibleEncryptionCredentialsRecoverable("inaccessible-encryption-credentials-recoverable", true),
     IncompatibleNetwork("incompatible-network", true),
     IncompatibleParameters("incompatible-parameters", true),
-    IncompatibleRestore("incompatible-restore", true);
+    IncompatibleRestore("incompatible-restore", true),
+    MigrationFailed("migration-failed", true),
+    RestoreFailed("restore-failed", true);
+
 
     private final String value;
     private final boolean isTerminal;

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/status/DBInstanceStatus.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/status/DBInstanceStatus.java
@@ -9,10 +9,15 @@ public enum DBInstanceStatus implements TerminableStatus {
     Deleting("deleting"),
     Failed("failed", true),
     InaccessibleEncryptionCredentials("inaccessible-encryption-credentials", true),
+    InaccessibleEncryptionCredentialsRecoverable("inaccessible-encryption-credentials-recoverable", true),
+    IncompatibleCreate("incompatible-create", true),
+    IncompatibleCredentials("incompatible-credentials", true),
     IncompatibleNetwork("incompatible-network", true),
     IncompatibleParameters("incompatible-parameters", true),
     IncompatibleRestore("incompatible-restore", true),
-    StorageFull("storage-full");
+    ModifyFailed("modify-failed", true),
+    StorageFull("storage-full"),
+    UpgradeFailed("upgrade-failed", true);
 
     private final String value;
     private final boolean terminal;


### PR DESCRIPTION
This change is to add more terminal states so that instance/cluster operations fail fast if these states are reached, instead of waiting for the stabilization process to time out.

Status references:
- https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/accessing-monitoring.html
- https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/accessing-monitoring.html

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
