### PR TITLE
[DBInstance] - Port should not be createOnly/writeOnlyProperty

### DIFF
--- a/aws-rds-dbinstance/aws-rds-dbinstance.json
+++ b/aws-rds-dbinstance/aws-rds-dbinstance.json
@@ -502,7 +502,6 @@
     "/properties/KmsKeyId",
     "/properties/MasterUsername",
     "/properties/NcharCharacterSetName",
-    "/properties/Port",
     "/properties/SourceRegion",
     "/properties/StorageEncrypted",
     "/properties/Timezone"
@@ -537,7 +536,6 @@
     "/properties/DBSnapshotIdentifier",
     "/properties/DeleteAutomatedBackups",
     "/properties/MasterUserPassword",
-    "/properties/Port",
     "/properties/RestoreTime",
     "/properties/SourceDBInstanceAutomatedBackupsArn",
     "/properties/SourceDBInstanceIdentifier",

--- a/aws-rds-dbinstance/docs/README.md
+++ b/aws-rds-dbinstance/docs/README.md
@@ -773,7 +773,7 @@ _Type_: String
 
 _Pattern_: <code>^\d*$</code>
 
-_Update requires_: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 
 #### PreferredBackupWindow
 


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

Port can be modified in-place by modify-db-instance: https://docs.aws.amazon.com/cli/latest/reference/rds/modify-db-instance.html

It does not need to be a replacement operation.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
