### PR TITLE
fix(DBInstance): allow deleting cluster instances through CCAPI

### DIFF
--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/CallbackContext.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/CallbackContext.java
@@ -14,6 +14,7 @@ import software.amazon.rds.common.handler.TimestampContext;
 @lombok.ToString
 @lombok.EqualsAndHashCode(callSuper = true)
 public class CallbackContext extends StdCallbackContext implements TaggingContext.Provider, TimestampContext.Provider {
+    private boolean described;
     private boolean created;
     private boolean deleted;
     private boolean updatedRoles;
@@ -27,6 +28,7 @@ public class CallbackContext extends StdCallbackContext implements TaggingContex
     private String dbInstanceArn;
     private String currentRegion;
     private String kmsKeyId;
+    private String snapshotIdentifier;
 
     private TaggingContext taggingContext;
     private Map<String, Long> timestamps;

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/DeleteHandler.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/DeleteHandler.java
@@ -1,20 +1,24 @@
 package software.amazon.rds.dbinstance;
 
+import java.util.Collections;
 import java.util.function.Function;
+import java.util.Optional;
 
+import com.google.common.annotations.VisibleForTesting;
 import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
 
 import software.amazon.awssdk.services.ec2.Ec2Client;
 import software.amazon.awssdk.services.rds.RdsClient;
+import software.amazon.awssdk.services.rds.model.DBInstance;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.ProgressEvent;
+import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 import software.amazon.rds.common.handler.Commons;
 import software.amazon.rds.common.handler.HandlerConfig;
 import software.amazon.rds.common.request.ValidatedRequest;
 import software.amazon.rds.common.util.IdentifierFactory;
 import software.amazon.rds.dbinstance.client.VersionedProxyClient;
-import software.amazon.rds.dbinstance.util.ResourceModelHelper;
 
 public class DeleteHandler extends BaseHandlerStd {
 
@@ -42,25 +46,23 @@ public class DeleteHandler extends BaseHandlerStd {
             final VersionedProxyClient<RdsClient> rdsProxyClient,
             final VersionedProxyClient<Ec2Client> ec2ProxyClient
     ) {
+        // !!!: For delete handlers, the only input guaranteed to exist in the model is the DB instance identifier.
+        // This is why we fetch the DB instance instead of poking into the model.
+        // https://docs.aws.amazon.com/cloudformation-cli/latest/userguide/resource-type-test-contract.html#resource-type-test-contract-delete
         final ResourceModel resourceModel = request.getDesiredResourceState();
-        String snapshotIdentifier = null;
-        // https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html
-        // For AWS::RDS::DBInstance resources that don't specify the DBClusterIdentifier property, the default policy is Snapshot.
-        // Final snapshots are not allowed for read replicas and cluster instances.
-        if (BooleanUtils.isNotFalse(request.getSnapshotRequested()) &&
-                !ResourceModelHelper.isReadReplica(resourceModel) &&
-                !isDBClusterMember(resourceModel)) {
-            snapshotIdentifier = snapshotIdentifierFactory.newIdentifier()
-                    .withStackId(request.getStackId())
-                    .withResourceId(StringUtils.prependIfMissing(request.getLogicalResourceIdentifier(), SNAPSHOT_PREFIX))
-                    .withRequestToken(request.getClientRequestToken())
-                    .toString();
-        }
-        final String finalSnapshotIdentifier = snapshotIdentifier;
 
         return ProgressEvent.progress(resourceModel, callbackContext)
+                .then(progress -> Commons.execOnce(progress, () -> {
+                        try {
+                            final var dbInstance = fetchDBInstance(rdsProxyClient.defaultClient(), progress.getResourceModel());
+                            callbackContext.setSnapshotIdentifier(decideSnapshotIdentifier(request, dbInstance));
+                        } catch (Exception exception) {
+                            return Commons.handleException(progress, exception, DEFAULT_DB_INSTANCE_ERROR_RULE_SET, requestLogger);
+                        }
+                        return progress;
+                }, CallbackContext::isDescribed, CallbackContext::setDescribed))
                 .then(progress -> proxy.initiate("rds::delete-db-instance", rdsProxyClient.defaultClient(), resourceModel, callbackContext)
-                        .translateToServiceRequest(model -> Translator.deleteDbInstanceRequest(model, finalSnapshotIdentifier))
+                        .translateToServiceRequest(model -> Translator.deleteDbInstanceRequest(model, callbackContext.getSnapshotIdentifier()))
                         .backoffDelay(config.getBackoff())
                         .makeServiceCall((deleteRequest, proxyInvocation) -> proxyInvocation.injectCredentialsAndInvokeV2(
                                 deleteRequest,
@@ -73,12 +75,9 @@ public class DeleteHandler extends BaseHandlerStd {
                                 requestLogger
                         )).progress()
                 )
-                // The reason we split a pretty trivial execution chain in 2 is because of the error handling.
-                // Delete handler should ignore some exceptions and go straight to the stabilization step.
-                // The execution chain interrupts immediately once handleError is called. This eliminates
-                // the stabilization step. For the sake of enforcing the stabilization, we spin up a separate
-                // execution chain with a no-op service call. Note that it is only supposed to handle exceptions
-                // thrown by isDbInstanceDeleted, hence the default ruleset is put in place instead.
+                // We split the delete and stabilize into two call chains because any error interrupts the entire chain.
+                // The delete operation can return certain errors that we wish to ignore. To ensure that stabilization
+                // happens when these errors occur, stabilization needs to be in a separate chain.
                 .then(progress -> proxy.initiate("rds::delete-db-instance-stabilize", rdsProxyClient.defaultClient(), progress.getResourceModel(), progress.getCallbackContext())
                         .translateToServiceRequest(Function.identity())
                         .backoffDelay(config.getBackoff())
@@ -93,5 +92,29 @@ public class DeleteHandler extends BaseHandlerStd {
                         .progress()
                 )
                 .then(progress -> ProgressEvent.defaultSuccessHandler(null));
+    }
+
+    @VisibleForTesting
+    static String decideSnapshotIdentifier(
+            final ResourceHandlerRequest<ResourceModel> request,
+            final DBInstance dbInstance
+    ) {
+        // CFN sends true or false for snapshotRequested based on the template's DeletionPolicy.
+        // However, CCAPI leaves it null. In that case, we take a snapshot, since that is CFN's default.
+        // Exception is that final snapshots are not allowed for read replicas and cluster instances.
+        boolean shouldAttemptToTakeSnapshot = BooleanUtils.isNotFalse(request.getSnapshotRequested());
+        boolean isReadReplica = StringUtils.isNotEmpty(dbInstance.readReplicaSourceDBInstanceIdentifier()) ||
+                StringUtils.isNotEmpty(dbInstance.readReplicaSourceDBClusterIdentifier());
+        boolean isSnapshotPossible = !isReadReplica && StringUtils.isEmpty(dbInstance.dbClusterIdentifier());
+
+        if (shouldAttemptToTakeSnapshot && isSnapshotPossible) {
+            return snapshotIdentifierFactory.newIdentifier()
+                    .withStackId(request.getStackId())
+                    .withResourceId(StringUtils.prependIfMissing(request.getLogicalResourceIdentifier(), SNAPSHOT_PREFIX))
+                    .withRequestToken(request.getClientRequestToken())
+                    .toString();
+        } else {
+            return null;
+        }
     }
 }

--- a/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/AbstractHandlerTest.java
+++ b/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/AbstractHandlerTest.java
@@ -25,6 +25,7 @@ import software.amazon.awssdk.services.rds.model.CreateDbInstanceReadReplicaResp
 import software.amazon.awssdk.services.rds.model.CreateDbInstanceRequest;
 import software.amazon.awssdk.services.rds.model.CreateDbInstanceResponse;
 import software.amazon.awssdk.services.rds.model.DBInstance;
+import software.amazon.awssdk.services.rds.model.DBInstanceStatusInfo;
 import software.amazon.awssdk.services.rds.model.DeleteDbInstanceRequest;
 import software.amazon.awssdk.services.rds.model.DeleteDbInstanceResponse;
 import software.amazon.awssdk.services.rds.model.DescribeDbInstancesRequest;
@@ -204,14 +205,17 @@ public abstract class AbstractHandlerTest extends AbstractTestBase<DBInstance, R
     protected static final ResourceModel RESOURCE_MODEL_RESTORING_FROM_SNAPSHOT;
     protected static final ResourceModel RESOURCE_MODEL_RESTORING_TO_POINT_IN_TIME;
 
-    protected static final DBInstance DB_INSTANCE_BASE;
-    protected static final DBInstance DB_INSTANCE_ACTIVE;
-    protected static final DBInstance DB_INSTANCE_SQLSERVER_ACTIVE;
-    protected static final DBInstance DB_INSTANCE_DELETING;
-    protected static final DBInstance DB_INSTANCE_FAILED;
-    protected static final DBInstance DB_INSTANCE_MODIFYING;
-    protected static final DBInstance DB_INSTANCE_EMPTY_PORT;
-    protected static final DBInstance DB_INSTANCE_STORAGE_FULL;
+    static final DBInstance DB_INSTANCE_BASE;
+    static final DBInstance DB_INSTANCE_ACTIVE;
+    static final DBInstance DB_INSTANCE_AURORA_ACTIVE;
+    static final DBInstance DB_INSTANCE_SQLSERVER_ACTIVE;
+    static final DBInstance DB_INSTANCE_READ_REPLICA_ACTIVE;
+    static final DBInstance DB_INSTANCE_MAZ_CLUSTER_READ_REPLICA_ACTIVE;
+    static final DBInstance DB_INSTANCE_DELETING;
+    static final DBInstance DB_INSTANCE_FAILED;
+    static final DBInstance DB_INSTANCE_MODIFYING;
+    static final DBInstance DB_INSTANCE_EMPTY_PORT;
+    static final DBInstance DB_INSTANCE_STORAGE_FULL;
 
     protected static Constant TEST_BACKOFF_DELAY = Constant.of()
             .delay(Duration.ofMillis(1L))
@@ -572,8 +576,21 @@ public abstract class AbstractHandlerTest extends AbstractTestBase<DBInstance, R
                 .promotionTier(PROMOTION_TIER_DEFAULT)
                 .build();
 
+        DB_INSTANCE_AURORA_ACTIVE = DB_INSTANCE_ACTIVE.toBuilder()
+                .dbClusterIdentifier(DB_CLUSTER_IDENTIFIER_NON_EMPTY)
+                .engine(ENGINE_AURORA_MYSQL)
+                .build();
+
         DB_INSTANCE_SQLSERVER_ACTIVE = DB_INSTANCE_ACTIVE.toBuilder()
                 .engine(ENGINE_SQLSERVER_SE)
+                .build();
+
+        DB_INSTANCE_READ_REPLICA_ACTIVE = DB_INSTANCE_ACTIVE.toBuilder()
+                .readReplicaSourceDBInstanceIdentifier(SOURCE_DB_INSTANCE_IDENTIFIER_NON_EMPTY)
+                .build();
+
+        DB_INSTANCE_MAZ_CLUSTER_READ_REPLICA_ACTIVE = DB_INSTANCE_ACTIVE.toBuilder()
+                .readReplicaSourceDBClusterIdentifier(SOURCE_DB_INSTANCE_IDENTIFIER_NON_EMPTY)
                 .build();
 
         DB_INSTANCE_DELETING = DB_INSTANCE_ACTIVE.toBuilder()

--- a/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/DeleteHandlerHelperTest.java
+++ b/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/DeleteHandlerHelperTest.java
@@ -1,0 +1,78 @@
+package software.amazon.rds.dbinstance;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import software.amazon.awssdk.services.rds.model.DBInstance;
+import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static software.amazon.rds.dbinstance.AbstractHandlerTest.DB_INSTANCE_ACTIVE;
+import static software.amazon.rds.dbinstance.AbstractHandlerTest.DB_INSTANCE_AURORA_ACTIVE;
+import static software.amazon.rds.dbinstance.AbstractHandlerTest.DB_INSTANCE_MAZ_CLUSTER_READ_REPLICA_ACTIVE;
+import static software.amazon.rds.dbinstance.AbstractHandlerTest.DB_INSTANCE_READ_REPLICA_ACTIVE;
+import static software.amazon.rds.dbinstance.AbstractHandlerTest.RESOURCE_MODEL_BLDR;
+
+class DeleteHandlerHelperTest {
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void decideSnapshotIdentifier_FollowsSnapshotRequested(boolean isSnapshotRequested) {
+        ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+                .desiredResourceState(RESOURCE_MODEL_BLDR().build())
+                .logicalResourceIdentifier("dbinstance")
+                .clientRequestToken("token")
+                .snapshotRequested(isSnapshotRequested)
+                .build();
+
+        final String snapshotIdentifier = DeleteHandler.decideSnapshotIdentifier(request, DB_INSTANCE_ACTIVE);
+
+        if (isSnapshotRequested) {
+            assertThat(snapshotIdentifier).isNotBlank();
+        } else {
+            assertThat(snapshotIdentifier).isNull();
+        }
+    }
+
+    @Test
+    void decideSnapshotIdentifier_DefaultsToSnapshot() {
+        ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+                .desiredResourceState(RESOURCE_MODEL_BLDR().build())
+                .logicalResourceIdentifier("dbinstance")
+                .clientRequestToken("token")
+                .build();
+
+        final String snapshotIdentifier = DeleteHandler.decideSnapshotIdentifier(request, DB_INSTANCE_ACTIVE);
+
+        assertThat(snapshotIdentifier).isNotBlank();
+    }
+
+    void testDecideSnapshotIdentifierImpossible(DBInstance instance) {
+        ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+                .desiredResourceState(RESOURCE_MODEL_BLDR().build())
+                .logicalResourceIdentifier("dbinstance")
+                .clientRequestToken("token")
+                .snapshotRequested(true)
+                .build();
+
+        final String snapshotIdentifier = DeleteHandler.decideSnapshotIdentifier(request, instance);
+
+        assertThat(snapshotIdentifier).isNull();
+    }
+
+    @Test
+    void decideSnapshotIdentifier_NoSnapshotClusterInstance() {
+        testDecideSnapshotIdentifierImpossible(DB_INSTANCE_AURORA_ACTIVE);
+    }
+
+    @Test
+    void decideSnapshotIdentifier_NoSnapshotReadReplica() {
+        testDecideSnapshotIdentifierImpossible(DB_INSTANCE_READ_REPLICA_ACTIVE);
+    }
+
+    @Test
+    void decideSnapshotIdentifier_NoSnapshotReadReplicaOfMultiAzCluster() {
+        testDecideSnapshotIdentifierImpossible(DB_INSTANCE_MAZ_CLUSTER_READ_REPLICA_ACTIVE);
+    }
+
+}


### PR DESCRIPTION
This change fixes an issue preventing cluster instances from being deleted using Cloud Control API.

Final snapshots are not possible for read replicas and cluster instances. The issue was that the handler was determining this based on instance details provided in the request. CCAPI does not provide these details. The fix is to retrieve the instance details from RDS instead of relying on the request.

Test: unit tests and contract tests.

Issue: aws-cloudformation/cloudformation-coverage-roadmap#2013

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
