### PR TITLE
Support for Aurora Limitless Databases

### DIFF
--- a/aws-rds-cfn-common/pom.xml
+++ b/aws-rds-cfn-common/pom.xml
@@ -28,12 +28,12 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>utils</artifactId>
-            <version>2.25.12</version>
+            <version>2.28.14</version>
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>rds</artifactId>
-            <version>2.25.56</version>
+            <version>2.28.14</version>
         </dependency>
         <dependency>
             <groupId>software.amazon.cloudformation</groupId>

--- a/aws-rds-customdbengineversion/pom.xml
+++ b/aws-rds-customdbengineversion/pom.xml
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>rds</artifactId>
-            <version>2.25.56</version>
+            <version>2.28.14</version>
         </dependency>
         <dependency>
             <groupId>software.amazon.rds.common</groupId>

--- a/aws-rds-dbcluster/aws-rds-dbcluster.json
+++ b/aws-rds-dbcluster/aws-rds-dbcluster.json
@@ -44,6 +44,10 @@
       "minimum": 1,
       "type": "integer"
     },
+    "ClusterScalabilityType": {
+      "type": "string",
+      "description": "The scalability type for the DB cluster."
+    },
     "CopyTagsToSnapshot": {
       "description": "A value that indicates whether to copy all tags from the DB cluster to snapshots of the DB cluster. The default is not to copy them.",
       "type": "boolean"
@@ -434,6 +438,7 @@
   ],
   "createOnlyProperties": [
     "/properties/AvailabilityZones",
+    "/properties/ClusterScalabilityType",
     "/properties/DBClusterIdentifier",
     "/properties/DBSubnetGroupName",
     "/properties/DBSystemId",
@@ -458,6 +463,7 @@
     "/properties/DBClusterIdentifier"
   ],
   "writeOnlyProperties": [
+    "/properties/ClusterScalabilityType",
     "/properties/DBInstanceParameterGroupName",
     "/properties/MasterUserPassword",
     "/properties/RestoreToTime",

--- a/aws-rds-dbcluster/docs/README.md
+++ b/aws-rds-dbcluster/docs/README.md
@@ -19,6 +19,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
         "<a href="#autominorversionupgrade" title="AutoMinorVersionUpgrade">AutoMinorVersionUpgrade</a>" : <i>Boolean</i>,
         "<a href="#backtrackwindow" title="BacktrackWindow">BacktrackWindow</a>" : <i>Integer</i>,
         "<a href="#backupretentionperiod" title="BackupRetentionPeriod">BackupRetentionPeriod</a>" : <i>Integer</i>,
+        "<a href="#clusterscalabilitytype" title="ClusterScalabilityType">ClusterScalabilityType</a>" : <i>String</i>,
         "<a href="#copytagstosnapshot" title="CopyTagsToSnapshot">CopyTagsToSnapshot</a>" : <i>Boolean</i>,
         "<a href="#databasename" title="DatabaseName">DatabaseName</a>" : <i>String</i>,
         "<a href="#dbclusterinstanceclass" title="DBClusterInstanceClass">DBClusterInstanceClass</a>" : <i>String</i>,
@@ -87,6 +88,7 @@ Properties:
     <a href="#autominorversionupgrade" title="AutoMinorVersionUpgrade">AutoMinorVersionUpgrade</a>: <i>Boolean</i>
     <a href="#backtrackwindow" title="BacktrackWindow">BacktrackWindow</a>: <i>Integer</i>
     <a href="#backupretentionperiod" title="BackupRetentionPeriod">BackupRetentionPeriod</a>: <i>Integer</i>
+    <a href="#clusterscalabilitytype" title="ClusterScalabilityType">ClusterScalabilityType</a>: <i>String</i>
     <a href="#copytagstosnapshot" title="CopyTagsToSnapshot">CopyTagsToSnapshot</a>: <i>Boolean</i>
     <a href="#databasename" title="DatabaseName">DatabaseName</a>: <i>String</i>
     <a href="#dbclusterinstanceclass" title="DBClusterInstanceClass">DBClusterInstanceClass</a>: <i>String</i>
@@ -211,6 +213,16 @@ _Required_: No
 _Type_: Integer
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+
+#### ClusterScalabilityType
+
+The scalability type for the DB cluster.
+
+_Required_: No
+
+_Type_: String
+
+_Update requires_: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
 
 #### CopyTagsToSnapshot
 
@@ -498,7 +510,7 @@ _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormati
 
 #### MonitoringInterval
 
-The interval, in seconds, between points when Enhanced Monitoring metrics are collected for the DB cluster. To turn off collecting Enhanced Monitoring metrics, specify 0. The default is 0.
+The interval, in seconds, between points when Enhanced Monitoring metrics are collected for the DB cluster. To turn off collecting Enhanced Monitoring metrics, specify 0. The default is not to enable Enhanced Monitoring.
 
 _Required_: No
 

--- a/aws-rds-dbcluster/pom.xml
+++ b/aws-rds-dbcluster/pom.xml
@@ -30,18 +30,18 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>rds</artifactId>
-            <version>2.25.56</version>
+            <version>2.28.14</version>
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>ec2</artifactId>
-            <version>2.22.12</version>
+            <version>2.28.14</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/software.amazon.awssdk/aws-query-protocol -->
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>aws-query-protocol</artifactId>
-            <version>2.20.138</version>
+            <version>2.28.14</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/software.amazon.cloudformation/aws-cloudformation-rpdk-java-plugin -->
         <dependency>

--- a/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/Translator.java
+++ b/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/Translator.java
@@ -55,6 +55,7 @@ public class Translator {
                 .availabilityZones(model.getAvailabilityZones())
                 .backtrackWindow(castToLong(model.getBacktrackWindow()))
                 .backupRetentionPeriod(model.getBackupRetentionPeriod())
+                .clusterScalabilityType(model.getClusterScalabilityType())
                 .copyTagsToSnapshot(model.getCopyTagsToSnapshot())
                 .databaseName(model.getDatabaseName())
                 .dbClusterIdentifier(model.getDBClusterIdentifier())

--- a/aws-rds-dbclusterendpoint/pom.xml
+++ b/aws-rds-dbclusterendpoint/pom.xml
@@ -30,7 +30,7 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>rds</artifactId>
-            <version>2.25.56</version>
+            <version>2.28.14</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/software.amazon.cloudformation/aws-cloudformation-rpdk-java-plugin -->
         <dependency>

--- a/aws-rds-dbclusterparametergroup/pom.xml
+++ b/aws-rds-dbclusterparametergroup/pom.xml
@@ -30,7 +30,7 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>rds</artifactId>
-            <version>2.25.56</version>
+            <version>2.28.14</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/software.amazon.cloudformation/aws-cloudformation-rpdk-java-plugin -->
         <dependency>

--- a/aws-rds-dbinstance/docs/README.md
+++ b/aws-rds-dbinstance/docs/README.md
@@ -697,7 +697,7 @@ _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormati
 
 #### MonitoringInterval
 
-The interval, in seconds, between points when Enhanced Monitoring metrics are collected for the DB instance. To disable collecting Enhanced Monitoring metrics, specify 0. The default is 0.
+The interval, in seconds, between points when Enhanced Monitoring metrics are collected for the DB instance. To disable collecting Enhanced Monitoring metrics, specify 0. The default is not to enable Enhanced Monitoring.
 
 _Required_: No
 

--- a/aws-rds-dbinstance/pom.xml
+++ b/aws-rds-dbinstance/pom.xml
@@ -34,7 +34,7 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>rds</artifactId>
-            <version>2.25.56</version>
+            <version>2.28.14</version>
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>

--- a/aws-rds-dbparametergroup/pom.xml
+++ b/aws-rds-dbparametergroup/pom.xml
@@ -29,7 +29,7 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>rds</artifactId>
-            <version>2.25.56</version>
+            <version>2.28.14</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/software.amazon.cloudformation/aws-cloudformation-rpdk-java-plugin -->
         <dependency>

--- a/aws-rds-dbshardgroup/.gitignore
+++ b/aws-rds-dbshardgroup/.gitignore
@@ -1,0 +1,28 @@
+# macOS
+.DS_Store
+._*
+
+# Maven outputs
+.classpath
+/aws-rds-dbshardgroup.zip
+
+# IntelliJ
+*.iml
+.idea
+out.java
+out/
+.settings
+.project
+
+# auto-generated files
+target/
+/build/
+
+# our logs
+rpdk.log
+
+# contains credentials
+sam-tests/
+
+# auto-generated sam file
+.aws-sam/build.toml

--- a/aws-rds-dbshardgroup/.rpdk-config
+++ b/aws-rds-dbshardgroup/.rpdk-config
@@ -1,0 +1,22 @@
+{
+    "artifact_type": "RESOURCE",
+    "typeName": "AWS::RDS::DBShardGroup",
+    "language": "java",
+    "runtime": "java17",
+    "entrypoint": "software.amazon.rds.dbshardgroup.HandlerWrapper::handleRequest",
+    "testEntrypoint": "software.amazon.rds.dbshardgroup.HandlerWrapper::testEntrypoint",
+    "settings": {
+        "namespace": [
+            "software",
+            "amazon",
+            "rds",
+            "dbshardgroup"
+        ],
+        "codegen_template_path": "guided_aws",
+        "protocolVersion": "2.0.0"
+    },
+    "logProcessorEnabled": "true",
+    "executableEntrypoint": "software.amazon.rds.dbshardgroup.HandlerWrapperExecutable",
+    "contractSettings": {},
+    "canarySettings": {}
+}

--- a/aws-rds-dbshardgroup/aws-rds-dbshardgroup.json
+++ b/aws-rds-dbshardgroup/aws-rds-dbshardgroup.json
@@ -1,0 +1,155 @@
+{
+  "typeName": "AWS::RDS::DBShardGroup",
+  "description": "The AWS::RDS::DBShardGroup resource creates an Amazon Aurora Limitless DB Shard Group.",
+  "sourceUrl": "https://github.com/aws-cloudformation/aws-cloudformation-resource-providers-rds",
+  "tagging": {
+    "cloudFormationSystemTags": true,
+    "permissions": [
+      "rds:AddTagsToResource",
+      "rds:RemoveTagsFromResource"
+    ],
+    "taggable": true,
+    "tagOnCreate": false,
+    "tagUpdatable": true,
+    "tagProperty": "/properties/Tags"
+  },
+  "properties": {
+    "DBShardGroupResourceId": {
+      "description": "The Amazon Web Services Region-unique, immutable identifier for the DB shard group.",
+      "type": "string"
+    },
+    "DBShardGroupIdentifier": {
+      "description": "The name of the DB shard group.",
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 63
+    },
+    "DBClusterIdentifier": {
+      "description": "The name of the primary DB cluster for the DB shard group.",
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 63
+    },
+    "ComputeRedundancy": {
+      "description": "Specifies whether to create standby instances for the DB shard group.",
+      "minimum": 0,
+      "type": "integer"
+    },
+    "MaxACU": {
+      "description": "The maximum capacity of the DB shard group in Aurora capacity units (ACUs).",
+      "type": "number"
+    },
+    "MinACU": {
+      "description": "The minimum capacity of the DB shard group in Aurora capacity units (ACUs).",
+      "type": "number"
+    },
+    "PubliclyAccessible": {
+      "description": "Indicates whether the DB shard group is publicly accessible.",
+      "type": "boolean"
+    },
+    "Endpoint": {
+      "description": "The connection endpoint for the DB shard group.",
+      "type": "string"
+    },
+    "Tags": {
+      "type": "array",
+      "maxItems": 50,
+      "uniqueItems": true,
+      "insertionOrder": false,
+      "description": "An array of key-value pairs to apply to this resource.",
+      "items": {
+        "$ref": "#/definitions/Tag"
+      }
+    }
+  },
+  "definitions": {
+    "Tag": {
+      "description": "A key-value pair to associate with a resource.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "Key": {
+          "type": "string",
+          "description": "The key name of the tag. You can specify a value that is 1 to 128 Unicode characters in length and cannot be prefixed with aws:. You can use any of the following characters: the set of Unicode letters, digits, whitespace, _, ., /, =, +, and -. ",
+          "minLength": 1,
+          "maxLength": 128
+        },
+        "Value": {
+          "type": "string",
+          "description": "The value for the tag. You can specify a value that is 0 to 256 Unicode characters in length and cannot be prefixed with aws:. You can use any of the following characters: the set of Unicode letters, digits, whitespace, _, ., /, =, +, and -. ",
+          "minLength": 0,
+          "maxLength": 256
+        }
+      },
+      "required": [
+        "Key"
+      ]
+    }
+  },
+  "additionalProperties": false,
+  "propertyTransform": {
+    "/properties/DBClusterIdentifier": "$lowercase(DBClusterIdentifier)",
+    "/properties/DBShardGroupIdentifier": "$lowercase(DBShardGroupIdentifier)"
+  },
+  "required": [
+    "DBClusterIdentifier",
+    "MaxACU"
+  ],
+  "createOnlyProperties": [
+    "/properties/DBClusterIdentifier",
+    "/properties/DBShardGroupIdentifier",
+    "/properties/PubliclyAccessible"
+  ],
+  "readOnlyProperties": [
+    "/properties/DBShardGroupResourceId",
+    "/properties/Endpoint"
+  ],
+  "writeOnlyProperties": [
+    "/properties/MinACU"
+  ],
+  "primaryIdentifier": [
+    "/properties/DBShardGroupIdentifier"
+  ],
+  "handlers": {
+    "create": {
+      "permissions": [
+        "rds:AddTagsToResource",
+        "rds:CreateDBShardGroup",
+        "rds:DescribeDBClusters",
+        "rds:DescribeDBShardGroups",
+        "rds:ListTagsForResource"
+      ],
+      "timeoutInMinutes": 2160
+    },
+    "read": {
+      "permissions": [
+        "rds:DescribeDBShardGroups",
+        "rds:ListTagsForResource"
+      ]
+    },
+    "update": {
+      "permissions": [
+        "rds:AddTagsToResource",
+        "rds:DescribeDBShardGroups",
+        "rds:DescribeDBClusters",
+        "rds:RemoveTagsFromResource",
+        "rds:ModifyDBShardGroup",
+        "rds:ListTagsForResource"
+      ]
+    },
+    "delete": {
+      "permissions": [
+        "rds:DeleteDBShardGroup",
+        "rds:DescribeDBClusters",
+        "rds:DescribeDbShardGroups"
+      ],
+      "timeoutInMinutes": 2160
+    },
+    "list": {
+      "permissions": [
+        "rds:DescribeDBShardGroups",
+        "rds:ListTagsForResource"
+      ]
+    }
+  }
+}

--- a/aws-rds-dbshardgroup/docs/README.md
+++ b/aws-rds-dbshardgroup/docs/README.md
@@ -1,0 +1,139 @@
+# AWS::RDS::DBShardGroup
+
+The AWS::RDS::DBShardGroup resource creates an Amazon Aurora Limitless DB Shard Group.
+
+## Syntax
+
+To declare this entity in your AWS CloudFormation template, use the following syntax:
+
+### JSON
+
+<pre>
+{
+    "Type" : "AWS::RDS::DBShardGroup",
+    "Properties" : {
+        "<a href="#dbshardgroupidentifier" title="DBShardGroupIdentifier">DBShardGroupIdentifier</a>" : <i>String</i>,
+        "<a href="#dbclusteridentifier" title="DBClusterIdentifier">DBClusterIdentifier</a>" : <i>String</i>,
+        "<a href="#computeredundancy" title="ComputeRedundancy">ComputeRedundancy</a>" : <i>Integer</i>,
+        "<a href="#maxacu" title="MaxACU">MaxACU</a>" : <i>Double</i>,
+        "<a href="#minacu" title="MinACU">MinACU</a>" : <i>Double</i>,
+        "<a href="#publiclyaccessible" title="PubliclyAccessible">PubliclyAccessible</a>" : <i>Boolean</i>,
+        "<a href="#tags" title="Tags">Tags</a>" : <i>[ <a href="tag.md">Tag</a>, ... ]</i>
+    }
+}
+</pre>
+
+### YAML
+
+<pre>
+Type: AWS::RDS::DBShardGroup
+Properties:
+    <a href="#dbshardgroupidentifier" title="DBShardGroupIdentifier">DBShardGroupIdentifier</a>: <i>String</i>
+    <a href="#dbclusteridentifier" title="DBClusterIdentifier">DBClusterIdentifier</a>: <i>String</i>
+    <a href="#computeredundancy" title="ComputeRedundancy">ComputeRedundancy</a>: <i>Integer</i>
+    <a href="#maxacu" title="MaxACU">MaxACU</a>: <i>Double</i>
+    <a href="#minacu" title="MinACU">MinACU</a>: <i>Double</i>
+    <a href="#publiclyaccessible" title="PubliclyAccessible">PubliclyAccessible</a>: <i>Boolean</i>
+    <a href="#tags" title="Tags">Tags</a>: <i>
+      - <a href="tag.md">Tag</a></i>
+</pre>
+
+## Properties
+
+#### DBShardGroupIdentifier
+
+The name of the DB shard group.
+
+_Required_: No
+
+_Type_: String
+
+_Minimum Length_: <code>1</code>
+
+_Maximum Length_: <code>63</code>
+
+_Update requires_: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
+
+#### DBClusterIdentifier
+
+The name of the primary DB cluster for the DB shard group.
+
+_Required_: Yes
+
+_Type_: String
+
+_Minimum Length_: <code>1</code>
+
+_Maximum Length_: <code>63</code>
+
+_Update requires_: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
+
+#### ComputeRedundancy
+
+Specifies whether to create standby instances for the DB shard group.
+
+_Required_: No
+
+_Type_: Integer
+
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+
+#### MaxACU
+
+The maximum capacity of the DB shard group in Aurora capacity units (ACUs).
+
+_Required_: Yes
+
+_Type_: Double
+
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+
+#### MinACU
+
+The minimum capacity of the DB shard group in Aurora capacity units (ACUs).
+
+_Required_: No
+
+_Type_: Double
+
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+
+#### PubliclyAccessible
+
+Indicates whether the DB shard group is publicly accessible.
+
+_Required_: No
+
+_Type_: Boolean
+
+_Update requires_: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
+
+#### Tags
+
+An array of key-value pairs to apply to this resource.
+
+_Required_: No
+
+_Type_: List of <a href="tag.md">Tag</a>
+
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+
+## Return Values
+
+### Ref
+
+When you pass the logical ID of this resource to the intrinsic `Ref` function, Ref returns the DBShardGroupIdentifier.
+
+### Fn::GetAtt
+
+The `Fn::GetAtt` intrinsic function returns a value for a specified attribute of this type. The following are the available attributes and sample return values.
+
+For more information about using the `Fn::GetAtt` intrinsic function, see [Fn::GetAtt](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-getatt.html).
+
+#### DBShardGroupResourceId
+
+The Amazon Web Services Region-unique, immutable identifier for the DB shard group.
+
+#### Endpoint
+
+The connection endpoint for the DB shard group.

--- a/aws-rds-dbshardgroup/docs/tag.md
+++ b/aws-rds-dbshardgroup/docs/tag.md
@@ -1,0 +1,51 @@
+# AWS::RDS::DBShardGroup Tag
+
+A key-value pair to associate with a resource.
+
+## Syntax
+
+To declare this entity in your AWS CloudFormation template, use the following syntax:
+
+### JSON
+
+<pre>
+{
+    "<a href="#key" title="Key">Key</a>" : <i>String</i>,
+    "<a href="#value" title="Value">Value</a>" : <i>String</i>
+}
+</pre>
+
+### YAML
+
+<pre>
+<a href="#key" title="Key">Key</a>: <i>String</i>
+<a href="#value" title="Value">Value</a>: <i>String</i>
+</pre>
+
+## Properties
+
+#### Key
+
+The key name of the tag. You can specify a value that is 1 to 128 Unicode characters in length and cannot be prefixed with aws:. You can use any of the following characters: the set of Unicode letters, digits, whitespace, _, ., /, =, +, and -.
+
+_Required_: Yes
+
+_Type_: String
+
+_Minimum Length_: <code>1</code>
+
+_Maximum Length_: <code>128</code>
+
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+
+#### Value
+
+The value for the tag. You can specify a value that is 0 to 256 Unicode characters in length and cannot be prefixed with aws:. You can use any of the following characters: the set of Unicode letters, digits, whitespace, _, ., /, =, +, and -.
+
+_Required_: No
+
+_Type_: String
+
+_Maximum Length_: <code>256</code>
+
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)

--- a/aws-rds-dbshardgroup/lombok.config
+++ b/aws-rds-dbshardgroup/lombok.config
@@ -1,0 +1,1 @@
+lombok.addLombokGeneratedAnnotation = true

--- a/aws-rds-dbshardgroup/pom.xml
+++ b/aws-rds-dbshardgroup/pom.xml
@@ -1,30 +1,35 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project
-        xmlns="http://maven.apache.org/POM/4.0.0"
-        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>software.amazon.rds.dbsubnetgroup</groupId>
-    <artifactId>aws-rds-dbsubnetgroup-handler</artifactId>
-    <name>aws-rds-dbsubnetgroup-handler</name>
+    <groupId>software.amazon.rds.dbshardgroup</groupId>
+    <artifactId>aws-rds-dbshardgroup-handler</artifactId>
+    <name>aws-rds-dbshardgroup-handler</name>
     <version>1.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <properties>
-        <java.version>17</java.version>
-        <maven.compiler.source>${java.version}</maven.compiler.source>
-        <maven.compiler.target>${java.version}</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <org.projectlombok.version>1.18.30</org.projectlombok.version>
+        <cfn.generate.args/>
     </properties>
 
     <dependencies>
-        <!-- https://mvnrepository.com/artifact/software.amazon.awssdk/aws-query-protocol -->
         <dependency>
-            <groupId>software.amazon.awssdk</groupId>
-            <artifactId>aws-query-protocol</artifactId>
-            <version>2.20.138</version>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.12.0</version>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.rds.common</groupId>
+            <artifactId>aws-rds-cfn-common</artifactId>
+            <version>1.0</version>
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
@@ -35,16 +40,21 @@
         <dependency>
             <groupId>software.amazon.cloudformation</groupId>
             <artifactId>aws-cloudformation-rpdk-java-plugin</artifactId>
-            <version>[2.0.0, 3.0.0)</version>
+            <version>[2.0.0,3.0.0)</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.projectlombok/lombok -->
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.22</version>
+            <version>${org.projectlombok.version}</version>
             <scope>provided</scope>
         </dependency>
-
+        <!-- https://mvnrepository.com/artifact/software.amazon.awssdk/aws-query-protocol -->
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>aws-query-protocol</artifactId>
+            <version>2.20.138</version>
+        </dependency>
         <!-- https://mvnrepository.com/artifact/org.assertj/assertj-core -->
         <dependency>
             <groupId>org.assertj</groupId>
@@ -75,12 +85,6 @@
         </dependency>
         <dependency>
             <groupId>software.amazon.rds.common</groupId>
-            <artifactId>aws-rds-cfn-common</artifactId>
-            <version>1.0</version>
-            <scope>compile</scope>
-        </dependency>
-        <dependency>
-            <groupId>software.amazon.rds.common</groupId>
             <artifactId>aws-rds-cfn-test-common</artifactId>
             <version>1.0</version>
             <scope>test</scope>
@@ -96,14 +100,13 @@
                 <configuration>
                     <compilerArgs>
                         <arg>-Xlint:all,-options,-processing</arg>
-                        <arg>-Werror</arg>
                     </compilerArgs>
                 </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>2.3</version>
+                <version>3.2.4</version>
                 <configuration>
                     <createDependencyReducedPom>false</createDependencyReducedPom>
                 </configuration>
@@ -160,6 +163,7 @@
                 <version>2.4</version>
             </plugin>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>3.0.0-M3</version>
             </plugin>
@@ -169,24 +173,10 @@
                 <version>0.8.8</version>
                 <configuration>
                     <excludes>
-                        <!-- Generated classes -->
-                        <exclude>**/software/amazon/rds/dbsubnetgroup/BaseConfiguration.class</exclude>
-                        <exclude>**/software/amazon/rds/dbsubnetgroup/BaseHandler.class</exclude>
-                        <exclude>**/software/amazon/rds/dbsubnetgroup/BaseHandlerStd.class</exclude>
-                        <exclude>**/software/amazon/rds/dbsubnetgroup/CallbackContext.class</exclude>
-                        <exclude>**/software/amazon/rds/dbsubnetgroup/ClientProvider.class</exclude>
-                        <exclude>**/software/amazon/rds/dbsubnetgroup/Configuration.class</exclude>
-                        <exclude>**/software/amazon/rds/dbsubnetgroup/CreateHandler.class</exclude>
-                        <exclude>**/software/amazon/rds/dbsubnetgroup/DeleteHandler.class</exclude>
-                        <exclude>**/software/amazon/rds/dbsubnetgroup/HandlerWrapper.class</exclude>
-                        <exclude>**/software/amazon/rds/dbsubnetgroup/HandlerWrapperExecutable.class</exclude>
-                        <exclude>**/software/amazon/rds/dbsubnetgroup/ListHandler.class</exclude>
-                        <exclude>**/software/amazon/rds/dbsubnetgroup/ReadHandler.class</exclude>
-                        <exclude>**/software/amazon/rds/dbsubnetgroup/ResourceModel.class</exclude>
-                        <exclude>**/software/amazon/rds/dbsubnetgroup/Tag.class</exclude>
-                        <exclude>**/software/amazon/rds/dbsubnetgroup/Translator.class</exclude>
-                        <exclude>**/software/amazon/rds/dbsubnetgroup/TypeConfigurationModel.class</exclude>
-                        <exclude>**/software/amazon/rds/dbsubnetgroup/UpdateHandler.class</exclude>
+                        <exclude>**/BaseConfiguration*</exclude>
+                        <exclude>**/BaseHandler*</exclude>
+                        <exclude>**/HandlerWrapper*</exclude>
+                        <exclude>**/ResourceModel*</exclude>
                     </excludes>
                 </configuration>
                 <executions>
@@ -210,7 +200,7 @@
                         <configuration>
                             <rules>
                                 <rule>
-                                    <element>BUNDLE</element>
+                                    <element>PACKAGE</element>
                                     <limits>
                                         <limit>
                                             <counter>BRANCH</counter>
@@ -220,7 +210,7 @@
                                         <limit>
                                             <counter>INSTRUCTION</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.0</minimum>
+                                            <minimum>0.8</minimum>
                                         </limit>
                                     </limits>
                                 </rule>
@@ -234,7 +224,7 @@
             <resource>
                 <directory>${project.basedir}</directory>
                 <includes>
-                    <include>aws-rds-dbsubnetgroup.json</include>
+                    <include>aws-rds-dbshardgroup.json</include>
                 </includes>
             </resource>
         </resources>

--- a/aws-rds-dbshardgroup/resource-role.yaml
+++ b/aws-rds-dbshardgroup/resource-role.yaml
@@ -1,0 +1,46 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: >
+  This CloudFormation template creates a role assumed by CloudFormation
+  during CRUDL operations to mutate resources on behalf of the customer.
+
+Resources:
+  ExecutionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      MaxSessionDuration: 43200
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: resources.cloudformation.amazonaws.com
+            Action: sts:AssumeRole
+            Condition:
+              StringEquals:
+                aws:SourceAccount:
+                  Ref: AWS::AccountId
+              StringLike:
+                aws:SourceArn:
+                  Fn::Sub: arn:${AWS::Partition}:cloudformation:${AWS::Region}:${AWS::AccountId}:type/resource/AWS-RDS-DBShardGroup/*
+      Path: "/"
+      Policies:
+        - PolicyName: ResourceTypePolicy
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                - "rds:AddTagsToResource"
+                - "rds:CreateDBShardGroup"
+                - "rds:DeleteDBShardGroup"
+                - "rds:DescribeDBClusters"
+                - "rds:DescribeDBShardGroups"
+                - "rds:DescribeDbShardGroups"
+                - "rds:ListTagsForResource"
+                - "rds:ModifyDBShardGroup"
+                - "rds:RemoveTagsFromResource"
+                Resource: "*"
+Outputs:
+  ExecutionRoleArn:
+    Value:
+      Fn::GetAtt: ExecutionRole.Arn

--- a/aws-rds-dbshardgroup/settings.internal.json
+++ b/aws-rds-dbshardgroup/settings.internal.json
@@ -1,0 +1,7 @@
+{
+  "FasPolicyPath": {
+    "aws": "/policies/AuthRuntime/authNPolicy/cloudformation/aws-rds-dbshardgroup.2024-09-27-21-08-30",
+    "aws-iso-e": "/policies/AuthRuntime/authNPolicy/cloudformation/aws-rds-dbshardgroup.2024-09-27-21-10-01",
+    "aws-iso-f": "/policies/AuthRuntime/authNPolicy/cloudformation/aws-rds-dbshardgroup.2024-09-27-21-12-26"
+  }
+}

--- a/aws-rds-dbshardgroup/src/main/java/software/amazon/rds/dbshardgroup/BaseHandlerStd.java
+++ b/aws-rds-dbshardgroup/src/main/java/software/amazon/rds/dbshardgroup/BaseHandlerStd.java
@@ -1,0 +1,263 @@
+package software.amazon.rds.dbshardgroup;
+
+import com.amazonaws.arn.Arn;
+import com.amazonaws.arn.ArnResource;
+import java.util.Set;
+import java.util.function.BiFunction;
+import software.amazon.awssdk.services.rds.RdsClient;
+import software.amazon.awssdk.services.rds.model.DBCluster;
+import software.amazon.awssdk.services.rds.model.DBShardGroup;
+import software.amazon.awssdk.services.rds.model.DbClusterNotFoundException;
+import software.amazon.awssdk.services.rds.model.DbShardGroupAlreadyExistsException;
+import software.amazon.awssdk.services.rds.model.DbShardGroupNotFoundException;
+import software.amazon.awssdk.services.rds.model.InvalidDbClusterStateException;
+import software.amazon.awssdk.services.rds.model.InvalidVpcNetworkStateException;
+import software.amazon.awssdk.services.rds.model.MaxDbShardGroupLimitReachedException;
+import software.amazon.awssdk.services.rds.model.Tag;
+import software.amazon.awssdk.services.rds.model.UnsupportedDbEngineVersionException;
+import software.amazon.awssdk.utils.ImmutableMap;
+import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
+import software.amazon.cloudformation.proxy.HandlerErrorCode;
+import software.amazon.cloudformation.proxy.Logger;
+import software.amazon.cloudformation.proxy.ProgressEvent;
+import software.amazon.cloudformation.proxy.ProxyClient;
+import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
+import software.amazon.cloudformation.proxy.delay.Constant;
+import software.amazon.rds.common.error.ErrorRuleSet;
+import software.amazon.rds.common.error.ErrorStatus;
+import software.amazon.rds.common.handler.Commons;
+import software.amazon.rds.common.handler.HandlerConfig;
+import software.amazon.rds.common.handler.Tagging;
+import software.amazon.rds.common.logging.LoggingProxyClient;
+import software.amazon.rds.common.logging.RequestLogger;
+import software.amazon.rds.common.printer.FilteredJsonPrinter;
+
+import java.time.Duration;
+import java.util.Collection;
+
+public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
+    protected final static HandlerConfig DEFAULT_DB_SHARD_GROUP_HANDLER_CONFIG = HandlerConfig.builder()
+            .backoff(Constant.of().delay(Duration.ofSeconds(30)).timeout(Duration.ofMinutes(180)).build())
+            .build();
+
+    protected final static HandlerConfig DB_SHARD_GROUP_HANDLER_CONFIG_36H = HandlerConfig.builder()
+            .backoff(Constant.of().delay(Duration.ofSeconds(30)).timeout(Duration.ofHours(36)).build())
+            .build();
+
+    protected static final ErrorRuleSet DEFAULT_DB_SHARD_GROUP_ERROR_RULE_SET = ErrorRuleSet
+            .extend(Commons.DEFAULT_ERROR_RULE_SET)
+            .withErrorClasses(ErrorStatus.failWith(HandlerErrorCode.AlreadyExists),
+                    DbShardGroupAlreadyExistsException.class)
+            .withErrorClasses(ErrorStatus.failWith(HandlerErrorCode.NotFound),
+                    DbShardGroupNotFoundException.class,
+                    DbClusterNotFoundException.class)
+            .withErrorClasses(ErrorStatus.failWith(HandlerErrorCode.ServiceLimitExceeded),
+                    MaxDbShardGroupLimitReachedException.class)
+            .withErrorClasses(ErrorStatus.failWith(HandlerErrorCode.InvalidRequest),
+                    UnsupportedDbEngineVersionException.class)
+            .withErrorClasses(ErrorStatus.failWith(HandlerErrorCode.ResourceConflict),
+                    InvalidDbClusterStateException.class,
+                    InvalidVpcNetworkStateException.class)
+            .build();
+
+    private final FilteredJsonPrinter PARAMETERS_FILTER = new FilteredJsonPrinter();
+
+    /**
+     * Custom handler config, mostly to facilitate faster unit test
+     */
+    final HandlerConfig config;
+    protected RequestLogger requestLogger;
+    protected static final BiFunction<ResourceModel, ProxyClient<RdsClient>, ResourceModel> NOOP_CALL = (model, proxyClient) -> model;
+
+    public BaseHandlerStd() {
+        this(HandlerConfig.builder().build());
+    }
+
+    BaseHandlerStd(HandlerConfig config) {
+        this.config = config;
+    }
+
+    @Override
+    public final ProgressEvent<ResourceModel, CallbackContext> handleRequest(
+            final AmazonWebServicesClientProxy proxy,
+            final ResourceHandlerRequest<ResourceModel> request,
+            final CallbackContext callbackContext,
+            final Logger logger) {
+        return RequestLogger.handleRequest(
+                logger,
+                request,
+                PARAMETERS_FILTER,
+                requestLogger -> handleRequest(
+                        proxy,
+                        new LoggingProxyClient<>(requestLogger, proxy.newProxy(new ClientProvider()::getClient)),
+                        request,
+                        callbackContext != null ? callbackContext : new CallbackContext(),
+                        requestLogger
+                ));
+    }
+
+    protected abstract ProgressEvent<ResourceModel, CallbackContext> handleRequest(
+            final AmazonWebServicesClientProxy proxy,
+            final ProxyClient<RdsClient> proxyClient,
+            final ResourceHandlerRequest<ResourceModel> request,
+            final CallbackContext callbackContext);
+
+    protected ProgressEvent<ResourceModel, CallbackContext> handleRequest(
+            final AmazonWebServicesClientProxy proxy,
+            final ProxyClient<RdsClient> proxyClient,
+            final ResourceHandlerRequest<ResourceModel> request,
+            final CallbackContext context,
+            final RequestLogger requestLogger
+    ) {
+        this.requestLogger = requestLogger;
+        return handleRequest(proxy, proxyClient, request, context);
+    }
+
+    protected boolean isDBShardGroupStabilizedAfterMutate(
+            final ResourceModel model,
+            final ProxyClient<RdsClient> proxyClient
+    ) {
+        boolean isDBShardGroupStabilized = isDBShardGroupStabilized(model, proxyClient);
+        boolean isDBClusterStabilized = isDBClusterStabilized(model, proxyClient);
+
+        requestLogger.log(String.format("isDBShardGroupStabilizedAfterMutate: %b", isDBShardGroupStabilized && isDBClusterStabilized),
+                ImmutableMap.of("isDBShardGroupStabilized", isDBShardGroupStabilized,
+                        "isDBClusterStabilized", isDBClusterStabilized),
+                ImmutableMap.of("Description", "isDBShardGroupStabilizedAfterMutate method will be repeatedly" +
+                " called with a backoff mechanism after the modify call until it returns true. This" +
+                " process will continue until all included flags are true."));
+
+        return isDBShardGroupStabilized && isDBClusterStabilized;
+    }
+
+    protected boolean isDBShardGroupStabilized(
+            final ResourceModel model,
+            final ProxyClient<RdsClient> proxyClient
+    ) {
+        final DBShardGroup dbShardGroup = proxyClient.injectCredentialsAndInvokeV2(
+                Translator.describeDbShardGroupsRequest(model),
+                proxyClient.client()::describeDBShardGroups
+        ).dbShardGroups().get(0);
+
+        return isDBShardGroupAvailable(dbShardGroup);
+    }
+
+    protected boolean isDBClusterStabilized(
+            final ResourceModel model,
+            final ProxyClient<RdsClient> proxyClient
+    ) {
+        final DBCluster dbCluster = proxyClient.injectCredentialsAndInvokeV2(
+                Translator.describeDbClustersRequest(model),
+                proxyClient.client()::describeDBClusters
+        ).dbClusters().get(0);
+
+        return isDBClusterAvailable(dbCluster);
+    }
+
+    protected boolean isDBShardGroupAvailable(final DBShardGroup dbShardGroup) {
+        return ResourceStatus.AVAILABLE.equalsString(dbShardGroup.status());
+    }
+
+    protected boolean isDBClusterAvailable(final DBCluster dbCluster) {
+        return ResourceStatus.AVAILABLE.equalsString(dbCluster.status());
+    }
+
+    protected ProgressEvent<ResourceModel, CallbackContext> addTags(
+            final ProxyClient<RdsClient> proxyClient,
+            final ResourceHandlerRequest request,
+            final ProgressEvent<ResourceModel, CallbackContext> progress,
+            final Tagging.TagSet desiredTags
+    ) {
+        DBShardGroup dbShardGroup;
+        try {
+            dbShardGroup = proxyClient.injectCredentialsAndInvokeV2(
+                    Translator.describeDbShardGroupsRequest(progress.getResourceModel()), proxyClient.client()::describeDBShardGroups
+            ).dbShardGroups().get(0);
+        } catch (Exception exception) {
+            return Commons.handleException(progress, exception, DEFAULT_DB_SHARD_GROUP_ERROR_RULE_SET, requestLogger);
+        }
+
+        final String arn = assembleArn(request.getAwsPartition(), request.getRegion(), request.getAwsAccountId(), dbShardGroup.dbShardGroupResourceId());
+
+        try {
+            Tagging.addTags(proxyClient, arn, Tagging.translateTagsToSdk(desiredTags));
+        } catch (Exception exception) {
+            return Commons.handleException(
+                    progress,
+                    exception,
+                    DEFAULT_DB_SHARD_GROUP_ERROR_RULE_SET.extendWith(Tagging.getUpdateTagsAccessDeniedRuleSet(desiredTags, Tagging.TagSet.emptySet())),
+                    requestLogger
+            );
+        }
+
+        return progress;
+    }
+
+    protected ProgressEvent<ResourceModel, CallbackContext> updateTags(
+            final ProxyClient<RdsClient> proxyClient,
+            final ResourceHandlerRequest request,
+            final ProgressEvent<ResourceModel, CallbackContext> progress,
+            final Tagging.TagSet previousTags,
+            final Tagging.TagSet desiredTags
+    ) {
+        final Collection<Tag> effectivePreviousTags = Tagging.translateTagsToSdk(previousTags);
+        final Collection<Tag> effectiveDesiredTags = Tagging.translateTagsToSdk(desiredTags);
+
+        final Collection<Tag> tagsToRemove = Tagging.exclude(effectivePreviousTags, effectiveDesiredTags);
+        final Collection<Tag> tagsToAdd = Tagging.exclude(effectiveDesiredTags, effectivePreviousTags);
+
+        if (tagsToAdd.isEmpty() && tagsToRemove.isEmpty()) {
+            return progress;
+        }
+
+        final Tagging.TagSet rulesetTagsToAdd = Tagging.exclude(desiredTags, previousTags);
+        final Tagging.TagSet rulesetTagsToRemove = Tagging.exclude(previousTags, desiredTags);
+
+        DBShardGroup dbShardGroup;
+        try {
+            dbShardGroup = proxyClient.injectCredentialsAndInvokeV2(
+                    Translator.describeDbShardGroupsRequest(progress.getResourceModel()), proxyClient.client()::describeDBShardGroups
+            ).dbShardGroups().get(0);
+        } catch (Exception exception) {
+            return Commons.handleException(progress, exception, DEFAULT_DB_SHARD_GROUP_ERROR_RULE_SET, requestLogger);
+        }
+
+        final String arn = assembleArn(request.getAwsPartition(), request.getRegion(), request.getAwsAccountId(), dbShardGroup.dbShardGroupResourceId());
+
+        try {
+            Tagging.removeTags(proxyClient, arn, Tagging.translateTagsToSdk(tagsToRemove));
+            Tagging.addTags(proxyClient, arn, Tagging.translateTagsToSdk(tagsToAdd));
+        } catch (Exception exception) {
+            return Commons.handleException(
+                    progress,
+                    exception,
+                    DEFAULT_DB_SHARD_GROUP_ERROR_RULE_SET.extendWith(Tagging.getUpdateTagsAccessDeniedRuleSet(rulesetTagsToAdd, rulesetTagsToRemove)),
+                    requestLogger
+            );
+        }
+
+        return progress;
+    }
+
+    protected Set<Tag> getTags(
+            final ProxyClient<RdsClient> proxyClient,
+            final ResourceHandlerRequest request,
+            final DBShardGroup dbShardGroup
+    ) {
+        String arn = assembleArn(request.getAwsPartition(), request.getRegion(), request.getAwsAccountId(), dbShardGroup.dbShardGroupResourceId());
+        return Tagging.listTagsForResource(proxyClient, arn);
+    }
+
+    private String assembleArn(String partition, String region, String accountId, String dbShardGroupResourceId) {
+        return Arn.builder()
+                .withPartition(partition)
+                .withService("rds")
+                .withRegion(region)
+                .withAccountId(accountId)
+                .withResource(ArnResource.builder()
+                        .withResourceType("shard-group")
+                        .withResource(dbShardGroupResourceId)
+                        .build().toString())
+                .build().toString();
+    }
+}

--- a/aws-rds-dbshardgroup/src/main/java/software/amazon/rds/dbshardgroup/CallbackContext.java
+++ b/aws-rds-dbshardgroup/src/main/java/software/amazon/rds/dbshardgroup/CallbackContext.java
@@ -1,0 +1,37 @@
+package software.amazon.rds.dbshardgroup;
+
+import software.amazon.cloudformation.proxy.StdCallbackContext;
+import software.amazon.rds.common.handler.TaggingContext;
+
+@lombok.Getter
+@lombok.Setter
+@lombok.ToString
+@lombok.EqualsAndHashCode(callSuper = true)
+public class CallbackContext extends StdCallbackContext implements TaggingContext.Provider {
+    private boolean described;
+    private boolean updated;
+
+    private TaggingContext taggingContext;
+
+    public CallbackContext() {
+        super();
+        this.taggingContext = new TaggingContext();
+    }
+
+    @Override
+    public TaggingContext getTaggingContext() {
+        return taggingContext;
+    }
+
+    public boolean isAddTagsComplete() {
+        return taggingContext.isAddTagsComplete();
+    }
+
+    public void setAddTagsComplete(final boolean addTagsComplete) {
+        taggingContext.setAddTagsComplete(addTagsComplete);
+    }
+
+    private String dbClusterIdentifier;
+
+    private int waitTime;
+}

--- a/aws-rds-dbshardgroup/src/main/java/software/amazon/rds/dbshardgroup/ClientProvider.java
+++ b/aws-rds-dbshardgroup/src/main/java/software/amazon/rds/dbshardgroup/ClientProvider.java
@@ -1,0 +1,15 @@
+package software.amazon.rds.dbshardgroup;
+
+import software.amazon.awssdk.services.rds.RdsClient;
+import software.amazon.awssdk.services.rds.RdsClientBuilder;
+import software.amazon.rds.common.annotations.ExcludeFromJacocoGeneratedReport;
+import software.amazon.rds.common.client.BaseSdkClientProvider;
+
+public class ClientProvider extends BaseSdkClientProvider<RdsClientBuilder, RdsClient> {
+
+    @ExcludeFromJacocoGeneratedReport
+    @Override
+    public RdsClient getClient() {
+        return setHttpClient(setUserAgent(RdsClient.builder())).build();
+    }
+}

--- a/aws-rds-dbshardgroup/src/main/java/software/amazon/rds/dbshardgroup/Configuration.java
+++ b/aws-rds-dbshardgroup/src/main/java/software/amazon/rds/dbshardgroup/Configuration.java
@@ -1,0 +1,8 @@
+package software.amazon.rds.dbshardgroup;
+
+class Configuration extends BaseConfiguration {
+
+    public Configuration() {
+        super("aws-rds-dbshardgroup.json");
+    }
+}

--- a/aws-rds-dbshardgroup/src/main/java/software/amazon/rds/dbshardgroup/CreateHandler.java
+++ b/aws-rds-dbshardgroup/src/main/java/software/amazon/rds/dbshardgroup/CreateHandler.java
@@ -1,0 +1,85 @@
+package software.amazon.rds.dbshardgroup;
+
+import java.util.function.Function;
+
+import com.amazonaws.util.StringUtils;
+import software.amazon.awssdk.services.rds.RdsClient;
+import software.amazon.awssdk.services.rds.model.DBCluster;
+import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
+import software.amazon.cloudformation.proxy.ProgressEvent;
+import software.amazon.cloudformation.proxy.ProxyClient;
+import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
+import software.amazon.rds.common.handler.Commons;
+import software.amazon.rds.common.handler.HandlerConfig;
+import software.amazon.rds.common.handler.Tagging;
+import software.amazon.rds.common.util.IdentifierFactory;
+
+import java.util.HashSet;
+
+public class CreateHandler extends BaseHandlerStd {
+
+    public static final String STACK_NAME = "rds";
+    public static final String RESOURCE_IDENTIFIER = "dbshardgroup";
+    public static final int RESOURCE_ID_MAX_LENGTH = 63;
+
+    public static final IdentifierFactory dbShardGroupIdentifierFactory = new IdentifierFactory(
+            STACK_NAME,
+            RESOURCE_IDENTIFIER,
+            RESOURCE_ID_MAX_LENGTH
+    );
+
+    /** Default constructor w/ default backoff */
+    public CreateHandler() {
+        this(DB_SHARD_GROUP_HANDLER_CONFIG_36H);
+    }
+
+    /** Default constructor w/ custom config */
+    public CreateHandler(HandlerConfig config) {
+        super(config);
+    }
+
+    protected ProgressEvent<ResourceModel, CallbackContext> handleRequest(
+            final AmazonWebServicesClientProxy proxy,
+            final ProxyClient<RdsClient> proxyClient,
+            final ResourceHandlerRequest<ResourceModel> request,
+            final CallbackContext callbackContext) {
+        final Tagging.TagSet allTags = Tagging.TagSet.builder()
+                .systemTags(Tagging.translateTagsToSdk(request.getSystemTags()))
+                .stackTags(Tagging.translateTagsToSdk(request.getDesiredResourceTags()))
+                .resourceTags(new HashSet<>(Translator.translateTagsToSdk(request.getDesiredResourceState().getTags())))
+                .build();
+        ResourceModel model = request.getDesiredResourceState();
+        if (StringUtils.isNullOrEmpty(model.getDBShardGroupIdentifier())) {
+            model.setDBShardGroupIdentifier(
+                    dbShardGroupIdentifierFactory.newIdentifier()
+                            .withStackId(request.getStackId())
+                            .withResourceId(request.getLogicalResourceIdentifier())
+                            .withRequestToken(request.getClientRequestToken())
+                            .toString());
+        }
+
+        return ProgressEvent.progress(request.getDesiredResourceState(), callbackContext)
+                .then(progress -> createDbShardGroup(proxy, proxyClient, progress))
+                .then(progress -> Commons.execOnce(progress, () -> addTags(proxyClient, request, progress, allTags), CallbackContext::isAddTagsComplete, CallbackContext::setAddTagsComplete))
+                .then(progress -> new ReadHandler().handleRequest(proxy, proxyClient, request, callbackContext));
+    }
+
+    private ProgressEvent<ResourceModel, CallbackContext> createDbShardGroup(
+            final AmazonWebServicesClientProxy proxy,
+            final ProxyClient<RdsClient> proxyClient,
+            final ProgressEvent<ResourceModel, CallbackContext> progress
+    ) {
+        return proxy.initiate("rds::create-db-shard-group", proxyClient, progress.getResourceModel(), progress.getCallbackContext())
+                .translateToServiceRequest((resourceModel) -> Translator.createDbShardGroupRequest(resourceModel))
+                .backoffDelay(config.getBackoff())
+                .makeServiceCall((createDbShardGroupRequest, proxyInvocation) -> proxyInvocation.injectCredentialsAndInvokeV2(createDbShardGroupRequest, proxyInvocation.client()::createDBShardGroup))
+                .stabilize((createRequest, createResponse, proxyInvocation, model, context) -> isDBShardGroupStabilizedAfterMutate(model, proxyInvocation))
+                .handleError((deleteRequest, exception, client, resourceModel, ctx) -> Commons.handleException(
+                        ProgressEvent.progress(resourceModel, ctx),
+                        exception,
+                        DEFAULT_DB_SHARD_GROUP_ERROR_RULE_SET,
+                        requestLogger
+                ))
+                .progress();
+    }
+}

--- a/aws-rds-dbshardgroup/src/main/java/software/amazon/rds/dbshardgroup/DeleteHandler.java
+++ b/aws-rds-dbshardgroup/src/main/java/software/amazon/rds/dbshardgroup/DeleteHandler.java
@@ -1,0 +1,135 @@
+package software.amazon.rds.dbshardgroup;
+
+import java.util.List;
+import java.util.function.Function;
+import org.apache.commons.collections.CollectionUtils;
+import software.amazon.awssdk.services.rds.RdsClient;
+import software.amazon.awssdk.services.rds.model.DBCluster;
+import software.amazon.awssdk.services.rds.model.DBShardGroup;
+import software.amazon.awssdk.services.rds.model.DbClusterNotFoundException;
+import software.amazon.awssdk.services.rds.model.DbShardGroupNotFoundException;
+import software.amazon.awssdk.services.rds.model.DescribeDbClustersRequest;
+import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
+import software.amazon.cloudformation.proxy.HandlerErrorCode;
+import software.amazon.cloudformation.proxy.OperationStatus;
+import software.amazon.cloudformation.proxy.ProgressEvent;
+import software.amazon.cloudformation.proxy.ProxyClient;
+import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
+import software.amazon.rds.common.error.ErrorRuleSet;
+import software.amazon.rds.common.error.ErrorStatus;
+import software.amazon.rds.common.handler.Commons;
+import software.amazon.rds.common.handler.HandlerConfig;
+
+public class DeleteHandler extends BaseHandlerStd {
+    protected static final ErrorRuleSet DELETE_DB_SHARD_GROUP_ERROR_RULE_SET = ErrorRuleSet
+            .extend(DEFAULT_DB_SHARD_GROUP_ERROR_RULE_SET)
+            .withErrorClasses(ErrorStatus.ignore(OperationStatus.IN_PROGRESS),
+                    DbShardGroupNotFoundException.class)
+            .withErrorClasses(ErrorStatus.ignore(OperationStatus.SUCCESS),
+                    DbClusterNotFoundException.class)
+            .build();
+
+    /** Default constructor with default backoff */
+    public DeleteHandler() {
+        this(DB_SHARD_GROUP_HANDLER_CONFIG_36H);
+    }
+
+    /** Default constructor with custom config */
+    public DeleteHandler(HandlerConfig config) {
+        super(config);
+    }
+
+    protected ProgressEvent<ResourceModel, CallbackContext> handleRequest(
+            final AmazonWebServicesClientProxy proxy,
+            final ProxyClient<RdsClient> proxyClient,
+            final ResourceHandlerRequest<ResourceModel> request,
+            final CallbackContext callbackContext) {
+
+        return ProgressEvent.progress(request.getDesiredResourceState(), callbackContext)
+                .then(progress -> Commons.execOnce(progress, () -> deleteDbShardGroupIfNotInProgress(progress, proxy, request, callbackContext, proxyClient),
+                        CallbackContext::isDescribed, CallbackContext::setDescribed))
+                // Stabilize as an independent step for cases where there is an out-of-band delete
+                .then(progress -> proxy.initiate("rds::delete-db-shard-group-stabilize", proxyClient, request.getDesiredResourceState(), callbackContext)
+                        .translateToServiceRequest(Function.identity())
+                        .backoffDelay(config.getBackoff())
+                        .makeServiceCall(NOOP_CALL)
+                        .stabilize((noopRequest, noopResponse, proxyInvocation, model, context) -> isDbShardGroupDeleted(model, proxyInvocation) && isDbClusterStabilizedOrDeleted(proxyInvocation, context))
+                        .handleError((noopRequest, exception, client, model, context) -> Commons.handleException(
+                                ProgressEvent.progress(model, context),
+                                exception,
+                                DELETE_DB_SHARD_GROUP_ERROR_RULE_SET,
+                                requestLogger
+                        )).progress())
+                .then(progress -> ProgressEvent.defaultSuccessHandler(null));
+    }
+
+    private ProgressEvent<ResourceModel, CallbackContext> deleteDbShardGroupIfNotInProgress(final ProgressEvent<ResourceModel, CallbackContext> progress,
+                                                                                            final AmazonWebServicesClientProxy proxy,
+                                                                                            final ResourceHandlerRequest<ResourceModel> request,
+                                                                                            final CallbackContext callbackContext,
+                                                                                            final ProxyClient<RdsClient> proxyClient) {
+        try {
+            final DBShardGroup dbShardGroup = proxyClient.injectCredentialsAndInvokeV2(
+                            Translator.describeDbShardGroupsRequest(request.getDesiredResourceState()),
+                            proxyClient.client()::describeDBShardGroups)
+                    .dbShardGroups().get(0);
+            callbackContext.setDbClusterIdentifier(dbShardGroup.dbClusterIdentifier());
+            if (!ResourceStatus.DELETING.equalsString(dbShardGroup.status())){
+                return deleteDbShardGroup(proxy, request, callbackContext, proxyClient);
+            } else {
+                return progress;
+            }
+        } catch (DbShardGroupNotFoundException e) {
+            // If the shard group is not found, we exit.
+            return ProgressEvent.defaultFailureHandler(e, HandlerErrorCode.NotFound);
+        }
+    }
+
+    private ProgressEvent<ResourceModel, CallbackContext> deleteDbShardGroup(final AmazonWebServicesClientProxy proxy,
+                                                                             final ResourceHandlerRequest<ResourceModel> request,
+                                                                             final CallbackContext callbackContext,
+                                                                             final ProxyClient<RdsClient> proxyClient) {
+        return proxy.initiate("rds::delete-db-shard-group", proxyClient, request.getDesiredResourceState(), callbackContext)
+                .translateToServiceRequest(Translator::deleteDbShardGroupRequest)
+                .backoffDelay(config.getBackoff())
+                .makeServiceCall((deleteDbShardGroupRequest, proxyInvocation) -> proxyInvocation.injectCredentialsAndInvokeV2(deleteDbShardGroupRequest, proxyInvocation.client()::deleteDBShardGroup))
+                .handleError((deleteRequest, exception, client, resourceModel, ctx) -> Commons.handleException(
+                        ProgressEvent.progress(resourceModel, ctx),
+                        exception,
+                        DELETE_DB_SHARD_GROUP_ERROR_RULE_SET,
+                        requestLogger
+                )).progress();
+    }
+
+    private boolean isDbShardGroupDeleted(final ResourceModel model,
+                                final ProxyClient<RdsClient> proxyClient) {
+        try {
+            proxyClient.injectCredentialsAndInvokeV2(Translator.describeDbShardGroupsRequest(model), proxyClient.client()::describeDBShardGroups);
+            return false;
+        } catch (DbShardGroupNotFoundException e) {
+            return true;
+        }
+    }
+
+    private boolean isDbClusterStabilizedOrDeleted(final ProxyClient<RdsClient> proxyClient,
+                                                   final CallbackContext callbackContext) {
+        try {
+            final List<DBCluster> dbClusters = proxyClient.injectCredentialsAndInvokeV2(
+                    DescribeDbClustersRequest.builder()
+                            .dbClusterIdentifier(callbackContext.getDbClusterIdentifier())
+                            .build(),
+                    proxyClient.client()::describeDBClusters
+            ).dbClusters();
+
+            if (CollectionUtils.isEmpty(dbClusters)) {
+                // For an empty response, we assume the same behavior for a DbClusterNotFoundException
+                // https://jira.rds.a2z.com/browse/WS-6673
+                return true;
+            } else {
+                return isDBClusterAvailable(dbClusters.get(0));
+            }
+        } catch (DbClusterNotFoundException e) {
+            return true;
+        }
+    }
+}

--- a/aws-rds-dbshardgroup/src/main/java/software/amazon/rds/dbshardgroup/ListHandler.java
+++ b/aws-rds-dbshardgroup/src/main/java/software/amazon/rds/dbshardgroup/ListHandler.java
@@ -1,0 +1,64 @@
+package software.amazon.rds.dbshardgroup;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import software.amazon.awssdk.services.rds.RdsClient;
+import software.amazon.awssdk.services.rds.model.DBShardGroup;
+import software.amazon.awssdk.services.rds.model.DescribeDbShardGroupsRequest;
+import software.amazon.awssdk.services.rds.model.DescribeDbShardGroupsResponse;
+import software.amazon.awssdk.services.rds.model.Tag;
+import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
+import software.amazon.cloudformation.proxy.OperationStatus;
+import software.amazon.cloudformation.proxy.ProgressEvent;
+import software.amazon.cloudformation.proxy.ProxyClient;
+import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
+import software.amazon.rds.common.handler.Commons;
+import software.amazon.rds.common.handler.HandlerConfig;
+
+import java.util.stream.Collectors;
+import software.amazon.rds.common.handler.Tagging;
+
+public class ListHandler extends BaseHandlerStd {
+
+    /** Default constructor w/ default backoff */
+    public ListHandler() {
+    }
+
+    /** Default constructor w/ custom config */
+    public ListHandler(HandlerConfig config) {
+        super(config);
+    }
+
+    @Override
+    public ProgressEvent<ResourceModel, CallbackContext> handleRequest(
+            final AmazonWebServicesClientProxy proxy,
+            final ProxyClient<RdsClient> proxyClient,
+            final ResourceHandlerRequest<ResourceModel> request,
+            final CallbackContext callbackContext
+    ) {
+        final DescribeDbShardGroupsRequest describeDbShardGroupsRequest = Translator.describeDbShardGroupsRequest(request.getNextToken());
+        DescribeDbShardGroupsResponse describeDbShardGroupsResponse;
+        List<ResourceModel> models = new ArrayList<>();
+        try {
+            describeDbShardGroupsResponse = proxy.injectCredentialsAndInvokeV2(describeDbShardGroupsRequest, proxyClient.client()::describeDBShardGroups);
+            for (DBShardGroup dbShardGroup : describeDbShardGroupsResponse.dbShardGroups()) {
+                Set<Tag> tagSet = getTags(proxyClient, request, dbShardGroup);
+                models.add(Translator.translateDbShardGroupFromSdk(dbShardGroup, tagSet));
+            }
+        } catch (Exception e) {
+            return Commons.handleException(
+                    ProgressEvent.progress(request.getDesiredResourceState(), callbackContext),
+                    e,
+                    DEFAULT_DB_SHARD_GROUP_ERROR_RULE_SET,
+                    requestLogger
+            );
+        }
+        return ProgressEvent.<ResourceModel, CallbackContext>builder()
+                .resourceModels(models)
+                .nextToken(describeDbShardGroupsResponse.marker())
+                .status(OperationStatus.SUCCESS)
+                .build();
+    }
+}

--- a/aws-rds-dbshardgroup/src/main/java/software/amazon/rds/dbshardgroup/ReadHandler.java
+++ b/aws-rds-dbshardgroup/src/main/java/software/amazon/rds/dbshardgroup/ReadHandler.java
@@ -1,0 +1,48 @@
+package software.amazon.rds.dbshardgroup;
+
+import java.util.Set;
+
+import software.amazon.awssdk.services.rds.RdsClient;
+import software.amazon.awssdk.services.rds.model.DBShardGroup;
+import software.amazon.awssdk.services.rds.model.DescribeDbShardGroupsRequest;
+import software.amazon.awssdk.services.rds.model.Tag;
+import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
+import software.amazon.cloudformation.proxy.ProgressEvent;
+import software.amazon.cloudformation.proxy.ProxyClient;
+import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
+import software.amazon.rds.common.handler.Commons;
+import software.amazon.rds.common.handler.HandlerConfig;
+
+public class ReadHandler extends BaseHandlerStd {
+
+    /** Default constructor w/ default backoff */
+    public ReadHandler() {
+    }
+
+    /** Default constructor w/ custom config */
+    public ReadHandler(HandlerConfig config) {
+        super(config);
+    }
+
+    protected ProgressEvent<ResourceModel, CallbackContext> handleRequest(
+            final AmazonWebServicesClientProxy proxy,
+            final ProxyClient<RdsClient> proxyClient,
+            final ResourceHandlerRequest<ResourceModel> request,
+            final CallbackContext callbackContext) {
+        DescribeDbShardGroupsRequest describeDbShardGroupsRequest = Translator.describeDbShardGroupsRequest(request.getDesiredResourceState());
+        ResourceModel model;
+        try {
+            DBShardGroup dbShardGroup = proxyClient.injectCredentialsAndInvokeV2(describeDbShardGroupsRequest, proxyClient.client()::describeDBShardGroups).dbShardGroups().get(0);
+            Set<Tag> tagSet = getTags(proxyClient, request, dbShardGroup);
+            model = Translator.translateDbShardGroupFromSdk(dbShardGroup, tagSet);
+        } catch (Exception e) {
+            return Commons.handleException(
+                    ProgressEvent.progress(request.getDesiredResourceState(), callbackContext),
+                    e,
+                    DEFAULT_DB_SHARD_GROUP_ERROR_RULE_SET,
+                    requestLogger
+            );
+        }
+        return ProgressEvent.success(model, callbackContext);
+    }
+}

--- a/aws-rds-dbshardgroup/src/main/java/software/amazon/rds/dbshardgroup/ResourceStatus.java
+++ b/aws-rds-dbshardgroup/src/main/java/software/amazon/rds/dbshardgroup/ResourceStatus.java
@@ -1,0 +1,25 @@
+package software.amazon.rds.dbshardgroup;
+
+import software.amazon.awssdk.utils.StringUtils;
+
+public enum ResourceStatus {
+    AVAILABLE("available"),
+    CREATING("creating"),
+    DELETING("deleting"),
+    MODIFYING("modifying");
+
+    private final String value;
+
+    ResourceStatus(final String value) {
+        this.value = value;
+    }
+
+    @Override
+    public String toString() {
+        return value;
+    }
+
+    public boolean equalsString(final String other) {
+        return StringUtils.equals(value, other);
+    }
+}

--- a/aws-rds-dbshardgroup/src/main/java/software/amazon/rds/dbshardgroup/Translator.java
+++ b/aws-rds-dbshardgroup/src/main/java/software/amazon/rds/dbshardgroup/Translator.java
@@ -1,0 +1,120 @@
+package software.amazon.rds.dbshardgroup;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import software.amazon.awssdk.services.rds.model.CreateDbShardGroupRequest;
+import software.amazon.awssdk.services.rds.model.DBShardGroup;
+import software.amazon.awssdk.services.rds.model.DeleteDbShardGroupRequest;
+import software.amazon.awssdk.services.rds.model.DescribeDbClustersRequest;
+import software.amazon.awssdk.services.rds.model.DescribeDbShardGroupsRequest;
+import software.amazon.awssdk.services.rds.model.ModifyDbShardGroupRequest;
+import software.amazon.rds.common.handler.Tagging;
+
+public class Translator {
+
+    static CreateDbShardGroupRequest createDbShardGroupRequest(final ResourceModel model) {
+        return CreateDbShardGroupRequest.builder()
+                .computeRedundancy(model.getComputeRedundancy())
+                .dbClusterIdentifier(model.getDBClusterIdentifier())
+                .dbShardGroupIdentifier(model.getDBShardGroupIdentifier())
+                .maxACU(model.getMaxACU())
+                .minACU(model.getMinACU())
+                .publiclyAccessible(model.getPubliclyAccessible())
+                .build();
+    }
+
+  static CreateDbShardGroupRequest createDbShardGroupRequest(final ResourceModel model, final Tagging.TagSet tags) {
+    return CreateDbShardGroupRequest.builder()
+            .computeRedundancy(model.getComputeRedundancy())
+            .dbClusterIdentifier(model.getDBClusterIdentifier())
+            .dbShardGroupIdentifier(model.getDBShardGroupIdentifier())
+            .maxACU(model.getMaxACU())
+            .minACU(model.getMinACU())
+            .publiclyAccessible(model.getPubliclyAccessible())
+            .tags(Tagging.translateTagsToSdk(tags))
+            .build();
+  }
+
+  static ModifyDbShardGroupRequest modifyDbShardGroupRequest(final ResourceModel desiredModel) {
+    return ModifyDbShardGroupRequest.builder()
+            .computeRedundancy(desiredModel.getComputeRedundancy())
+            .dbShardGroupIdentifier(desiredModel.getDBShardGroupIdentifier())
+            .maxACU(desiredModel.getMaxACU())
+            .minACU(desiredModel.getMinACU())
+            .build();
+  }
+
+  static DescribeDbShardGroupsRequest describeDbShardGroupsRequest(final ResourceModel model) {
+    return DescribeDbShardGroupsRequest.builder()
+            .dbShardGroupIdentifier(model.getDBShardGroupIdentifier())
+            .build();
+  }
+
+  static DescribeDbClustersRequest describeDbClustersRequest(final ResourceModel model) {
+    return DescribeDbClustersRequest.builder()
+            .dbClusterIdentifier(model.getDBClusterIdentifier())
+            .build();
+  }
+
+  static DescribeDbShardGroupsRequest describeDbShardGroupsRequest(final String nextToken) {
+    return DescribeDbShardGroupsRequest.builder()
+            .marker(nextToken)
+            .build();
+  }
+
+  static DeleteDbShardGroupRequest deleteDbShardGroupRequest(final ResourceModel model) {
+    return DeleteDbShardGroupRequest.builder()
+            .dbShardGroupIdentifier(model.getDBShardGroupIdentifier())
+            .build();
+  }
+
+  public static Map<String, String> translateTagsToRequest(final Collection<Tag> tags) {
+    return Optional.ofNullable(tags).orElse(Collections.emptyList())
+            .stream()
+            .collect(Collectors.toMap(Tag::getKey, Tag::getValue));
+  }
+
+  static Set<software.amazon.awssdk.services.rds.model.Tag> translateTagsToSdk(
+          final Collection<Tag> tags
+  ) {
+    return Optional.ofNullable(tags).orElse(Collections.emptySet())
+            .stream()
+            .map(tag -> software.amazon.awssdk.services.rds.model.Tag.builder()
+                    .key(tag.getKey())
+                    .value(tag.getValue())
+                    .build())
+            .collect(Collectors.toSet());
+  }
+
+  static Set<Tag> translateTagsFromSdk(
+          final Collection<software.amazon.awssdk.services.rds.model.Tag> tags
+  ) {
+    return Optional.ofNullable(tags).orElse(Collections.emptySet())
+            .stream()
+            .map(tag -> software.amazon.rds.dbshardgroup.Tag.builder()
+                    .key(tag.key())
+                    .value(tag.value())
+                    .build())
+            .collect(Collectors.toSet());
+  }
+
+  static ResourceModel translateDbShardGroupFromSdk(final DBShardGroup dbShardGroup, final Set<software.amazon.awssdk.services.rds.model.Tag> tags) {
+    return ResourceModel.builder()
+            .dBShardGroupResourceId(dbShardGroup.dbShardGroupResourceId())
+            .dBShardGroupIdentifier(dbShardGroup.dbShardGroupIdentifier())
+            .dBClusterIdentifier(dbShardGroup.dbClusterIdentifier())
+            .computeRedundancy(dbShardGroup.computeRedundancy())
+            .maxACU(dbShardGroup.maxACU())
+            // TODO: Return minACU when describeDBShardGroup includes value
+//            .minACU(dbShardGroup.minACU())
+            .publiclyAccessible(dbShardGroup.publiclyAccessible())
+            .tags(translateTagsFromSdk(tags))
+            .endpoint(dbShardGroup.endpoint())
+            .build();
+  }
+}

--- a/aws-rds-dbshardgroup/src/main/java/software/amazon/rds/dbshardgroup/UpdateHandler.java
+++ b/aws-rds-dbshardgroup/src/main/java/software/amazon/rds/dbshardgroup/UpdateHandler.java
@@ -1,0 +1,87 @@
+package software.amazon.rds.dbshardgroup;
+
+import java.util.function.Function;
+import software.amazon.awssdk.services.rds.RdsClient;
+import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
+import software.amazon.cloudformation.proxy.ProgressEvent;
+import software.amazon.cloudformation.proxy.ProxyClient;
+import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
+import software.amazon.rds.common.handler.Commons;
+import software.amazon.rds.common.handler.HandlerConfig;
+import software.amazon.rds.common.handler.Tagging;
+
+import java.util.HashSet;
+
+public class UpdateHandler extends BaseHandlerStd {
+    static final int POST_MODIFY_DELAY_SEC = 300;
+    static final int CALLBACK_DELAY = 6;
+
+    /** Default constructor w/ default backoff */
+    public UpdateHandler() {
+    }
+
+    /** Default constructor w/ custom config */
+    public UpdateHandler(HandlerConfig config) {
+        super(config);
+    }
+
+    protected ProgressEvent<ResourceModel, CallbackContext> handleRequest(final AmazonWebServicesClientProxy proxy,
+                                                                          final ProxyClient<RdsClient> proxyClient,
+                                                                          final ResourceHandlerRequest<ResourceModel> request,
+                                                                          final CallbackContext callbackContext) {
+        final Tagging.TagSet previousTags = Tagging.TagSet.builder()
+                .systemTags(Tagging.translateTagsToSdk(request.getPreviousSystemTags()))
+                .stackTags(Tagging.translateTagsToSdk(request.getPreviousResourceTags()))
+                .resourceTags(new HashSet<>(Translator.translateTagsToSdk(request.getPreviousResourceState().getTags())))
+                .build();
+
+        final Tagging.TagSet desiredTags = Tagging.TagSet.builder()
+                .systemTags(Tagging.translateTagsToSdk(request.getSystemTags()))
+                .stackTags(Tagging.translateTagsToSdk(request.getDesiredResourceTags()))
+                .resourceTags(new HashSet<>(Translator.translateTagsToSdk(request.getDesiredResourceState().getTags())))
+                .build();
+
+        ResourceModel desiredModel = request.getDesiredResourceState();
+
+        return ProgressEvent.progress(desiredModel, callbackContext)
+                .then(progress -> Commons.execOnce(
+                        progress,
+                        () -> proxy.initiate("rds::modify-db-shard-group", proxyClient, request.getDesiredResourceState(), callbackContext)
+                                .translateToServiceRequest(Translator::modifyDbShardGroupRequest)
+                                .backoffDelay(config.getBackoff())
+                                .makeServiceCall((modifyDbShardGroupRequest, proxyInvocation) -> proxyInvocation.injectCredentialsAndInvokeV2(modifyDbShardGroupRequest, proxyClient.client()::modifyDBShardGroup))
+                                .handleError((describeRequest, exception, client, resourceModel, ctx) -> Commons.handleException(
+                                        ProgressEvent.progress(resourceModel, ctx),
+                                        exception,
+                                    DEFAULT_DB_SHARD_GROUP_ERROR_RULE_SET,
+                                    requestLogger))
+                                .progress(), CallbackContext::isUpdated, CallbackContext::setUpdated))
+                .then(progress -> Commons.execOnce(progress, () -> updateTags(proxyClient, request, progress, previousTags, desiredTags), CallbackContext::isAddTagsComplete, CallbackContext::setAddTagsComplete))
+                // There is a lag between the modifyDbShardGroup request call and the shard group state moving to "modifying", so we introduce a fixed delay prior to stabilization
+                .then((progress) -> delay(progress, POST_MODIFY_DELAY_SEC))
+                .then(progress -> proxy.initiate("rds::update-db-shard-group-stabilize", proxyClient, request.getDesiredResourceState(), callbackContext)
+                        .translateToServiceRequest(Function.identity())
+                        .backoffDelay(config.getBackoff())
+                        .makeServiceCall(NOOP_CALL)
+                        .stabilize((noopRequest, noopResponse, proxyInvocation, model, context) -> isDBShardGroupStabilizedAfterMutate(model, proxyInvocation))
+                        .handleError((deleteRequest, exception, client, resourceModel, ctx) -> Commons.handleException(
+                                ProgressEvent.progress(resourceModel, ctx),
+                                exception,
+                                DEFAULT_DB_SHARD_GROUP_ERROR_RULE_SET,
+                                requestLogger
+                        ))
+                        .progress())
+                .then(progress -> new ReadHandler().handleRequest(proxy, proxyClient, request, callbackContext));
+    }
+
+    /** Inserts an artificial delay */
+    private ProgressEvent<ResourceModel, CallbackContext> delay(final ProgressEvent<ResourceModel, CallbackContext> evt, final int seconds) {
+        CallbackContext callbackContext = evt.getCallbackContext();
+        if (callbackContext.getWaitTime() <= seconds) {
+            callbackContext.setWaitTime(callbackContext.getWaitTime() + CALLBACK_DELAY);
+            return ProgressEvent.defaultInProgressHandler(callbackContext, CALLBACK_DELAY, evt.getResourceModel());
+        } else {
+            return ProgressEvent.progress(evt.getResourceModel(), callbackContext);
+        }
+    }
+}

--- a/aws-rds-dbshardgroup/src/resources/log4j2.xml
+++ b/aws-rds-dbshardgroup/src/resources/log4j2.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="WARN">
+    <Appenders>
+        <Console name="Console" target="SYSTEM_OUT">
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>
+        </Console>
+        <File name="APPLICATION" fileName="log/application.log">
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>
+        </File>
+    </Appenders>
+    <Loggers>
+        <Root level="DEBUG">
+            <AppenderRef ref="Console"/>
+            <AppenderRef ref="APPLICATION"/>
+        </Root>
+    </Loggers>
+</Configuration>

--- a/aws-rds-dbshardgroup/src/test/java/software/amazon/rds/dbshardgroup/AbstractHandlerTest.java
+++ b/aws-rds-dbshardgroup/src/test/java/software/amazon/rds/dbshardgroup/AbstractHandlerTest.java
@@ -1,0 +1,167 @@
+package software.amazon.rds.dbshardgroup;
+
+import java.time.Duration;
+import java.util.Set;
+import java.util.UUID;
+import java.util.function.Supplier;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.ImmutableSet;
+import software.amazon.awssdk.services.rds.RdsClient;
+import software.amazon.awssdk.services.rds.model.DBShardGroup;
+import software.amazon.awssdk.services.rds.model.DescribeDbShardGroupsRequest;
+import software.amazon.awssdk.services.rds.model.DescribeDbShardGroupsResponse;
+import software.amazon.cloudformation.proxy.*;
+import software.amazon.cloudformation.proxy.delay.Constant;
+import software.amazon.rds.common.handler.HandlerConfig;
+import software.amazon.rds.common.handler.Tagging;
+import software.amazon.rds.common.logging.RequestLogger;
+import software.amazon.rds.common.printer.FilteredJsonPrinter;
+import software.amazon.rds.test.common.core.AbstractTestBase;
+
+public abstract class AbstractHandlerTest extends AbstractTestBase <DBShardGroup, ResourceModel, CallbackContext> {
+
+    protected static final String LOGICAL_RESOURCE_IDENTIFIER = "dbshardgroup";
+    protected static final String CLIENT_REQUEST_TOKEN = UUID.randomUUID().toString();
+    protected static final String STACK_ID = UUID.randomUUID().toString();
+
+    protected static final Credentials MOCK_CREDENTIALS;
+    protected static final LoggerProxy logger;
+    static final Set<Tag> TAG_LIST;
+    static final Set<Tag> TAG_LIST_EMPTY;
+    static final Set<Tag> TAG_LIST_ALTER;
+    static final Tagging.TagSet TAG_SET;
+
+    static {
+        MOCK_CREDENTIALS = new Credentials("accessKey", "secretKey", "token");
+        logger = new LoggerProxy();
+
+        TAG_LIST_EMPTY = ImmutableSet.of();
+
+        TAG_LIST = ImmutableSet.of(
+                Tag.builder().key("foo").value("bar").build()
+        );
+
+        TAG_LIST_ALTER = ImmutableSet.of(
+                Tag.builder().key("bar").value("baz").build(),
+                Tag.builder().key("fizz").value("buzz").build()
+        );
+
+        TAG_SET = Tagging.TagSet.builder()
+                .systemTags(ImmutableSet.of(
+                        software.amazon.awssdk.services.rds.model.Tag.builder().key("system-tag-1").value("system-tag-value1").build(),
+                        software.amazon.awssdk.services.rds.model.Tag.builder().key("system-tag-2").value("system-tag-value2").build(),
+                        software.amazon.awssdk.services.rds.model.Tag.builder().key("system-tag-3").value("system-tag-value3").build()
+                )).stackTags(ImmutableSet.of(
+                        software.amazon.awssdk.services.rds.model.Tag.builder().key("stack-tag-1").value("stack-tag-value1").build(),
+                        software.amazon.awssdk.services.rds.model.Tag.builder().key("stack-tag-2").value("stack-tag-value2").build(),
+                        software.amazon.awssdk.services.rds.model.Tag.builder().key("stack-tag-3").value("stack-tag-value3").build()
+                )).resourceTags(ImmutableSet.of(
+                        software.amazon.awssdk.services.rds.model.Tag.builder().key("resource-tag-1").value("resource-tag-value1").build(),
+                        software.amazon.awssdk.services.rds.model.Tag.builder().key("resource-tag-2").value("resource-tag-value2").build(),
+                        software.amazon.awssdk.services.rds.model.Tag.builder().key("resource-tag-3").value("resource-tag-value3").build()
+                )).build();
+    }
+
+    static final String DB_SHARD_GROUP_IDENTIFIER = "testDbShardGroup";
+    static final String DB_SHARD_GROUP_RESOURCE_ID = "testDbShardGroupId";
+    static final String DB_CLUSTER_IDENTIFIER = "testDbCluster";
+
+    static final String ACCOUNT_ID = "123456789012";
+    static final String REGION = "us-east-1";
+    static final String PARTITION = "aws";
+    static final String DB_SHARD_GROUP_ARN = "arn:aws:rds:us-east-1:123456789012:shard-group:testDbShardGroupId";
+    static final int COMPUTE_REDUNDANCY = 1;
+    static final Double MAX_ACU = 3.5;
+    static final Double MAX_ACU_ALTER = 5d;
+
+    static final ResourceModel RESOURCE_MODEL = ResourceModel.builder()
+            .dBShardGroupIdentifier(DB_SHARD_GROUP_IDENTIFIER)
+            .dBClusterIdentifier(DB_CLUSTER_IDENTIFIER)
+            .dBShardGroupResourceId(DB_SHARD_GROUP_RESOURCE_ID)
+            .computeRedundancy(COMPUTE_REDUNDANCY)
+            .maxACU(MAX_ACU)
+            .publiclyAccessible(false)
+            .build();
+
+    static final ResourceModel RESOURCE_MODEL_NO_IDENT = ResourceModel.builder()
+            .dBClusterIdentifier(DB_CLUSTER_IDENTIFIER)
+            .dBShardGroupResourceId(DB_SHARD_GROUP_RESOURCE_ID)
+            .computeRedundancy(COMPUTE_REDUNDANCY)
+            .maxACU(MAX_ACU)
+            .publiclyAccessible(false)
+            .build();
+
+    static final DBShardGroup DB_SHARD_GROUP = DBShardGroup.builder()
+            .dbShardGroupIdentifier(DB_SHARD_GROUP_IDENTIFIER)
+            .dbClusterIdentifier(DB_CLUSTER_IDENTIFIER)
+            .dbShardGroupResourceId(DB_SHARD_GROUP_RESOURCE_ID)
+            .computeRedundancy(COMPUTE_REDUNDANCY)
+            .maxACU(MAX_ACU)
+            .publiclyAccessible(false)
+            .build();
+
+    protected static final DBShardGroup DB_SHARD_GROUP_AVAILABLE = DB_SHARD_GROUP.toBuilder()
+            .status(ResourceStatus.AVAILABLE.toString())
+            .build();
+
+    protected static final DBShardGroup DB_SHARD_GROUP_CREATING = DB_SHARD_GROUP.toBuilder()
+            .status(ResourceStatus.CREATING.toString())
+            .build();
+
+    protected static final DBShardGroup DB_SHARD_GROUP_MODIFYING = DB_SHARD_GROUP.toBuilder()
+            .status(ResourceStatus.MODIFYING.toString())
+            .build();
+
+    protected static final DBShardGroup DB_SHARD_GROUP_DELETING = DB_SHARD_GROUP.toBuilder()
+            .status(ResourceStatus.DELETING.toString())
+            .build();
+
+    // use an accelerated backoff for faster unit testing
+    protected final HandlerConfig TEST_HANDLER_CONFIG = HandlerConfig.builder()
+            .probingEnabled(false)
+            .backoff(Constant.of().delay(Duration.ofMillis(1))
+                    .timeout(Duration.ofSeconds(120))
+                    .build())
+            .build();
+
+    static <ClientT> ProxyClient<ClientT> MOCK_PROXY(final AmazonWebServicesClientProxy proxy, final ClientT client) {
+        return new BaseProxyClient<>(proxy, client);
+    }
+
+    protected abstract BaseHandlerStd getHandler();
+
+    protected abstract AmazonWebServicesClientProxy getProxy();
+
+    protected abstract ProxyClient<RdsClient> getProxyClient();
+
+    @Override
+    protected String getLogicalResourceIdentifier() {
+        return LOGICAL_RESOURCE_IDENTIFIER;
+    }
+
+    @Override
+    protected String newClientRequestToken() {
+        return CLIENT_REQUEST_TOKEN;
+    }
+
+    protected String newStackId() {
+        return STACK_ID;
+    }
+
+    @Override
+    protected void expectResourceSupply(Supplier<DBShardGroup> supplier) {
+        when(getProxyClient().client().describeDBShardGroups(any(DescribeDbShardGroupsRequest.class)))
+                .then((req) ->
+                        DescribeDbShardGroupsResponse.builder()
+                                .dbShardGroups(supplier.get())
+                                .build());
+    }
+
+    @Override
+    protected ProgressEvent<ResourceModel, CallbackContext> invokeHandleRequest(ResourceHandlerRequest<ResourceModel> request, CallbackContext context) {
+        return getHandler().handleRequest(getProxy(), getProxyClient(), request, context, new RequestLogger(logger, request, new FilteredJsonPrinter()));
+    }
+}

--- a/aws-rds-dbshardgroup/src/test/java/software/amazon/rds/dbshardgroup/BaseProxyClient.java
+++ b/aws-rds-dbshardgroup/src/test/java/software/amazon/rds/dbshardgroup/BaseProxyClient.java
@@ -1,0 +1,65 @@
+package software.amazon.rds.dbshardgroup;
+
+import software.amazon.awssdk.awscore.AwsRequest;
+import software.amazon.awssdk.awscore.AwsResponse;
+import software.amazon.awssdk.core.ResponseBytes;
+import software.amazon.awssdk.core.ResponseInputStream;
+import software.amazon.awssdk.core.pagination.sync.SdkIterable;
+import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
+import software.amazon.cloudformation.proxy.ProxyClient;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
+
+public class BaseProxyClient<ClientT> implements ProxyClient<ClientT> {
+
+    protected final AmazonWebServicesClientProxy proxy;
+    protected final ClientT client;
+
+    public BaseProxyClient(
+            final AmazonWebServicesClientProxy proxy,
+            final ClientT client
+    ) {
+        this.proxy = proxy;
+        this.client = client;
+    }
+
+    @Override
+    public <RequestT extends AwsRequest, ResponseT extends AwsResponse> ResponseT injectCredentialsAndInvokeV2(RequestT request,
+                                                                                                               Function<RequestT, ResponseT> requestFunction) {
+        return proxy.injectCredentialsAndInvokeV2(request, requestFunction);
+    }
+
+    @Override
+    public <RequestT extends AwsRequest, ResponseT extends AwsResponse> CompletableFuture<ResponseT> injectCredentialsAndInvokeV2Async(
+            RequestT request,
+            Function<RequestT, CompletableFuture<ResponseT>> requestFunction) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public <RequestT extends AwsRequest, ResponseT extends AwsResponse, IterableT extends SdkIterable<ResponseT>> IterableT injectCredentialsAndInvokeIterableV2(
+            RequestT request,
+            Function<RequestT, IterableT> requestFunction) {
+        return proxy.injectCredentialsAndInvokeIterableV2(request, requestFunction);
+    }
+
+    @Override
+    public <RequestT extends AwsRequest, ResponseT extends AwsResponse> ResponseInputStream<ResponseT> injectCredentialsAndInvokeV2InputStream(
+            RequestT request,
+            Function<RequestT, ResponseInputStream<ResponseT>> requestFunction) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public <RequestT extends AwsRequest, ResponseT extends AwsResponse> ResponseBytes<ResponseT> injectCredentialsAndInvokeV2Bytes(
+            RequestT request,
+            Function<RequestT, ResponseBytes<ResponseT>> requestFunction) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public ClientT client() {
+        return client;
+    }
+}

--- a/aws-rds-dbshardgroup/src/test/java/software/amazon/rds/dbshardgroup/CreateHandlerTest.java
+++ b/aws-rds-dbshardgroup/src/test/java/software/amazon/rds/dbshardgroup/CreateHandlerTest.java
@@ -1,0 +1,301 @@
+package software.amazon.rds.dbshardgroup;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.Objects;
+
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import lombok.Getter;
+import org.mockito.ArgumentMatchers;
+import software.amazon.awssdk.services.rds.RdsClient;
+import software.amazon.awssdk.services.rds.model.CreateDbShardGroupRequest;
+import software.amazon.awssdk.services.rds.model.CreateDbShardGroupResponse;
+import software.amazon.awssdk.services.rds.model.DBCluster;
+import software.amazon.awssdk.services.rds.model.DBShardGroup;
+import software.amazon.awssdk.services.rds.model.DbShardGroupAlreadyExistsException;
+import software.amazon.awssdk.services.rds.model.DbShardGroupNotFoundException;
+import software.amazon.awssdk.services.rds.model.DescribeDbClustersRequest;
+import software.amazon.awssdk.services.rds.model.DescribeDbClustersResponse;
+import software.amazon.awssdk.services.rds.model.DescribeDbShardGroupsRequest;
+import software.amazon.awssdk.services.rds.model.ListTagsForResourceRequest;
+import software.amazon.awssdk.services.rds.model.ListTagsForResourceResponse;
+import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
+import software.amazon.cloudformation.proxy.HandlerErrorCode;
+import software.amazon.cloudformation.proxy.ProxyClient;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+import static software.amazon.rds.dbshardgroup.CreateHandler.STACK_NAME;
+import static software.amazon.rds.dbshardgroup.CreateHandler.dbShardGroupIdentifierFactory;
+
+@ExtendWith(MockitoExtension.class)
+public class CreateHandlerTest extends AbstractHandlerTest {
+
+    @Mock
+    @Getter
+    private AmazonWebServicesClientProxy proxy;
+
+    @Mock
+    @Getter
+    private ProxyClient<RdsClient> proxyClient;
+
+    @Mock
+    RdsClient rdsClient;
+
+    @Getter
+    private CreateHandler handler;
+
+    @BeforeEach
+    public void setup() {
+        handler = new CreateHandler(TEST_HANDLER_CONFIG);
+        proxy = new AmazonWebServicesClientProxy(logger, MOCK_CREDENTIALS, () -> Duration.ofSeconds(600).toMillis());
+        rdsClient = mock(RdsClient.class);
+        proxyClient = MOCK_PROXY(proxy, rdsClient);
+    }
+
+    @AfterEach
+    public void tear_down() {
+        verify(rdsClient, atLeastOnce()).serviceName();
+        verifyNoMoreInteractions(rdsClient);
+    }
+
+    @Test
+    public void handleRequest_SimpleSuccess() {
+        ResourceHandlerRequest.ResourceHandlerRequestBuilder<ResourceModel> requestBuilder = ResourceHandlerRequest.builder();
+        requestBuilder.region(REGION);
+        requestBuilder.awsAccountId(ACCOUNT_ID);
+        requestBuilder.awsPartition(PARTITION);
+
+        when(proxyClient.client().createDBShardGroup(any(CreateDbShardGroupRequest.class)))
+                .thenReturn(CreateDbShardGroupResponse.builder()
+                        .dbShardGroupIdentifier(DB_SHARD_GROUP_AVAILABLE.dbShardGroupIdentifier())
+                        .dbClusterIdentifier(DB_SHARD_GROUP_AVAILABLE.dbClusterIdentifier())
+                        .computeRedundancy(DB_SHARD_GROUP_AVAILABLE.computeRedundancy())
+                        .maxACU(DB_SHARD_GROUP_AVAILABLE.maxACU())
+                        .publiclyAccessible(DB_SHARD_GROUP_AVAILABLE.publiclyAccessible())
+                        .build());
+        when(proxyClient.client().describeDBClusters(any(DescribeDbClustersRequest.class)))
+                .thenReturn(DescribeDbClustersResponse.builder().dbClusters(
+                                        DBCluster.builder()
+                                                .status(String.valueOf(ResourceStatus.AVAILABLE))
+                                                .build()
+                                )
+                                .build()
+                );
+        when(proxyClient.client().listTagsForResource(any(ListTagsForResourceRequest.class)))
+                .thenReturn(ListTagsForResourceResponse.builder()
+                        .build());
+
+        final CallbackContext context = new CallbackContext();
+
+        test_handleRequest_base(
+                context,
+                requestBuilder,
+                () -> DB_SHARD_GROUP_AVAILABLE,
+                null,
+                () -> RESOURCE_MODEL,
+                expectSuccess()
+        );
+
+        verify(proxyClient.client(), times(1)).createDBShardGroup(
+                ArgumentMatchers.<CreateDbShardGroupRequest>argThat(req ->
+                        Objects.equals(DB_SHARD_GROUP_CREATING.dbShardGroupIdentifier(), req.dbShardGroupIdentifier())
+                )
+        );
+        verify(proxyClient.client(), times(3)).describeDBShardGroups(
+                ArgumentMatchers.<DescribeDbShardGroupsRequest>argThat(req ->
+                        Objects.equals(DB_SHARD_GROUP_CREATING.dbShardGroupIdentifier(), req.dbShardGroupIdentifier())
+                )
+        );
+        verify(proxyClient.client(), times(1)).describeDBClusters(
+                ArgumentMatchers.<DescribeDbClustersRequest>argThat(req ->
+                        Objects.equals(DB_SHARD_GROUP_CREATING.dbClusterIdentifier(), req.dbClusterIdentifier())
+                )
+        );
+        verify(proxyClient.client(), times(1)).listTagsForResource(
+                ArgumentMatchers.<ListTagsForResourceRequest>argThat(
+                        req -> DB_SHARD_GROUP_ARN.equalsIgnoreCase(req.resourceName()))
+        );
+    }
+
+    @Test
+    public void handleRequest_NoDbShardGroupIdentifier() {
+        ResourceHandlerRequest.ResourceHandlerRequestBuilder<ResourceModel> requestBuilder = ResourceHandlerRequest.builder();
+        requestBuilder.region(REGION);
+        requestBuilder.awsAccountId(ACCOUNT_ID);
+        requestBuilder.awsPartition(PARTITION);
+
+        String dbShardGroupIdentifier = dbShardGroupIdentifierFactory.newIdentifier()
+                .withStackId(STACK_ID)
+                .withResourceId(LOGICAL_RESOURCE_IDENTIFIER)
+                .withRequestToken(CLIENT_REQUEST_TOKEN)
+                .toString();
+
+        when(proxyClient.client().createDBShardGroup(any(CreateDbShardGroupRequest.class)))
+                .thenReturn(CreateDbShardGroupResponse.builder()
+                        .dbShardGroupIdentifier(dbShardGroupIdentifier)
+                        .dbClusterIdentifier(DB_SHARD_GROUP_AVAILABLE.dbClusterIdentifier())
+                        .computeRedundancy(DB_SHARD_GROUP_AVAILABLE.computeRedundancy())
+                        .maxACU(DB_SHARD_GROUP_AVAILABLE.maxACU())
+                        .publiclyAccessible(DB_SHARD_GROUP_AVAILABLE.publiclyAccessible())
+                        .build());
+        when(proxyClient.client().describeDBClusters(any(DescribeDbClustersRequest.class)))
+                .thenReturn(DescribeDbClustersResponse.builder().dbClusters(
+                                        DBCluster.builder()
+                                                .status(String.valueOf(ResourceStatus.AVAILABLE))
+                                                .build()
+                                )
+                                .build()
+                );
+        when(proxyClient.client().listTagsForResource(any(ListTagsForResourceRequest.class)))
+                .thenReturn(ListTagsForResourceResponse.builder()
+                        .build());
+
+        final CallbackContext context = new CallbackContext();
+
+        test_handleRequest_base(
+                context,
+                requestBuilder,
+                () -> DB_SHARD_GROUP_AVAILABLE,
+                null,
+                () -> RESOURCE_MODEL_NO_IDENT,
+                expectSuccess()
+        );
+
+        verify(proxyClient.client(), times(1)).createDBShardGroup(
+                ArgumentMatchers.<CreateDbShardGroupRequest>argThat(req ->
+                        Objects.equals(dbShardGroupIdentifier, req.dbShardGroupIdentifier())
+                )
+        );
+        verify(proxyClient.client(), times(3)).describeDBShardGroups(
+                ArgumentMatchers.<DescribeDbShardGroupsRequest>argThat(req ->
+                        Objects.equals(dbShardGroupIdentifier, req.dbShardGroupIdentifier())
+                )
+        );
+        verify(proxyClient.client(), times(1)).describeDBClusters(
+                ArgumentMatchers.<DescribeDbClustersRequest>argThat(req ->
+                        Objects.equals(DB_SHARD_GROUP_CREATING.dbClusterIdentifier(), req.dbClusterIdentifier())
+                )
+        );
+        verify(proxyClient.client(), times(1)).listTagsForResource(
+                ArgumentMatchers.<ListTagsForResourceRequest>argThat(
+                        req -> DB_SHARD_GROUP_ARN.equalsIgnoreCase(req.resourceName()))
+        );
+    }
+
+    @Test
+    public void handleRequest_Stabilize() {
+        ResourceHandlerRequest.ResourceHandlerRequestBuilder<ResourceModel> requestBuilder = ResourceHandlerRequest.builder();
+        requestBuilder.region(REGION);
+        requestBuilder.awsAccountId(ACCOUNT_ID);
+        requestBuilder.awsPartition(PARTITION);
+
+        when(proxyClient.client().createDBShardGroup(any(CreateDbShardGroupRequest.class)))
+                .thenReturn(CreateDbShardGroupResponse.builder()
+                        .dbShardGroupIdentifier(DB_SHARD_GROUP_AVAILABLE.dbShardGroupIdentifier())
+                        .dbClusterIdentifier(DB_SHARD_GROUP_AVAILABLE.dbClusterIdentifier())
+                        .computeRedundancy(DB_SHARD_GROUP_AVAILABLE.computeRedundancy())
+                        .maxACU(DB_SHARD_GROUP_AVAILABLE.maxACU())
+                        .publiclyAccessible(DB_SHARD_GROUP_AVAILABLE.publiclyAccessible())
+                        .build());
+        when(proxyClient.client().describeDBClusters(any(DescribeDbClustersRequest.class)))
+                .thenReturn(DescribeDbClustersResponse.builder().dbClusters(
+                                        DBCluster.builder()
+                                                .status(String.valueOf(ResourceStatus.MODIFYING))
+                                                .build()
+                                )
+                                .build()
+                ).thenReturn(DescribeDbClustersResponse.builder().dbClusters(
+                                        DBCluster.builder()
+                                                .status(String.valueOf(ResourceStatus.AVAILABLE))
+                                                .build()
+                                )
+                                .build()
+                );
+        when(proxyClient.client().listTagsForResource(any(ListTagsForResourceRequest.class)))
+                .thenReturn(ListTagsForResourceResponse.builder()
+                        .build());
+
+        final CallbackContext context = new CallbackContext();
+        final Queue<DBShardGroup> transitions = new ConcurrentLinkedQueue<>();
+        transitions.add(DB_SHARD_GROUP_CREATING);
+        transitions.add(DB_SHARD_GROUP_AVAILABLE);
+        transitions.add(DB_SHARD_GROUP_AVAILABLE);
+        transitions.add(DB_SHARD_GROUP_MODIFYING);
+
+        test_handleRequest_base(
+                context,
+                requestBuilder,
+                () -> {
+                    if (transitions.size() > 0) {
+                        return transitions.remove();
+                    }
+                    return DB_SHARD_GROUP_AVAILABLE;
+                },
+                null,
+                () -> RESOURCE_MODEL,
+                expectSuccess()
+        );
+
+        verify(proxyClient.client(), times(1)).createDBShardGroup(
+                ArgumentMatchers.<CreateDbShardGroupRequest>argThat(req ->
+                        Objects.equals(DB_SHARD_GROUP_CREATING.dbShardGroupIdentifier(), req.dbShardGroupIdentifier())
+                )
+        );
+        verify(proxyClient.client(), times(4)).describeDBShardGroups(
+                ArgumentMatchers.<DescribeDbShardGroupsRequest>argThat(req ->
+                        Objects.equals(DB_SHARD_GROUP_CREATING.dbShardGroupIdentifier(), req.dbShardGroupIdentifier())
+                )
+        );
+        verify(proxyClient.client(), times(2)).describeDBClusters(
+                ArgumentMatchers.<DescribeDbClustersRequest>argThat(req ->
+                        Objects.equals(DB_SHARD_GROUP_CREATING.dbClusterIdentifier(), req.dbClusterIdentifier())
+                )
+        );
+        verify(proxyClient.client(), times(1)).listTagsForResource(
+                ArgumentMatchers.<ListTagsForResourceRequest>argThat(
+                        req -> DB_SHARD_GROUP_ARN.equalsIgnoreCase(req.resourceName()))
+        );
+    }
+
+    @Test
+    public void handleRequest_CreateDbShardGroupException() {
+        ResourceHandlerRequest.ResourceHandlerRequestBuilder<ResourceModel> requestBuilder = ResourceHandlerRequest.builder();
+        requestBuilder.region(REGION);
+        requestBuilder.awsAccountId(ACCOUNT_ID);
+        requestBuilder.awsPartition(PARTITION);
+
+        when(proxyClient.client().createDBShardGroup(any(CreateDbShardGroupRequest.class)))
+                .thenThrow(DbShardGroupAlreadyExistsException.builder().message("error").build());
+
+        final CallbackContext context = new CallbackContext();
+
+        test_handleRequest_base(
+                context,
+                requestBuilder,
+                null,
+                null,
+                () -> RESOURCE_MODEL,
+                expectFailed(HandlerErrorCode.AlreadyExists)
+        );
+
+        verify(proxyClient.client(), times(1)).createDBShardGroup(
+                ArgumentMatchers.<CreateDbShardGroupRequest>argThat(req ->
+                        Objects.equals(DB_SHARD_GROUP_CREATING.dbShardGroupIdentifier(), req.dbShardGroupIdentifier())
+                )
+        );
+    }
+}

--- a/aws-rds-dbshardgroup/src/test/java/software/amazon/rds/dbshardgroup/DeleteHandlerTest.java
+++ b/aws-rds-dbshardgroup/src/test/java/software/amazon/rds/dbshardgroup/DeleteHandlerTest.java
@@ -1,0 +1,206 @@
+package software.amazon.rds.dbshardgroup;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Objects;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+
+import lombok.Getter;
+import org.mockito.ArgumentMatchers;
+import software.amazon.awssdk.services.rds.RdsClient;
+import software.amazon.awssdk.services.rds.model.*;
+import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
+import software.amazon.cloudformation.proxy.HandlerErrorCode;
+import software.amazon.cloudformation.proxy.ProxyClient;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.times;
+
+@ExtendWith(MockitoExtension.class)
+public class DeleteHandlerTest extends AbstractHandlerTest {
+
+    @Mock
+    @Getter
+    private AmazonWebServicesClientProxy proxy;
+
+    @Mock
+    @Getter
+    private ProxyClient<RdsClient> proxyClient;
+
+    @Mock
+    RdsClient rdsClient;
+
+    @Getter
+    private DeleteHandler handler;
+    private boolean expectClientInvocation;
+
+    @BeforeEach
+    public void setup() {
+        handler = new DeleteHandler(TEST_HANDLER_CONFIG);
+        proxy = new AmazonWebServicesClientProxy(logger, MOCK_CREDENTIALS, () -> Duration.ofSeconds(600).toMillis());
+        rdsClient = mock(RdsClient.class);
+        proxyClient = MOCK_PROXY(proxy, rdsClient);
+        expectClientInvocation = true;
+    }
+
+    @AfterEach
+    public void tear_down() {
+        if (expectClientInvocation){
+            verify(rdsClient, atLeastOnce()).serviceName();
+        }
+        verifyNoMoreInteractions(rdsClient);
+    }
+
+    @Test
+    public void handleRequest_SimpleSuccess() {
+        when(proxyClient.client().deleteDBShardGroup(any(DeleteDbShardGroupRequest.class)))
+                .thenReturn(DeleteDbShardGroupResponse.builder()
+                        .dbShardGroupIdentifier(DB_SHARD_GROUP_AVAILABLE.dbShardGroupIdentifier())
+                        .dbClusterIdentifier(DB_SHARD_GROUP_AVAILABLE.dbClusterIdentifier())
+                        .computeRedundancy(DB_SHARD_GROUP_AVAILABLE.computeRedundancy())
+                        .maxACU(DB_SHARD_GROUP_AVAILABLE.maxACU())
+                        .publiclyAccessible(DB_SHARD_GROUP_AVAILABLE.publiclyAccessible())
+                        .build());
+        when(proxyClient.client().describeDBClusters(any(DescribeDbClustersRequest.class)))
+                .thenReturn(DescribeDbClustersResponse.builder().dbClusters(
+                                        DBCluster.builder()
+                                                .status(String.valueOf(ResourceStatus.AVAILABLE))
+                                                .build()
+                                )
+                                .build()
+                );
+
+        final CallbackContext context = new CallbackContext();
+
+        final Queue<DBShardGroup> transitions = new ConcurrentLinkedQueue<>();
+        transitions.add(DB_SHARD_GROUP_AVAILABLE);
+        transitions.add(DB_SHARD_GROUP_AVAILABLE);
+
+        test_handleRequest_base(
+                context,
+                () -> {
+                    if (transitions.size() > 0) {
+                        return transitions.remove();
+                    }
+                    throw DbShardGroupNotFoundException.builder().message("db shard group not found").build();
+                },
+                () -> RESOURCE_MODEL,
+                expectSuccess()
+        );
+
+        verify(proxyClient.client(), times(1)).deleteDBShardGroup(
+                ArgumentMatchers.any(DeleteDbShardGroupRequest.class)
+        );
+        verify(proxyClient.client(), times(3)).describeDBShardGroups(
+                ArgumentMatchers.<DescribeDbShardGroupsRequest>argThat(req ->
+                        Objects.equals(DB_SHARD_GROUP_AVAILABLE.dbShardGroupIdentifier(), req.dbShardGroupIdentifier())
+                )
+        );
+        verify(proxyClient.client(), times(1)).describeDBClusters(
+                ArgumentMatchers.<DescribeDbClustersRequest>argThat(req ->
+                        Objects.equals(DB_SHARD_GROUP_AVAILABLE.dbClusterIdentifier(), req.dbClusterIdentifier())
+                )
+        );
+    }
+
+    @Test
+    public void handleRequest_ShardGroupDeleting() {
+        when(proxyClient.client().describeDBClusters(any(DescribeDbClustersRequest.class)))
+                .thenThrow(DbClusterNotFoundException.builder().message("db cluster not found").build());
+
+        final CallbackContext context = new CallbackContext();
+
+        final Queue<DBShardGroup> transitions = new ConcurrentLinkedQueue<>();
+        transitions.add(DB_SHARD_GROUP_DELETING);
+        transitions.add(DB_SHARD_GROUP_DELETING);
+
+        test_handleRequest_base(
+                context,
+                () -> {
+                    if (transitions.size() > 0) {
+                        return transitions.remove();
+                    }
+                    throw DbShardGroupNotFoundException.builder().message("db shard group not found").build();
+                },
+                () -> RESOURCE_MODEL,
+                expectSuccess()
+        );
+
+        verify(proxyClient.client(), times(3)).describeDBShardGroups(
+                ArgumentMatchers.<DescribeDbShardGroupsRequest>argThat(req ->
+                        Objects.equals(DB_SHARD_GROUP_DELETING.dbShardGroupIdentifier(), req.dbShardGroupIdentifier())
+                )
+        );
+        verify(proxyClient.client(), times(1)).describeDBClusters(
+                ArgumentMatchers.<DescribeDbClustersRequest>argThat(req ->
+                        Objects.equals(DB_SHARD_GROUP_DELETING.dbClusterIdentifier(), req.dbClusterIdentifier())
+                )
+        );
+    }
+
+    @Test
+    public void handleRequest_ShardGroupDeleting_ClusterEmptyResponse() {
+        when(proxyClient.client().describeDBClusters(any(DescribeDbClustersRequest.class)))
+                .thenReturn(DescribeDbClustersResponse.builder().dbClusters(Collections.emptyList()).build());
+
+        final CallbackContext context = new CallbackContext();
+
+        final Queue<DBShardGroup> transitions = new ConcurrentLinkedQueue<>();
+        transitions.add(DB_SHARD_GROUP_DELETING);
+        transitions.add(DB_SHARD_GROUP_DELETING);
+
+        test_handleRequest_base(
+                context,
+                () -> {
+                    if (transitions.size() > 0) {
+                        return transitions.remove();
+                    }
+                    throw DbShardGroupNotFoundException.builder().message("db shard group not found").build();
+                },
+                () -> RESOURCE_MODEL,
+                expectSuccess()
+        );
+
+        verify(proxyClient.client(), times(3)).describeDBShardGroups(
+                ArgumentMatchers.<DescribeDbShardGroupsRequest>argThat(req ->
+                        Objects.equals(DB_SHARD_GROUP_DELETING.dbShardGroupIdentifier(), req.dbShardGroupIdentifier())
+                )
+        );
+        verify(proxyClient.client(), times(1)).describeDBClusters(
+                ArgumentMatchers.<DescribeDbClustersRequest>argThat(req ->
+                        Objects.equals(DB_SHARD_GROUP_DELETING.dbClusterIdentifier(), req.dbClusterIdentifier())
+                )
+        );
+    }
+
+    @Test
+    public void handleRequest_ShardGroupDeleted() {
+        expectClientInvocation = false;
+        final CallbackContext context = new CallbackContext();
+
+        test_handleRequest_base(
+                context,
+                () -> {
+                    throw DbShardGroupNotFoundException.builder().message("db shard group not found").build();
+                },
+                () -> RESOURCE_MODEL,
+                expectFailed(HandlerErrorCode.NotFound)
+        );
+
+        verify(proxyClient.client(), times(1)).describeDBShardGroups(
+                ArgumentMatchers.<DescribeDbShardGroupsRequest>argThat(req ->
+                        Objects.equals(DB_SHARD_GROUP_DELETING.dbShardGroupIdentifier(), req.dbShardGroupIdentifier())
+                )
+        );
+    }
+}

--- a/aws-rds-dbshardgroup/src/test/java/software/amazon/rds/dbshardgroup/ListHandlerTest.java
+++ b/aws-rds-dbshardgroup/src/test/java/software/amazon/rds/dbshardgroup/ListHandlerTest.java
@@ -1,0 +1,104 @@
+package software.amazon.rds.dbshardgroup;
+
+import java.util.Collections;
+import java.time.Duration;
+
+import lombok.Getter;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.awssdk.services.rds.RdsClient;
+import software.amazon.awssdk.services.rds.model.DescribeDbShardGroupsRequest;
+import software.amazon.awssdk.services.rds.model.DescribeDbShardGroupsResponse;
+import software.amazon.awssdk.services.rds.model.ListTagsForResourceRequest;
+import software.amazon.awssdk.services.rds.model.ListTagsForResourceResponse;
+import software.amazon.cloudformation.proxy.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.times;
+
+@ExtendWith(MockitoExtension.class)
+public class ListHandlerTest extends AbstractHandlerTest {
+
+    @Mock
+    @Getter
+    private AmazonWebServicesClientProxy proxy;
+
+    @Mock
+    @Getter
+    private ProxyClient<RdsClient> proxyClient;
+
+    @Mock
+    RdsClient rdsClient;
+
+    @Getter
+    private ListHandler handler;
+
+    private boolean expectServiceInvocation;
+
+    @BeforeEach
+    public void setup() {
+        handler = new ListHandler(TEST_HANDLER_CONFIG);
+        proxy = new AmazonWebServicesClientProxy(logger, MOCK_CREDENTIALS, () -> Duration.ofSeconds(600).toMillis());
+        rdsClient = mock(RdsClient.class);
+        proxyClient = MOCK_PROXY(proxy, rdsClient);
+        expectServiceInvocation = true;
+    }
+
+    @AfterEach
+    public void tear_down() {
+        if (expectServiceInvocation) {
+            verify(rdsClient, atLeastOnce()).serviceName();
+        }
+        verifyNoMoreInteractions(rdsClient);
+    }
+
+    @Test
+    public void handleRequest_SimpleSuccess() {
+        expectServiceInvocation = false;
+
+        ResourceHandlerRequest.ResourceHandlerRequestBuilder<ResourceModel> requestBuilder = ResourceHandlerRequest.builder();
+        requestBuilder.region(REGION);
+        requestBuilder.awsAccountId(ACCOUNT_ID);
+        requestBuilder.awsPartition(PARTITION);
+
+        when(proxyClient.client().describeDBShardGroups(any(DescribeDbShardGroupsRequest.class)))
+                .thenReturn(DescribeDbShardGroupsResponse.builder()
+                        .dbShardGroups(DB_SHARD_GROUP_AVAILABLE)
+                        .marker("marker2")
+                        .build());
+        when(proxyClient.client().listTagsForResource(any(ListTagsForResourceRequest.class)))
+                .thenReturn(ListTagsForResourceResponse.builder()
+                        .build());
+
+        final ProgressEvent<ResourceModel, CallbackContext> response = test_handleRequest_base(
+                new CallbackContext(),
+                requestBuilder,
+                null,
+                null,
+                () -> RESOURCE_MODEL,
+                expectSuccess()
+        );
+
+        assertThat(response.getResourceModel()).isNull();
+        assertThat(response.getResourceModels().size()).isEqualTo(1);
+        assertThat(response.getResourceModels().stream().anyMatch(model ->
+                Translator.translateDbShardGroupFromSdk(DB_SHARD_GROUP_AVAILABLE, Collections.emptySet()).equals(model))).isTrue();
+        assertThat(response.getNextToken()).isEqualTo("marker2");
+
+
+
+        verify(proxyClient.client(), times(1)).describeDBShardGroups(any(DescribeDbShardGroupsRequest.class));
+        verify(proxyClient.client(), times(1))
+                .listTagsForResource(
+                        ArgumentMatchers.<ListTagsForResourceRequest>argThat(
+                                req -> DB_SHARD_GROUP_ARN.equalsIgnoreCase(req.resourceName()))
+                );
+    }
+}

--- a/aws-rds-dbshardgroup/src/test/java/software/amazon/rds/dbshardgroup/ReadHandlerTest.java
+++ b/aws-rds-dbshardgroup/src/test/java/software/amazon/rds/dbshardgroup/ReadHandlerTest.java
@@ -1,0 +1,92 @@
+package software.amazon.rds.dbshardgroup;
+
+import java.time.Duration;
+
+import lombok.Getter;
+import org.mockito.ArgumentMatchers;
+import software.amazon.awssdk.services.rds.RdsClient;
+import software.amazon.awssdk.services.rds.model.DescribeDbShardGroupsRequest;
+import software.amazon.awssdk.services.rds.model.ListTagsForResourceRequest;
+import software.amazon.awssdk.services.rds.model.ListTagsForResourceResponse;
+import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
+import software.amazon.cloudformation.proxy.ProxyClient;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
+
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class ReadHandlerTest extends AbstractHandlerTest {
+
+    @Mock
+    @Getter
+    private AmazonWebServicesClientProxy proxy;
+
+    @Mock
+    @Getter
+    private ProxyClient<RdsClient> proxyClient;
+
+    @Mock
+    RdsClient rdsClient;
+
+    @Getter
+    private ReadHandler handler;
+
+    private boolean expectServiceInvocation;
+
+    @BeforeEach
+    public void setup() {
+        handler = new ReadHandler(TEST_HANDLER_CONFIG);
+        proxy = new AmazonWebServicesClientProxy(logger, MOCK_CREDENTIALS, () -> Duration.ofSeconds(600).toMillis());
+        rdsClient = mock(RdsClient.class);
+        proxyClient = MOCK_PROXY(proxy, rdsClient);
+        expectServiceInvocation = true;
+    }
+
+    @AfterEach
+    public void tear_down() {
+        if (expectServiceInvocation) {
+            verify(rdsClient, atLeastOnce()).serviceName();
+        }
+        verifyNoMoreInteractions(rdsClient);
+    }
+
+    @Test
+    public void handleRequest_SimpleSuccess() {
+        expectServiceInvocation = false;
+
+        ResourceHandlerRequest.ResourceHandlerRequestBuilder<ResourceModel> requestBuilder = ResourceHandlerRequest.builder();
+        requestBuilder.region(REGION);
+        requestBuilder.awsAccountId(ACCOUNT_ID);
+        requestBuilder.awsPartition(PARTITION);
+
+        when(proxyClient.client().listTagsForResource(any(ListTagsForResourceRequest.class)))
+                .thenReturn(ListTagsForResourceResponse.builder()
+                        .build());
+
+        test_handleRequest_base(
+                new CallbackContext(),
+                requestBuilder,
+                () -> DB_SHARD_GROUP_AVAILABLE,
+                null,
+                () -> RESOURCE_MODEL,
+                expectSuccess()
+        );
+
+        verify(proxyClient.client(), times(1))
+                .describeDBShardGroups(
+                        ArgumentMatchers.<DescribeDbShardGroupsRequest>argThat(
+                                req -> DB_SHARD_GROUP_IDENTIFIER.equals(req.dbShardGroupIdentifier()))
+                );
+        verify(proxyClient.client(), times(1))
+                .listTagsForResource(
+                        ArgumentMatchers.<ListTagsForResourceRequest>argThat(
+                                req -> DB_SHARD_GROUP_ARN.equalsIgnoreCase(req.resourceName()))
+                );
+    }
+}

--- a/aws-rds-dbshardgroup/src/test/java/software/amazon/rds/dbshardgroup/UpdateHandlerTest.java
+++ b/aws-rds-dbshardgroup/src/test/java/software/amazon/rds/dbshardgroup/UpdateHandlerTest.java
@@ -1,0 +1,234 @@
+package software.amazon.rds.dbshardgroup;
+
+import java.time.Duration;
+import java.util.Objects;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+
+import lombok.Getter;
+import org.mockito.ArgumentMatchers;
+import software.amazon.awssdk.services.rds.RdsClient;
+import software.amazon.awssdk.services.rds.model.*;
+import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
+import software.amazon.cloudformation.proxy.HandlerErrorCode;
+import software.amazon.cloudformation.proxy.ProgressEvent;
+import software.amazon.cloudformation.proxy.ProxyClient;
+import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.times;
+
+@ExtendWith(MockitoExtension.class)
+public class UpdateHandlerTest extends AbstractHandlerTest {
+
+    @Mock
+    @Getter
+    private AmazonWebServicesClientProxy proxy;
+
+    @Mock
+    @Getter
+    private ProxyClient<RdsClient> proxyClient;
+
+    @Mock
+    RdsClient rdsClient;
+
+    @Getter
+    private UpdateHandler handler;
+
+    @BeforeEach
+    public void setup() {
+        handler = new UpdateHandler(TEST_HANDLER_CONFIG);
+        proxy = new AmazonWebServicesClientProxy(logger, MOCK_CREDENTIALS, () -> Duration.ofSeconds(600).toMillis());
+        rdsClient = mock(RdsClient.class);
+        proxyClient = MOCK_PROXY(proxy, rdsClient);
+    }
+
+    @AfterEach
+    public void tear_down() {
+        verify(rdsClient, atLeastOnce()).serviceName();
+        verifyNoMoreInteractions(rdsClient);
+    }
+
+    @Test
+    public void handleRequest_SimpleSuccess() {
+        ResourceHandlerRequest.ResourceHandlerRequestBuilder<ResourceModel> requestBuilder = ResourceHandlerRequest.builder();
+        requestBuilder.region(REGION);
+        requestBuilder.awsAccountId(ACCOUNT_ID);
+        requestBuilder.awsPartition(PARTITION);
+        requestBuilder.previousResourceTags(Translator.translateTagsToRequest(TAG_LIST));
+        requestBuilder.desiredResourceTags(Translator.translateTagsToRequest(TAG_LIST_ALTER));
+
+        when(proxyClient.client().removeTagsFromResource(any(RemoveTagsFromResourceRequest.class)))
+                .thenReturn(RemoveTagsFromResourceResponse.builder().build());
+        when(proxyClient.client().addTagsToResource(any(AddTagsToResourceRequest.class)))
+                .thenReturn(AddTagsToResourceResponse.builder().build());
+        when(proxyClient.client().modifyDBShardGroup(any(ModifyDbShardGroupRequest.class)))
+                .thenReturn(ModifyDbShardGroupResponse.builder().build());
+        when(proxyClient.client().describeDBClusters(any(DescribeDbClustersRequest.class)))
+                .thenReturn(DescribeDbClustersResponse.builder().dbClusters(
+                                        DBCluster.builder()
+                                                .status(String.valueOf(ResourceStatus.AVAILABLE))
+                                                .build()
+                                )
+                                .build()
+                );
+        when(proxyClient.client().listTagsForResource(any(ListTagsForResourceRequest.class)))
+                .thenReturn(ListTagsForResourceResponse.builder()
+                        .build());
+
+        Queue<DBShardGroup> transitions = new ConcurrentLinkedQueue<>();
+        transitions.add(DB_SHARD_GROUP_MODIFYING);
+
+        ProgressEvent<ResourceModel, CallbackContext> progressEvent = ProgressEvent.<ResourceModel, CallbackContext>builder()
+                .callbackContext(new CallbackContext()).build();
+
+        progressEvent.getCallbackContext().setWaitTime(301);
+
+        test_handleRequest_base(
+                progressEvent.getCallbackContext(),
+                requestBuilder,
+                () -> {
+                    if (transitions.size() > 0) {
+                        return transitions.remove();
+                    }
+                    return DB_SHARD_GROUP_AVAILABLE.toBuilder()
+                            .maxACU(MAX_ACU_ALTER)
+                            .build();
+                },
+                () -> RESOURCE_MODEL.toBuilder()
+                        .build(),
+                () -> RESOURCE_MODEL.toBuilder()
+                        .maxACU(MAX_ACU_ALTER)
+                        .build(),
+                expectSuccess()
+        );
+
+        verify(proxyClient.client(), times(1)).modifyDBShardGroup(any(ModifyDbShardGroupRequest.class));
+        verify(proxyClient.client(), times(3)).describeDBShardGroups(any(DescribeDbShardGroupsRequest.class));
+        verify(proxyClient.client(), times(1)).removeTagsFromResource(any(RemoveTagsFromResourceRequest.class));
+        verify(proxyClient.client(), times(1)).addTagsToResource(any(AddTagsToResourceRequest.class));
+        verify(proxyClient.client(), times(1)).describeDBClusters(
+                ArgumentMatchers.<DescribeDbClustersRequest>argThat(req ->
+                        Objects.equals(DB_SHARD_GROUP_CREATING.dbClusterIdentifier(), req.dbClusterIdentifier())
+                )
+        );
+        verify(proxyClient.client(), times(1)).listTagsForResource(
+                ArgumentMatchers.<ListTagsForResourceRequest>argThat(
+                                req -> DB_SHARD_GROUP_ARN.equalsIgnoreCase(req.resourceName()))
+                );
+    }
+
+    @Test
+    public void handleRequest_Stabilize() {
+        ResourceHandlerRequest.ResourceHandlerRequestBuilder<ResourceModel> requestBuilder = ResourceHandlerRequest.builder();
+        requestBuilder.region(REGION);
+        requestBuilder.awsAccountId(ACCOUNT_ID);
+        requestBuilder.awsPartition(PARTITION);
+        requestBuilder.previousResourceTags(Translator.translateTagsToRequest(TAG_LIST));
+        requestBuilder.desiredResourceTags(Translator.translateTagsToRequest(TAG_LIST_ALTER));
+
+        when(proxyClient.client().removeTagsFromResource(any(RemoveTagsFromResourceRequest.class)))
+                .thenReturn(RemoveTagsFromResourceResponse.builder().build());
+        when(proxyClient.client().addTagsToResource(any(AddTagsToResourceRequest.class)))
+                .thenReturn(AddTagsToResourceResponse.builder().build());
+        when(proxyClient.client().modifyDBShardGroup(any(ModifyDbShardGroupRequest.class)))
+                .thenReturn(ModifyDbShardGroupResponse.builder().build());
+        when(proxyClient.client().describeDBClusters(any(DescribeDbClustersRequest.class)))
+                .thenReturn(DescribeDbClustersResponse.builder().dbClusters(
+                                        DBCluster.builder()
+                                                .status(String.valueOf(ResourceStatus.MODIFYING))
+                                                .build()
+                                )
+                                .build()
+                ).thenReturn(DescribeDbClustersResponse.builder().dbClusters(
+                                        DBCluster.builder()
+                                                .status(String.valueOf(ResourceStatus.AVAILABLE))
+                                                .build()
+                                )
+                                .build()
+                );
+        when(proxyClient.client().listTagsForResource(any(ListTagsForResourceRequest.class)))
+                .thenReturn(ListTagsForResourceResponse.builder()
+                        .build());
+
+        Queue<DBShardGroup> transitions = new ConcurrentLinkedQueue<>();
+        transitions.add(DB_SHARD_GROUP_MODIFYING);
+        transitions.add(DB_SHARD_GROUP_MODIFYING);
+        transitions.add(DB_SHARD_GROUP_MODIFYING);
+
+        ProgressEvent<ResourceModel, CallbackContext> progressEvent = ProgressEvent.<ResourceModel, CallbackContext>builder()
+                .callbackContext(new CallbackContext()).build();
+
+        progressEvent.getCallbackContext().setWaitTime(301);
+
+        test_handleRequest_base(
+                progressEvent.getCallbackContext(),
+                requestBuilder,
+                () -> {
+                    if (transitions.size() > 0) {
+                        return transitions.remove();
+                    }
+                    return DB_SHARD_GROUP_AVAILABLE.toBuilder()
+                            .maxACU(MAX_ACU_ALTER)
+                            .build();
+                },
+                () -> RESOURCE_MODEL.toBuilder()
+                        .build(),
+                () -> RESOURCE_MODEL.toBuilder()
+                        .maxACU(MAX_ACU_ALTER)
+                        .build(),
+                expectSuccess()
+        );
+
+        verify(proxyClient.client(), times(1)).modifyDBShardGroup(any(ModifyDbShardGroupRequest.class));
+        verify(proxyClient.client(), times(5)).describeDBShardGroups(any(DescribeDbShardGroupsRequest.class));
+        verify(proxyClient.client(), times(1)).removeTagsFromResource(any(RemoveTagsFromResourceRequest.class));
+        verify(proxyClient.client(), times(1)).addTagsToResource(any(AddTagsToResourceRequest.class));
+        verify(proxyClient.client(), times(3)).describeDBClusters(
+                ArgumentMatchers.<DescribeDbClustersRequest>argThat(req ->
+                        Objects.equals(DB_SHARD_GROUP_CREATING.dbClusterIdentifier(), req.dbClusterIdentifier())
+                )
+        );
+        verify(proxyClient.client(), times(1)).listTagsForResource(
+                ArgumentMatchers.<ListTagsForResourceRequest>argThat(
+                        req -> DB_SHARD_GROUP_ARN.equalsIgnoreCase(req.resourceName()))
+        );
+    }
+
+    @Test
+    public void handleRequest_Exception() {
+        ResourceHandlerRequest.ResourceHandlerRequestBuilder<ResourceModel> requestBuilder = ResourceHandlerRequest.builder();
+        requestBuilder.region(REGION);
+        requestBuilder.awsAccountId(ACCOUNT_ID);
+        requestBuilder.awsPartition(PARTITION);
+        requestBuilder.previousResourceTags(Translator.translateTagsToRequest(TAG_LIST));
+        requestBuilder.desiredResourceTags(Translator.translateTagsToRequest(TAG_LIST_ALTER));
+
+        when(proxyClient.client().modifyDBShardGroup(any(ModifyDbShardGroupRequest.class)))
+                .thenThrow(DbShardGroupNotFoundException.builder().message("error").build());
+
+        ProgressEvent<ResourceModel, CallbackContext> progressEvent = ProgressEvent.<ResourceModel, CallbackContext>builder()
+                .callbackContext(new CallbackContext()).build();
+
+        test_handleRequest_base(
+                progressEvent.getCallbackContext(),
+                requestBuilder,
+                null,
+                () -> RESOURCE_MODEL.toBuilder()
+                        .build(),
+                () -> RESOURCE_MODEL.toBuilder()
+                        .maxACU(MAX_ACU_ALTER)
+                        .build(),
+                expectFailed(HandlerErrorCode.NotFound)
+        );
+
+        verify(proxyClient.client(), times(1)).modifyDBShardGroup(any(ModifyDbShardGroupRequest.class));
+    }
+}

--- a/aws-rds-dbshardgroup/template.yml
+++ b/aws-rds-dbshardgroup/template.yml
@@ -1,0 +1,23 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Transform: AWS::Serverless-2016-10-31
+Description: AWS SAM template for the AWS::RDS::DBShardGroup resource type
+
+Globals:
+  Function:
+    Timeout: 180  # docker start-up times can be long for SAM CLI
+    MemorySize: 512
+
+Resources:
+  TypeFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: software.amazon.rds.dbshardgroup.HandlerWrapper::handleRequest
+      Runtime: java17
+      CodeUri: ./target/aws-rds-dbshardgroup-handler-1.0-SNAPSHOT.jar
+
+  TestEntrypoint:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: software.amazon.rds.dbshardgroup.HandlerWrapper::testEntrypoint
+      Runtime: java17
+      CodeUri: ./target/aws-rds-dbshardgroup-handler-1.0-SNAPSHOT.jar

--- a/aws-rds-eventsubscription/pom.xml
+++ b/aws-rds-eventsubscription/pom.xml
@@ -35,7 +35,7 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>rds</artifactId>
-            <version>2.25.56</version>
+            <version>2.28.14</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/software.amazon.cloudformation/aws-cloudformation-rpdk-java-plugin -->
         <dependency>

--- a/aws-rds-globalcluster/pom.xml
+++ b/aws-rds-globalcluster/pom.xml
@@ -35,7 +35,7 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>rds</artifactId>
-            <version>2.25.56</version>
+            <version>2.28.14</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/software.amazon.cloudformation/aws-cloudformation-rpdk-java-plugin -->
         <dependency>

--- a/aws-rds-integration/pom.xml
+++ b/aws-rds-integration/pom.xml
@@ -28,7 +28,7 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>rds</artifactId>
-            <version>2.25.56</version>
+            <version>2.28.14</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/software.amazon.cloudformation/aws-cloudformation-rpdk-java-plugin -->
         <dependency>

--- a/aws-rds-optiongroup/pom.xml
+++ b/aws-rds-optiongroup/pom.xml
@@ -29,7 +29,7 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>rds</artifactId>
-            <version>2.25.56</version>
+            <version>2.28.14</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/software.amazon.cloudformation/aws-cloudformation-rpdk-java-plugin -->
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -5,6 +5,10 @@
     <groupId>software.amazon.rds</groupId>
     <artifactId>aws-rds-handlers</artifactId>
     <packaging>pom</packaging>
+    <properties>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+    </properties>
     <version>1.0</version>
     <name>The CloudFormation Resource Provider Package For Amazon Relational Database Service</name>
 
@@ -17,6 +21,7 @@
         <module>aws-rds-dbclusterparametergroup</module>
         <module>aws-rds-dbinstance</module>
         <module>aws-rds-dbparametergroup</module>
+        <module>aws-rds-dbshardgroup</module>
         <module>aws-rds-dbsubnetgroup</module>
         <module>aws-rds-eventsubscription</module>
         <module>aws-rds-globalcluster</module>


### PR DESCRIPTION
https://aws.amazon.com/blogs/aws/amazon-aurora-postgresql-limitless-database-is-now-generally-available/

*Description of changes:*

RDS CloudFormation now supports creation of Aurora Limitless DBShardGroups.

A new DBShardGroup resource has been introduced allowing you to scale beyond existing Aurora limits for write throughput and storage by distributing database workload over multiple Aurora writer instances while maintaining the ability to use it as a single database.

To begin using a DBShardGroup, you need a DBCluster with ClusterScalabilityType set to Limitless.

*Example:*

```
AWSTemplateFormatVersion: 2010-09-09
Description: IAM role, DBCluster, and DBInstance required for DBShardGroup creation

Resources:
  EnhancedMonitoringAccessRole:
    Type: AWS::IAM::Role
    DeletionPolicy: Delete
    Properties:
      AssumeRolePolicyDocument:
        Version: "2012-10-17"
        Statement:
          - Effect: "Allow"
            Principal:
              Service:
                - "monitoring.rds.amazonaws.com"
            Action: "sts:AssumeRole"
      ManagedPolicyArns:
        - !Sub "arn:${AWS::Partition}:iam::aws:policy/service-role/AmazonRDSEnhancedMonitoringRole"
      PermissionsBoundary: !Sub "arn:${AWS::Partition}:iam::aws:policy/service-role/AmazonRDSEnhancedMonitoringRole"
  DBCluster:
    Type: AWS::RDS::DBCluster
    DeletionPolicy: Delete
    Properties:
      ClusterScalabilityType: "limitless"
      EnableCloudwatchLogsExports:
        - postgresql
      Engine: "aurora-postgresql"
      EngineVersion: "16.4-limitless"
      MasterUsername: "username"
      MasterUserPassword: "password"
      MonitoringInterval: 60
      MonitoringRoleArn: !GetAtt EnhancedMonitoringAccessRole.Arn
      Port: 5432
      PerformanceInsightsEnabled: "true"
      PerformanceInsightsRetentionPeriod: 31
      StorageType: "aurora-iopt1"
  DBShardGroup:
    Properties:
      ComputeRedundancy: '0'
      DBClusterIdentifier: !Ref DBCluster
      MaxACU: '32'
      MinACU: '16'
      PubliclyAccessible: 'False'
      Tags:
        - Key: created-with
          Value: created-value
    Type: AWS::RDS::DBShardGroup
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
