### PR TITLE
fix(DBCluster): fix local write forwarding error on cluster update (c…

### DIFF
--- a/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/Translator.java
+++ b/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/Translator.java
@@ -275,7 +275,6 @@ public class Translator {
                 .domainIAMRoleName(desiredModel.getDomainIAMRoleName())
                 .enableGlobalWriteForwarding(desiredModel.getEnableGlobalWriteForwarding())
                 .enableIAMDatabaseAuthentication(diff(previousModel.getEnableIAMDatabaseAuthentication(), desiredModel.getEnableIAMDatabaseAuthentication()))
-                .enableLocalWriteForwarding(diff(previousModel.getEnableLocalWriteForwarding(), desiredModel.getEnableLocalWriteForwarding()))
                 .enablePerformanceInsights(desiredModel.getPerformanceInsightsEnabled())
                 .iops(desiredModel.getIops())
                 .masterUserPassword(diff(previousModel.getMasterUserPassword(), desiredModel.getMasterUserPassword()))
@@ -295,6 +294,18 @@ public class Translator {
                         )
                 )
                 .storageType(desiredModel.getStorageType());
+
+        if (previousModel.getEnableLocalWriteForwarding() == null && desiredModel.getEnableLocalWriteForwarding() == Boolean.FALSE) {
+            // RDS disables LocalWriteForwarding by default. Therefore, if the previous model is null and the desired model is false,
+            // do not set the value in the modify request to maintain the status as false.
+            builder.enableLocalWriteForwarding(null);
+        } else if (previousModel.getEnableLocalWriteForwarding() == Boolean.TRUE && desiredModel.getEnableLocalWriteForwarding() == null) {
+            // By default, RDS disables LocalWriteForwarding when the property is null. Therefore, if the previous model is true and the desired model is null,
+            // need to explicitly set the value in the modify request to update the status to false.
+            builder.enableLocalWriteForwarding(false);
+        } else {
+            builder.enableLocalWriteForwarding(diff(previousModel.getEnableLocalWriteForwarding(), desiredModel.getEnableLocalWriteForwarding()));
+        }
 
         if (!(isRollback || Objects.equals(previousModel.getEngineVersion(), desiredModel.getEngineVersion()))) {
             builder.engineVersion(desiredModel.getEngineVersion());

--- a/aws-rds-dbcluster/src/test/java/software/amazon/rds/dbcluster/TranslatorTest.java
+++ b/aws-rds-dbcluster/src/test/java/software/amazon/rds/dbcluster/TranslatorTest.java
@@ -244,23 +244,53 @@ public class TranslatorTest extends AbstractHandlerTest {
         assertThat(request.serverlessV2ScalingConfiguration()).isEqualTo(null);
     }
 
+    /*
+     * The test case verifies the following truth table:
+     * | previousModel | desiredModel | LWF in the request|
+     * | null          | null         | null              |
+     * | true          | null         | false             |
+     * | false         | null         | null              |
+     * | null          | true         | true              |
+     * | true          | true         | null              |
+     * | false         | true         | true              |
+     * | null          | false        | null              |
+     * | true          | false        | false             |
+     * | false         | false        | null              |
+     */
     @Test
     public void modifyDbClusterRequest_enableLocalWriteForwarding() {
-        final var previousModel = RESOURCE_MODEL.toBuilder().enableLocalWriteForwarding(null).build();
+        final var modelNull = RESOURCE_MODEL.toBuilder().enableLocalWriteForwarding(null).build();
+        final var modelTrue = RESOURCE_MODEL.toBuilder().enableLocalWriteForwarding(true).build();
+        final var modelFalse = RESOURCE_MODEL.toBuilder().enableLocalWriteForwarding(false).build();
 
-        final var desiredModel = RESOURCE_MODEL.toBuilder().enableLocalWriteForwarding(true).build();
-
-        final var request = Translator.modifyDbClusterRequest(previousModel, desiredModel, IS_NOT_ROLLBACK);
-        assertThat(request.enableLocalWriteForwarding()).isEqualTo(true);
-    }
-
-    @Test
-    public void modifyDbClusterRequest_sameLocalWriteForwarding() {
-        final var previousModel = RESOURCE_MODEL.toBuilder().enableLocalWriteForwarding(false).build();
-        final var desiredModel = RESOURCE_MODEL.toBuilder().enableLocalWriteForwarding(false).build();
-
-        final var request = Translator.modifyDbClusterRequest(previousModel, desiredModel, IS_NOT_ROLLBACK);
+        var request = Translator.modifyDbClusterRequest(modelNull, modelNull, IS_NOT_ROLLBACK);
         assertThat(request.enableLocalWriteForwarding()).isNull();
+
+        request = Translator.modifyDbClusterRequest(modelTrue, modelNull, IS_NOT_ROLLBACK);
+        assertThat(request.enableLocalWriteForwarding()).isEqualTo(false);
+
+        request = Translator.modifyDbClusterRequest(modelFalse, modelNull, IS_NOT_ROLLBACK);
+        assertThat(request.enableLocalWriteForwarding()).isNull();
+
+        request = Translator.modifyDbClusterRequest(modelNull, modelTrue, IS_NOT_ROLLBACK);
+        assertThat(request.enableLocalWriteForwarding()).isEqualTo(true);
+
+        request = Translator.modifyDbClusterRequest(modelTrue, modelTrue, IS_NOT_ROLLBACK);
+        assertThat(request.enableLocalWriteForwarding()).isNull();
+
+        request = Translator.modifyDbClusterRequest(modelFalse, modelTrue, IS_NOT_ROLLBACK);
+        assertThat(request.enableLocalWriteForwarding()).isEqualTo(true);
+
+
+        request = Translator.modifyDbClusterRequest(modelNull, modelFalse, IS_NOT_ROLLBACK);
+        assertThat(request.enableLocalWriteForwarding()).isNull();
+
+        request = Translator.modifyDbClusterRequest(modelTrue, modelFalse, IS_NOT_ROLLBACK);
+        assertThat(request.enableLocalWriteForwarding()).isEqualTo(false);
+
+        request = Translator.modifyDbClusterRequest(modelFalse, modelFalse, IS_NOT_ROLLBACK);
+        assertThat(request.enableLocalWriteForwarding()).isNull();
+
     }
 
     @Test


### PR DESCRIPTION
This is a continuation for PR #552 which to fix an issue causing resource updates to fail with a "Local Write Forwarding is already disabled/enabled on cluster" error. 

This issue occurs because RDS validates the `enableLocalWriteForwarding` variable and will throw an exception if it is already disabled/enabled but still receives the same value in the modify request. PR #552 introduced a fix to set `enableLocalWriteForwarding` in the modify request only when this property is actually changing in the CFN template. However, there are two issues remaining:

1. Transforming the property from `null -> false` still encounters an 'already disabled' exception because CFN passes `false` to the modify request when the status is already `false`.
2. Transforming the property from `true -> null` fails to update the LocalWriteForwarding status to disabled. This occurs because CFN passes `null` to the modify request, which results in RDS not updating the status.

This fix did the following:

1. Explicitly set `enableLocalWriteForwarding: null` when the property is from `null -> false`, allows RDS to retain the status as `false` without throwing an exception."
2. Explicitly set `enableLocalWriteForwarding: false` when the property is from `true -> null`, forces RDS to update the status to `false`.

Below is the truth table after the fix:

PreviousCFNValue | DesiredCFNValue | ValueInModifyRequest | CurrentDBClusterState | DesiredDBClusterState
-- | -- | -- | -- | --
null | null | null | false | false
true | null | false | true | false
false | null | null | false | false
null | true | true | false | true
true | true | null | true | true
false | true | true | false | true
null | false | null | false | false
true | false | false | true | false
false | false | null | false | false



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
