### PR TITLE
fix(DBInstance): handle cases where both previous and desired allocated storage are null

### DIFF
--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/Translator.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/Translator.java
@@ -1076,6 +1076,6 @@ public class Translator {
     }
 
     private static Integer max(Integer a, Integer b) {
-        return a == null ? b : b == null ? a : Math.max(a, b);
+        return a == null ? b : b == null ? a : Integer.valueOf(Math.max(a, b));
     }
 }

--- a/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/TranslatorTest.java
+++ b/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/TranslatorTest.java
@@ -94,6 +94,20 @@ class TranslatorTest extends AbstractHandlerTest {
     }
 
     @Test
+    public void test_modifyDbInstanceRequest_isRollback_NoAllocatedStorage() {
+        final ResourceModel previousModel = RESOURCE_MODEL_BLDR()
+                .allocatedStorage(null)
+                .build();
+        final ResourceModel desiredModel = RESOURCE_MODEL_BLDR()
+                .allocatedStorage(null)
+                .storageType(STORAGE_TYPE_IO1)
+                .build();
+        final Boolean isRollback = true;
+        final ModifyDbInstanceRequest request = Translator.modifyDbInstanceRequest(previousModel, desiredModel, isRollback);
+        assertThat(request.allocatedStorage()).isNull();
+    }
+
+    @Test
     public void test_modifyDbInstanceRequestV12_isRollback_IncreaseAllocatedStorage() {
         final ResourceModel previousModel = RESOURCE_MODEL_BLDR()
                 .allocatedStorage(ALLOCATED_STORAGE.toString())


### PR DESCRIPTION
This change addresses an issue causing DB instance updates to fail during rollback with an InternalFailure. The error message was "Cannot invoke 'java.lang.Integer.intValue()' because 'b' is null". The fix ensures the max() function can handle null inputs.
