### PR TITLE
fix(DBCluster): allow creating clusters from PITR with backtracking enabled

### DIFF
--- a/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/Translator.java
+++ b/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/Translator.java
@@ -107,6 +107,7 @@ public class Translator {
             final Tagging.TagSet tagSet
     ) {
         RestoreDbClusterToPointInTimeRequest.Builder builder = RestoreDbClusterToPointInTimeRequest.builder()
+                .backtrackWindow(castToLong(model.getBacktrackWindow()))
                 .copyTagsToSnapshot(model.getCopyTagsToSnapshot())
                 .dbClusterIdentifier(model.getDBClusterIdentifier())
                 .dbClusterInstanceClass(model.getDBClusterInstanceClass())
@@ -236,7 +237,6 @@ public class Translator {
 
         if (EngineMode.fromString(desiredModel.getEngineMode()) != EngineMode.Serverless) {
             builder.allocatedStorage(desiredModel.getAllocatedStorage())
-                    .backtrackWindow(castToLong(desiredModel.getBacktrackWindow()))
                     .enableIAMDatabaseAuthentication(desiredModel.getEnableIAMDatabaseAuthentication())
                     .preferredBackupWindow(desiredModel.getPreferredBackupWindow());
         } else {

--- a/aws-rds-dbcluster/src/test/java/software/amazon/rds/dbcluster/TranslatorTest.java
+++ b/aws-rds-dbcluster/src/test/java/software/amazon/rds/dbcluster/TranslatorTest.java
@@ -459,14 +459,12 @@ public class TranslatorTest extends AbstractHandlerTest {
                 .engineMode(EngineMode.Serverless.toString())
                 .enableIAMDatabaseAuthentication(true)
                 .preferredBackupWindow("backup")
-                .backtrackWindow(100)
                 .allocatedStorage(200)
                 .build();
         final ModifyDbClusterRequest request = Translator.modifyDbClusterAfterCreateRequest(model);
 
         assertThat(request.enableIAMDatabaseAuthentication()).isNull();
         assertThat(request.preferredBackupWindow()).isNull();
-        assertThat(request.backtrackWindow()).isNull();
         assertThat(request.allocatedStorage()).isNull();
     }
 
@@ -476,14 +474,12 @@ public class TranslatorTest extends AbstractHandlerTest {
                 .engineMode(EngineMode.Provisioned.toString())
                 .enableIAMDatabaseAuthentication(true)
                 .preferredBackupWindow("backup")
-                .backtrackWindow(100)
                 .allocatedStorage(200)
                 .build();
         final ModifyDbClusterRequest request = Translator.modifyDbClusterAfterCreateRequest(model);
 
         assertThat(request.enableIAMDatabaseAuthentication()).isEqualTo(true);
         assertThat(request.preferredBackupWindow()).isEqualTo("backup");
-        assertThat(request.backtrackWindow()).isEqualTo(100);
         assertThat(request.allocatedStorage()).isEqualTo(200);
     }
 
@@ -494,11 +490,13 @@ public class TranslatorTest extends AbstractHandlerTest {
                 .enableIAMDatabaseAuthentication(true)
                 .useLatestRestorableTime(false)
                 .restoreToTime("2019-03-07T23:45:00Z")
+                .backtrackWindow(0)
                 .build();
         final RestoreDbClusterToPointInTimeRequest request = Translator.restoreDbClusterToPointInTimeRequest(model, Tagging.TagSet.emptySet());
 
         assertThat(request.useLatestRestorableTime()).isEqualTo(false);
         assertThat(request.restoreToTime()).isEqualTo("2019-03-07T23:45:00Z");
+        assertThat(request.backtrackWindow()).isEqualTo(0);
     }
 
     @Test


### PR DESCRIPTION
This change fixes an issue preventing customers from creating DB clusters with both SourceDBClusterIdentifier and BacktrackWindow.

The fix is to ensure that BacktrackWindow is passed in the RestoreDBClusterToPointInTime call, as backtracking can only be enabled at time of cluster creation.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
