### PR TITLE
[DBClusterParameterGroup] Add binlog_replication_globaldb in the same request as binlog_backup and aurora_enhanced_binlog

### DIFF
--- a/aws-rds-dbclusterparametergroup/src/main/java/software/amazon/rds/dbclusterparametergroup/BaseHandlerStd.java
+++ b/aws-rds-dbclusterparametergroup/src/main/java/software/amazon/rds/dbclusterparametergroup/BaseHandlerStd.java
@@ -71,7 +71,7 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
             ImmutableSet.of("password_encryption", "rds.accepted_password_auth_method"),
             ImmutableSet.of("ssl_max_protocol_version", "ssl_min_protocol_version"),
             ImmutableSet.of("rds.change_data_capture_streaming", "binlog_format"),
-            ImmutableSet.of("aurora_enhanced_binlog", "binlog_backup")
+            ImmutableSet.of("aurora_enhanced_binlog", "binlog_backup", "binlog_replication_globaldb")
     );
     protected static final BiFunction<ResourceModel, ProxyClient<RdsClient>, ResourceModel> EMPTY_CALL = (model, proxyClient) -> model;
     protected static final String AVAILABLE = "available";


### PR DESCRIPTION
There is a third parameter "binlog_replication_globaldb" that has to be sent in the same request for DBClusterParameterGroup along with "aurora_enhanced_binlog" and "binlog_backup"