### PR TITLE
[Dependencies] - Add dependency on aws-query-protocol

### DIFF
--- a/aws-rds-dbclusterendpoint/pom.xml
+++ b/aws-rds-dbclusterendpoint/pom.xml
@@ -74,6 +74,12 @@
             <version>4.3.1</version>
             <scope>test</scope>
         </dependency>
+        <!-- https://mvnrepository.com/artifact/software.amazon.awssdk/aws-query-protocol -->
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>aws-query-protocol</artifactId>
+            <version>2.20.138</version>
+        </dependency>
         <dependency>
             <groupId>software.amazon.rds.common</groupId>
             <artifactId>aws-rds-cfn-common</artifactId>

--- a/aws-rds-dbclusterparametergroup/pom.xml
+++ b/aws-rds-dbclusterparametergroup/pom.xml
@@ -74,6 +74,12 @@
             <version>4.3.1</version>
             <scope>test</scope>
         </dependency>
+        <!-- https://mvnrepository.com/artifact/software.amazon.awssdk/aws-query-protocol -->
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>aws-query-protocol</artifactId>
+            <version>2.20.138</version>
+        </dependency>
         <dependency>
             <groupId>software.amazon.rds.common</groupId>
             <artifactId>aws-rds-cfn-common</artifactId>

--- a/aws-rds-dbinstance/pom.xml
+++ b/aws-rds-dbinstance/pom.xml
@@ -54,7 +54,7 @@
             <version>${org.projectlombok.version}</version>
             <scope>provided</scope>
         </dependency>
-       <!-- https://mvnrepository.com/artifact/software.amazon.awssdk/aws-query-protocol -->
+        <!-- https://mvnrepository.com/artifact/software.amazon.awssdk/aws-query-protocol -->
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>aws-query-protocol</artifactId>

--- a/aws-rds-dbparametergroup/pom.xml
+++ b/aws-rds-dbparametergroup/pom.xml
@@ -20,6 +20,12 @@
     </properties>
 
     <dependencies>
+        <!-- https://mvnrepository.com/artifact/software.amazon.awssdk/aws-query-protocol -->
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>aws-query-protocol</artifactId>
+            <version>2.20.138</version>
+        </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>rds</artifactId>

--- a/aws-rds-dbsubnetgroup/pom.xml
+++ b/aws-rds-dbsubnetgroup/pom.xml
@@ -20,6 +20,12 @@
     </properties>
 
     <dependencies>
+        <!-- https://mvnrepository.com/artifact/software.amazon.awssdk/aws-query-protocol -->
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>aws-query-protocol</artifactId>
+            <version>2.20.138</version>
+        </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>rds</artifactId>

--- a/aws-rds-eventsubscription/pom.xml
+++ b/aws-rds-eventsubscription/pom.xml
@@ -20,6 +20,12 @@
     </properties>
 
     <dependencies>
+        <!-- https://mvnrepository.com/artifact/software.amazon.awssdk/aws-query-protocol -->
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>aws-query-protocol</artifactId>
+            <version>2.20.138</version>
+        </dependency>
         <dependency>
             <groupId>software.amazon.rds.common</groupId>
             <artifactId>aws-rds-cfn-common</artifactId>

--- a/aws-rds-globalcluster/pom.xml
+++ b/aws-rds-globalcluster/pom.xml
@@ -20,6 +20,12 @@
     </properties>
 
     <dependencies>
+        <!-- https://mvnrepository.com/artifact/software.amazon.awssdk/aws-query-protocol -->
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>aws-query-protocol</artifactId>
+            <version>2.20.138</version>
+        </dependency>
         <dependency>
             <groupId>software.amazon.rds.common</groupId>
             <artifactId>aws-rds-cfn-common</artifactId>

--- a/aws-rds-integration/pom.xml
+++ b/aws-rds-integration/pom.xml
@@ -19,6 +19,12 @@
     </properties>
 
     <dependencies>
+        <!-- https://mvnrepository.com/artifact/software.amazon.awssdk/aws-query-protocol -->
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>aws-query-protocol</artifactId>
+            <version>2.20.138</version>
+        </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>rds</artifactId>

--- a/aws-rds-optiongroup/pom.xml
+++ b/aws-rds-optiongroup/pom.xml
@@ -20,6 +20,12 @@
     </properties>
 
     <dependencies>
+        <!-- https://mvnrepository.com/artifact/software.amazon.awssdk/aws-query-protocol -->
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>aws-query-protocol</artifactId>
+            <version>2.20.138</version>
+        </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>rds</artifactId>


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

When attempting to invoke a newly registered resource, you'll get an exception

```
Resource handler returned message: "software/amazon/awssdk/protocols/query/interceptor/QueryParametersToBodyInterceptor" (RequestToken: 62cbe134-1a8d-1c93-2ec1-70feb14d55cf, HandlerErrorCode: InternalFailure)
```

Adding the aws-query-protocol dependency fixes this.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
