### PR TITLE
[DBCluster/DBInstance] Add tagging permissions on delete handlers for FinalSnapshots

### DIFF
--- a/aws-rds-dbcluster/aws-rds-dbcluster.json
+++ b/aws-rds-dbcluster/aws-rds-dbcluster.json
@@ -520,6 +520,7 @@
     },
     "delete": {
       "permissions": [
+        "rds:AddTagsToResource",
         "rds:CreateDBClusterSnapshot",
         "rds:DeleteDBCluster",
         "rds:DeleteDBInstance",

--- a/aws-rds-dbinstance/aws-rds-dbinstance.json
+++ b/aws-rds-dbinstance/aws-rds-dbinstance.json
@@ -648,6 +648,7 @@
     },
     "delete": {
       "permissions": [
+        "rds:AddTagsToResource",
         "rds:CreateDBSnapshot",
         "rds:DeleteDBInstance",
         "rds:DescribeDBInstances"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This code change includes explicit `AddTagsToResource` to delete handlers. When deleting DB instances/DB clusters, the handlers could create a final snapshot which could be tagged. This operation is working currently but the effect is implicit. This code change adds the explicit permissions to clearly state that `AddTagsToResource` could be invoked depending on the specific workload requested.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
