### PR TITLE
fix: remove defaults on backtrackwindow

### DIFF
--- a/aws-rds-dbcluster/aws-rds-dbcluster.json
+++ b/aws-rds-dbcluster/aws-rds-dbcluster.json
@@ -35,7 +35,6 @@
     },
     "BacktrackWindow": {
       "description": "The target backtrack window, in seconds. To disable backtracking, set this value to 0.",
-      "default": 0,
       "minimum": 0,
       "type": "integer"
     },


### PR DESCRIPTION
*Issue #, if available:*

Original issue  : https://github.com/hashicorp/terraform-provider-awscc/issues/1805


*Description of changes:*

* The change here is to ensure that the default value of `BacktrackWindow` is removed so that the schema referenced by entities like AWSCC provider from Terraform do not send this for every DB engine. Opening this based on the internal ticket opened with the team and their suggestions. 

* The default behaviour - if BacktrackWindow is missing/null - is for backtrack to be disabled.
* Setting BacktrackWindow to 0 also disables backtrack.
* BacktrackWindow can only be specified if the engine version supports the backtrack feature, otherwise you get the "Backtrack is not enabled" error.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
