### PR TITLE
[DBInstance] Add region validation for the attributes AutomaticBackup…

### DIFF
--- a/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/CreateHandlerTest.java
+++ b/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/CreateHandlerTest.java
@@ -2258,4 +2258,84 @@ public class CreateHandlerTest extends AbstractHandlerTest {
                 expectFailed(HandlerErrorCode.InvalidRequest)
         );
     }
+
+    @Test
+    public void invalidSourceRegion() {
+        expectServiceInvocation = false;
+        final CallbackContext context = new CallbackContext();
+        context.setCreated(true);
+        context.setUpdated(true);
+        context.setRebooted(true);
+        context.setUpdatedRoles(true);
+        context.setAddTagsComplete(true);
+
+        test_handleRequest_base(
+                context,
+                null,
+                () -> RESOURCE_MODEL_BAREBONE_BLDR()
+                        .sourceRegion("clearlyNotAValidRegion")
+                        .build(),
+                expectFailed(HandlerErrorCode.InvalidRequest)
+        );
+    }
+
+    @Test
+    public void invalidAutomaticBackupReplicationRegion() {
+        expectServiceInvocation = false;
+        final CallbackContext context = new CallbackContext();
+        context.setCreated(true);
+        context.setUpdated(true);
+        context.setRebooted(true);
+        context.setUpdatedRoles(true);
+        context.setAddTagsComplete(true);
+
+        test_handleRequest_base(
+                context,
+                null,
+                () -> RESOURCE_MODEL_BAREBONE_BLDR()
+                        .automaticBackupReplicationRegion("clearlyNotAValidRegion")
+                        .build(),
+                expectFailed(HandlerErrorCode.InvalidRequest)
+        );
+    }
+
+    @Test
+    public void invalidSourceDBInstanceIdentifierRegion() {
+        expectServiceInvocation = false;
+        final CallbackContext context = new CallbackContext();
+        context.setCreated(true);
+        context.setUpdated(true);
+        context.setRebooted(true);
+        context.setUpdatedRoles(true);
+        context.setAddTagsComplete(true);
+
+        test_handleRequest_base(
+                context,
+                null,
+                () -> RESOURCE_MODEL_BAREBONE_BLDR()
+                        .sourceDBInstanceIdentifier("arn:aws:rds:clearlyNotAValidRegion:340834135580:db:databaseName")
+                        .build(),
+                expectFailed(HandlerErrorCode.InvalidRequest)
+        );
+    }
+
+    @Test
+    public void invalidSourceDBClusterIdentifierRegion() {
+        expectServiceInvocation = false;
+        final CallbackContext context = new CallbackContext();
+        context.setCreated(true);
+        context.setUpdated(true);
+        context.setRebooted(true);
+        context.setUpdatedRoles(true);
+        context.setAddTagsComplete(true);
+
+        test_handleRequest_base(
+                context,
+                null,
+                () -> RESOURCE_MODEL_BAREBONE_BLDR()
+                        .sourceDBClusterIdentifier("arn:aws:rds:clearlyNotAValidRegion:340834135580:cluster:clusterName")
+                        .build(),
+                expectFailed(HandlerErrorCode.InvalidRequest)
+        );
+    }
 }


### PR DESCRIPTION
AWS::RDS::DBInstance takes an AWS region name as input without validation and passes it directly into the AWS Java SDK v2 client. This can be specified in the AutomaticBackupReplicationRegion, SourceDBInstanceIdentifier, SourceDBClusterIdentifier properties.

The consequence of not validating this field is both a possible security issue where you could try to hit user-specified URLs, and also when it fails, it gives back a non-friendly error response to the client, making it hard to troubleshoot.