### PR TITLE
fix(DBCluster): fix local write forwarding error on cluster update (c…

### DIFF
--- a/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/Translator.java
+++ b/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/Translator.java
@@ -275,7 +275,6 @@ public class Translator {
                 .domainIAMRoleName(desiredModel.getDomainIAMRoleName())
                 .enableGlobalWriteForwarding(desiredModel.getEnableGlobalWriteForwarding())
                 .enableIAMDatabaseAuthentication(diff(previousModel.getEnableIAMDatabaseAuthentication(), desiredModel.getEnableIAMDatabaseAuthentication()))
-                .enableLocalWriteForwarding(diff(previousModel.getEnableLocalWriteForwarding(), desiredModel.getEnableLocalWriteForwarding()))
                 .enablePerformanceInsights(desiredModel.getPerformanceInsightsEnabled())
                 .iops(desiredModel.getIops())
                 .masterUserPassword(diff(previousModel.getMasterUserPassword(), desiredModel.getMasterUserPassword()))
@@ -295,6 +294,13 @@ public class Translator {
                         )
                 )
                 .storageType(desiredModel.getStorageType());
+
+        if (previousModel.getEnableLocalWriteForwarding() == null && desiredModel.getEnableLocalWriteForwarding() == Boolean.FALSE) {
+            // RDS disables LocalWriteForwarding by default, so no need to set the value in the modify request.
+            builder.enableLocalWriteForwarding(null);
+        } else {
+            builder.enableLocalWriteForwarding(diff(previousModel.getEnableLocalWriteForwarding(), desiredModel.getEnableLocalWriteForwarding()));
+        }
 
         if (!(isRollback || Objects.equals(previousModel.getEngineVersion(), desiredModel.getEngineVersion()))) {
             builder.engineVersion(desiredModel.getEngineVersion());

--- a/aws-rds-dbcluster/src/test/java/software/amazon/rds/dbcluster/TranslatorTest.java
+++ b/aws-rds-dbcluster/src/test/java/software/amazon/rds/dbcluster/TranslatorTest.java
@@ -244,23 +244,53 @@ public class TranslatorTest extends AbstractHandlerTest {
         assertThat(request.serverlessV2ScalingConfiguration()).isEqualTo(null);
     }
 
+    /*
+     * The test case verifies the following truth table:
+     * | previousModel | desiredModel | LWF in the request|
+     * | null          | null         | null              |
+     * | true          | null         | null              |
+     * | false         | null         | null              |
+     * | null          | true         | true              |
+     * | true          | true         | null              |
+     * | false         | true         | true              |
+     * | null          | false        | null              |
+     * | true          | false        | false             |
+     * | false         | false        | null              |
+     */
     @Test
     public void modifyDbClusterRequest_enableLocalWriteForwarding() {
-        final var previousModel = RESOURCE_MODEL.toBuilder().enableLocalWriteForwarding(null).build();
+        final var modelNull = RESOURCE_MODEL.toBuilder().enableLocalWriteForwarding(null).build();
+        final var modelTrue = RESOURCE_MODEL.toBuilder().enableLocalWriteForwarding(true).build();
+        final var modelFalse = RESOURCE_MODEL.toBuilder().enableLocalWriteForwarding(false).build();
 
-        final var desiredModel = RESOURCE_MODEL.toBuilder().enableLocalWriteForwarding(true).build();
-
-        final var request = Translator.modifyDbClusterRequest(previousModel, desiredModel, IS_NOT_ROLLBACK);
-        assertThat(request.enableLocalWriteForwarding()).isEqualTo(true);
-    }
-
-    @Test
-    public void modifyDbClusterRequest_sameLocalWriteForwarding() {
-        final var previousModel = RESOURCE_MODEL.toBuilder().enableLocalWriteForwarding(false).build();
-        final var desiredModel = RESOURCE_MODEL.toBuilder().enableLocalWriteForwarding(false).build();
-
-        final var request = Translator.modifyDbClusterRequest(previousModel, desiredModel, IS_NOT_ROLLBACK);
+        var request = Translator.modifyDbClusterRequest(modelNull, modelNull, IS_NOT_ROLLBACK);
         assertThat(request.enableLocalWriteForwarding()).isNull();
+
+        request = Translator.modifyDbClusterRequest(modelTrue, modelNull, IS_NOT_ROLLBACK);
+        assertThat(request.enableLocalWriteForwarding()).isNull();
+
+        request = Translator.modifyDbClusterRequest(modelFalse, modelNull, IS_NOT_ROLLBACK);
+        assertThat(request.enableLocalWriteForwarding()).isNull();
+
+        request = Translator.modifyDbClusterRequest(modelNull, modelTrue, IS_NOT_ROLLBACK);
+        assertThat(request.enableLocalWriteForwarding()).isEqualTo(true);
+
+        request = Translator.modifyDbClusterRequest(modelTrue, modelTrue, IS_NOT_ROLLBACK);
+        assertThat(request.enableLocalWriteForwarding()).isNull();
+
+        request = Translator.modifyDbClusterRequest(modelFalse, modelTrue, IS_NOT_ROLLBACK);
+        assertThat(request.enableLocalWriteForwarding()).isEqualTo(true);
+
+
+        request = Translator.modifyDbClusterRequest(modelNull, modelFalse, IS_NOT_ROLLBACK);
+        assertThat(request.enableLocalWriteForwarding()).isNull();
+
+        request = Translator.modifyDbClusterRequest(modelTrue, modelFalse, IS_NOT_ROLLBACK);
+        assertThat(request.enableLocalWriteForwarding()).isEqualTo(false);
+
+        request = Translator.modifyDbClusterRequest(modelFalse, modelFalse, IS_NOT_ROLLBACK);
+        assertThat(request.enableLocalWriteForwarding()).isNull();
+
     }
 
     @Test


### PR DESCRIPTION
This is a continuation for PR #552 which to fix an issue causing resource updates to fail with a "Local Write Forwarding is already disabled/enabled on cluster" error. Since RDS disables LocalWriteForwarding by default, so no need to set the value in the modify request.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
