### PR TITLE
[DBInstance] Support for Oracle Multitenant SID

### DIFF
--- a/aws-rds-dbinstance/aws-rds-dbinstance.json
+++ b/aws-rds-dbinstance/aws-rds-dbinstance.json
@@ -480,6 +480,7 @@
     "/properties/DBParameterGroupName": "$lowercase(DBParameterGroupName)",
     "/properties/DBSnapshotIdentifier": "$lowercase(DBSnapshotIdentifier)",
     "/properties/DBSubnetGroupName": "$lowercase(DBSubnetGroupName)",
+    "/properties/DBSystemId": "$uppercase(DBSystemId)",
     "/properties/Engine": "$lowercase(Engine)",
     "/properties/EngineVersion": "$join([$string(EngineVersion), \".*\"])",
     "/properties/KmsKeyId": "$join([\"arn:.+?:kms:.+?:.+?:key\\/\", KmsKeyId])",
@@ -499,6 +500,7 @@
     "/properties/DBInstanceIdentifier",
     "/properties/DBName",
     "/properties/DBSubnetGroupName",
+    "/properties/DBSystemId",
     "/properties/KmsKeyId",
     "/properties/MasterUsername",
     "/properties/NcharCharacterSetName",
@@ -551,7 +553,6 @@
     "/properties/Endpoint/HostedZoneId",
     "/properties/DbiResourceId",
     "/properties/DBInstanceArn",
-    "/properties/DBSystemId",
     "/properties/MasterUserSecret/SecretArn",
     "/properties/CertificateDetails/CAIdentifier",
     "/properties/CertificateDetails/ValidTill"

--- a/aws-rds-dbinstance/docs/README.md
+++ b/aws-rds-dbinstance/docs/README.md
@@ -35,6 +35,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
         "<a href="#dbsecuritygroups" title="DBSecurityGroups">DBSecurityGroups</a>" : <i>[ String, ... ]</i>,
         "<a href="#dbsnapshotidentifier" title="DBSnapshotIdentifier">DBSnapshotIdentifier</a>" : <i>String</i>,
         "<a href="#dbsubnetgroupname" title="DBSubnetGroupName">DBSubnetGroupName</a>" : <i>String</i>,
+        "<a href="#dbsystemid" title="DBSystemId">DBSystemId</a>" : <i>String</i>,
         "<a href="#dedicatedlogvolume" title="DedicatedLogVolume">DedicatedLogVolume</a>" : <i>Boolean</i>,
         "<a href="#deleteautomatedbackups" title="DeleteAutomatedBackups">DeleteAutomatedBackups</a>" : <i>Boolean</i>,
         "<a href="#deletionprotection" title="DeletionProtection">DeletionProtection</a>" : <i>Boolean</i>,
@@ -124,6 +125,7 @@ Properties:
       - String</i>
     <a href="#dbsnapshotidentifier" title="DBSnapshotIdentifier">DBSnapshotIdentifier</a>: <i>String</i>
     <a href="#dbsubnetgroupname" title="DBSubnetGroupName">DBSubnetGroupName</a>: <i>String</i>
+    <a href="#dbsystemid" title="DBSystemId">DBSystemId</a>: <i>String</i>
     <a href="#dedicatedlogvolume" title="DedicatedLogVolume">DedicatedLogVolume</a>: <i>Boolean</i>
     <a href="#deleteautomatedbackups" title="DeleteAutomatedBackups">DeleteAutomatedBackups</a>: <i>Boolean</i>
     <a href="#deletionprotection" title="DeletionProtection">DeletionProtection</a>: <i>Boolean</i>
@@ -441,6 +443,16 @@ _Type_: String
 
 _Update requires_: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
 
+#### DBSystemId
+
+The Oracle system ID (Oracle SID) for a container database (CDB). The Oracle SID is also the name of the CDB. This setting is valid for RDS Custom only.
+
+_Required_: No
+
+_Type_: String
+
+_Update requires_: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
+
 #### DedicatedLogVolume
 
 Indicates whether the DB instance has a dedicated log volume (DLV) enabled.
@@ -587,7 +599,7 @@ _Required_: No
 
 _Type_: String
 
-_Update requires_: [Some interruptions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-some-interrupt)
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 
 #### EngineVersion
 
@@ -1026,10 +1038,6 @@ The AWS Region-unique, immutable identifier for the DB instance. This identifier
 #### DBInstanceArn
 
 The Amazon Resource Name (ARN) for the DB instance.
-
-#### DBSystemId
-
-The Oracle system ID (Oracle SID) for a container database (CDB). The Oracle SID is also the name of the CDB. This setting is valid for RDS Custom only.
 
 #### SecretArn
 

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/CreateHandler.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/CreateHandler.java
@@ -32,6 +32,7 @@ import software.amazon.rds.dbinstance.client.ApiVersion;
 import software.amazon.rds.dbinstance.client.RdsClientProvider;
 import software.amazon.rds.dbinstance.client.VersionedProxyClient;
 import software.amazon.rds.dbinstance.util.ResourceModelHelper;
+import software.amazon.rds.dbinstance.validators.OracleCustomSystemId;
 
 public class CreateHandler extends BaseHandlerStd {
 
@@ -56,6 +57,8 @@ public class CreateHandler extends BaseHandlerStd {
         super.validateRequest(request);
         validateDeletionPolicyForClusterInstance(request);
         Validations.validateTimestamp(request.getDesiredResourceState().getRestoreTime());
+
+        OracleCustomSystemId.validateRequest(request.getDesiredResourceState());
     }
 
     private void validateDeletionPolicyForClusterInstance(final ResourceHandlerRequest<ResourceModel> request) throws RequestValidationException {

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/Translator.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/Translator.java
@@ -290,6 +290,7 @@ public class Translator {
                 .dbName(model.getDBName())
                 .dbParameterGroupName(model.getDBParameterGroupName())
                 .dbSubnetGroupName(model.getDBSubnetGroupName())
+                .dbSystemId(model.getDBSystemId())
                 .dedicatedLogVolume(model.getDedicatedLogVolume())
                 .deletionProtection(model.getDeletionProtection())
                 .domain(model.getDomain())

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/client/RdsClientProvider.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/client/RdsClientProvider.java
@@ -17,6 +17,7 @@ import software.amazon.awssdk.services.rds.RdsClientBuilder;
 import software.amazon.rds.common.client.BaseSdkClientProvider;
 import software.amazon.rds.common.client.RdsUserAgentProvider;
 
+
 public class RdsClientProvider extends BaseSdkClientProvider<RdsClientBuilder, RdsClient> {
 
     public static final String VERSION_QUERY_PARAM = "Version";

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/validators/OracleCustomSystemId.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/validators/OracleCustomSystemId.java
@@ -1,0 +1,21 @@
+package software.amazon.rds.dbinstance.validators;
+
+import software.amazon.rds.common.request.RequestValidationException;
+import software.amazon.rds.dbinstance.ResourceModel;
+import software.amazon.rds.dbinstance.util.ResourceModelHelper;
+
+public class OracleCustomSystemId {
+    public static void validateRequest(final ResourceModel model) throws RequestValidationException {
+        if (ResourceModelHelper.isRestoreToPointInTime(model) && model.getDBSystemId() != null) {
+            throw new RequestValidationException("Cannot set DBSystemId when restoring to point in time");
+        }
+
+        if (ResourceModelHelper.isDBInstanceReadReplica(model) && model.getDBSystemId() != null) {
+            throw new RequestValidationException("Cannot set DBSystemId when creating read replica");
+        }
+
+        if (ResourceModelHelper.isRestoreFromSnapshot(model) && model.getDBSystemId() != null) {
+            throw new RequestValidationException("Cannot set DBSystemId when restoring from snapshot");
+        }
+    }
+}

--- a/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/AbstractHandlerTest.java
+++ b/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/AbstractHandlerTest.java
@@ -95,6 +95,7 @@ public abstract class AbstractHandlerTest extends AbstractTestBase<DBInstance, R
     protected static final String DB_INSTANCE_STATUS_MODIFYING = "modifying";
     protected static final String DB_INSTANCE_STATUS_FAILED = "failed";
     protected static final String DB_INSTANCE_STATUS_STORAGE_FULL = "storage-full";
+    protected static final String DB_INSTANCE_SYSTEM_ID = "UNITTEST";
     protected static final String DB_NAME = "db-instance-db-name";
     protected static final String DB_PARAMETER_GROUP_NAME_DEFAULT = "default";
     protected static final String DB_PARAMETER_GROUP_NAME_ALTER = "alternative-parameter-group";
@@ -207,6 +208,7 @@ public abstract class AbstractHandlerTest extends AbstractTestBase<DBInstance, R
 
     static final DBInstance DB_INSTANCE_BASE;
     static final DBInstance DB_INSTANCE_ACTIVE;
+    static final DBInstance DB_INSTANCE_ACTIVE_SYSTEM_ID;
     static final DBInstance DB_INSTANCE_AURORA_ACTIVE;
     static final DBInstance DB_INSTANCE_SQLSERVER_ACTIVE;
     static final DBInstance DB_INSTANCE_READ_REPLICA_ACTIVE;
@@ -575,6 +577,8 @@ public abstract class AbstractHandlerTest extends AbstractTestBase<DBInstance, R
                 .masterUsername(MASTER_USERNAME)
                 .promotionTier(PROMOTION_TIER_DEFAULT)
                 .build();
+
+        DB_INSTANCE_ACTIVE_SYSTEM_ID = DB_INSTANCE_ACTIVE.toBuilder().dbSystemId(DB_INSTANCE_SYSTEM_ID).build();
 
         DB_INSTANCE_AURORA_ACTIVE = DB_INSTANCE_ACTIVE.toBuilder()
                 .dbClusterIdentifier(DB_CLUSTER_IDENTIFIER_NON_EMPTY)

--- a/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/CreateHandlerTest.java
+++ b/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/CreateHandlerTest.java
@@ -2242,6 +2242,82 @@ public class CreateHandlerTest extends AbstractHandlerTest {
     }
 
     @Test
+    public void handleRequest_CreateDBInstanceWithSid_IsSuccessful() {
+        when(rdsProxy.client().addTagsToResource(any(AddTagsToResourceRequest.class)))
+            .thenReturn(AddTagsToResourceResponse.builder().build());
+
+        final CallbackContext context = new CallbackContext();
+        context.setCreated(true);
+        context.setUpdated(true);
+        context.setRebooted(true);
+        context.setUpdatedRoles(true);
+
+        test_handleRequest_base(
+            context,
+            () -> DB_INSTANCE_ACTIVE_SYSTEM_ID,
+            () -> RESOURCE_MODEL_BLDR().dBSystemId("UNITTEST").build(),
+            expectSuccess()
+        );
+
+        verify(rdsProxy.client(), times(3)).describeDBInstances(any(DescribeDbInstancesRequest.class));
+        verify(rdsProxy.client(), times(1)).addTagsToResource(any(AddTagsToResourceRequest.class));
+    }
+
+    @Test
+    public void handleRequest_CreateReadReplicaWithSid_ThrowsRequestValidationException() {
+        expectServiceInvocation = false;
+        final CallbackContext context = new CallbackContext();
+        context.setCreated(false);
+        context.setUpdated(true);
+        context.setRebooted(true);
+        context.setUpdatedRoles(true);
+        context.setAddTagsComplete(true);
+
+        test_handleRequest_base(
+            context,
+            null,
+            () -> RESOURCE_MODEL_READ_REPLICA.toBuilder().dBSystemId("UNITTEST").build(),
+            expectFailed(HandlerErrorCode.InvalidRequest)
+        );
+    }
+
+    @Test
+    public void handleRequest_CreateDBInstanceFromSnapshotWithSid_ThrowsRequestValidationException() {
+        expectServiceInvocation = false;
+        final CallbackContext context = new CallbackContext();
+        context.setCreated(false);
+        context.setUpdated(true);
+        context.setRebooted(true);
+        context.setUpdatedRoles(true);
+        context.setAddTagsComplete(true);
+
+        test_handleRequest_base(
+            context,
+            null,
+            () -> RESOURCE_MODEL_RESTORING_FROM_SNAPSHOT.toBuilder().dBSystemId("UNITTEST").build(),
+            expectFailed(HandlerErrorCode.InvalidRequest)
+        );
+    }
+
+    @Test
+    public void handleRequest_CreateDBInstanceFromPitrWithSid_ThrowsRequestValidationException() {
+        expectServiceInvocation = false;
+        final CallbackContext context = new CallbackContext();
+        context.setCreated(false);
+        context.setUpdated(true);
+        context.setRebooted(true);
+        context.setUpdatedRoles(true);
+        context.setAddTagsComplete(true);
+
+        test_handleRequest_base(
+            context,
+            null,
+            () -> RESOURCE_MODEL_RESTORING_TO_POINT_IN_TIME.toBuilder().dBSystemId("UNITTEST").build(),
+            expectFailed(HandlerErrorCode.InvalidRequest)
+        );
+    }
+
+    @Test
     public void fetchEngineForUnknownScenario() {
         expectServiceInvocation = false;
         final CallbackContext context = new CallbackContext();


### PR DESCRIPTION
*Description of changes:*

DBSystemId is a property used to customise RDS Oracle Custom container databases' system id.

This is a createOnlyProperty which requires replacement of the DBInstance resource if the customer attempts to rename it. 

Because DBSystemId is only passed in on [create-db-instance](https://docs.aws.amazon.com/cli/latest/reference/rds/create-db-instance.html), it means that there is potential for open fail scenarios, where user sets the DBSystemId and sees no results.

For example: We want to block users from being able to set a DBSystemId for [read replicas](https://docs.aws.amazon.com/cli/latest/reference/rds/create-db-instance-read-replica.html), [restore from PITR](https://docs.aws.amazon.com/cli/latest/reference/rds/restore-db-instance-to-point-in-time.html) and [restore from snapshot](https://docs.aws.amazon.com/cli/latest/reference/rds/restore-db-instance-from-db-snapshot.html)