### PR TITLE
[DBClusterParameterGroup] Enforce that "aurora_enhanced_binlog" and "binlog_backup" get bundled in the same ModifyDBParameterGroup request

### DIFF
--- a/aws-rds-dbclusterparametergroup/src/main/java/software/amazon/rds/dbclusterparametergroup/BaseHandlerStd.java
+++ b/aws-rds-dbclusterparametergroup/src/main/java/software/amazon/rds/dbclusterparametergroup/BaseHandlerStd.java
@@ -70,7 +70,8 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
             ImmutableSet.of("gtid-mode", "enforce_gtid_consistency"),
             ImmutableSet.of("password_encryption", "rds.accepted_password_auth_method"),
             ImmutableSet.of("ssl_max_protocol_version", "ssl_min_protocol_version"),
-            ImmutableSet.of("rds.change_data_capture_streaming", "binlog_format")
+            ImmutableSet.of("rds.change_data_capture_streaming", "binlog_format"),
+            ImmutableSet.of("aurora_enhanced_binlog", "binlog_backup")
     );
     protected static final BiFunction<ResourceModel, ProxyClient<RdsClient>, ResourceModel> EMPTY_CALL = (model, proxyClient) -> model;
     protected static final String AVAILABLE = "available";


### PR DESCRIPTION
There are combinations of ParameterGroups that ModifyDBParameterGroup expected them come in the same request, as they are related and configure a particular functionality. At the same time, the ModifyDBParameterGroup API expects a maximum of 20 parameters that can be modified in a single request. (https://docs.aws.amazon.com/cli/latest/reference/rds/modify-db-parameter-group.html)

In the case that the parameters included in the CFN template exceed the request limit, we could end up in a condition in which 2 related parameters existing in the CFN template, end up in 2 different requests. We need to ensure that all related parameters are sent in the same request.