### PR TITLE
fix: make schemas guard rail compliant

### DIFF
--- a/aws-rds-cfn-common/pom.xml
+++ b/aws-rds-cfn-common/pom.xml
@@ -37,6 +37,11 @@
         </dependency>
         <dependency>
             <groupId>software.amazon.cloudformation</groupId>
+            <artifactId>aws-cloudformation-resource-schema</artifactId>
+            <version>[2.0.10,3.0.0)</version>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.cloudformation</groupId>
             <artifactId>aws-cloudformation-rpdk-java-plugin</artifactId>
             <version>[2.0.0,3.0.0)</version>
         </dependency>

--- a/aws-rds-customdbengineversion/aws-rds-customdbengineversion.json
+++ b/aws-rds-customdbengineversion/aws-rds-customdbengineversion.json
@@ -3,7 +3,15 @@
   "description": "The AWS::RDS::CustomDBEngineVersion resource creates an Amazon RDS custom DB engine version.",
   "sourceUrl": "https://github.com/aws-cloudformation/aws-cloudformation-rpdk.git",
   "tagging": {
-    "taggable": true
+    "taggable": true,
+    "tagOnCreate": true,
+    "tagUpdatable": true,
+    "cloudFormationSystemTags": true,
+    "tagProperty": "/properties/Tags",
+    "permissions": [
+      "rds:AddTagsToResource",
+      "rds:RemoveTagsFromResource"
+    ]
   },
   "definitions": {
     "Tag": {

--- a/aws-rds-dbcluster/aws-rds-dbcluster.json
+++ b/aws-rds-dbcluster/aws-rds-dbcluster.json
@@ -431,7 +431,6 @@
     "/properties/Endpoint",
     "/properties/Endpoint/Address",
     "/properties/Endpoint/Port",
-    "/properties/ReadEndpoint/Port",
     "/properties/ReadEndpoint/Address",
     "/properties/MasterUserSecret/SecretArn",
     "/properties/StorageThroughput"
@@ -534,5 +533,16 @@
         "rds:DescribeDBClusters"
       ]
     }
+  },
+  "tagging": {
+    "taggable": true,
+    "tagOnCreate": true,
+    "tagUpdatable": true,
+    "cloudFormationSystemTags": true,
+    "tagProperty": "/properties/Tags",
+    "permissions": [
+      "rds:AddTagsToResource",
+      "rds:RemoveTagsFromResource"
+    ]
   }
 }

--- a/aws-rds-dbclusterendpoint/aws-rds-dbclusterendpoint.json
+++ b/aws-rds-dbclusterendpoint/aws-rds-dbclusterendpoint.json
@@ -3,7 +3,15 @@
   "description": "The AWS::RDS::DBClusterEndpoint resource allows you to create custom Aurora Cluster endpoint. For more information, see Using custom endpoints in the Amazon RDS Aurora Guide.",
   "sourceUrl": "https://github.com/aws-cloudformation/aws-cloudformation-resource-providers-rds",
   "tagging": {
-    "taggable": true
+    "taggable": true,
+    "tagOnCreate": true,
+    "tagUpdatable": true,
+    "cloudFormationSystemTags": true,
+    "tagProperty": "/properties/Tags",
+    "permissions": [
+      "rds:AddTagsToResource",
+      "rds:RemoveTagsFromResource"
+    ]
   },
   "definitions": {
     "Tag": {

--- a/aws-rds-dbclusterparametergroup/aws-rds-dbclusterparametergroup.json
+++ b/aws-rds-dbclusterparametergroup/aws-rds-dbclusterparametergroup.json
@@ -118,5 +118,16 @@
         "rds:DescribeDBClusterParameterGroups"
       ]
     }
+  },
+  "tagging": {
+    "taggable": true,
+    "tagOnCreate": true,
+    "tagUpdatable": true,
+    "cloudFormationSystemTags": true,
+    "tagProperty": "/properties/Tags",
+    "permissions": [
+      "rds:AddTagsToResource",
+      "rds:RemoveTagsFromResource"
+    ]
   }
 }

--- a/aws-rds-dbinstance/aws-rds-dbinstance.json
+++ b/aws-rds-dbinstance/aws-rds-dbinstance.json
@@ -660,5 +660,16 @@
         "rds:DescribeDBInstances"
       ]
     }
+  },
+  "tagging": {
+    "taggable": true,
+    "tagOnCreate": true,
+    "tagUpdatable": true,
+    "cloudFormationSystemTags": true,
+    "tagProperty": "/properties/Tags",
+    "permissions": [
+      "rds:AddTagsToResource",
+      "rds:RemoveTagsFromResource"
+    ]
   }
 }

--- a/aws-rds-dbparametergroup/aws-rds-dbparametergroup.json
+++ b/aws-rds-dbparametergroup/aws-rds-dbparametergroup.json
@@ -115,5 +115,16 @@
         "rds:DescribeDBParameterGroups"
       ]
     }
+  },
+  "tagging": {
+    "taggable": true,
+    "tagOnCreate": true,
+    "tagUpdatable": true,
+    "cloudFormationSystemTags": true,
+    "tagProperty": "/properties/Tags",
+    "permissions": [
+      "rds:AddTagsToResource",
+      "rds:RemoveTagsFromResource"
+    ]
   }
 }

--- a/aws-rds-dbsubnetgroup/aws-rds-dbsubnetgroup.json
+++ b/aws-rds-dbsubnetgroup/aws-rds-dbsubnetgroup.json
@@ -106,5 +106,16 @@
         "rds:DescribeDBSubnetGroups"
       ]
     }
+  },
+  "tagging": {
+    "taggable": true,
+    "tagOnCreate": true,
+    "tagUpdatable": true,
+    "cloudFormationSystemTags": true,
+    "tagProperty": "/properties/Tags",
+    "permissions": [
+      "rds:AddTagsToResource",
+      "rds:RemoveTagsFromResource"
+    ]
   }
 }

--- a/aws-rds-eventsubscription/aws-rds-eventsubscription.json
+++ b/aws-rds-eventsubscription/aws-rds-eventsubscription.json
@@ -126,5 +126,16 @@
         "rds:DescribeEventSubscriptions"
       ]
     }
+  },
+  "tagging": {
+    "taggable": true,
+    "tagOnCreate": true,
+    "tagUpdatable": true,
+    "cloudFormationSystemTags": true,
+    "tagProperty": "/properties/Tags",
+    "permissions": [
+      "rds:AddTagsToResource",
+      "rds:RemoveTagsFromResource"
+    ]
   }
 }

--- a/aws-rds-globalcluster/aws-rds-globalcluster.json
+++ b/aws-rds-globalcluster/aws-rds-globalcluster.json
@@ -103,5 +103,8 @@
         "rds:DescribeGlobalClusters"
       ]
     }
+  },
+  "tagging": {
+    "taggable": false
   }
 }

--- a/aws-rds-integration/aws-rds-integration.json
+++ b/aws-rds-integration/aws-rds-integration.json
@@ -162,7 +162,12 @@
     "taggable": true,
     "tagOnCreate": true,
     "tagUpdatable": true,
-    "tagProperty": "/properties/Tags"
+    "cloudFormationSystemTags": true,
+    "tagProperty": "/properties/Tags",
+    "permissions": [
+      "rds:AddTagsToResource",
+      "rds:RemoveTagsFromResource"
+    ]
   },
   "additionalProperties": false
 }

--- a/aws-rds-optiongroup/aws-rds-optiongroup.json
+++ b/aws-rds-optiongroup/aws-rds-optiongroup.json
@@ -182,5 +182,16 @@
         "rds:DescribeOptionGroups"
       ]
     }
+  },
+  "tagging": {
+    "taggable": true,
+    "tagOnCreate": true,
+    "tagUpdatable": true,
+    "cloudFormationSystemTags": true,
+    "tagProperty": "/properties/Tags",
+    "permissions": [
+      "rds:AddTagsToResource",
+      "rds:RemoveTagsFromResource"
+    ]
   }
 }


### PR DESCRIPTION
This change updates the RDS resource schemas to be compliant with the CFN guard rail rules.

Specific changes are:
- Added tagging element to all schemas.
- Removed non-existent property from DBCluster readOnlyProperties.
- Updated aws-cloudformation-resource-schema to 2.0.10, required for tagging permissions in the schema.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
