### PR TITLE
chore - Fix reformatter conflicts between eclipse java formatter and pre commit checks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,11 +4,9 @@ repos:
     hooks:
       - id: check-case-conflict
       - id: detect-private-key
-      - id: end-of-file-fixer
       - id: mixed-line-ending
         args:
           - --fix=lf
-      - id: trailing-whitespace
       - id: pretty-format-json
         args:
           - --autofix

--- a/aws-rds-customdbengineversion/docs/README.md
+++ b/aws-rds-customdbengineversion/docs/README.md
@@ -211,3 +211,4 @@ For more information about using the `Fn::GetAtt` intrinsic function, see [Fn::G
 #### DBEngineVersionArn
 
 The ARN of the custom engine version.
+

--- a/aws-rds-customdbengineversion/docs/tag.md
+++ b/aws-rds-customdbengineversion/docs/tag.md
@@ -49,3 +49,4 @@ _Type_: String
 _Maximum Length_: <code>256</code>
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+

--- a/aws-rds-dbcluster/docs/README.md
+++ b/aws-rds-dbcluster/docs/README.md
@@ -412,7 +412,7 @@ _Required_: No
 
 _Type_: String
 
-_Update requires_: [Some interruptions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-some-interrupt)
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 
 #### EngineMode
 
@@ -498,7 +498,7 @@ _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormati
 
 #### MonitoringInterval
 
-The interval, in seconds, between points when Enhanced Monitoring metrics are collected for the DB cluster. To turn off collecting Enhanced Monitoring metrics, specify 0. The default is 0.
+The interval, in seconds, between points when Enhanced Monitoring metrics are collected for the DB cluster. To turn off collecting Enhanced Monitoring metrics, specify 0. The default is not to enable Enhanced Monitoring.
 
 _Required_: No
 
@@ -763,10 +763,6 @@ Returns the <code>Address</code> value.
 
 Returns the <code>Port</code> value.
 
-#### Port
-
-Returns the <code>Port</code> value.
-
 #### Address
 
 Returns the <code>Address</code> value.
@@ -778,3 +774,4 @@ Returns the <code>SecretArn</code> value.
 #### StorageThroughput
 
 Specifies the storage throughput value for the DB cluster. This setting applies only to the gp3 storage type.
+

--- a/aws-rds-dbcluster/docs/dbclusterrole.md
+++ b/aws-rds-dbcluster/docs/dbclusterrole.md
@@ -43,3 +43,4 @@ _Required_: Yes
 _Type_: String
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+

--- a/aws-rds-dbcluster/docs/endpoint.md
+++ b/aws-rds-dbcluster/docs/endpoint.md
@@ -17,3 +17,4 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 </pre>
 
 ## Properties
+

--- a/aws-rds-dbcluster/docs/masterusersecret.md
+++ b/aws-rds-dbcluster/docs/masterusersecret.md
@@ -29,3 +29,4 @@ _Required_: No
 _Type_: String
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+

--- a/aws-rds-dbcluster/docs/readendpoint.md
+++ b/aws-rds-dbcluster/docs/readendpoint.md
@@ -17,3 +17,4 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 </pre>
 
 ## Properties
+

--- a/aws-rds-dbcluster/docs/scalingconfiguration.md
+++ b/aws-rds-dbcluster/docs/scalingconfiguration.md
@@ -102,3 +102,4 @@ _Required_: No
 _Type_: String
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+

--- a/aws-rds-dbcluster/docs/serverlessv2scalingconfiguration.md
+++ b/aws-rds-dbcluster/docs/serverlessv2scalingconfiguration.md
@@ -43,3 +43,4 @@ _Required_: No
 _Type_: Double
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+

--- a/aws-rds-dbcluster/docs/tag.md
+++ b/aws-rds-dbcluster/docs/tag.md
@@ -26,7 +26,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 
 #### Key
 
-The key name of the tag. You can specify a value that is 1 to 128 Unicode characters in length and cannot be prefixed with aws:. You can use any of the following characters: the set of Unicode letters, digits, whitespace, _, ., /, =, +, and -.
+The key name of the tag. You can specify a value that is 1 to 128 Unicode characters in length and cannot be prefixed with aws:. You can use any of the following characters: the set of Unicode letters, digits, whitespace, _, ., /, =, +, and -. 
 
 _Required_: Yes
 
@@ -40,7 +40,7 @@ _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormati
 
 #### Value
 
-The value for the tag. You can specify a value that is 0 to 256 Unicode characters in length and cannot be prefixed with aws:. You can use any of the following characters: the set of Unicode letters, digits, whitespace, _, ., /, =, +, and -.
+The value for the tag. You can specify a value that is 0 to 256 Unicode characters in length and cannot be prefixed with aws:. You can use any of the following characters: the set of Unicode letters, digits, whitespace, _, ., /, =, +, and -. 
 
 _Required_: No
 
@@ -49,3 +49,4 @@ _Type_: String
 _Maximum Length_: <code>256</code>
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+

--- a/aws-rds-dbclusterendpoint/docs/README.md
+++ b/aws-rds-dbclusterendpoint/docs/README.md
@@ -127,3 +127,4 @@ The DNS address of the endpoint.
 #### DBClusterEndpointArn
 
 The Amazon Resource Name (ARN) for the endpoint.
+

--- a/aws-rds-dbclusterendpoint/docs/tag.md
+++ b/aws-rds-dbclusterendpoint/docs/tag.md
@@ -49,3 +49,4 @@ _Type_: String
 _Maximum Length_: <code>256</code>
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+

--- a/aws-rds-dbclusterparametergroup/docs/tag.md
+++ b/aws-rds-dbclusterparametergroup/docs/tag.md
@@ -49,3 +49,4 @@ _Type_: String
 _Maximum Length_: <code>256</code>
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+

--- a/aws-rds-dbinstance/docs/README.md
+++ b/aws-rds-dbinstance/docs/README.md
@@ -697,7 +697,7 @@ _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormati
 
 #### MonitoringInterval
 
-The interval, in seconds, between points when Enhanced Monitoring metrics are collected for the DB instance. To disable collecting Enhanced Monitoring metrics, specify 0. The default is 0.
+The interval, in seconds, between points when Enhanced Monitoring metrics are collected for the DB instance. To disable collecting Enhanced Monitoring metrics, specify 0. The default is not to enable Enhanced Monitoring.
 
 _Required_: No
 
@@ -1050,3 +1050,4 @@ Returns the <code>CAIdentifier</code> value.
 #### ValidTill
 
 Returns the <code>ValidTill</code> value.
+

--- a/aws-rds-dbinstance/docs/certificatedetails.md
+++ b/aws-rds-dbinstance/docs/certificatedetails.md
@@ -17,3 +17,4 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 </pre>
 
 ## Properties
+

--- a/aws-rds-dbinstance/docs/dbinstancerole.md
+++ b/aws-rds-dbinstance/docs/dbinstancerole.md
@@ -41,3 +41,4 @@ _Required_: Yes
 _Type_: String
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+

--- a/aws-rds-dbinstance/docs/endpoint.md
+++ b/aws-rds-dbinstance/docs/endpoint.md
@@ -17,3 +17,4 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 </pre>
 
 ## Properties
+

--- a/aws-rds-dbinstance/docs/masterusersecret.md
+++ b/aws-rds-dbinstance/docs/masterusersecret.md
@@ -29,3 +29,4 @@ _Required_: No
 _Type_: String
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+

--- a/aws-rds-dbinstance/docs/processorfeature.md
+++ b/aws-rds-dbinstance/docs/processorfeature.md
@@ -43,3 +43,4 @@ _Required_: No
 _Type_: String
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+

--- a/aws-rds-dbinstance/docs/tag.md
+++ b/aws-rds-dbinstance/docs/tag.md
@@ -26,7 +26,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 
 #### Key
 
-The key name of the tag. You can specify a value that is 1 to 128 Unicode characters in length and cannot be prefixed with aws:. You can use any of the following characters: the set of Unicode letters, digits, whitespace, _, ., /, =, +, and -.
+The key name of the tag. You can specify a value that is 1 to 128 Unicode characters in length and cannot be prefixed with aws:. You can use any of the following characters: the set of Unicode letters, digits, whitespace, _, ., /, =, +, and -. 
 
 _Required_: Yes
 
@@ -40,7 +40,7 @@ _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormati
 
 #### Value
 
-The value for the tag. You can specify a value that is 0 to 256 Unicode characters in length and cannot be prefixed with aws:. You can use any of the following characters: the set of Unicode letters, digits, whitespace, _, ., /, =, +, and -.
+The value for the tag. You can specify a value that is 0 to 256 Unicode characters in length and cannot be prefixed with aws:. You can use any of the following characters: the set of Unicode letters, digits, whitespace, _, ., /, =, +, and -. 
 
 _Required_: No
 
@@ -49,3 +49,4 @@ _Type_: String
 _Maximum Length_: <code>256</code>
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+

--- a/aws-rds-dbparametergroup/docs/tag.md
+++ b/aws-rds-dbparametergroup/docs/tag.md
@@ -49,3 +49,4 @@ _Type_: String
 _Maximum Length_: <code>256</code>
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+

--- a/aws-rds-dbsubnetgroup/docs/tag.md
+++ b/aws-rds-dbsubnetgroup/docs/tag.md
@@ -26,7 +26,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 
 #### Key
 
-The key name of the tag. You can specify a value that is 1 to 128 Unicode characters in length and cannot be prefixed with aws:. You can use any of the following characters: the set of Unicode letters, digits, whitespace, _, ., /, =, +, and -.
+The key name of the tag. You can specify a value that is 1 to 128 Unicode characters in length and cannot be prefixed with aws:. You can use any of the following characters: the set of Unicode letters, digits, whitespace, _, ., /, =, +, and -. 
 
 _Required_: Yes
 
@@ -40,7 +40,7 @@ _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormati
 
 #### Value
 
-The value for the tag. You can specify a value that is 0 to 256 Unicode characters in length and cannot be prefixed with aws:. You can use any of the following characters: the set of Unicode letters, digits, whitespace, _, ., /, =, +, and -.
+The value for the tag. You can specify a value that is 0 to 256 Unicode characters in length and cannot be prefixed with aws:. You can use any of the following characters: the set of Unicode letters, digits, whitespace, _, ., /, =, +, and -. 
 
 _Required_: No
 
@@ -49,3 +49,4 @@ _Type_: String
 _Maximum Length_: <code>256</code>
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+

--- a/aws-rds-eventsubscription/docs/tag.md
+++ b/aws-rds-eventsubscription/docs/tag.md
@@ -49,3 +49,4 @@ _Type_: String
 _Maximum Length_: <code>256</code>
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+

--- a/aws-rds-globalcluster/docs/README.md
+++ b/aws-rds-globalcluster/docs/README.md
@@ -29,7 +29,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 Type: AWS::RDS::GlobalCluster
 Properties:
     <a href="#engine" title="Engine">Engine</a>: <i>String</i>
-    <a href="#enginelifecyclesupport" title="EngineLifecycleSupport">EngineLifecycleSupport</a> : <i>String</i>,
+    <a href="#enginelifecyclesupport" title="EngineLifecycleSupport">EngineLifecycleSupport</a>: <i>String</i>
     <a href="#engineversion" title="EngineVersion">EngineVersion</a>: <i>String</i>
     <a href="#deletionprotection" title="DeletionProtection">DeletionProtection</a>: <i>Boolean</i>
     <a href="#globalclusteridentifier" title="GlobalClusterIdentifier">GlobalClusterIdentifier</a>: <i>String</i>
@@ -60,7 +60,7 @@ _Required_: No
 
 _Type_: String
 
-_Update requires_: [Some interruptions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-some-interrupt)
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 
 #### EngineVersion
 

--- a/aws-rds-integration/docs/README.md
+++ b/aws-rds-integration/docs/README.md
@@ -155,3 +155,4 @@ The ARN of the integration.
 #### CreateTime
 
 Returns the <code>CreateTime</code> value.
+

--- a/aws-rds-integration/docs/additionalencryptioncontext.md
+++ b/aws-rds-integration/docs/additionalencryptioncontext.md
@@ -31,3 +31,4 @@ _Type_: String
 _Maximum Length_: <code>131072</code>
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+

--- a/aws-rds-integration/docs/tag.md
+++ b/aws-rds-integration/docs/tag.md
@@ -26,7 +26,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 
 #### Key
 
-The key name of the tag. You can specify a value that is 1 to 128 Unicode characters in length and cannot be prefixed with aws:. You can use any of the following characters: the set of Unicode letters, digits, whitespace, _, ., /, =, +, and -.
+The key name of the tag. You can specify a value that is 1 to 128 Unicode characters in length and cannot be prefixed with aws:. You can use any of the following characters: the set of Unicode letters, digits, whitespace, _, ., /, =, +, and -. 
 
 _Required_: Yes
 
@@ -40,7 +40,7 @@ _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormati
 
 #### Value
 
-The value for the tag. You can specify a value that is 0 to 256 Unicode characters in length and cannot be prefixed with aws:. You can use any of the following characters: the set of Unicode letters, digits, whitespace, _, ., /, =, +, and -.
+The value for the tag. You can specify a value that is 0 to 256 Unicode characters in length and cannot be prefixed with aws:. You can use any of the following characters: the set of Unicode letters, digits, whitespace, _, ., /, =, +, and -. 
 
 _Required_: No
 
@@ -49,3 +49,4 @@ _Type_: String
 _Maximum Length_: <code>256</code>
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+

--- a/aws-rds-optiongroup/docs/optionconfiguration.md
+++ b/aws-rds-optiongroup/docs/optionconfiguration.md
@@ -94,3 +94,4 @@ _Required_: No
 _Type_: List of String
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+

--- a/aws-rds-optiongroup/docs/optionsetting.md
+++ b/aws-rds-optiongroup/docs/optionsetting.md
@@ -43,3 +43,4 @@ _Required_: No
 _Type_: String
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+

--- a/aws-rds-optiongroup/docs/tag.md
+++ b/aws-rds-optiongroup/docs/tag.md
@@ -26,7 +26,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 
 #### Key
 
-The key name of the tag. You can specify a value that is 1 to 128 Unicode characters in length and cannot be prefixed with aws:. You can use any of the following characters: the set of Unicode letters, digits, whitespace, _, ., /, =, +, and -.
+The key name of the tag. You can specify a value that is 1 to 128 Unicode characters in length and cannot be prefixed with aws:. You can use any of the following characters: the set of Unicode letters, digits, whitespace, _, ., /, =, +, and -. 
 
 _Required_: Yes
 
@@ -40,7 +40,7 @@ _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormati
 
 #### Value
 
-The value for the tag. You can specify a value that is 0 to 256 Unicode characters in length and cannot be prefixed with aws:. You can use any of the following characters: the set of Unicode letters, digits, whitespace, _, ., /, =, +, and -.
+The value for the tag. You can specify a value that is 0 to 256 Unicode characters in length and cannot be prefixed with aws:. You can use any of the following characters: the set of Unicode letters, digits, whitespace, _, ., /, =, +, and -. 
 
 _Required_: No
 
@@ -49,3 +49,4 @@ _Type_: String
 _Maximum Length_: <code>256</code>
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+


### PR DESCRIPTION
*Context*: When you run mvn package, it uses the Eclipse Java Formatter: https://github.com/aws-cloudformation/cloudformation-cli-java-plugin/blob/master/src/main/resources/com/amazonaws/cloudformation/eclipse-java-formatter.xml#L1

But the pre-commit hook we use has a different set of reformatting rules, which conflict with the Eclipse Java Formatter.

*Problem*

This means, whenever you run `mvn package` to build the project, your project gets reformatted via the eclipse formatter, but maven verify step in our build process runs lint checks from the pre-commit hook - these 2 conflict, meaning everytime you build the project with `mvn package` your project WILL reformat itself.

*Description of changes:*

This change commits:
* Removes `end-of-file-fixer` from precommit because it conflicts with https://github.com/aws-cloudformation/cloudformation-cli-java-plugin/blob/master/src/main/resources/com/amazonaws/cloudformation/eclipse-java-formatter.xml#L120, precommit tries to add a new line, and eclipse formatter tries to remove it

* Removes `trailing-whitespace` from precommit, as precommit tried to remove whitespace at the end, and eclipse java formatter tried to add it

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
