### PR TITLE
[DBCluster] Support EnableHttpEndpoint for Aurora MySQL engine to support Data Api

### DIFF
--- a/aws-rds-dbcluster/aws-rds-dbcluster.json
+++ b/aws-rds-dbcluster/aws-rds-dbcluster.json
@@ -410,7 +410,7 @@
     "/properties/DBClusterIdentifier": "$lowercase(DBClusterIdentifier)",
     "/properties/DBClusterParameterGroupName": "$lowercase(DBClusterParameterGroupName)",
     "/properties/DBSubnetGroupName": "$lowercase(DBSubnetGroupName)",
-    "/properties/EnableHttpEndpoint": "$lowercase($string(EngineMode)) = 'serverless' ? EnableHttpEndpoint : ($lowercase($string(Engine)) = 'aurora-postgresql' ? EnableHttpEndpoint : false )",
+    "/properties/EnableHttpEndpoint": "$lowercase($string(EngineMode)) = 'serverless' ? EnableHttpEndpoint : ($lowercase($string(Engine)) in ['aurora-postgresql', 'aurora-mysql'] ? EnableHttpEndpoint : false )",
     "/properties/Engine": "$lowercase(Engine)",
     "/properties/EngineVersion": "$join([$string(EngineVersion), \".*\"])",
     "/properties/KmsKeyId": "$join([\"arn:(aws)[-]{0,1}[a-z]{0,2}[-]{0,1}[a-z]{0,3}:kms:[a-z]{2}[-]{1}[a-z]{3,10}[-]{0,1}[a-z]{0,10}[-]{1}[1-3]{1}:[0-9]{12}[:]{1}key\\/\", KmsKeyId])",

--- a/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/BaseHandlerStd.java
+++ b/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/BaseHandlerStd.java
@@ -94,6 +94,7 @@ import software.amazon.rds.common.request.Validations;
 public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
     public static final String RESOURCE_IDENTIFIER = "dbcluster";
     public static final String ENGINE_AURORA_POSTGRESQL = "aurora-postgresql";
+    public static final String ENGINE_AURORA_MYSQL = "aurora-mysql";
     private static final String MASTER_USER_SECRET_ACTIVE = "active";
     protected static final String DB_CLUSTER_REQUEST_STARTED_AT = "dbcluster-request-started-at";
     protected static final String DB_CLUSTER_REQUEST_IN_PROGRESS_AT = "dbcluster-request-in-progress-at";
@@ -729,7 +730,7 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
     }
 
     protected boolean shouldUpdateHttpEndpointV2(final ResourceModel previousState, final ResourceModel desiredState) {
-        return ENGINE_AURORA_POSTGRESQL.equalsIgnoreCase(desiredState.getEngine()) &&
+        return (ENGINE_AURORA_POSTGRESQL.equalsIgnoreCase(desiredState.getEngine()) || ENGINE_AURORA_MYSQL.equalsIgnoreCase(desiredState.getEngine())) &&
                 !EngineMode.Serverless.equals(EngineMode.fromString(desiredState.getEngineMode())) &&
                 ObjectUtils.notEqual(previousState.getEnableHttpEndpoint(), desiredState.getEnableHttpEndpoint());
     }

--- a/aws-rds-dbcluster/src/test/java/software/amazon/rds/dbcluster/SchemaTest.java
+++ b/aws-rds-dbcluster/src/test/java/software/amazon/rds/dbcluster/SchemaTest.java
@@ -156,6 +156,21 @@ class SchemaTest {
     }
 
     @Test
+    void testDrift_EnableHttpEndpoint_Aurora_Mysql_Drifted() {
+        final ResourceModel input = ResourceModel.builder()
+                .enableHttpEndpoint(true)
+                .engine("aurora-mysql")
+                .build();
+        final ResourceModel output = ResourceModel.builder()
+                .enableHttpEndpoint(false)
+                .engine("aurora-mysql")
+                .build();
+        Assertions.assertThatThrownBy(() -> {
+            assertResourceNotDrifted(input, output, resourceSchema);
+        }).isInstanceOf(AssertionError.class);
+    }
+
+    @Test
     void testDrift_EnableHttpEndpoint_Provisioned() {
         final ResourceModel input = ResourceModel.builder()
                 .enableHttpEndpoint(true)


### PR DESCRIPTION
*Description of changes:*

Update DBCluster handler to support EnableHttpEndpoint for Aurora MySQL engine to support Data Api.

Ref: https://aws.amazon.com/about-aws/whats-new/2024/09/amazon-aurora-mysql-rds-data-api/

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
