### PR TITLE
fix(DBCluster, DBInstance): remove incorrect defaults from schema

### DIFF
--- a/aws-rds-dbcluster/aws-rds-dbcluster.json
+++ b/aws-rds-dbcluster/aws-rds-dbcluster.json
@@ -88,8 +88,7 @@
     },
     "DBClusterParameterGroupName": {
       "description": "The name of the DB cluster parameter group to associate with this DB cluster.",
-      "type": "string",
-      "default": "default.aurora5.6"
+      "type": "string"
     },
     "DBSubnetGroupName": {
       "description": "A DB subnet group that you want to associate with this DB cluster.",
@@ -174,9 +173,8 @@
       "description": "Contains the secret managed by RDS in AWS Secrets Manager for the master user password."
     },
     "MonitoringInterval": {
-      "description": "The interval, in seconds, between points when Enhanced Monitoring metrics are collected for the DB cluster. To turn off collecting Enhanced Monitoring metrics, specify 0. The default is 0.",
-      "type": "integer",
-      "default": 0
+      "description": "The interval, in seconds, between points when Enhanced Monitoring metrics are collected for the DB cluster. To turn off collecting Enhanced Monitoring metrics, specify 0. The default is not to enable Enhanced Monitoring.",
+      "type": "integer"
     },
     "MonitoringRoleArn": {
       "description": "The Amazon Resource Name (ARN) for the IAM role that permits RDS to send Enhanced Monitoring metrics to Amazon CloudWatch Logs.",
@@ -224,8 +222,7 @@
     },
     "RestoreType": {
       "description": "The type of restore to be performed. You can specify one of the following values:\nfull-copy - The new DB cluster is restored as a full copy of the source DB cluster.\ncopy-on-write - The new DB cluster is restored as a clone of the source DB cluster.",
-      "type": "string",
-      "default": "full-copy"
+      "type": "string"
     },
     "ServerlessV2ScalingConfiguration": {
       "description": "Contains the scaling configuration of an Aurora Serverless v2 DB cluster.",

--- a/aws-rds-dbinstance/aws-rds-dbinstance.json
+++ b/aws-rds-dbinstance/aws-rds-dbinstance.json
@@ -145,7 +145,6 @@
     "BackupRetentionPeriod": {
       "type": "integer",
       "minimum": 0,
-      "default": 1,
       "description": "The number of days for which automated backups are retained. Setting this parameter to a positive number enables backups. Setting this parameter to 0 disables automated backups."
     },
     "CACertificateIdentifier": {
@@ -334,8 +333,7 @@
     },
     "MonitoringInterval": {
       "type": "integer",
-      "default": 0,
-      "description": "The interval, in seconds, between points when Enhanced Monitoring metrics are collected for the DB instance. To disable collecting Enhanced Monitoring metrics, specify 0. The default is 0."
+      "description": "The interval, in seconds, between points when Enhanced Monitoring metrics are collected for the DB instance. To disable collecting Enhanced Monitoring metrics, specify 0. The default is not to enable Enhanced Monitoring."
     },
     "MonitoringRoleArn": {
       "type": "string",
@@ -388,7 +386,6 @@
     "PromotionTier": {
       "type": "integer",
       "minimum": 0,
-      "default": 1,
       "description": "A value that specifies the order in which an Aurora Replica is promoted to the primary instance after a failure of the existing primary instance."
     },
     "PubliclyAccessible": {


### PR DESCRIPTION
Removing incorrect defaults from the schema.

We noticed that some customers use the default values from the schema to fill in missing values. This was never the intended purpose, but because the defaults were wrong, the incorrect values caused resources to fail to create or update.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.