### PR TITLE
[CFN-27] Working towards a more extensible DBInstance create flow....

### DIFF
--- a/aws-rds-cfn-common/src/main/java/software/amazon/rds/ProgressStep.java
+++ b/aws-rds-cfn-common/src/main/java/software/amazon/rds/ProgressStep.java
@@ -1,0 +1,4 @@
+package software.amazon.rds;
+
+public class ProgressStep {
+}

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/BaseHandlerStd.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/BaseHandlerStd.java
@@ -13,83 +13,37 @@ import java.util.Set;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.Predicate;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.apache.commons.lang3.BooleanUtils;
 
-import com.amazonaws.arn.Arn;
-import com.amazonaws.util.CollectionUtils;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import software.amazon.awssdk.services.ec2.Ec2Client;
 import software.amazon.awssdk.services.ec2.model.DescribeSecurityGroupsResponse;
 import software.amazon.awssdk.services.ec2.model.SecurityGroup;
 import software.amazon.awssdk.services.rds.RdsClient;
-import software.amazon.awssdk.services.rds.model.AuthorizationNotFoundException;
-import software.amazon.awssdk.services.rds.model.CertificateNotFoundException;
 import software.amazon.awssdk.services.rds.model.DBCluster;
 import software.amazon.awssdk.services.rds.model.DBClusterSnapshot;
 import software.amazon.awssdk.services.rds.model.DBInstance;
 import software.amazon.awssdk.services.rds.model.DBInstanceAutomatedBackup;
 import software.amazon.awssdk.services.rds.model.DBSnapshot;
-import software.amazon.awssdk.services.rds.model.DbClusterNotFoundException;
-import software.amazon.awssdk.services.rds.model.DbClusterSnapshotNotFoundException;
-import software.amazon.awssdk.services.rds.model.DbInstanceAlreadyExistsException;
-import software.amazon.awssdk.services.rds.model.DbInstanceAutomatedBackupQuotaExceededException;
 import software.amazon.awssdk.services.rds.model.DbInstanceNotFoundException;
-import software.amazon.awssdk.services.rds.model.DbInstanceRoleAlreadyExistsException;
-import software.amazon.awssdk.services.rds.model.DbInstanceRoleNotFoundException;
-import software.amazon.awssdk.services.rds.model.DbParameterGroupNotFoundException;
-import software.amazon.awssdk.services.rds.model.DbSecurityGroupNotFoundException;
-import software.amazon.awssdk.services.rds.model.DbSnapshotAlreadyExistsException;
-import software.amazon.awssdk.services.rds.model.DbSnapshotNotFoundException;
-import software.amazon.awssdk.services.rds.model.DbSubnetGroupDoesNotCoverEnoughAZsException;
-import software.amazon.awssdk.services.rds.model.DbSubnetGroupNotFoundException;
-import software.amazon.awssdk.services.rds.model.DbUpgradeDependencyFailureException;
 import software.amazon.awssdk.services.rds.model.DescribeDbClusterSnapshotsResponse;
 import software.amazon.awssdk.services.rds.model.DescribeDbClustersResponse;
 import software.amazon.awssdk.services.rds.model.DescribeDbInstanceAutomatedBackupsResponse;
 import software.amazon.awssdk.services.rds.model.DescribeDbInstancesResponse;
 import software.amazon.awssdk.services.rds.model.DescribeDbSnapshotsResponse;
-import software.amazon.awssdk.services.rds.model.DomainMembership;
-import software.amazon.awssdk.services.rds.model.DomainNotFoundException;
 import software.amazon.awssdk.services.rds.model.Event;
-import software.amazon.awssdk.services.rds.model.InstanceQuotaExceededException;
-import software.amazon.awssdk.services.rds.model.InsufficientDbInstanceCapacityException;
-import software.amazon.awssdk.services.rds.model.InvalidDbClusterStateException;
-import software.amazon.awssdk.services.rds.model.InvalidDbInstanceAutomatedBackupStateException;
-import software.amazon.awssdk.services.rds.model.InvalidDbInstanceStateException;
-import software.amazon.awssdk.services.rds.model.InvalidDbSecurityGroupStateException;
-import software.amazon.awssdk.services.rds.model.InvalidDbSnapshotStateException;
-import software.amazon.awssdk.services.rds.model.InvalidRestoreException;
-import software.amazon.awssdk.services.rds.model.InvalidSubnetException;
-import software.amazon.awssdk.services.rds.model.InvalidVpcNetworkStateException;
-import software.amazon.awssdk.services.rds.model.KmsKeyNotAccessibleException;
-import software.amazon.awssdk.services.rds.model.NetworkTypeNotSupportedException;
-import software.amazon.awssdk.services.rds.model.OptionGroupMembership;
-import software.amazon.awssdk.services.rds.model.OptionGroupNotFoundException;
-import software.amazon.awssdk.services.rds.model.PendingModifiedValues;
-import software.amazon.awssdk.services.rds.model.ProvisionedIopsNotAvailableInAzException;
-import software.amazon.awssdk.services.rds.model.SnapshotQuotaExceededException;
-import software.amazon.awssdk.services.rds.model.StorageQuotaExceededException;
-import software.amazon.awssdk.services.rds.model.StorageTypeNotSupportedException;
 import software.amazon.awssdk.services.rds.model.Tag;
 import software.amazon.awssdk.utils.StringUtils;
-import software.amazon.cloudformation.exceptions.CfnInvalidRequestException;
-import software.amazon.cloudformation.exceptions.CfnNotStabilizedException;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.HandlerErrorCode;
 import software.amazon.cloudformation.proxy.Logger;
-import software.amazon.cloudformation.proxy.OperationStatus;
 import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 import software.amazon.cloudformation.proxy.delay.Constant;
 import software.amazon.cloudformation.resource.ResourceTypeSchema;
-import software.amazon.rds.common.error.ErrorCode;
-import software.amazon.rds.common.error.ErrorRuleSet;
-import software.amazon.rds.common.error.ErrorStatus;
 import software.amazon.rds.common.handler.Commons;
 import software.amazon.rds.common.handler.Events;
 import software.amazon.rds.common.handler.HandlerConfig;
@@ -106,27 +60,14 @@ import software.amazon.rds.dbinstance.client.ApiVersionDispatcher;
 import software.amazon.rds.dbinstance.client.Ec2ClientProvider;
 import software.amazon.rds.dbinstance.client.RdsClientProvider;
 import software.amazon.rds.dbinstance.client.VersionedProxyClient;
-import software.amazon.rds.dbinstance.status.DBInstanceStatus;
-import software.amazon.rds.dbinstance.status.DBParameterGroupStatus;
-import software.amazon.rds.dbinstance.status.DomainMembershipStatus;
-import software.amazon.rds.dbinstance.status.OptionGroupStatus;
-import software.amazon.rds.dbinstance.status.ReadReplicaStatus;
-import software.amazon.rds.dbinstance.status.VPCSecurityGroupStatus;
+import software.amazon.rds.dbinstance.common.Errors;
 
 public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
 
-    public static final String SECRET_STATUS_ACTIVE = "active";
     public static final String RESOURCE_IDENTIFIER = "dbinstance";
     public static final String STACK_NAME = "rds";
 
     public static final String API_VERSION_V12 = "2012-09-17";
-
-    static final String READ_REPLICA_STATUS_TYPE = "read replication";
-
-    protected static final List<String> RDS_CUSTOM_ORACLE_ENGINES = ImmutableList.of(
-            "custom-oracle-ee",
-            "custom-oracle-ee-cdb"
-    );
 
     protected static final int RESOURCE_ID_MAX_LENGTH = 63;
 
@@ -147,8 +88,6 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
     // upon a stack deletion: if an instance is being deleted out-of-bounds. This is a pretty corner (still common) case
     // where the CFN handler is trying to help the customer. A regular stack deletion will not be impacted.
     // Considered bounded-safe.
-    protected static final String IS_ALREADY_BEING_DELETED_ERROR_FRAGMENT = "is already being deleted";
-
     protected static final String ILLEGAL_DELETION_POLICY_ERROR = "DeletionPolicy:Snapshot cannot be specified for a cluster instance, use deletion policy on the cluster instead.";
 
     protected static final String UNKNOWN_SOURCE_REGION_ERROR = "Unknown source region";
@@ -171,13 +110,6 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
 
     protected static final BiFunction<ResourceModel, ProxyClient<RdsClient>, ResourceModel> NOOP_CALL = (model, proxyClient) -> model;
 
-    protected static final Function<Exception, ErrorStatus> ignoreDBInstanceBeingDeletedConditionalErrorStatus = exception -> {
-        if (isDBInstanceBeingDeletedException(exception)) {
-            return ErrorStatus.ignore(OperationStatus.IN_PROGRESS);
-        }
-        return ErrorStatus.failWith(HandlerErrorCode.ResourceConflict);
-    };
-
     //TODO: This list should be gone eventually. Event ID should be checked instead.
     private static final List<Predicate<Event>> EVENT_FAIL_CHECKERS = ImmutableList.of(
             (e) -> Events.isEventMessageContains(e, "failed to join a host to a domain"),
@@ -194,168 +126,6 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
             (e) -> Events.isEventMessageContains(e, "instance is in a state that cannot be upgraded")
     );
 
-    protected static final ErrorRuleSet DEFAULT_DB_INSTANCE_ERROR_RULE_SET = ErrorRuleSet
-            .extend(Commons.DEFAULT_ERROR_RULE_SET)
-            .withErrorCodes(ErrorStatus.failWith(HandlerErrorCode.ServiceLimitExceeded),
-                    ErrorCode.InstanceQuotaExceeded,
-                    ErrorCode.InsufficientDBInstanceCapacity,
-                    ErrorCode.SnapshotQuotaExceeded,
-                    ErrorCode.StorageQuotaExceeded)
-            .withErrorCodes(ErrorStatus.failWith(HandlerErrorCode.InvalidRequest),
-                    ErrorCode.DBSubnetGroupNotAllowedFault,
-                    ErrorCode.InvalidParameterCombination,
-                    ErrorCode.InvalidParameterValue,
-                    ErrorCode.InvalidVPCNetworkStateFault,
-                    ErrorCode.KMSKeyNotAccessibleFault,
-                    ErrorCode.MissingParameter,
-                    ErrorCode.ProvisionedIopsNotAvailableInAZFault,
-                    ErrorCode.StorageTypeNotSupportedFault)
-            .withErrorCodes(ErrorStatus.failWith(HandlerErrorCode.NotFound),
-                    ErrorCode.DBClusterNotFoundFault,
-                    ErrorCode.DBParameterGroupNotFound,
-                    ErrorCode.DBSecurityGroupNotFound,
-                    ErrorCode.DBSnapshotNotFound,
-                    ErrorCode.DBSubnetGroupNotFoundFault)
-            .withErrorClasses(ErrorStatus.failWith(HandlerErrorCode.NotFound),
-                    CertificateNotFoundException.class,
-                    DbClusterNotFoundException.class,
-                    DbInstanceNotFoundException.class,
-                    DbParameterGroupNotFoundException.class,
-                    DbSecurityGroupNotFoundException.class,
-                    DbSnapshotNotFoundException.class,
-                    DbClusterSnapshotNotFoundException.class,
-                    DbSubnetGroupNotFoundException.class,
-                    DomainNotFoundException.class,
-                    OptionGroupNotFoundException.class)
-            .withErrorClasses(ErrorStatus.failWith(HandlerErrorCode.ServiceLimitExceeded),
-                    DbInstanceAutomatedBackupQuotaExceededException.class,
-                    InsufficientDbInstanceCapacityException.class,
-                    InstanceQuotaExceededException.class,
-                    SnapshotQuotaExceededException.class,
-                    StorageQuotaExceededException.class)
-            .withErrorClasses(ErrorStatus.failWith(HandlerErrorCode.ResourceConflict),
-                    InvalidDbInstanceStateException.class,
-                    InvalidDbClusterStateException.class,
-                    DbUpgradeDependencyFailureException.class,
-                    InvalidDbSecurityGroupStateException.class)
-            .withErrorClasses(ErrorStatus.failWith(HandlerErrorCode.InvalidRequest),
-                    AuthorizationNotFoundException.class,
-                    DbSubnetGroupDoesNotCoverEnoughAZsException.class,
-                    InvalidVpcNetworkStateException.class,
-                    KmsKeyNotAccessibleException.class,
-                    NetworkTypeNotSupportedException.class,
-                    ProvisionedIopsNotAvailableInAzException.class,
-                    StorageTypeNotSupportedException.class)
-            .withErrorClasses(ErrorStatus.failWith(HandlerErrorCode.AlreadyExists),
-                    DbInstanceAlreadyExistsException.class)
-            .withErrorClasses(ErrorStatus.failWith(HandlerErrorCode.GeneralServiceException),
-                    InvalidSubnetException.class)
-            .build();
-
-    protected static final ErrorRuleSet DB_INSTANCE_FETCH_ENGINE_RULE_SET = ErrorRuleSet
-            .extend(DEFAULT_DB_INSTANCE_ERROR_RULE_SET)
-            .withErrorClasses(ErrorStatus.failWith(HandlerErrorCode.InvalidRequest),
-                    CfnInvalidRequestException.class)
-            .build();
-
-    public static final ErrorRuleSet RESTORE_DB_INSTANCE_ERROR_RULE_SET = ErrorRuleSet
-            .extend(DEFAULT_DB_INSTANCE_ERROR_RULE_SET)
-            .withErrorCodes(ErrorStatus.failWith(HandlerErrorCode.AlreadyExists),
-                    ErrorCode.DBInstanceAlreadyExists)
-            .withErrorCodes(ErrorStatus.failWith(HandlerErrorCode.InvalidRequest),
-                    ErrorCode.InvalidDBSnapshotState,
-                    ErrorCode.InvalidRestoreFault)
-            .withErrorClasses(ErrorStatus.failWith(HandlerErrorCode.AlreadyExists),
-                    DbInstanceAlreadyExistsException.class)
-            .withErrorClasses(ErrorStatus.failWith(HandlerErrorCode.InvalidRequest),
-                    InvalidDbSnapshotStateException.class,
-                    InvalidRestoreException.class)
-            .build();
-
-    protected static final ErrorRuleSet CREATE_DB_INSTANCE_ERROR_RULE_SET = ErrorRuleSet
-            .extend(DEFAULT_DB_INSTANCE_ERROR_RULE_SET)
-            .withErrorCodes(ErrorStatus.failWith(HandlerErrorCode.AlreadyExists),
-                    ErrorCode.DBInstanceAlreadyExists)
-            .withErrorClasses(
-                    ErrorStatus.failWith(HandlerErrorCode.AlreadyExists),
-                    DbInstanceAlreadyExistsException.class)
-            .build();
-
-    protected static final ErrorRuleSet CREATE_DB_INSTANCE_READ_REPLICA_ERROR_RULE_SET = ErrorRuleSet
-            .extend(DEFAULT_DB_INSTANCE_ERROR_RULE_SET)
-            .withErrorCodes(ErrorStatus.failWith(HandlerErrorCode.AlreadyExists),
-                    ErrorCode.DBInstanceAlreadyExists)
-            .withErrorClasses(ErrorStatus.failWith(HandlerErrorCode.AlreadyExists),
-                    DbInstanceAlreadyExistsException.class)
-            .withErrorClasses(ErrorStatus.failWith(HandlerErrorCode.NotFound),
-                    DbClusterNotFoundException.class)
-            .withErrorClasses(ErrorStatus.failWith(HandlerErrorCode.ResourceConflict),
-                    InvalidDbClusterStateException.class)
-            .build();
-
-    protected static final ErrorRuleSet REBOOT_DB_INSTANCE_ERROR_RULE_SET = ErrorRuleSet
-            .extend(DEFAULT_DB_INSTANCE_ERROR_RULE_SET)
-            .withErrorCodes(ErrorStatus.failWith(HandlerErrorCode.NotFound),
-                    ErrorCode.DBInstanceNotFound)
-            .withErrorCodes(ErrorStatus.failWith(HandlerErrorCode.ResourceConflict),
-                    ErrorCode.InvalidDBInstanceState)
-            .withErrorClasses(ErrorStatus.failWith(HandlerErrorCode.NotFound),
-                    DbInstanceNotFoundException.class)
-            .withErrorClasses(ErrorStatus.failWith(HandlerErrorCode.ResourceConflict),
-                    InvalidDbInstanceStateException.class)
-            .build();
-
-    protected static final ErrorRuleSet MODIFY_DB_INSTANCE_AUTOMATIC_BACKUP_REPLICATION_ERROR_RULE_SET = ErrorRuleSet
-            .extend(DEFAULT_DB_INSTANCE_ERROR_RULE_SET)
-            .withErrorClasses(ErrorStatus.ignore(OperationStatus.IN_PROGRESS),
-                    InvalidDbInstanceAutomatedBackupStateException.class)
-            .withErrorClasses(ErrorStatus.failWith(HandlerErrorCode.ServiceLimitExceeded),
-                    DbInstanceAutomatedBackupQuotaExceededException.class)
-            .build();
-
-    protected static final ErrorRuleSet MODIFY_DB_INSTANCE_ERROR_RULE_SET = ErrorRuleSet
-            .extend(DEFAULT_DB_INSTANCE_ERROR_RULE_SET)
-            .withErrorCodes(ErrorStatus.failWith(HandlerErrorCode.ResourceConflict),
-                    ErrorCode.InvalidDBInstanceState)
-            .withErrorCodes(ErrorStatus.failWith(HandlerErrorCode.NotFound),
-                    ErrorCode.DBInstanceNotFound)
-            .withErrorCodes(ErrorStatus.failWith(HandlerErrorCode.InvalidRequest),
-                    ErrorCode.InvalidDBSecurityGroupState,
-                    ErrorCode.InvalidParameterCombination)
-            .withErrorClasses(ErrorStatus.failWith(HandlerErrorCode.ResourceConflict),
-                    InvalidDbInstanceStateException.class)
-            .withErrorClasses(ErrorStatus.failWith(HandlerErrorCode.NotFound),
-                    DbInstanceNotFoundException.class)
-            .withErrorClasses(ErrorStatus.failWith(HandlerErrorCode.InvalidRequest),
-                    CfnInvalidRequestException.class,
-                    InvalidDbSecurityGroupStateException.class)
-            .build();
-
-    protected static final ErrorRuleSet UPDATE_ASSOCIATED_ROLES_ERROR_RULE_SET = ErrorRuleSet
-            .extend(DEFAULT_DB_INSTANCE_ERROR_RULE_SET)
-            .withErrorClasses(ErrorStatus.ignore(),
-                    DbInstanceRoleAlreadyExistsException.class,
-                    DbInstanceRoleNotFoundException.class)
-            .build();
-
-    protected static final ErrorRuleSet DELETE_DB_INSTANCE_ERROR_RULE_SET = ErrorRuleSet
-            .extend(DEFAULT_DB_INSTANCE_ERROR_RULE_SET)
-            .withErrorCodes(ErrorStatus.failWith(HandlerErrorCode.InvalidRequest),
-                    ErrorCode.InvalidParameterValue)
-            .withErrorCodes(ErrorStatus.failWith(HandlerErrorCode.NotFound),
-                    ErrorCode.DBInstanceNotFound)
-            .withErrorCodes(ErrorStatus.conditional(ignoreDBInstanceBeingDeletedConditionalErrorStatus),
-                    ErrorCode.InvalidDBInstanceState)
-            .withErrorCodes(ErrorStatus.failWith(HandlerErrorCode.InvalidRequest),
-                    ErrorCode.DBSnapshotAlreadyExists)
-            .withErrorClasses(ErrorStatus.failWith(HandlerErrorCode.NotFound),
-                    DbInstanceNotFoundException.class)
-            .withErrorClasses(ErrorStatus.conditional(ignoreDBInstanceBeingDeletedConditionalErrorStatus),
-                    InvalidDbInstanceStateException.class)
-            .withErrorClasses(ErrorStatus.failWith(HandlerErrorCode.InvalidRequest),
-                    DbSnapshotAlreadyExistsException.class)
-            .build();
-
     protected static final ResourceTypeSchema resourceTypeSchema = ResourceTypeSchema.load(new Configuration().resourceSchemaJsonObject());
 
     public BaseHandlerStd(final HandlerConfig config) {
@@ -363,20 +133,6 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
         this.config = config;
         this.apiVersionDispatcher = new ApiVersionDispatcher<ResourceModel, CallbackContext>()
                 .register(ApiVersion.V12, (m, c) -> !software.amazon.awssdk.utils.CollectionUtils.isNullOrEmpty(m.getDBSecurityGroups()));
-    }
-
-    private static boolean looksLikeDBInstanceBeingDeletedMessage(final String message) {
-        if (StringUtils.isBlank(message)) {
-            return false;
-        }
-        return message.contains(IS_ALREADY_BEING_DELETED_ERROR_FRAGMENT);
-    }
-
-    private static boolean isDBInstanceBeingDeletedException(final Exception e) {
-        if (e instanceof InvalidDbInstanceStateException) {
-            return looksLikeDBInstanceBeingDeletedMessage(e.getMessage());
-        }
-        return false;
     }
 
     protected ApiVersionDispatcher<ResourceModel, CallbackContext> getApiVersionDispatcher() {
@@ -463,7 +219,7 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
                 .handleError((modifyRequest, exception, client, model, context) -> Commons.handleException(
                         ProgressEvent.progress(model, context),
                         exception,
-                        MODIFY_DB_INSTANCE_ERROR_RULE_SET,
+                        Errors.MODIFY_DB_INSTANCE_ERROR_RULE_SET,
                         requestLogger
                 ))
                 .progress();
@@ -490,18 +246,10 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
                 .handleError((modifyRequest, exception, client, model, context) -> Commons.handleException(
                         ProgressEvent.progress(model, context),
                         exception,
-                        MODIFY_DB_INSTANCE_ERROR_RULE_SET,
+                        Errors.MODIFY_DB_INSTANCE_ERROR_RULE_SET,
                         requestLogger
                 ))
                 .progress();
-    }
-
-    protected boolean isDBClusterMember(final ResourceModel model) {
-        return StringUtils.isNotBlank(model.getDBClusterIdentifier());
-    }
-
-    protected boolean isRdsCustomOracleInstance(final ResourceModel model) {
-        return RDS_CUSTOM_ORACLE_ENGINES.contains(model.getEngine());
     }
 
     protected boolean isFailureEvent(final Event event) {
@@ -627,83 +375,13 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
         return false;
     }
 
-    private void assertNoDBInstanceTerminalStatus(final DBInstance dbInstance) throws CfnNotStabilizedException {
-        final DBInstanceStatus status = DBInstanceStatus.fromString(dbInstance.dbInstanceStatus());
-        if (status != null && status.isTerminal()) {
-            throw new CfnNotStabilizedException(new Exception("DB Instance is in state: " + status.toString()));
-        }
-    }
-
-    private void assertNoOptionGroupTerminalStatus(final DBInstance dbInstance) throws CfnNotStabilizedException {
-        final List<OptionGroupMembership> termOptionGroups = Optional.ofNullable(dbInstance.optionGroupMemberships()).orElse(Collections.emptyList())
-                .stream()
-                .filter(optionGroup -> {
-                    final OptionGroupStatus status = OptionGroupStatus.fromString(optionGroup.status());
-                    return status != null && status.isTerminal();
-                })
-                .collect(Collectors.toList());
-
-        if (!termOptionGroups.isEmpty()) {
-            throw new CfnNotStabilizedException(new Exception(
-                    String.format("OptionGroup %s is in a terminal state",
-                            termOptionGroups.get(0).optionGroupName())));
-        }
-    }
-
-    private void assertNoDomainMembershipTerminalStatus(final DBInstance dbInstance) throws CfnNotStabilizedException {
-        final List<DomainMembership> terminalDomainMemberships = Optional.ofNullable(dbInstance.domainMemberships()).orElse(Collections.emptyList())
-                .stream()
-                .filter(domainMembership -> {
-                    final DomainMembershipStatus status = DomainMembershipStatus.fromString(domainMembership.status());
-                    return status != null && status.isTerminal();
-                })
-                .collect(Collectors.toList());
-
-        if (!terminalDomainMemberships.isEmpty()) {
-            throw new CfnNotStabilizedException(new Exception(String.format("Domain %s is in a terminal state",
-                    terminalDomainMemberships.get(0).domain())));
-        }
-    }
-
-    private void assertNoTerminalStatus(final DBInstance dbInstance) throws CfnNotStabilizedException {
-        assertNoDBInstanceTerminalStatus(dbInstance);
-        assertNoOptionGroupTerminalStatus(dbInstance);
-        assertNoDomainMembershipTerminalStatus(dbInstance);
-    }
-
     protected boolean isDBInstanceStabilizedAfterMutate(
             final ProxyClient<RdsClient> rdsProxyClient,
             final ResourceModel model,
             final CallbackContext context
     ) {
         final DBInstance dbInstance = fetchDBInstance(rdsProxyClient, model);
-
-        assertNoTerminalStatus(dbInstance);
-
-
-        final boolean isDBInstanceStabilizedAfterMutateResult = isDBInstanceAvailable(dbInstance) &&
-                isReplicationComplete(dbInstance) &&
-                isDBParameterGroupNotApplying(dbInstance) &&
-                isNoPendingChanges(dbInstance) &&
-                isCaCertificateChangesApplied(dbInstance, model) &&
-                isVpcSecurityGroupsActive(dbInstance) &&
-                isDomainMembershipsJoined(dbInstance) &&
-                isMasterUserSecretStabilized(dbInstance);
-
-        requestLogger.log(String.format("isDBInstanceStabilizedAfterMutate: %b", isDBInstanceStabilizedAfterMutateResult),
-                ImmutableMap.of("isDBInstanceAvailable", isDBInstanceAvailable(dbInstance),
-                        "isReplicationComplete", isReplicationComplete(dbInstance),
-                        "isDBParameterGroupNotApplying", isDBParameterGroupNotApplying(dbInstance),
-                        "isNoPendingChanges", isNoPendingChanges(dbInstance),
-                        "isCaCertificateChangesApplied", isCaCertificateChangesApplied(dbInstance, model),
-                        "isVpcSecurityGroupsActive", isVpcSecurityGroupsActive(dbInstance),
-                        "isDomainMembershipsJoined", isDomainMembershipsJoined(dbInstance),
-                        "isMasterUserSecretStabilized", isMasterUserSecretStabilized(dbInstance)),
-                ImmutableMap.of("Description", "isDBInstanceStabilizedAfterMutate method will be repeatedly" +
-                        " called with a backoff mechanism after the modify call until it returns true. This" +
-                        " process will continue until all included flags are true."));
-
-        return isDBInstanceStabilizedAfterMutateResult;
+        return DBInstancePredicates.isDBInstanceStabilizedAfterMutate(dbInstance, model, context, requestLogger);
     }
 
     private void resourceStabilizationTime(final CallbackContext context) {
@@ -715,23 +393,15 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
     protected boolean isInstanceStabilizedAfterReplicationStop(final ProxyClient<RdsClient> rdsProxyClient,
                                                                final ResourceModel model) {
         final DBInstance dbInstance = fetchDBInstance(rdsProxyClient, model);
-
-        assertNoTerminalStatus(dbInstance);
-        return isDBInstanceAvailable(dbInstance)
-                && !dbInstance.hasDbInstanceAutomatedBackupsReplications();
+        return DBInstancePredicates.isInstanceStabilizedAfterReplicationStop(dbInstance, model);
     }
 
-    protected boolean isInstanceStabilizedAfterReplicationStart(final ProxyClient<RdsClient> rdsProxyClient,
-                                                                final ResourceModel model) {
+    protected boolean isInstanceStabilizedAfterReplicationStart(
+        final ProxyClient<RdsClient> rdsProxyClient,
+        final ResourceModel model
+    ) {
         final DBInstance dbInstance = fetchDBInstance(rdsProxyClient, model);
-
-        assertNoTerminalStatus(dbInstance);
-        return isDBInstanceAvailable(dbInstance)
-                && dbInstance.hasDbInstanceAutomatedBackupsReplications() &&
-                !dbInstance.dbInstanceAutomatedBackupsReplications().isEmpty() &&
-                model.getAutomaticBackupReplicationRegion()
-                        .equalsIgnoreCase(
-                                Arn.fromString(dbInstance.dbInstanceAutomatedBackupsReplications().get(0).dbInstanceAutomatedBackupsArn()).getRegion());
+        return DBInstancePredicates.isInstanceStabilizedAfterReplicationStart(dbInstance, model);
     }
 
     protected boolean isDBInstanceStabilizedAfterReboot(
@@ -739,126 +409,32 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
             final ResourceModel model
     ) {
         final DBInstance dbInstance = fetchDBInstance(rdsProxyClient, model);
-
-        assertNoTerminalStatus(dbInstance);
-
-        final boolean isDBClusterParameterGroupStabilized = !isDBClusterMember(model) || isDBClusterParameterGroupStabilized(rdsProxyClient, model);
-        final boolean isDBInstanceStabilizedAfterReboot = isDBInstanceAvailable(dbInstance) &&
-                isDBParameterGroupInSync(dbInstance) &&
-                isOptionGroupInSync(dbInstance) &&
-                isDBClusterParameterGroupStabilized;
-
-        requestLogger.log(String.format("isDBInstanceStabilizedAfterReboot: %b", isDBInstanceStabilizedAfterReboot),
-                ImmutableMap.of("isDBInstanceAvailable", isDBInstanceAvailable(dbInstance),
-                        "isDBParameterGroupInSync", isDBParameterGroupInSync(dbInstance),
-                        "isOptionGroupInSync", isOptionGroupInSync(dbInstance),
-                        "isDBClusterParameterGroupStabilized", isDBClusterParameterGroupStabilized),
-                ImmutableMap.of("Description", "isDBInstanceStabilizedAfterReboot method will be repeatedly" +
-                        " called with a backoff mechanism after the reboot call until it returns true. This" +
-                        " process will continue until all included flags are true."));
-
-        return isDBInstanceStabilizedAfterReboot;
-    }
-
-    boolean isDBInstanceAvailable(final DBInstance dbInstance) {
-        return DBInstanceStatus.Available.equalsString(dbInstance.dbInstanceStatus());
-    }
-
-    boolean isDomainMembershipsJoined(final DBInstance dbInstance) {
-        return Optional.ofNullable(dbInstance.domainMemberships()).orElse(Collections.emptyList())
-                .stream()
-                .allMatch(membership -> DomainMembershipStatus.Joined.equalsString(membership.status()) ||
-                        DomainMembershipStatus.KerberosEnabled.equalsString(membership.status()));
-    }
-
-    boolean isVpcSecurityGroupsActive(final DBInstance dbInstance) {
-        return Optional.ofNullable(dbInstance.vpcSecurityGroups()).orElse(Collections.emptyList())
-                .stream()
-                .allMatch(group -> VPCSecurityGroupStatus.Active.equalsString(group.status()));
-    }
-
-    boolean isNoPendingChanges(final DBInstance dbInstance) {
-        final PendingModifiedValues pending = dbInstance.pendingModifiedValues();
-        return (pending == null) || (pending.dbInstanceClass() == null &&
-                pending.allocatedStorage() == null &&
-                pending.automationMode() == null &&
-                pending.backupRetentionPeriod() == null &&
-                pending.dbInstanceIdentifier() == null &&
-                pending.dbSubnetGroupName() == null &&
-                pending.engine() == null &&
-                pending.engineVersion() == null &&
-                pending.iamDatabaseAuthenticationEnabled() == null &&
-                pending.iops() == null &&
-                pending.licenseModel() == null &&
-                pending.masterUserPassword() == null &&
-                pending.multiAZ() == null &&
-                pending.pendingCloudwatchLogsExports() == null &&
-                pending.port() == null &&
-                CollectionUtils.isNullOrEmpty(pending.processorFeatures()) &&
-                pending.resumeFullAutomationModeTime() == null &&
-                pending.storageThroughput() == null &&
-                pending.storageType() == null
-        );
-    }
-
-    boolean isCaCertificateChangesApplied(final DBInstance dbInstance, final ResourceModel model) {
-        final PendingModifiedValues pending = dbInstance.pendingModifiedValues();
-        return pending == null ||
-                pending.caCertificateIdentifier() == null ||
-                BooleanUtils.isNotTrue(model.getCertificateRotationRestart());
-    }
-
-    boolean isDBParameterGroupNotApplying(final DBInstance dbInstance) {
-        return Optional.ofNullable(dbInstance.dbParameterGroups()).orElse(Collections.emptyList())
-                .stream()
-                .noneMatch(group -> DBParameterGroupStatus.Applying.equalsString(group.parameterApplyStatus()));
-    }
-
-    boolean isReplicationComplete(final DBInstance dbInstance) {
-        return Optional.ofNullable(dbInstance.statusInfos()).orElse(Collections.emptyList())
-                .stream()
-                .filter(statusInfo -> READ_REPLICA_STATUS_TYPE.equals(statusInfo.statusType()))
-                .allMatch(statusInfo -> ReadReplicaStatus.Replicating.equalsString(statusInfo.status()));
+        final Optional<DBCluster>  maybeDbCluster = DBInstancePredicates.isDBClusterMember(model)
+            ? Optional.of(fetchDBCluster(rdsProxyClient, model))
+            : Optional.empty();
+        return DBInstancePredicates.isDBInstanceStabilizedAfterReboot(dbInstance, maybeDbCluster, model, requestLogger);
     }
 
     protected boolean isOptionGroupStabilized(
             final ProxyClient<RdsClient> rdsProxyClient,
             final ResourceModel model
     ) {
-        return isOptionGroupInSync(fetchDBInstance(rdsProxyClient, model));
-    }
-
-    protected boolean isOptionGroupInSync(final DBInstance dbInstance) {
-        return Optional.ofNullable(dbInstance.optionGroupMemberships()).orElse(Collections.emptyList())
-                .stream()
-                .allMatch(optionGroup -> OptionGroupStatus.InSync.equalsString(optionGroup.status()));
+        return DBInstancePredicates.isOptionGroupInSync(fetchDBInstance(rdsProxyClient, model));
     }
 
     protected boolean isDBParameterGroupStabilized(
             final ProxyClient<RdsClient> rdsProxyClient,
             final ResourceModel model
     ) {
-        return isDBParameterGroupInSync(fetchDBInstance(rdsProxyClient, model));
-    }
-
-    protected boolean isDBParameterGroupInSync(final DBInstance dbInstance) {
-        return Optional.ofNullable(dbInstance.dbParameterGroups()).orElse(Collections.emptyList())
-                .stream()
-                .allMatch(parameterGroup -> DBParameterGroupStatus.InSync.equalsString(parameterGroup.parameterApplyStatus()));
+        return DBInstancePredicates.isDBParameterGroupInSync(fetchDBInstance(rdsProxyClient, model));
     }
 
     protected boolean isDBClusterParameterGroupStabilized(
             final ProxyClient<RdsClient> rdsProxyClient,
             final ResourceModel model
     ) {
-        return isDBClusterParameterGroupInSync(model, fetchDBCluster(rdsProxyClient, model));
-    }
-
-    protected boolean isDBClusterParameterGroupInSync(final ResourceModel model, final DBCluster dbCluster) {
-        return Optional.ofNullable(dbCluster.dbClusterMembers()).orElse(Collections.emptyList())
-                .stream()
-                .filter(member -> model.getDBInstanceIdentifier().equalsIgnoreCase(member.dbInstanceIdentifier()))
-                .anyMatch(member -> DBParameterGroupStatus.InSync.equalsString(member.dbClusterParameterGroupStatus()));
+        final DBCluster dbCluster = fetchDBCluster(rdsProxyClient, model);
+        return DBInstancePredicates.isDBClusterParameterGroupInSync(model, dbCluster);
     }
 
     protected boolean isDBInstanceRoleStabilized(
@@ -895,13 +471,6 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
                 model,
                 (roles) -> roles.noneMatch(role -> role.roleArn().equals(lookupRole.getRoleArn()))
         );
-    }
-
-    protected boolean isMasterUserSecretStabilized(final DBInstance instance) {
-        if (instance.masterUserSecret() == null) {
-            return true;
-        }
-        return SECRET_STATUS_ACTIVE.equalsIgnoreCase(instance.masterUserSecret().secretStatus());
     }
 
     protected ProgressEvent<ResourceModel, CallbackContext> updateAssociatedRoles(
@@ -941,7 +510,7 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
                     .handleError((request, exception, proxyInvocation, resourceModel, context) -> Commons.handleException(
                             ProgressEvent.progress(resourceModel, context),
                             exception,
-                            UPDATE_ASSOCIATED_ROLES_ERROR_RULE_SET,
+                            Errors.UPDATE_ASSOCIATED_ROLES_ERROR_RULE_SET,
                             requestLogger
                     ))
                     .success();
@@ -973,7 +542,7 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
                     .handleError((request, exception, proxyInvocation, resourceModel, context) -> Commons.handleException(
                             ProgressEvent.progress(resourceModel, context),
                             exception,
-                            UPDATE_ASSOCIATED_ROLES_ERROR_RULE_SET,
+                            Errors.UPDATE_ASSOCIATED_ROLES_ERROR_RULE_SET,
                             requestLogger
                     ))
                     .success();
@@ -1003,7 +572,7 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
                 .handleError((request, exception, client, model, context) -> Commons.handleException(
                         ProgressEvent.progress(model, context),
                         exception,
-                        REBOOT_DB_INSTANCE_ERROR_RULE_SET,
+                        Errors.REBOOT_DB_INSTANCE_ERROR_RULE_SET,
                         requestLogger
                 ))
                 .progress();
@@ -1035,7 +604,7 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
                 .handleError((request, exception, proxyInvocation, resourceModel, context) -> Commons.handleException(
                         ProgressEvent.progress(resourceModel, context),
                         exception,
-                        UPDATE_ASSOCIATED_ROLES_ERROR_RULE_SET,
+                        Errors.UPDATE_ASSOCIATED_ROLES_ERROR_RULE_SET,
                         requestLogger
                 ))
                 .progress();
@@ -1051,7 +620,7 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
                 final DBInstance dbInstance = fetchDBInstance(rdsProxyClient, model);
                 model.setEngine(dbInstance.engine());
             } catch (Exception e) {
-                return Commons.handleException(progress, e, DEFAULT_DB_INSTANCE_ERROR_RULE_SET, requestLogger);
+                return Commons.handleException(progress, e, Errors.DEFAULT_DB_INSTANCE_ERROR_RULE_SET, requestLogger);
             }
         }
         return progress;
@@ -1082,7 +651,7 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
         try {
             dbInstance = fetchDBInstance(rdsProxyClient, progress.getResourceModel());
         } catch (Exception exception) {
-            return Commons.handleException(progress, exception, DEFAULT_DB_INSTANCE_ERROR_RULE_SET, requestLogger);
+            return Commons.handleException(progress, exception, Errors.DEFAULT_DB_INSTANCE_ERROR_RULE_SET, requestLogger);
         }
 
         final String arn = dbInstance.dbInstanceArn();
@@ -1094,7 +663,7 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
             return Commons.handleException(
                     progress,
                     exception,
-                    DEFAULT_DB_INSTANCE_ERROR_RULE_SET.extendWith(Tagging.getUpdateTagsAccessDeniedRuleSet(rulesetTagsToAdd, rulesetTagsToRemove)),
+                    Errors.DEFAULT_DB_INSTANCE_ERROR_RULE_SET.extendWith(Tagging.getUpdateTagsAccessDeniedRuleSet(rulesetTagsToAdd, rulesetTagsToRemove)),
                     requestLogger
             );
         }
@@ -1139,7 +708,7 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
                 .handleError((request, exception, client, model, context) -> Commons.handleException(
                         ProgressEvent.progress(model, context),
                         exception,
-                        MODIFY_DB_INSTANCE_AUTOMATIC_BACKUP_REPLICATION_ERROR_RULE_SET,
+                        Errors.MODIFY_DB_INSTANCE_AUTOMATIC_BACKUP_REPLICATION_ERROR_RULE_SET,
                         requestLogger
                 ))
                 .progress();
@@ -1170,7 +739,7 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
                     ProgressEvent<ResourceModel, CallbackContext> progressEvent = Commons.handleException(
                             ProgressEvent.progress(model, context),
                             exception,
-                            MODIFY_DB_INSTANCE_AUTOMATIC_BACKUP_REPLICATION_ERROR_RULE_SET,
+                            Errors.MODIFY_DB_INSTANCE_AUTOMATIC_BACKUP_REPLICATION_ERROR_RULE_SET,
                             requestLogger
                     );
                     if (exception.getMessage().contains(AUTOMATIC_REPLICATION_KMS_KEY_ERROR)) {

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/CreateHandler.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/CreateHandler.java
@@ -31,6 +31,9 @@ import software.amazon.rds.common.util.IdentifierFactory;
 import software.amazon.rds.dbinstance.client.ApiVersion;
 import software.amazon.rds.dbinstance.client.RdsClientProvider;
 import software.amazon.rds.dbinstance.client.VersionedProxyClient;
+import software.amazon.rds.dbinstance.common.Errors;
+import software.amazon.rds.dbinstance.common.create.DBInstanceFactory;
+import software.amazon.rds.dbinstance.common.create.DBInstanceFactoryFactory;
 import software.amazon.rds.dbinstance.util.ResourceModelHelper;
 
 public class CreateHandler extends BaseHandlerStd {
@@ -57,7 +60,7 @@ public class CreateHandler extends BaseHandlerStd {
     }
 
     private void validateDeletionPolicyForClusterInstance(final ResourceHandlerRequest<ResourceModel> request) throws RequestValidationException {
-        if (isDBClusterMember(request.getDesiredResourceState()) && BooleanUtils.isTrue(request.getSnapshotRequested())) {
+        if (DBInstancePredicates.isDBClusterMember(request.getDesiredResourceState()) && BooleanUtils.isTrue(request.getSnapshotRequested())) {
             throw new RequestValidationException(ILLEGAL_DELETION_POLICY_ERROR);
         }
     }
@@ -88,18 +91,24 @@ public class CreateHandler extends BaseHandlerStd {
                 .resourceTags(Translator.translateTagsToSdk(request.getDesiredResourceState().getTags()))
                 .build();
 
+        final DBInstanceFactoryFactory factoryFactory = new DBInstanceFactoryFactory(
+            proxy, rdsProxyClient, allTags, requestLogger, config, getApiVersionDispatcher()
+        );
+
         return ProgressEvent.progress(model, callbackContext)
                 .then(progress -> {
                     if (StringUtils.isNullOrEmpty(progress.getResourceModel().getEngine())) {
                         try {
                             model.setEngine(fetchEngine(rdsProxyClient.defaultClient(), progress, proxy));
                         } catch (Exception e) {
-                            return Commons.handleException(progress, e, DB_INSTANCE_FETCH_ENGINE_RULE_SET, requestLogger);
+                            return Commons.handleException(progress, e, Errors.DB_INSTANCE_FETCH_ENGINE_RULE_SET, requestLogger);
                         }
                     }
                     return progress;
                 })
                 .then(progress -> Commons.execOnce(progress, () -> {
+                    final DBInstanceFactory dbInstanceFactory = factoryFactory.createFactory(progress);
+
                     if (ResourceModelHelper.isRestoreToPointInTime(progress.getResourceModel())) {
                         // restoreDBInstanceToPointInTime is not a versioned call.
                         return safeAddTags(this::restoreDbInstanceToPointInTimeRequest)
@@ -121,7 +130,7 @@ public class CreateHandler extends BaseHandlerStd {
                                     progress.getResourceModel().setMultiAZ(ResourceModelHelper.getDefaultMultiAzForEngine(engine));
                                 }
                             } catch (Exception e) {
-                                return Commons.handleException(progress, e, RESTORE_DB_INSTANCE_ERROR_RULE_SET, requestLogger);
+                                return Commons.handleException(progress, e, Errors.RESTORE_DB_INSTANCE_ERROR_RULE_SET, requestLogger);
                             }
                         }
                         return versioned(proxy, rdsProxyClient, progress, allTags, ImmutableMap.of(
@@ -129,10 +138,8 @@ public class CreateHandler extends BaseHandlerStd {
                                 ApiVersion.DEFAULT, safeAddTags(this::restoreDbInstanceFromSnapshot)
                         ));
                     }
-                    return versioned(proxy, rdsProxyClient, progress, allTags, ImmutableMap.of(
-                            ApiVersion.V12, this::createDbInstanceV12,
-                            ApiVersion.DEFAULT, safeAddTags(this::createDbInstance)
-                    ));
+                    // FIXME Currently only handling the fresh instance. TODO Handle above cases in factory.
+                    return dbInstanceFactory.create(progress);
                 }, CallbackContext::isCreated, CallbackContext::setCreated))
                 .then(progress -> Commons.execOnce(progress, () -> {
                     final Tagging.TagSet extraTags = Tagging.TagSet.builder()
@@ -295,7 +302,7 @@ public class CreateHandler extends BaseHandlerStd {
                 .handleError((request, exception, client, model, context) -> Commons.handleException(
                         ProgressEvent.progress(model, context),
                         exception,
-                        CREATE_DB_INSTANCE_ERROR_RULE_SET,
+                        Errors.CREATE_DB_INSTANCE_ERROR_RULE_SET,
                         requestLogger
                 ))
                 .progress();
@@ -323,7 +330,7 @@ public class CreateHandler extends BaseHandlerStd {
                 .handleError((request, exception, client, model, context) -> Commons.handleException(
                         ProgressEvent.progress(model, context),
                         exception,
-                        CREATE_DB_INSTANCE_ERROR_RULE_SET,
+                        Errors.CREATE_DB_INSTANCE_ERROR_RULE_SET,
                         requestLogger
                 ))
                 .progress();
@@ -355,7 +362,7 @@ public class CreateHandler extends BaseHandlerStd {
                 .handleError((request, exception, client, model, context) -> Commons.handleException(
                         ProgressEvent.progress(model, context),
                         exception,
-                        RESTORE_DB_INSTANCE_ERROR_RULE_SET,
+                        Errors.RESTORE_DB_INSTANCE_ERROR_RULE_SET,
                         requestLogger
                 ))
                 .progress();
@@ -383,7 +390,7 @@ public class CreateHandler extends BaseHandlerStd {
                 .handleError((request, exception, client, model, context) -> Commons.handleException(
                         ProgressEvent.progress(model, context),
                         exception,
-                        RESTORE_DB_INSTANCE_ERROR_RULE_SET,
+                        Errors.RESTORE_DB_INSTANCE_ERROR_RULE_SET,
                         requestLogger
                 ))
                 .progress();
@@ -411,7 +418,7 @@ public class CreateHandler extends BaseHandlerStd {
                 .handleError((request, exception, client, model, context) -> Commons.handleException(
                         ProgressEvent.progress(model, context),
                         exception,
-                        RESTORE_DB_INSTANCE_ERROR_RULE_SET,
+                        Errors.RESTORE_DB_INSTANCE_ERROR_RULE_SET,
                         requestLogger
                 ))
                 .progress();
@@ -440,7 +447,7 @@ public class CreateHandler extends BaseHandlerStd {
                 .handleError((request, exception, client, model, context) -> Commons.handleException(
                         ProgressEvent.progress(model, context),
                         exception,
-                        CREATE_DB_INSTANCE_READ_REPLICA_ERROR_RULE_SET,
+                        Errors.CREATE_DB_INSTANCE_READ_REPLICA_ERROR_RULE_SET,
                         requestLogger
                 ))
                 .progress();
@@ -467,7 +474,7 @@ public class CreateHandler extends BaseHandlerStd {
                 .handleError((modifyRequest, exception, client, model, context) -> Commons.handleException(
                         ProgressEvent.progress(model, context),
                         exception,
-                        MODIFY_DB_INSTANCE_ERROR_RULE_SET,
+                        Errors.MODIFY_DB_INSTANCE_ERROR_RULE_SET,
                         requestLogger
                 ))
                 .progress();
@@ -490,7 +497,7 @@ public class CreateHandler extends BaseHandlerStd {
                 .handleError((modifyRequest, exception, client, model, context) -> Commons.handleException(
                         ProgressEvent.progress(model, context),
                         exception,
-                        MODIFY_DB_INSTANCE_ERROR_RULE_SET,
+                        Errors.MODIFY_DB_INSTANCE_ERROR_RULE_SET,
                         requestLogger
                 ))
                 .progress();

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/DBInstancePredicates.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/DBInstancePredicates.java
@@ -1,0 +1,261 @@
+package software.amazon.rds.dbinstance;
+
+import com.amazonaws.arn.Arn;
+import com.amazonaws.util.CollectionUtils;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.apache.commons.lang3.BooleanUtils;
+import software.amazon.awssdk.services.rds.model.DBCluster;
+import software.amazon.awssdk.services.rds.model.DBInstance;
+import software.amazon.awssdk.services.rds.model.DomainMembership;
+import software.amazon.awssdk.services.rds.model.OptionGroupMembership;
+import software.amazon.awssdk.services.rds.model.PendingModifiedValues;
+import software.amazon.awssdk.utils.StringUtils;
+import software.amazon.cloudformation.exceptions.CfnNotStabilizedException;
+import software.amazon.rds.common.logging.RequestLogger;
+import software.amazon.rds.dbinstance.status.DBInstanceStatus;
+import software.amazon.rds.dbinstance.status.DBParameterGroupStatus;
+import software.amazon.rds.dbinstance.status.DomainMembershipStatus;
+import software.amazon.rds.dbinstance.status.OptionGroupStatus;
+import software.amazon.rds.dbinstance.status.ReadReplicaStatus;
+import software.amazon.rds.dbinstance.status.VPCSecurityGroupStatus;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class DBInstancePredicates {
+
+    private static final String SECRET_STATUS_ACTIVE = "active";
+    private static final List<String> RDS_CUSTOM_ORACLE_ENGINES = ImmutableList.of(
+            "custom-oracle-ee",
+            "custom-oracle-ee-cdb"
+    );
+    private static final String READ_REPLICA_STATUS_TYPE = "read replication";
+
+    public static void assertNoDBInstanceTerminalStatus(final DBInstance dbInstance) throws CfnNotStabilizedException {
+        final DBInstanceStatus status = DBInstanceStatus.fromString(dbInstance.dbInstanceStatus());
+        if (status != null && status.isTerminal()) {
+            throw new CfnNotStabilizedException(new Exception("DB Instance is in state: " + status.toString()));
+        }
+    }
+
+    public static void assertNoOptionGroupTerminalStatus(final DBInstance dbInstance) throws CfnNotStabilizedException {
+        final List<OptionGroupMembership> termOptionGroups = Optional.ofNullable(dbInstance.optionGroupMemberships()).orElse(Collections.emptyList())
+                .stream()
+                .filter(optionGroup -> {
+                    final OptionGroupStatus status = OptionGroupStatus.fromString(optionGroup.status());
+                    return status != null && status.isTerminal();
+                })
+                .collect(Collectors.toList());
+
+        if (!termOptionGroups.isEmpty()) {
+            throw new CfnNotStabilizedException(new Exception(
+                    String.format("OptionGroup %s is in a terminal state",
+                            termOptionGroups.get(0).optionGroupName())));
+        }
+    }
+
+    public static void assertNoDomainMembershipTerminalStatus(final DBInstance dbInstance) throws CfnNotStabilizedException {
+        final List<DomainMembership> terminalDomainMemberships = Optional.ofNullable(dbInstance.domainMemberships()).orElse(Collections.emptyList())
+                .stream()
+                .filter(domainMembership -> {
+                    final DomainMembershipStatus status = DomainMembershipStatus.fromString(domainMembership.status());
+                    return status != null && status.isTerminal();
+                })
+                .collect(Collectors.toList());
+
+        if (!terminalDomainMemberships.isEmpty()) {
+            throw new CfnNotStabilizedException(new Exception(String.format("Domain %s is in a terminal state",
+                    terminalDomainMemberships.get(0).domain())));
+        }
+    }
+
+    public static void assertNoTerminalStatus(final DBInstance dbInstance) throws CfnNotStabilizedException {
+        assertNoDBInstanceTerminalStatus(dbInstance);
+        assertNoOptionGroupTerminalStatus(dbInstance);
+        assertNoDomainMembershipTerminalStatus(dbInstance);
+    }
+
+    public static boolean isInstanceStabilizedAfterReplicationStop(
+        final DBInstance dbInstance,
+        final ResourceModel model
+    ) {
+        assertNoTerminalStatus(dbInstance);
+        return isDBInstanceAvailable(dbInstance)
+                && !dbInstance.hasDbInstanceAutomatedBackupsReplications();
+    }
+
+    public static boolean isDBInstanceAvailable(final DBInstance dbInstance) {
+        return DBInstanceStatus.Available.equalsString(dbInstance.dbInstanceStatus());
+    }
+
+    public static boolean isDomainMembershipsJoined(final DBInstance dbInstance) {
+        return Optional.ofNullable(dbInstance.domainMemberships()).orElse(Collections.emptyList())
+                .stream()
+                .allMatch(membership -> DomainMembershipStatus.Joined.equalsString(membership.status()) ||
+                        DomainMembershipStatus.KerberosEnabled.equalsString(membership.status()));
+    }
+
+    public static boolean isVpcSecurityGroupsActive(final DBInstance dbInstance) {
+        return Optional.ofNullable(dbInstance.vpcSecurityGroups()).orElse(Collections.emptyList())
+                .stream()
+                .allMatch(group -> VPCSecurityGroupStatus.Active.equalsString(group.status()));
+    }
+
+    public static boolean isNoPendingChanges(final DBInstance dbInstance) {
+        final PendingModifiedValues pending = dbInstance.pendingModifiedValues();
+        return (pending == null) || (pending.dbInstanceClass() == null &&
+                pending.allocatedStorage() == null &&
+                pending.automationMode() == null &&
+                pending.backupRetentionPeriod() == null &&
+                pending.dbInstanceIdentifier() == null &&
+                pending.dbSubnetGroupName() == null &&
+                pending.engine() == null &&
+                pending.engineVersion() == null &&
+                pending.iamDatabaseAuthenticationEnabled() == null &&
+                pending.iops() == null &&
+                pending.licenseModel() == null &&
+                pending.masterUserPassword() == null &&
+                pending.multiAZ() == null &&
+                pending.pendingCloudwatchLogsExports() == null &&
+                pending.port() == null &&
+                CollectionUtils.isNullOrEmpty(pending.processorFeatures()) &&
+                pending.resumeFullAutomationModeTime() == null &&
+                pending.storageThroughput() == null &&
+                pending.storageType() == null
+        );
+    }
+
+    public static boolean isCaCertificateChangesApplied(final DBInstance dbInstance, final ResourceModel model) {
+        final PendingModifiedValues pending = dbInstance.pendingModifiedValues();
+        return pending == null ||
+                pending.caCertificateIdentifier() == null ||
+                BooleanUtils.isNotTrue(model.getCertificateRotationRestart());
+    }
+
+    public static boolean isDBParameterGroupNotApplying(final DBInstance dbInstance) {
+        return Optional.ofNullable(dbInstance.dbParameterGroups()).orElse(Collections.emptyList())
+                .stream()
+                .noneMatch(group -> DBParameterGroupStatus.Applying.equalsString(group.parameterApplyStatus()));
+    }
+
+    public static boolean isReplicationComplete(final DBInstance dbInstance) {
+        return Optional.ofNullable(dbInstance.statusInfos()).orElse(Collections.emptyList())
+                .stream()
+                .filter(statusInfo -> READ_REPLICA_STATUS_TYPE.equals(statusInfo.statusType()))
+                .allMatch(statusInfo -> ReadReplicaStatus.Replicating.equalsString(statusInfo.status()));
+    }
+
+    public static boolean isDBClusterParameterGroupInSync(final ResourceModel model, final DBCluster dbCluster) {
+        return Optional.ofNullable(dbCluster.dbClusterMembers()).orElse(Collections.emptyList())
+                .stream()
+                .filter(member -> model.getDBInstanceIdentifier().equalsIgnoreCase(member.dbInstanceIdentifier()))
+                .anyMatch(member -> DBParameterGroupStatus.InSync.equalsString(member.dbClusterParameterGroupStatus()));
+    }
+
+    public static boolean isDBClusterMember(final ResourceModel model) {
+        return StringUtils.isNotBlank(model.getDBClusterIdentifier());
+    }
+
+    public static boolean isRdsCustomOracleInstance(final ResourceModel model) {
+        return RDS_CUSTOM_ORACLE_ENGINES.contains(model.getEngine());
+    }
+
+    public static boolean isOptionGroupInSync(final DBInstance dbInstance) {
+        return Optional.ofNullable(dbInstance.optionGroupMemberships()).orElse(Collections.emptyList())
+                .stream()
+                .allMatch(optionGroup -> OptionGroupStatus.InSync.equalsString(optionGroup.status()));
+    }
+
+    public static boolean isDBParameterGroupInSync(final DBInstance dbInstance) {
+        return Optional.ofNullable(dbInstance.dbParameterGroups()).orElse(Collections.emptyList())
+                .stream()
+                .allMatch(parameterGroup -> DBParameterGroupStatus.InSync.equalsString(parameterGroup.parameterApplyStatus()));
+    }
+
+    public static boolean isMasterUserSecretStabilized(final DBInstance instance) {
+        if (instance.masterUserSecret() == null) {
+            return true;
+        }
+        return SECRET_STATUS_ACTIVE.equalsIgnoreCase(instance.masterUserSecret().secretStatus());
+    }
+
+    public static boolean isDBInstanceStabilizedAfterMutate(
+        final DBInstance dbInstance,
+        final ResourceModel model,
+        final CallbackContext context,
+        final RequestLogger requestLogger
+    ) {
+        assertNoTerminalStatus(dbInstance);
+
+        final boolean isDBInstanceStabilizedAfterMutateResult = isDBInstanceAvailable(dbInstance) &&
+                isReplicationComplete(dbInstance) &&
+                isDBParameterGroupNotApplying(dbInstance) &&
+                isNoPendingChanges(dbInstance) &&
+                isCaCertificateChangesApplied(dbInstance, model) &&
+                isVpcSecurityGroupsActive(dbInstance) &&
+                isDomainMembershipsJoined(dbInstance) &&
+                isMasterUserSecretStabilized(dbInstance);
+
+        requestLogger.log(String.format("isDBInstanceStabilizedAfterMutate: %b", isDBInstanceStabilizedAfterMutateResult),
+                ImmutableMap.of("isDBInstanceAvailable", isDBInstanceAvailable(dbInstance),
+                        "isReplicationComplete", isReplicationComplete(dbInstance),
+                        "isDBParameterGroupNotApplying", isDBParameterGroupNotApplying(dbInstance),
+                        "isNoPendingChanges", isNoPendingChanges(dbInstance),
+                        "isCaCertificateChangesApplied", isCaCertificateChangesApplied(dbInstance, model),
+                        "isVpcSecurityGroupsActive", isVpcSecurityGroupsActive(dbInstance),
+                        "isDomainMembershipsJoined", isDomainMembershipsJoined(dbInstance),
+                        "isMasterUserSecretStabilized", isMasterUserSecretStabilized(dbInstance)),
+                ImmutableMap.of("Description", "isDBInstanceStabilizedAfterMutate method will be repeatedly" +
+                        " called with a backoff mechanism after the modify call until it returns true. This" +
+                        " process will continue until all included flags are true."));
+
+        return isDBInstanceStabilizedAfterMutateResult;
+    }
+
+    public static boolean isDBInstanceStabilizedAfterReboot(
+        final DBInstance dbInstance,
+        final Optional<DBCluster> maybeDbCluster,
+        final ResourceModel model,
+        final RequestLogger requestLogger
+    ) {
+        assertNoTerminalStatus(dbInstance);
+
+        final boolean isDBClusterParameterGroupStabilized = maybeDbCluster
+            .map(dbCluster -> isDBClusterParameterGroupInSync(model, dbCluster))
+            .orElseGet(() -> !DBInstancePredicates.isDBClusterMember(model));
+        final boolean isDBInstanceStabilizedAfterReboot = isDBInstanceAvailable(dbInstance) &&
+                isDBParameterGroupInSync(dbInstance) &&
+                isOptionGroupInSync(dbInstance) &&
+                isDBClusterParameterGroupStabilized;
+
+        requestLogger.log(String.format("isDBInstanceStabilizedAfterReboot: %b", isDBInstanceStabilizedAfterReboot),
+                ImmutableMap.of("isDBInstanceAvailable", isDBInstanceAvailable(dbInstance),
+                        "isDBParameterGroupInSync", isDBParameterGroupInSync(dbInstance),
+                        "isOptionGroupInSync", isOptionGroupInSync(dbInstance),
+                        "isDBClusterParameterGroupStabilized", isDBClusterParameterGroupStabilized),
+                ImmutableMap.of("Description", "isDBInstanceStabilizedAfterReboot method will be repeatedly" +
+                        " called with a backoff mechanism after the reboot call until it returns true. This" +
+                        " process will continue until all included flags are true."));
+
+        return isDBInstanceStabilizedAfterReboot;
+    }
+
+    public static boolean isInstanceStabilizedAfterReplicationStart(
+        final DBInstance dbInstance,
+        final ResourceModel model
+    ) {
+        assertNoTerminalStatus(dbInstance);
+        return isDBInstanceAvailable(dbInstance)
+                && dbInstance.hasDbInstanceAutomatedBackupsReplications() &&
+                !dbInstance.dbInstanceAutomatedBackupsReplications().isEmpty() &&
+                model.getAutomaticBackupReplicationRegion()
+                        .equalsIgnoreCase(
+                                Arn.fromString(dbInstance.dbInstanceAutomatedBackupsReplications().get(0).dbInstanceAutomatedBackupsArn()).getRegion());
+    }
+}

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/DeleteHandler.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/DeleteHandler.java
@@ -14,6 +14,7 @@ import software.amazon.rds.common.handler.HandlerConfig;
 import software.amazon.rds.common.request.ValidatedRequest;
 import software.amazon.rds.common.util.IdentifierFactory;
 import software.amazon.rds.dbinstance.client.VersionedProxyClient;
+import software.amazon.rds.dbinstance.common.Errors;
 import software.amazon.rds.dbinstance.util.ResourceModelHelper;
 
 public class DeleteHandler extends BaseHandlerStd {
@@ -49,7 +50,7 @@ public class DeleteHandler extends BaseHandlerStd {
         // Final snapshots are not allowed for read replicas and cluster instances.
         if (BooleanUtils.isNotFalse(request.getSnapshotRequested()) &&
                 !ResourceModelHelper.isReadReplica(resourceModel) &&
-                !isDBClusterMember(resourceModel)) {
+                !DBInstancePredicates.isDBClusterMember(resourceModel)) {
             snapshotIdentifier = snapshotIdentifierFactory.newIdentifier()
                     .withStackId(request.getStackId())
                     .withResourceId(StringUtils.prependIfMissing(request.getLogicalResourceIdentifier(), SNAPSHOT_PREFIX))
@@ -69,7 +70,7 @@ public class DeleteHandler extends BaseHandlerStd {
                         .handleError((deleteRequest, exception, client, model, context) -> Commons.handleException(
                                 ProgressEvent.progress(model, context),
                                 exception,
-                                DELETE_DB_INSTANCE_ERROR_RULE_SET,
+                                Errors.DELETE_DB_INSTANCE_ERROR_RULE_SET,
                                 requestLogger
                         )).progress()
                 )
@@ -87,7 +88,7 @@ public class DeleteHandler extends BaseHandlerStd {
                         .handleError((noopRequest, exception, client, model, context) -> Commons.handleException(
                                 ProgressEvent.progress(model, context),
                                 exception,
-                                DEFAULT_DB_INSTANCE_ERROR_RULE_SET,
+                                Errors.DEFAULT_DB_INSTANCE_ERROR_RULE_SET,
                                 requestLogger
                         ))
                         .progress()

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/ReadHandler.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/ReadHandler.java
@@ -9,6 +9,7 @@ import software.amazon.rds.common.handler.Commons;
 import software.amazon.rds.common.handler.HandlerConfig;
 import software.amazon.rds.common.request.ValidatedRequest;
 import software.amazon.rds.dbinstance.client.VersionedProxyClient;
+import software.amazon.rds.dbinstance.common.Errors;
 
 public class ReadHandler extends BaseHandlerStd {
 
@@ -36,7 +37,7 @@ public class ReadHandler extends BaseHandlerStd {
                 .handleError((describeRequest, exception, client, model, context) -> Commons.handleException(
                         ProgressEvent.progress(model, context),
                         exception,
-                        DEFAULT_DB_INSTANCE_ERROR_RULE_SET,
+                        Errors.DEFAULT_DB_INSTANCE_ERROR_RULE_SET,
                         requestLogger
                 ))
                 .done((describeRequest, describeResponse, proxyInvocation, resourceModel, context) -> {

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/UpdateHandler.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/UpdateHandler.java
@@ -37,6 +37,7 @@ import software.amazon.rds.common.handler.Tagging;
 import software.amazon.rds.common.request.ValidatedRequest;
 import software.amazon.rds.dbinstance.client.ApiVersion;
 import software.amazon.rds.dbinstance.client.VersionedProxyClient;
+import software.amazon.rds.dbinstance.common.Errors;
 import software.amazon.rds.dbinstance.status.DBInstanceStatus;
 import software.amazon.rds.dbinstance.status.DBParameterGroupStatus;
 import software.amazon.rds.dbinstance.util.ImmutabilityHelper;
@@ -68,7 +69,7 @@ public class UpdateHandler extends BaseHandlerStd {
             return Commons.handleException(
                     ProgressEvent.progress(request.getPreviousResourceState(), callbackContext),
                     ex,
-                    DEFAULT_DB_INSTANCE_ERROR_RULE_SET,
+                    Errors.DEFAULT_DB_INSTANCE_ERROR_RULE_SET,
                     requestLogger
             );
         }
@@ -110,7 +111,7 @@ public class UpdateHandler extends BaseHandlerStd {
                             throw new CfnInvalidRequestException("EngineLifecycleSupport cannot be modified.");
                         }
                     } catch (CfnInvalidRequestException e) {
-                        return Commons.handleException(progress, e, MODIFY_DB_INSTANCE_ERROR_RULE_SET, requestLogger);
+                        return Commons.handleException(progress, e, Errors.MODIFY_DB_INSTANCE_ERROR_RULE_SET, requestLogger);
                     }
                     return progress;
                 })
@@ -141,7 +142,7 @@ public class UpdateHandler extends BaseHandlerStd {
                         }
                         return progress;
                     } catch (Exception ex) {
-                        return Commons.handleException(progress, ex, MODIFY_DB_INSTANCE_ERROR_RULE_SET, requestLogger);
+                        return Commons.handleException(progress, ex, Errors.MODIFY_DB_INSTANCE_ERROR_RULE_SET, requestLogger);
                     }
                 }, CallbackContext::isStorageAllocated, CallbackContext::setStorageAllocated))
                 .then(progress -> Commons.execOnce(progress, () -> {
@@ -233,7 +234,7 @@ public class UpdateHandler extends BaseHandlerStd {
         return ProgressEvent.progress(request.getDesiredResourceState(), callbackContext)
                 .then(progress -> {
                     if (shouldReboot(rdsProxyClient.defaultClient(), progress) ||
-                            (isDBClusterMember(progress.getResourceModel()) && shouldRebootCluster(rdsProxyClient.defaultClient(), progress))) {
+                            (DBInstancePredicates.isDBClusterMember(progress.getResourceModel()) && shouldRebootCluster(rdsProxyClient.defaultClient(), progress))) {
                         return rebootAwait(proxy, rdsProxyClient.defaultClient(), progress);
                     }
                     return progress;
@@ -241,7 +242,7 @@ public class UpdateHandler extends BaseHandlerStd {
                 .then(progress -> awaitDBParameterGroupInSyncStatus(proxy, rdsProxyClient.defaultClient(), progress))
                 .then(progress -> awaitOptionGroupInSyncStatus(proxy, rdsProxyClient.defaultClient(), progress))
                 .then(progress -> {
-                    if (isDBClusterMember(progress.getResourceModel())) {
+                    if (DBInstancePredicates.isDBClusterMember(progress.getResourceModel())) {
                         return awaitDBClusterParameterGroup(proxy, rdsProxyClient.defaultClient(), progress);
                     }
                     return progress;
@@ -301,7 +302,7 @@ public class UpdateHandler extends BaseHandlerStd {
             final DBInstance dbInstance = fetchDBInstance(rdsProxyClient, request.getDesiredResourceState());
             request.getDesiredResourceState().setMaxAllocatedStorage(dbInstance.allocatedStorage());
         } catch (Exception exception) {
-            return Commons.handleException(progress, exception, MODIFY_DB_INSTANCE_ERROR_RULE_SET, requestLogger);
+            return Commons.handleException(progress, exception, Errors.MODIFY_DB_INSTANCE_ERROR_RULE_SET, requestLogger);
         }
         return progress;
     }
@@ -322,7 +323,7 @@ public class UpdateHandler extends BaseHandlerStd {
                 .handleError((request, exception, proxyInvocation, model, context) -> Commons.handleException(
                         ProgressEvent.progress(model, context),
                         exception,
-                        DEFAULT_DB_INSTANCE_ERROR_RULE_SET,
+                        Errors.DEFAULT_DB_INSTANCE_ERROR_RULE_SET,
                         requestLogger
                 ))
                 .progress();
@@ -369,8 +370,8 @@ public class UpdateHandler extends BaseHandlerStd {
 
     private boolean shouldSetDefaultVpcId(final ResourceHandlerRequest<ResourceModel> request) {
         // DBCluster member instances inherit default vpc security groups from the corresponding umbrella cluster
-        return !isDBClusterMember(request.getDesiredResourceState()) &&
-                !isRdsCustomOracleInstance(request.getDesiredResourceState()) &&
+        return !DBInstancePredicates.isDBClusterMember(request.getDesiredResourceState()) &&
+                !DBInstancePredicates.isRdsCustomOracleInstance(request.getDesiredResourceState()) &&
                 CollectionUtils.isNullOrEmpty(request.getDesiredResourceState().getVPCSecurityGroups());
     }
 
@@ -413,7 +414,7 @@ public class UpdateHandler extends BaseHandlerStd {
             final String vpcId = dbInstance.dbSubnetGroup().vpcId();
             securityGroup = fetchSecurityGroup(ec2ProxyClient, vpcId, "default");
         } catch (Exception e) {
-            return Commons.handleException(progress, e, DEFAULT_DB_INSTANCE_ERROR_RULE_SET, requestLogger);
+            return Commons.handleException(progress, e, Errors.DEFAULT_DB_INSTANCE_ERROR_RULE_SET, requestLogger);
         }
 
         if (securityGroup != null) {
@@ -439,7 +440,7 @@ public class UpdateHandler extends BaseHandlerStd {
                 .handleError((request, exception, proxyInvocation, model, context) -> Commons.handleException(
                         ProgressEvent.progress(model, context),
                         exception,
-                        DEFAULT_DB_INSTANCE_ERROR_RULE_SET,
+                        Errors.DEFAULT_DB_INSTANCE_ERROR_RULE_SET,
                         requestLogger
                 ))
                 .progress();
@@ -458,7 +459,7 @@ public class UpdateHandler extends BaseHandlerStd {
                 .handleError((request, exception, proxyInvocation, model, context) -> Commons.handleException(
                         ProgressEvent.progress(model, context),
                         exception,
-                        DEFAULT_DB_INSTANCE_ERROR_RULE_SET,
+                        Errors.DEFAULT_DB_INSTANCE_ERROR_RULE_SET,
                         requestLogger
                 ))
                 .progress();
@@ -477,7 +478,7 @@ public class UpdateHandler extends BaseHandlerStd {
                 .handleError((request, exception, proxyInvocation, model, context) -> Commons.handleException(
                         ProgressEvent.progress(model, context),
                         exception,
-                        DEFAULT_DB_INSTANCE_ERROR_RULE_SET,
+                        Errors.DEFAULT_DB_INSTANCE_ERROR_RULE_SET,
                         requestLogger
                 ))
                 .progress();
@@ -498,7 +499,7 @@ public class UpdateHandler extends BaseHandlerStd {
                 .handleError((request, exception, proxyInvocation, model, context) -> Commons.handleException(
                         ProgressEvent.progress(model, context),
                         exception,
-                        DEFAULT_DB_INSTANCE_ERROR_RULE_SET,
+                        Errors.DEFAULT_DB_INSTANCE_ERROR_RULE_SET,
                         requestLogger
                 ))
                 .progress();

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/common/Errors.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/common/Errors.java
@@ -1,0 +1,238 @@
+package software.amazon.rds.dbinstance.common;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import software.amazon.awssdk.services.rds.model.AuthorizationNotFoundException;
+import software.amazon.awssdk.services.rds.model.CertificateNotFoundException;
+import software.amazon.awssdk.services.rds.model.DbClusterNotFoundException;
+import software.amazon.awssdk.services.rds.model.DbClusterSnapshotNotFoundException;
+import software.amazon.awssdk.services.rds.model.DbInstanceAlreadyExistsException;
+import software.amazon.awssdk.services.rds.model.DbInstanceAutomatedBackupQuotaExceededException;
+import software.amazon.awssdk.services.rds.model.DbInstanceNotFoundException;
+import software.amazon.awssdk.services.rds.model.DbInstanceRoleAlreadyExistsException;
+import software.amazon.awssdk.services.rds.model.DbInstanceRoleNotFoundException;
+import software.amazon.awssdk.services.rds.model.DbParameterGroupNotFoundException;
+import software.amazon.awssdk.services.rds.model.DbSecurityGroupNotFoundException;
+import software.amazon.awssdk.services.rds.model.DbSnapshotAlreadyExistsException;
+import software.amazon.awssdk.services.rds.model.DbSnapshotNotFoundException;
+import software.amazon.awssdk.services.rds.model.DbSubnetGroupDoesNotCoverEnoughAZsException;
+import software.amazon.awssdk.services.rds.model.DbSubnetGroupNotFoundException;
+import software.amazon.awssdk.services.rds.model.DbUpgradeDependencyFailureException;
+import software.amazon.awssdk.services.rds.model.DomainNotFoundException;
+import software.amazon.awssdk.services.rds.model.InstanceQuotaExceededException;
+import software.amazon.awssdk.services.rds.model.InsufficientDbInstanceCapacityException;
+import software.amazon.awssdk.services.rds.model.InvalidDbClusterStateException;
+import software.amazon.awssdk.services.rds.model.InvalidDbInstanceAutomatedBackupStateException;
+import software.amazon.awssdk.services.rds.model.InvalidDbInstanceStateException;
+import software.amazon.awssdk.services.rds.model.InvalidDbSecurityGroupStateException;
+import software.amazon.awssdk.services.rds.model.InvalidDbSnapshotStateException;
+import software.amazon.awssdk.services.rds.model.InvalidRestoreException;
+import software.amazon.awssdk.services.rds.model.InvalidSubnetException;
+import software.amazon.awssdk.services.rds.model.InvalidVpcNetworkStateException;
+import software.amazon.awssdk.services.rds.model.KmsKeyNotAccessibleException;
+import software.amazon.awssdk.services.rds.model.NetworkTypeNotSupportedException;
+import software.amazon.awssdk.services.rds.model.OptionGroupNotFoundException;
+import software.amazon.awssdk.services.rds.model.ProvisionedIopsNotAvailableInAzException;
+import software.amazon.awssdk.services.rds.model.SnapshotQuotaExceededException;
+import software.amazon.awssdk.services.rds.model.StorageQuotaExceededException;
+import software.amazon.awssdk.services.rds.model.StorageTypeNotSupportedException;
+import software.amazon.awssdk.utils.StringUtils;
+import software.amazon.cloudformation.exceptions.CfnInvalidRequestException;
+import software.amazon.cloudformation.proxy.HandlerErrorCode;
+import software.amazon.cloudformation.proxy.OperationStatus;
+import software.amazon.rds.common.error.ErrorCode;
+import software.amazon.rds.common.error.ErrorRuleSet;
+import software.amazon.rds.common.error.ErrorStatus;
+import software.amazon.rds.common.handler.Commons;
+import software.amazon.rds.dbinstance.BaseHandlerStd;
+
+import java.util.function.Function;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class Errors {
+
+    public static final ErrorRuleSet DEFAULT_DB_INSTANCE_ERROR_RULE_SET = ErrorRuleSet
+        .extend(Commons.DEFAULT_ERROR_RULE_SET)
+        .withErrorCodes(ErrorStatus.failWith(HandlerErrorCode.ServiceLimitExceeded),
+            ErrorCode.InstanceQuotaExceeded,
+            ErrorCode.InsufficientDBInstanceCapacity,
+            ErrorCode.SnapshotQuotaExceeded,
+            ErrorCode.StorageQuotaExceeded)
+        .withErrorCodes(ErrorStatus.failWith(HandlerErrorCode.InvalidRequest),
+            ErrorCode.DBSubnetGroupNotAllowedFault,
+            ErrorCode.InvalidParameterCombination,
+            ErrorCode.InvalidParameterValue,
+            ErrorCode.InvalidVPCNetworkStateFault,
+            ErrorCode.KMSKeyNotAccessibleFault,
+            ErrorCode.MissingParameter,
+            ErrorCode.ProvisionedIopsNotAvailableInAZFault,
+            ErrorCode.StorageTypeNotSupportedFault)
+        .withErrorCodes(ErrorStatus.failWith(HandlerErrorCode.NotFound),
+            ErrorCode.DBClusterNotFoundFault,
+            ErrorCode.DBParameterGroupNotFound,
+            ErrorCode.DBSecurityGroupNotFound,
+            ErrorCode.DBSnapshotNotFound,
+            ErrorCode.DBSubnetGroupNotFoundFault)
+        .withErrorClasses(ErrorStatus.failWith(HandlerErrorCode.NotFound),
+            CertificateNotFoundException.class,
+            DbClusterNotFoundException.class,
+            DbInstanceNotFoundException.class,
+            DbParameterGroupNotFoundException.class,
+            DbSecurityGroupNotFoundException.class,
+            DbSnapshotNotFoundException.class,
+            DbClusterSnapshotNotFoundException.class,
+            DbSubnetGroupNotFoundException.class,
+            DomainNotFoundException.class,
+            OptionGroupNotFoundException.class)
+        .withErrorClasses(ErrorStatus.failWith(HandlerErrorCode.ServiceLimitExceeded),
+            DbInstanceAutomatedBackupQuotaExceededException.class,
+            InsufficientDbInstanceCapacityException.class,
+            InstanceQuotaExceededException.class,
+            SnapshotQuotaExceededException.class,
+            StorageQuotaExceededException.class)
+        .withErrorClasses(ErrorStatus.failWith(HandlerErrorCode.ResourceConflict),
+            InvalidDbInstanceStateException.class,
+            InvalidDbClusterStateException.class,
+            DbUpgradeDependencyFailureException.class,
+            InvalidDbSecurityGroupStateException.class)
+        .withErrorClasses(ErrorStatus.failWith(HandlerErrorCode.InvalidRequest),
+            AuthorizationNotFoundException.class,
+            DbSubnetGroupDoesNotCoverEnoughAZsException.class,
+            InvalidVpcNetworkStateException.class,
+            KmsKeyNotAccessibleException.class,
+            NetworkTypeNotSupportedException.class,
+            ProvisionedIopsNotAvailableInAzException.class,
+            StorageTypeNotSupportedException.class)
+        .withErrorClasses(ErrorStatus.failWith(HandlerErrorCode.AlreadyExists),
+            DbInstanceAlreadyExistsException.class)
+        .withErrorClasses(ErrorStatus.failWith(HandlerErrorCode.GeneralServiceException),
+            InvalidSubnetException.class)
+        .build();
+
+    public static final ErrorRuleSet DELETE_DB_INSTANCE_ERROR_RULE_SET = ErrorRuleSet
+        .extend(DEFAULT_DB_INSTANCE_ERROR_RULE_SET)
+        .withErrorCodes(ErrorStatus.failWith(HandlerErrorCode.InvalidRequest),
+            ErrorCode.InvalidParameterValue)
+        .withErrorCodes(ErrorStatus.failWith(HandlerErrorCode.NotFound),
+            ErrorCode.DBInstanceNotFound)
+        .withErrorCodes(ErrorStatus.conditional(Errors::ignoreDBInstanceBeingDeletedConditionalErrorStatus),
+            ErrorCode.InvalidDBInstanceState)
+        .withErrorCodes(ErrorStatus.failWith(HandlerErrorCode.InvalidRequest),
+            ErrorCode.DBSnapshotAlreadyExists)
+        .withErrorClasses(ErrorStatus.failWith(HandlerErrorCode.NotFound),
+            DbInstanceNotFoundException.class)
+        .withErrorClasses(ErrorStatus.conditional(Errors::ignoreDBInstanceBeingDeletedConditionalErrorStatus),
+            InvalidDbInstanceStateException.class)
+        .withErrorClasses(ErrorStatus.failWith(HandlerErrorCode.InvalidRequest),
+            DbSnapshotAlreadyExistsException.class)
+        .build();
+
+    public static final ErrorRuleSet UPDATE_ASSOCIATED_ROLES_ERROR_RULE_SET = ErrorRuleSet
+        .extend(DEFAULT_DB_INSTANCE_ERROR_RULE_SET)
+        .withErrorClasses(ErrorStatus.ignore(),
+            DbInstanceRoleAlreadyExistsException.class,
+            DbInstanceRoleNotFoundException.class)
+        .build();
+
+    public static final ErrorRuleSet MODIFY_DB_INSTANCE_ERROR_RULE_SET = ErrorRuleSet
+        .extend(DEFAULT_DB_INSTANCE_ERROR_RULE_SET)
+        .withErrorCodes(ErrorStatus.failWith(HandlerErrorCode.ResourceConflict),
+            ErrorCode.InvalidDBInstanceState)
+        .withErrorCodes(ErrorStatus.failWith(HandlerErrorCode.NotFound),
+            ErrorCode.DBInstanceNotFound)
+        .withErrorCodes(ErrorStatus.failWith(HandlerErrorCode.InvalidRequest),
+            ErrorCode.InvalidDBSecurityGroupState,
+            ErrorCode.InvalidParameterCombination)
+        .withErrorClasses(ErrorStatus.failWith(HandlerErrorCode.ResourceConflict),
+            InvalidDbInstanceStateException.class)
+        .withErrorClasses(ErrorStatus.failWith(HandlerErrorCode.NotFound),
+            DbInstanceNotFoundException.class)
+        .withErrorClasses(ErrorStatus.failWith(HandlerErrorCode.InvalidRequest),
+            CfnInvalidRequestException.class,
+            InvalidDbSecurityGroupStateException.class)
+        .build();
+
+    public static final ErrorRuleSet MODIFY_DB_INSTANCE_AUTOMATIC_BACKUP_REPLICATION_ERROR_RULE_SET = ErrorRuleSet
+        .extend(DEFAULT_DB_INSTANCE_ERROR_RULE_SET)
+        .withErrorClasses(ErrorStatus.ignore(OperationStatus.IN_PROGRESS),
+            InvalidDbInstanceAutomatedBackupStateException.class)
+        .withErrorClasses(ErrorStatus.failWith(HandlerErrorCode.ServiceLimitExceeded),
+            DbInstanceAutomatedBackupQuotaExceededException.class)
+        .build();
+
+    public static final ErrorRuleSet REBOOT_DB_INSTANCE_ERROR_RULE_SET = ErrorRuleSet
+        .extend(DEFAULT_DB_INSTANCE_ERROR_RULE_SET)
+        .withErrorCodes(ErrorStatus.failWith(HandlerErrorCode.NotFound),
+            ErrorCode.DBInstanceNotFound)
+        .withErrorCodes(ErrorStatus.failWith(HandlerErrorCode.ResourceConflict),
+            ErrorCode.InvalidDBInstanceState)
+        .withErrorClasses(ErrorStatus.failWith(HandlerErrorCode.NotFound),
+            DbInstanceNotFoundException.class)
+        .withErrorClasses(ErrorStatus.failWith(HandlerErrorCode.ResourceConflict),
+            InvalidDbInstanceStateException.class)
+        .build();
+
+    public static final ErrorRuleSet CREATE_DB_INSTANCE_READ_REPLICA_ERROR_RULE_SET = ErrorRuleSet
+        .extend(DEFAULT_DB_INSTANCE_ERROR_RULE_SET)
+        .withErrorCodes(ErrorStatus.failWith(HandlerErrorCode.AlreadyExists),
+            ErrorCode.DBInstanceAlreadyExists)
+        .withErrorClasses(ErrorStatus.failWith(HandlerErrorCode.AlreadyExists),
+            DbInstanceAlreadyExistsException.class)
+        .withErrorClasses(ErrorStatus.failWith(HandlerErrorCode.NotFound),
+            DbClusterNotFoundException.class)
+        .withErrorClasses(ErrorStatus.failWith(HandlerErrorCode.ResourceConflict),
+            InvalidDbClusterStateException.class)
+        .build();
+
+    public static final ErrorRuleSet RESTORE_DB_INSTANCE_ERROR_RULE_SET = ErrorRuleSet
+        .extend(DEFAULT_DB_INSTANCE_ERROR_RULE_SET)
+        .withErrorCodes(ErrorStatus.failWith(HandlerErrorCode.AlreadyExists),
+            ErrorCode.DBInstanceAlreadyExists)
+        .withErrorCodes(ErrorStatus.failWith(HandlerErrorCode.InvalidRequest),
+            ErrorCode.InvalidDBSnapshotState,
+            ErrorCode.InvalidRestoreFault)
+        .withErrorClasses(ErrorStatus.failWith(HandlerErrorCode.AlreadyExists),
+            DbInstanceAlreadyExistsException.class)
+        .withErrorClasses(ErrorStatus.failWith(HandlerErrorCode.InvalidRequest),
+            InvalidDbSnapshotStateException.class,
+            InvalidRestoreException.class)
+        .build();
+
+    public static final ErrorRuleSet DB_INSTANCE_FETCH_ENGINE_RULE_SET = ErrorRuleSet
+        .extend(DEFAULT_DB_INSTANCE_ERROR_RULE_SET)
+        .withErrorClasses(ErrorStatus.failWith(HandlerErrorCode.InvalidRequest),
+            CfnInvalidRequestException.class)
+        .build();
+
+    public static final ErrorRuleSet CREATE_DB_INSTANCE_ERROR_RULE_SET = ErrorRuleSet
+        .extend(DEFAULT_DB_INSTANCE_ERROR_RULE_SET)
+        .withErrorCodes(ErrorStatus.failWith(HandlerErrorCode.AlreadyExists),
+            ErrorCode.DBInstanceAlreadyExists)
+        .withErrorClasses(
+            ErrorStatus.failWith(HandlerErrorCode.AlreadyExists),
+            DbInstanceAlreadyExistsException.class)
+        .build();
+
+    private static ErrorStatus ignoreDBInstanceBeingDeletedConditionalErrorStatus(final Exception exception) {
+        if (isDBInstanceBeingDeletedException(exception)) {
+            return ErrorStatus.ignore(OperationStatus.IN_PROGRESS);
+        }
+        return ErrorStatus.failWith(HandlerErrorCode.ResourceConflict);
+    };
+
+    private static boolean isDBInstanceBeingDeletedException(final Exception e) {
+        if (e instanceof InvalidDbInstanceStateException) {
+            return looksLikeDBInstanceBeingDeletedMessage(e.getMessage());
+        }
+        return false;
+    }
+
+    private static final String IS_ALREADY_BEING_DELETED_ERROR_FRAGMENT = "is already being deleted";
+
+    private static boolean looksLikeDBInstanceBeingDeletedMessage(final String message) {
+        if (StringUtils.isBlank(message)) {
+            return false;
+        }
+        return message.contains(IS_ALREADY_BEING_DELETED_ERROR_FRAGMENT);
+    }
+}

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/common/create/DBInstanceFactory.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/common/create/DBInstanceFactory.java
@@ -1,0 +1,12 @@
+package software.amazon.rds.dbinstance.common.create;
+
+import software.amazon.cloudformation.proxy.ProgressEvent;
+import software.amazon.rds.dbinstance.CallbackContext;
+import software.amazon.rds.dbinstance.ResourceModel;
+
+public interface DBInstanceFactory {
+
+    ProgressEvent<ResourceModel, CallbackContext> create(
+        ProgressEvent<ResourceModel, CallbackContext> input
+    );
+}

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/common/create/DBInstanceFactoryFactory.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/common/create/DBInstanceFactoryFactory.java
@@ -1,0 +1,52 @@
+package software.amazon.rds.dbinstance.common.create;
+
+import lombok.AllArgsConstructor;
+import software.amazon.awssdk.services.rds.RdsClient;
+import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
+import software.amazon.cloudformation.proxy.ProgressEvent;
+import software.amazon.rds.common.handler.HandlerConfig;
+import software.amazon.rds.common.handler.Tagging;
+import software.amazon.rds.common.logging.RequestLogger;
+import software.amazon.rds.dbinstance.CallbackContext;
+import software.amazon.rds.dbinstance.ResourceModel;
+import software.amazon.rds.dbinstance.client.ApiVersionDispatcher;
+import software.amazon.rds.dbinstance.client.VersionedProxyClient;
+
+@AllArgsConstructor
+public class DBInstanceFactoryFactory {
+
+    private final AmazonWebServicesClientProxy proxy;
+    private final VersionedProxyClient<RdsClient> rdsProxyClient;
+    private final Tagging.TagSet allTags;
+    private final RequestLogger requestLogger;
+    private final HandlerConfig config;
+    private final ApiVersionDispatcher<ResourceModel, CallbackContext> apiVersionDispatcher;
+
+    private enum FactoryType {
+        IS_READ_REPLICA,
+        IS_FROM_SNAPSHOT,
+        IS_FROM_POINT_IN_TIME,
+        IS_FRESH_INSTANCE;
+    }
+
+    public DBInstanceFactory createFactory(
+        ProgressEvent<ResourceModel, CallbackContext> progress
+    ) {
+        switch (discernFactoryType()) {
+            case IS_FRESH_INSTANCE:
+                return new FreshInstance(
+                    proxy,
+                    rdsProxyClient,
+                    allTags,
+                    requestLogger,
+                    config,
+                    apiVersionDispatcher
+                );
+        }
+        return null;
+    }
+
+    private FactoryType discernFactoryType() {
+        return FactoryType.IS_FRESH_INSTANCE;
+    }
+}

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/common/create/FreshInstance.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/common/create/FreshInstance.java
@@ -1,0 +1,145 @@
+package software.amazon.rds.dbinstance.common.create;
+
+import lombok.AllArgsConstructor;
+import software.amazon.awssdk.services.rds.RdsClient;
+import software.amazon.awssdk.services.rds.model.DBInstance;
+import software.amazon.awssdk.services.rds.model.DescribeDbInstancesResponse;
+import software.amazon.awssdk.utils.ImmutableMap;
+import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
+import software.amazon.cloudformation.proxy.ProgressEvent;
+import software.amazon.cloudformation.proxy.ProxyClient;
+import software.amazon.rds.common.handler.Commons;
+import software.amazon.rds.common.handler.HandlerConfig;
+import software.amazon.rds.common.handler.HandlerMethod;
+import software.amazon.rds.common.handler.Tagging;
+import software.amazon.rds.common.logging.RequestLogger;
+import software.amazon.rds.dbinstance.CallbackContext;
+import software.amazon.rds.dbinstance.DBInstancePredicates;
+import software.amazon.rds.dbinstance.ResourceModel;
+import software.amazon.rds.dbinstance.Translator;
+import software.amazon.rds.dbinstance.client.ApiVersion;
+import software.amazon.rds.dbinstance.client.ApiVersionDispatcher;
+import software.amazon.rds.dbinstance.client.VersionedProxyClient;
+import software.amazon.rds.dbinstance.common.Errors;
+
+import java.util.Map;
+
+@AllArgsConstructor
+public class FreshInstance implements DBInstanceFactory {
+
+    private final AmazonWebServicesClientProxy proxy;
+    private final VersionedProxyClient<RdsClient> rdsProxyClient;
+    private final Tagging.TagSet allTags;
+    private final RequestLogger requestLogger;
+    private final HandlerConfig config;
+    private final ApiVersionDispatcher<ResourceModel, CallbackContext> apiVersionDispatcher;
+
+    public ProgressEvent<ResourceModel, CallbackContext> create(ProgressEvent<ResourceModel, CallbackContext> progress) {
+        return versioned(proxy, rdsProxyClient, progress, allTags, ImmutableMap.of(
+            ApiVersion.V12, this::createDbInstanceV12,
+            ApiVersion.DEFAULT, safeAddTags(this::createDbInstance)
+        ));
+    }
+
+    private ProgressEvent<ResourceModel, CallbackContext> createDbInstance(
+        final AmazonWebServicesClientProxy proxy,
+        final ProxyClient<RdsClient> rdsProxyClient,
+        final ProgressEvent<ResourceModel, CallbackContext> progress,
+        final Tagging.TagSet tagSet
+    ) {
+        return proxy.initiate(
+                "rds::create-db-instance",
+                rdsProxyClient,
+                progress.getResourceModel(),
+                progress.getCallbackContext()
+            ).translateToServiceRequest(model -> Translator.createDbInstanceRequest(model, tagSet))
+            .backoffDelay(config.getBackoff())
+            .makeServiceCall((createRequest, proxyInvocation) -> proxyInvocation.injectCredentialsAndInvokeV2(
+                createRequest,
+                proxyInvocation.client()::createDBInstance
+            ))
+            .stabilize((request, response, proxyInvocation, model, context) ->
+            {
+                final DBInstance dbInstance = fetchDBInstance(rdsProxyClient, model);
+                return DBInstancePredicates.isDBInstanceStabilizedAfterMutate(dbInstance, model, context, requestLogger) ;
+            })
+            .handleError((request, exception, client, model, context) -> Commons.handleException(
+                ProgressEvent.progress(model, context),
+                exception,
+                Errors.CREATE_DB_INSTANCE_ERROR_RULE_SET,
+                requestLogger
+            ))
+            .progress();
+    }
+
+    private DBInstance fetchDBInstance(
+        final ProxyClient<RdsClient> rdsProxyClient,
+        final ResourceModel model
+    ) {
+        final DescribeDbInstancesResponse response = rdsProxyClient.injectCredentialsAndInvokeV2(
+            Translator.describeDbInstancesRequest(model),
+            rdsProxyClient.client()::describeDBInstances
+        );
+        return response.dbInstances().get(0);
+    }
+
+    private ProgressEvent<ResourceModel, CallbackContext> createDbInstanceV12(
+        final AmazonWebServicesClientProxy proxy,
+        final ProxyClient<RdsClient> rdsProxyClient,
+        final ProgressEvent<ResourceModel, CallbackContext> progress,
+        final Tagging.TagSet tagSet
+    ) {
+        requestLogger.log("CreateDbInstanceAPIv12Invoked");
+        requestLogger.log("API version 12 create detected",
+            "This indicates that the customer is using DBSecurityGroup, which may result in certain features not" +
+                " functioning properly. Please refer to the API model for supported parameters");
+        return proxy.initiate(
+                "rds::create-db-instance-v12",
+                rdsProxyClient,
+                progress.getResourceModel(),
+                progress.getCallbackContext()
+            ).translateToServiceRequest(Translator::createDbInstanceRequestV12)
+            .backoffDelay(config.getBackoff())
+            .makeServiceCall((createRequest, proxyInvocation) -> proxyInvocation.injectCredentialsAndInvokeV2(
+                createRequest,
+                proxyInvocation.client()::createDBInstance
+            ))
+            .stabilize((request, response, proxyInvocation, model, context) -> {
+                final DBInstance dbInstance = fetchDBInstance(rdsProxyClient, model);
+                return DBInstancePredicates.isDBInstanceStabilizedAfterMutate(dbInstance, model, context, requestLogger) ;
+            })
+            .handleError((request, exception, client, model, context) -> Commons.handleException(
+                ProgressEvent.progress(model, context),
+                exception,
+                Errors.CREATE_DB_INSTANCE_ERROR_RULE_SET,
+                requestLogger
+            ))
+            .progress();
+    }
+
+    protected ProgressEvent<ResourceModel, CallbackContext> versioned(
+        final AmazonWebServicesClientProxy proxy,
+        final VersionedProxyClient<RdsClient> rdsProxyClient,
+        final ProgressEvent<ResourceModel, CallbackContext> progress,
+        final Tagging.TagSet allTags,
+        final Map<ApiVersion, HandlerMethod<ResourceModel, CallbackContext>> methodVersions
+    ) {
+        final ResourceModel model = progress.getResourceModel();
+        final CallbackContext callbackContext = progress.getCallbackContext();
+        final ApiVersion apiVersion = getApiVersionDispatcher().dispatch(model, callbackContext);
+        if (!methodVersions.containsKey(apiVersion)) {
+            throw new RuntimeException("Missing method version");
+        }
+        return methodVersions.get(apiVersion).invoke(proxy, rdsProxyClient.forVersion(apiVersion), progress, allTags);
+    }
+
+    protected ApiVersionDispatcher<ResourceModel, CallbackContext> getApiVersionDispatcher() {
+        return apiVersionDispatcher;
+    }
+
+    private HandlerMethod<ResourceModel, CallbackContext> safeAddTags(final HandlerMethod<ResourceModel, CallbackContext> handlerMethod) {
+        return (proxy, rdsProxyClient, progress, tagSet) -> progress.then(p -> Tagging.createWithTaggingFallback(proxy, rdsProxyClient, handlerMethod, progress, tagSet));
+    }
+
+
+}

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/common/create/FromPointInTime.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/common/create/FromPointInTime.java
@@ -1,0 +1,14 @@
+package software.amazon.rds.dbinstance.common.create;
+
+import org.apache.commons.lang3.NotImplementedException;
+import software.amazon.cloudformation.proxy.ProgressEvent;
+import software.amazon.rds.dbinstance.CallbackContext;
+import software.amazon.rds.dbinstance.ResourceModel;
+
+public class FromPointInTime implements DBInstanceFactory {
+
+    @Override
+    public ProgressEvent<ResourceModel, CallbackContext> create(ProgressEvent<ResourceModel, CallbackContext> input) {
+        throw new NotImplementedException();
+    }
+}

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/common/create/FromSnapshot.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/common/create/FromSnapshot.java
@@ -1,0 +1,14 @@
+package software.amazon.rds.dbinstance.common.create;
+
+import org.apache.commons.lang3.NotImplementedException;
+import software.amazon.cloudformation.proxy.ProgressEvent;
+import software.amazon.rds.dbinstance.CallbackContext;
+import software.amazon.rds.dbinstance.ResourceModel;
+
+public class FromSnapshot implements DBInstanceFactory {
+
+    @Override
+    public ProgressEvent<ResourceModel, CallbackContext> create(ProgressEvent<ResourceModel, CallbackContext> input) {
+        throw new NotImplementedException();
+    }
+}

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/common/create/ReadReplica.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/common/create/ReadReplica.java
@@ -1,0 +1,14 @@
+package software.amazon.rds.dbinstance.common.create;
+
+import org.apache.commons.lang3.NotImplementedException;
+import software.amazon.cloudformation.proxy.ProgressEvent;
+import software.amazon.rds.dbinstance.CallbackContext;
+import software.amazon.rds.dbinstance.ResourceModel;
+
+public class ReadReplica implements DBInstanceFactory {
+
+    @Override
+    public ProgressEvent<ResourceModel, CallbackContext> create(ProgressEvent<ResourceModel, CallbackContext> input) {
+        throw new NotImplementedException();
+    }
+}

--- a/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/BaseHandlerStdTest.java
+++ b/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/BaseHandlerStdTest.java
@@ -55,14 +55,14 @@ class BaseHandlerStdTest {
 
     @Test
     void isDomainMembershipsJoined_NullDomainMembershipReturnsTrue() {
-        Assertions.assertThat(handler.isDomainMembershipsJoined(
+        Assertions.assertThat(DBInstancePredicates.isDomainMembershipsJoined(
                 DBInstance.builder().build()
         )).isTrue();
     }
 
     @Test
     void isDomainMembershipsJoined_EmptyDomainMembershipReturnsTrue() {
-        Assertions.assertThat(handler.isDomainMembershipsJoined(
+        Assertions.assertThat(DBInstancePredicates.isDomainMembershipsJoined(
                 DBInstance.builder()
                         .domainMemberships(Collections.emptyList())
                         .build()
@@ -71,7 +71,7 @@ class BaseHandlerStdTest {
 
     @Test
     void isDomainMembershipsJoined_NonEmptyListJoinedAndKerberosReturnsTrue() {
-        Assertions.assertThat(handler.isDomainMembershipsJoined(
+        Assertions.assertThat(DBInstancePredicates.isDomainMembershipsJoined(
                 DBInstance.builder()
                         .domainMemberships(
                                 DomainMembership.builder().status("joined").build(),
@@ -83,7 +83,7 @@ class BaseHandlerStdTest {
 
     @Test
     void isDomainMembershipsJoined_NonEmptyListJoinedAndKerberosAndAnythingElseReturnsFalse() {
-        Assertions.assertThat(handler.isDomainMembershipsJoined(
+        Assertions.assertThat(DBInstancePredicates.isDomainMembershipsJoined(
                 DBInstance.builder()
                         .domainMemberships(
                                 DomainMembership.builder().status("joined").build(),
@@ -96,14 +96,14 @@ class BaseHandlerStdTest {
 
     @Test
     void isVpcSecurityGroupsActive_NullVpcSecurityGroupsReturnsTrue() {
-        Assertions.assertThat(handler.isVpcSecurityGroupsActive(
+        Assertions.assertThat(DBInstancePredicates.isVpcSecurityGroupsActive(
                 DBInstance.builder().build()
         )).isTrue();
     }
 
     @Test
     void isVpcSecurityGroupsActive_EmptyVpcSecurityGroupsReturnsTrue() {
-        Assertions.assertThat(handler.isVpcSecurityGroupsActive(
+        Assertions.assertThat(DBInstancePredicates.isVpcSecurityGroupsActive(
                 DBInstance.builder()
                         .vpcSecurityGroups(Collections.emptyList())
                         .build()
@@ -112,7 +112,7 @@ class BaseHandlerStdTest {
 
     @Test
     void isVpcSecurityGroupsActive_NonEmptyVpcSecurityGroupsActiveReturnsTrue() {
-        Assertions.assertThat(handler.isVpcSecurityGroupsActive(
+        Assertions.assertThat(DBInstancePredicates.isVpcSecurityGroupsActive(
                 DBInstance.builder()
                         .vpcSecurityGroups(
                                 VpcSecurityGroupMembership.builder().status("active").build(),
@@ -124,7 +124,7 @@ class BaseHandlerStdTest {
 
     @Test
     void isVpcSecurityGroupsActive_NonEmptyVpcSecurityGroupsNotActiveReturnsFalse() {
-        Assertions.assertThat(handler.isVpcSecurityGroupsActive(
+        Assertions.assertThat(DBInstancePredicates.isVpcSecurityGroupsActive(
                 DBInstance.builder()
                         .vpcSecurityGroups(
                                 VpcSecurityGroupMembership.builder().status("active").build(),
@@ -136,14 +136,14 @@ class BaseHandlerStdTest {
 
     @Test
     void isNoPendingChanges_NullPendingChangesReturnsTrue() {
-        Assertions.assertThat(handler.isNoPendingChanges(
+        Assertions.assertThat(DBInstancePredicates.isNoPendingChanges(
                 DBInstance.builder().build()
         )).isTrue();
     }
 
     @Test
     void isNoPendingChanges_EmptyPendingChangesReturnsTrue() {
-        Assertions.assertThat(handler.isNoPendingChanges(
+        Assertions.assertThat(DBInstancePredicates.isNoPendingChanges(
                 DBInstance.builder()
                         .pendingModifiedValues(PendingModifiedValues.builder().build())
                         .build()
@@ -152,7 +152,7 @@ class BaseHandlerStdTest {
 
     @Test
     void isNoPendingChanges_NonEmptyAllocatedStorageReturnsFalse() {
-        Assertions.assertThat(handler.isNoPendingChanges(
+        Assertions.assertThat(DBInstancePredicates.isNoPendingChanges(
                 DBInstance.builder()
                         .pendingModifiedValues(
                                 PendingModifiedValues.builder()
@@ -164,7 +164,7 @@ class BaseHandlerStdTest {
 
     @Test
     void isCaCertificateChangesApplied_NonEmptyCACertificateIdentifierReturnsFalse_WhenCertificateRotationRestartIsTrue() {
-        Assertions.assertThat(handler.isCaCertificateChangesApplied(
+        Assertions.assertThat(DBInstancePredicates.isCaCertificateChangesApplied(
                 DBInstance.builder()
                         .pendingModifiedValues(
                                 PendingModifiedValues.builder()
@@ -177,7 +177,7 @@ class BaseHandlerStdTest {
 
     @Test
     void isCaCertificateChangesApplied_NonEmptyCACertificateIdentifierReturnsTrue_WhenCertificateRotationRestartIsFalse() {
-        Assertions.assertThat(handler.isCaCertificateChangesApplied(
+        Assertions.assertThat(DBInstancePredicates.isCaCertificateChangesApplied(
                 DBInstance.builder()
                         .pendingModifiedValues(
                                 PendingModifiedValues.builder()
@@ -190,7 +190,7 @@ class BaseHandlerStdTest {
 
     @Test
     void isNoPendingChanges_NonEmptyMasterUserPasswordReturnsFalse() {
-        Assertions.assertThat(handler.isNoPendingChanges(
+        Assertions.assertThat(DBInstancePredicates.isNoPendingChanges(
                 DBInstance.builder()
                         .pendingModifiedValues(
                                 PendingModifiedValues.builder()
@@ -202,7 +202,7 @@ class BaseHandlerStdTest {
 
     @Test
     void isNoPendingChanges_NonEmptyBackupRetentionPeriodReturnsFalse() {
-        Assertions.assertThat(handler.isNoPendingChanges(
+        Assertions.assertThat(DBInstancePredicates.isNoPendingChanges(
                 DBInstance.builder()
                         .pendingModifiedValues(
                                 PendingModifiedValues.builder()
@@ -214,7 +214,7 @@ class BaseHandlerStdTest {
 
     @Test
     void isNoPendingChanges_NonEmptyMultiAZReturnsFalse() {
-        Assertions.assertThat(handler.isNoPendingChanges(
+        Assertions.assertThat(DBInstancePredicates.isNoPendingChanges(
                 DBInstance.builder()
                         .pendingModifiedValues(
                                 PendingModifiedValues.builder()
@@ -226,7 +226,7 @@ class BaseHandlerStdTest {
 
     @Test
     void isNoPendingChanges_NonEmptyEngineVersionReturnsFalse() {
-        Assertions.assertThat(handler.isNoPendingChanges(
+        Assertions.assertThat(DBInstancePredicates.isNoPendingChanges(
                 DBInstance.builder()
                         .pendingModifiedValues(
                                 PendingModifiedValues.builder()
@@ -238,7 +238,7 @@ class BaseHandlerStdTest {
 
     @Test
     void isNoPendingChanges_NonEmptyIopsReturnsFalse() {
-        Assertions.assertThat(handler.isNoPendingChanges(
+        Assertions.assertThat(DBInstancePredicates.isNoPendingChanges(
                 DBInstance.builder()
                         .pendingModifiedValues(
                                 PendingModifiedValues.builder()
@@ -250,7 +250,7 @@ class BaseHandlerStdTest {
 
     @Test
     void isNoPendingChanges_NonEmptyDBInstanceIdentifierReturnsFalse() {
-        Assertions.assertThat(handler.isNoPendingChanges(
+        Assertions.assertThat(DBInstancePredicates.isNoPendingChanges(
                 DBInstance.builder()
                         .pendingModifiedValues(
                                 PendingModifiedValues.builder()
@@ -262,7 +262,7 @@ class BaseHandlerStdTest {
 
     @Test
     void isNoPendingChanges_NonEmptyLicenseModelReturnsFalse() {
-        Assertions.assertThat(handler.isNoPendingChanges(
+        Assertions.assertThat(DBInstancePredicates.isNoPendingChanges(
                 DBInstance.builder()
                         .pendingModifiedValues(
                                 PendingModifiedValues.builder()
@@ -274,7 +274,7 @@ class BaseHandlerStdTest {
 
     @Test
     void isNoPendingChanges_NonEmptyStorageTypeReturnsFalse() {
-        Assertions.assertThat(handler.isNoPendingChanges(
+        Assertions.assertThat(DBInstancePredicates.isNoPendingChanges(
                 DBInstance.builder()
                         .pendingModifiedValues(
                                 PendingModifiedValues.builder()
@@ -286,7 +286,7 @@ class BaseHandlerStdTest {
 
     @Test
     void isNoPendingChanges_NonEmptyDBSubnetGroupNameReturnsFalse() {
-        Assertions.assertThat(handler.isNoPendingChanges(
+        Assertions.assertThat(DBInstancePredicates.isNoPendingChanges(
                 DBInstance.builder()
                         .pendingModifiedValues(
                                 PendingModifiedValues.builder()
@@ -298,7 +298,7 @@ class BaseHandlerStdTest {
 
     @Test
     void isNoPendingChanges_NonEmptyPendingCloudWatchLogsExportsReturnsFalse() {
-        Assertions.assertThat(handler.isNoPendingChanges(
+        Assertions.assertThat(DBInstancePredicates.isNoPendingChanges(
                 DBInstance.builder()
                         .pendingModifiedValues(
                                 PendingModifiedValues.builder()
@@ -310,7 +310,7 @@ class BaseHandlerStdTest {
 
     @Test
     void isNoPendingChanges_EmptyProcessorFeaturesReturnsTrue() {
-        Assertions.assertThat(handler.isNoPendingChanges(
+        Assertions.assertThat(DBInstancePredicates.isNoPendingChanges(
                 DBInstance.builder()
                         .pendingModifiedValues(
                                 PendingModifiedValues.builder()
@@ -322,7 +322,7 @@ class BaseHandlerStdTest {
 
     @Test
     void isNoPendingChanges_NonEmptyIamDatabaseAutenticationEnabledReturnsFalse() {
-        Assertions.assertThat(handler.isNoPendingChanges(
+        Assertions.assertThat(DBInstancePredicates.isNoPendingChanges(
                 DBInstance.builder()
                         .pendingModifiedValues(
                                 PendingModifiedValues.builder()
@@ -334,7 +334,7 @@ class BaseHandlerStdTest {
 
     @Test
     void isNoPendingChanges_NonEmptyAutomationModeReturnsFalse() {
-        Assertions.assertThat(handler.isNoPendingChanges(
+        Assertions.assertThat(DBInstancePredicates.isNoPendingChanges(
                 DBInstance.builder()
                         .pendingModifiedValues(
                                 PendingModifiedValues.builder()
@@ -346,7 +346,7 @@ class BaseHandlerStdTest {
 
     @Test
     void isNoPendingChanges_NonEmptyResumeFullAutomationModeTimeReturnsFalse() {
-        Assertions.assertThat(handler.isNoPendingChanges(
+        Assertions.assertThat(DBInstancePredicates.isNoPendingChanges(
                 DBInstance.builder()
                         .pendingModifiedValues(
                                 PendingModifiedValues.builder()
@@ -358,7 +358,7 @@ class BaseHandlerStdTest {
 
     @Test
     void isNoPendingChanges_NonEmptyReturnsFalse() {
-        Assertions.assertThat(handler.isNoPendingChanges(
+        Assertions.assertThat(DBInstancePredicates.isNoPendingChanges(
                 DBInstance.builder()
                         .pendingModifiedValues(
                                 PendingModifiedValues.builder()
@@ -370,21 +370,21 @@ class BaseHandlerStdTest {
 
     @Test
     void isDBParameterGroupSyncComplete_NullParameterGroupsReturnsTrue() {
-        Assertions.assertThat(handler.isDBParameterGroupNotApplying(
+        Assertions.assertThat(DBInstancePredicates.isDBParameterGroupNotApplying(
                 DBInstance.builder().build()
         )).isTrue();
     }
 
     @Test
     void isDBParameterGroupSyncComplete_EmptyParameterGroupsReturnsTrue() {
-        Assertions.assertThat(handler.isDBParameterGroupNotApplying(
+        Assertions.assertThat(DBInstancePredicates.isDBParameterGroupNotApplying(
                 DBInstance.builder().dbParameterGroups(Collections.emptyList()).build()
         )).isTrue();
     }
 
     @Test
     void isDBParameterGroupSyncComplete_NonEmptyParameterGroupsInSyncReturnsTrue() {
-        Assertions.assertThat(handler.isDBParameterGroupNotApplying(
+        Assertions.assertThat(DBInstancePredicates.isDBParameterGroupNotApplying(
                 DBInstance.builder()
                         .dbParameterGroups(
                                 DBParameterGroupStatus.builder().parameterApplyStatus("in-sync").build(),
@@ -396,7 +396,7 @@ class BaseHandlerStdTest {
 
     @Test
     void isDBParameterGroupSyncComplete_NonEmptyParameterGroupsApplyingReturnsFalse() {
-        Assertions.assertThat(handler.isDBParameterGroupNotApplying(
+        Assertions.assertThat(DBInstancePredicates.isDBParameterGroupNotApplying(
                 DBInstance.builder()
                         .dbParameterGroups(
                                 DBParameterGroupStatus.builder().parameterApplyStatus("in-sync").build(),
@@ -408,21 +408,21 @@ class BaseHandlerStdTest {
 
     @Test
     void isReplicationComplete_NullStatusInfoReturnsTrue() {
-        Assertions.assertThat(handler.isReplicationComplete(
+        Assertions.assertThat(DBInstancePredicates.isReplicationComplete(
                 DBInstance.builder().build()
         )).isTrue();
     }
 
     @Test
     void isReplicationComplete_EmptyStatusInfoReturnsTrue() {
-        Assertions.assertThat(handler.isReplicationComplete(
+        Assertions.assertThat(DBInstancePredicates.isReplicationComplete(
                 DBInstance.builder().statusInfos(Collections.emptyList()).build()
         )).isTrue();
     }
 
     @Test
     void isReplicationComplete_NonEmptyListNoReadReplicaInfoReturnsTrue() {
-        Assertions.assertThat(handler.isReplicationComplete(
+        Assertions.assertThat(DBInstancePredicates.isReplicationComplete(
                 DBInstance.builder()
                         .statusInfos(DBInstanceStatusInfo.builder()
                                 .statusType("something else")
@@ -434,7 +434,7 @@ class BaseHandlerStdTest {
 
     @Test
     void isReplicationComplete_NonEmptyListContainingReplicaInfoReplicatingReturnsTrue() {
-        Assertions.assertThat(handler.isReplicationComplete(
+        Assertions.assertThat(DBInstancePredicates.isReplicationComplete(
                 DBInstance.builder()
                         .statusInfos(
                                 DBInstanceStatusInfo.builder()
@@ -452,7 +452,7 @@ class BaseHandlerStdTest {
 
     @Test
     void isReplicationComplete_NonEmptyListContainingReplicaInfoNotReplicatingReturnsFalse() {
-        Assertions.assertThat(handler.isReplicationComplete(
+        Assertions.assertThat(DBInstancePredicates.isReplicationComplete(
                 DBInstance.builder()
                         .statusInfos(
                                 DBInstanceStatusInfo.builder()
@@ -470,7 +470,7 @@ class BaseHandlerStdTest {
 
     @Test
     void isMasterUserSecretStabilized_masterUserSecretIsNull() {
-        Assertions.assertThat(handler.isMasterUserSecretStabilized(
+        Assertions.assertThat(DBInstancePredicates.isMasterUserSecretStabilized(
                 DBInstance.builder()
                         .build()
         )).isTrue();
@@ -478,7 +478,7 @@ class BaseHandlerStdTest {
 
     @Test
     void isMasterUserSecretStabilized_masterUserSecretStatusActive() {
-        Assertions.assertThat(handler.isMasterUserSecretStabilized(
+        Assertions.assertThat(DBInstancePredicates.isMasterUserSecretStabilized(
                 DBInstance.builder()
                         .masterUserSecret(MasterUserSecret.builder()
                                 .secretStatus("Active")
@@ -489,7 +489,7 @@ class BaseHandlerStdTest {
 
     @Test
     void isMasterUserSecretStabilized_masterUserSecretStatusCreating() {
-        Assertions.assertThat(handler.isMasterUserSecretStabilized(
+        Assertions.assertThat(DBInstancePredicates.isMasterUserSecretStabilized(
                 DBInstance.builder()
                         .masterUserSecret(MasterUserSecret.builder()
                                 .secretStatus("Creating")


### PR DESCRIPTION
Incomplete, for early feedback from the other core maintainers. We (AWS RDS) have a number of upcoming features that stand to benefit from presenting an cleaner way to extend the create paths. The core team have discussed what this might look like and this is a first pass attempt to separate shape the code to that vision. 

*Description of changes:* Static methods and error rules have been pulled out of the base handler class; The instance create factory is now constructed by factory according to the model. 

I plan to follow up with a second revision but wanted to stop here as the decomposition of the BaseHandlerStd, while simple, has become somewhat large. The "FreshInstance" factory has copied a few methods that need to be reconciled. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
