### PR TITLE
fix(autopause) - Drift detection not including SecondsUntilAutoPause

### DIFF
--- a/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/Translator.java
+++ b/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/Translator.java
@@ -497,6 +497,7 @@ public class Translator {
         return ServerlessV2ScalingConfiguration.builder()
                 .maxCapacity(serverlessV2ScalingConfiguration.maxCapacity())
                 .minCapacity(serverlessV2ScalingConfiguration.minCapacity())
+                .secondsUntilAutoPause(serverlessV2ScalingConfiguration.secondsUntilAutoPause())
                 .build();
     }
 


### PR DESCRIPTION
*Description of changes:*

There was a bug in autopause read handler, where when you use the SecondsUntilAutoPause property, the DBCluster resource goes drifted.

This was because the SecondsUntilAutoPause property wasn't being returned in the read handler.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
