### PR TITLE
[Drift Detection] Adding handler action for DbInstance and DbCluster.

### DIFF
--- a/aws-rds-cfn-common/src/main/java/software/amazon/rds/common/handler/Commons.java
+++ b/aws-rds-cfn-common/src/main/java/software/amazon/rds/common/handler/Commons.java
@@ -126,16 +126,16 @@ public final class Commons {
             final M inputModel,
             final ProgressEvent<M, C> progress,
             final ResourceTypeSchema schema,
-            final RequestLogger logger
-    ) {
+            final RequestLogger requestLogger,
+            final String handlerAction) {
         try {
             final DriftDetector driftDetector = new DriftDetector(schema);
             final Map<String, Mutation> mutations = driftDetector.detectDrift(inputModel, progress.getResourceModel());
             if (!mutations.isEmpty()) {
-                logger.log("Resource drift detected", new DriftDetectorReport(mutations));
+                requestLogger.log(String.format("Resource drift detected! Action: %s", handlerAction), new DriftDetectorReport(mutations));
             }
         } catch (Exception e) {
-            logger.log("Drift detector internal error", e);
+            requestLogger.log("Drift detector internal error", e);
         }
         return progress;
     }

--- a/aws-rds-cfn-common/src/main/java/software/amazon/rds/common/handler/Commons.java
+++ b/aws-rds-cfn-common/src/main/java/software/amazon/rds/common/handler/Commons.java
@@ -5,6 +5,7 @@ import java.time.ZonedDateTime;
 import java.util.Map;
 import java.util.function.Function;
 
+import com.google.common.collect.ImmutableMap;
 import lombok.NonNull;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import software.amazon.awssdk.core.exception.SdkClientException;
@@ -132,7 +133,7 @@ public final class Commons {
             final DriftDetector driftDetector = new DriftDetector(schema);
             final Map<String, Mutation> mutations = driftDetector.detectDrift(inputModel, progress.getResourceModel());
             if (!mutations.isEmpty()) {
-                requestLogger.log(String.format("Resource drift detected! Action: %s", handlerAction), new DriftDetectorReport(mutations));
+                requestLogger.log("Resource drift detected", ImmutableMap.of("HandlerAction", handlerAction, "Report", new DriftDetectorReport(mutations)));
             }
         } catch (Exception e) {
             requestLogger.log("Drift detector internal error", e);

--- a/aws-rds-cfn-common/src/test/java/software/amazon/rds/common/handler/CommonsTest.java
+++ b/aws-rds-cfn-common/src/test/java/software/amazon/rds/common/handler/CommonsTest.java
@@ -331,10 +331,12 @@ class CommonsTest {
         final TestResourceModel output = new TestResourceModel();
         output.testProperty = "test-property-output";
 
+        final String handlerOperation = "test-property";
+
         Logger logger = Mockito.mock(Logger.class);
         Mockito.doNothing().when(logger).log(any(String.class));
 
-        Commons.reportResourceDrift(input, ProgressEvent.<TestResourceModel, Void>progress(output, null), TEST_RESOURCE_TYPE_SCHEMA, new RequestLogger(logger, new ResourceHandlerRequest<>(), new FilteredJsonPrinter()));
+        Commons.reportResourceDrift(input, ProgressEvent.<TestResourceModel, Void>progress(output, null), TEST_RESOURCE_TYPE_SCHEMA, new RequestLogger(logger, new ResourceHandlerRequest<>(), new FilteredJsonPrinter()), handlerOperation);
         ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
         verify(logger).log(captor.capture());
 
@@ -350,10 +352,30 @@ class CommonsTest {
         final TestResourceModel output = new TestResourceModel();
         output.testProperty = "test-property";
 
+        final String handlerOperation = "test-property";
+
         Logger logger = Mockito.mock(Logger.class);
 
-        Commons.reportResourceDrift(input, ProgressEvent.<TestResourceModel, Void>progress(output, null), TEST_RESOURCE_TYPE_SCHEMA, new RequestLogger(logger, new ResourceHandlerRequest<>(), new FilteredJsonPrinter()));
+        Commons.reportResourceDrift(input, ProgressEvent.<TestResourceModel, Void>progress(output, null), TEST_RESOURCE_TYPE_SCHEMA, new RequestLogger(logger, new ResourceHandlerRequest<>(), new FilteredJsonPrinter()), handlerOperation);
         verifyNoInteractions(logger);
+    }
+
+    @Test
+    void test_detectDrift_shouldFailIfSchemaIsNull(){
+
+        final TestResourceModel input = new TestResourceModel();
+        input.testProperty = "test-property";
+
+        final TestResourceModel output = new TestResourceModel();
+        output.testProperty = "test-property-1";
+
+        final String handlerOperation = null;
+
+        Commons.reportResourceDrift(input, ProgressEvent.<TestResourceModel, Void>progress(output, null), null, requestLogger, handlerOperation);
+
+        ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<Exception> exCaptor = ArgumentCaptor.forClass(Exception.class);
+        verify(requestLogger).log(captor.capture(), exCaptor.capture());
     }
 
     private AwsServiceException newAwsServiceException(final ErrorCode errorCode) {

--- a/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/CreateHandler.java
+++ b/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/CreateHandler.java
@@ -34,6 +34,8 @@ public class CreateHandler extends BaseHandlerStd {
         this(DB_CLUSTER_HANDLER_CONFIG_36H);
     }
 
+    final String handlerOperation = "CREATE";
+
     public CreateHandler(final HandlerConfig config) {
         super(config);
     }
@@ -120,7 +122,8 @@ public class CreateHandler extends BaseHandlerStd {
                             model,
                             new ReadHandler().handleRequest(proxy, request, progress.getCallbackContext(), rdsProxyClient, ec2ProxyClient),
                             resourceTypeSchema,
-                            requestLogger
+                            requestLogger,
+                            handlerOperation
                     );
                 });
     }

--- a/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/UpdateHandler.java
+++ b/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/UpdateHandler.java
@@ -35,6 +35,8 @@ public class UpdateHandler extends BaseHandlerStd {
         super(config);
     }
 
+    final String handlerOperation = "UPDATE";
+
     protected ProgressEvent<ResourceModel, CallbackContext> handleRequest(
             final AmazonWebServicesClientProxy proxy,
             final ValidatedRequest<ResourceModel> request,
@@ -133,7 +135,8 @@ public class UpdateHandler extends BaseHandlerStd {
                             desiredResourceState,
                             new ReadHandler().handleRequest(proxy, request, progress.getCallbackContext(), rdsProxyClient, ec2ProxyClient),
                             resourceTypeSchema,
-                            requestLogger
+                            requestLogger,
+                            handlerOperation
                     );
                 });
     }

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/CreateHandler.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/CreateHandler.java
@@ -49,6 +49,8 @@ public class CreateHandler extends BaseHandlerStd {
         super(config);
     }
 
+    final String handlerOperation = "CREATE";
+
     @Override
     protected void validateRequest(final ResourceHandlerRequest<ResourceModel> request) throws RequestValidationException {
         super.validateRequest(request);
@@ -206,7 +208,8 @@ public class CreateHandler extends BaseHandlerStd {
                             model,
                             new ReadHandler().handleRequest(proxy, request, progress.getCallbackContext(), rdsProxyClient, ec2ProxyClient, requestLogger),
                             resourceTypeSchema,
-                            requestLogger
+                            requestLogger,
+                            handlerOperation
                     );
                 });
     }

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/UpdateHandler.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/UpdateHandler.java
@@ -51,6 +51,8 @@ public class UpdateHandler extends BaseHandlerStd {
         super(config);
     }
 
+    final String handlerOperation = "UPDATE";
+
     protected ProgressEvent<ResourceModel, CallbackContext> handleRequest(
             final AmazonWebServicesClientProxy proxy,
             final ValidatedRequest<ResourceModel> request,
@@ -218,7 +220,8 @@ public class UpdateHandler extends BaseHandlerStd {
                             model,
                             new ReadHandler().handleRequest(proxy, request, progress.getCallbackContext(), rdsProxyClient, ec2ProxyClient),
                             resourceTypeSchema,
-                            requestLogger
+                            requestLogger,
+                            handlerOperation
                     );
                 });
     }


### PR DESCRIPTION
Adding Handler Action for DbInstance and DbCluster status in order to differentiate between CREATE and UPDATE resource state.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
