### PR TITLE
fix(DBCluster): fix local write forwarding error on cluster update

### DIFF
--- a/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/Translator.java
+++ b/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/Translator.java
@@ -275,7 +275,7 @@ public class Translator {
                 .domainIAMRoleName(desiredModel.getDomainIAMRoleName())
                 .enableGlobalWriteForwarding(desiredModel.getEnableGlobalWriteForwarding())
                 .enableIAMDatabaseAuthentication(diff(previousModel.getEnableIAMDatabaseAuthentication(), desiredModel.getEnableIAMDatabaseAuthentication()))
-                .enableLocalWriteForwarding(desiredModel.getEnableLocalWriteForwarding())
+                .enableLocalWriteForwarding(diff(previousModel.getEnableLocalWriteForwarding(), desiredModel.getEnableLocalWriteForwarding()))
                 .enablePerformanceInsights(desiredModel.getPerformanceInsightsEnabled())
                 .iops(desiredModel.getIops())
                 .masterUserPassword(diff(previousModel.getMasterUserPassword(), desiredModel.getMasterUserPassword()))

--- a/aws-rds-dbcluster/src/test/java/software/amazon/rds/dbcluster/TranslatorTest.java
+++ b/aws-rds-dbcluster/src/test/java/software/amazon/rds/dbcluster/TranslatorTest.java
@@ -245,6 +245,25 @@ public class TranslatorTest extends AbstractHandlerTest {
     }
 
     @Test
+    public void modifyDbClusterRequest_enableLocalWriteForwarding() {
+        final var previousModel = RESOURCE_MODEL.toBuilder().enableLocalWriteForwarding(null).build();
+
+        final var desiredModel = RESOURCE_MODEL.toBuilder().enableLocalWriteForwarding(true).build();
+
+        final var request = Translator.modifyDbClusterRequest(previousModel, desiredModel, IS_NOT_ROLLBACK);
+        assertThat(request.enableLocalWriteForwarding()).isEqualTo(true);
+    }
+
+    @Test
+    public void modifyDbClusterRequest_sameLocalWriteForwarding() {
+        final var previousModel = RESOURCE_MODEL.toBuilder().enableLocalWriteForwarding(false).build();
+        final var desiredModel = RESOURCE_MODEL.toBuilder().enableLocalWriteForwarding(false).build();
+
+        final var request = Translator.modifyDbClusterRequest(previousModel, desiredModel, IS_NOT_ROLLBACK);
+        assertThat(request.enableLocalWriteForwarding()).isNull();
+    }
+
+    @Test
     public void test_translateDbClusterFromSdk_emptyDomainMembership() {
         final DBCluster cluster = DBCluster.builder()
                 .domainMemberships((Collection<DomainMembership>) null)


### PR DESCRIPTION
This change fixes an issue causing resource updates to fail with a "Local Write Forwarding is already disabled/enabled on cluster" error. The fix is to send EnableLocalWriteForwarding in the modify request only when this property is actually changing.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
