### PR TITLE
CFN-564(DBClusterParameterGroup) - Fix DBClusterParameterGroup not resetting parameters

### DIFF
--- a/aws-rds-dbclusterparametergroup/src/main/java/software/amazon/rds/dbclusterparametergroup/CreateHandler.java
+++ b/aws-rds-dbclusterparametergroup/src/main/java/software/amazon/rds/dbclusterparametergroup/CreateHandler.java
@@ -1,6 +1,7 @@
 package software.amazon.rds.dbclusterparametergroup;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Map;
 
 import com.amazonaws.util.StringUtils;
@@ -46,7 +47,7 @@ public class CreateHandler extends BaseHandlerStd {
                 .build();
 
         final Map<String, Object> desiredParams = request.getDesiredResourceState().getParameters();
-        final Map<String, Parameter> currentClusterParameters = Maps.newHashMap();
+        final Map<String, Parameter> desiredClusterParameters = Maps.newHashMap();
 
         return ProgressEvent.progress(request.getDesiredResourceState(), callbackContext)
                 .then(progress -> setDbClusterParameterGroupNameIfMissing(request, progress))
@@ -59,8 +60,8 @@ public class CreateHandler extends BaseHandlerStd {
                     return updateTags(proxy, proxyClient, progress, Tagging.TagSet.emptySet(), extraTags);
                 }, CallbackContext::isAddTagsComplete, CallbackContext::setAddTagsComplete))
                 .then(progress -> Commons.execOnce(progress, () ->
-                                describeCurrentDBClusterParameters(proxy, proxyClient, progress, new ArrayList<>(desiredParams.keySet()), currentClusterParameters)
-                                        .then(p -> applyParameters(proxy, proxyClient, progress, currentClusterParameters, requestLogger)
+                                describeDBClusterParameters(proxy, proxyClient, progress, new ArrayList<>(desiredParams.keySet()), desiredClusterParameters)
+                                        .then(p -> applyParameters(proxyClient, progress, Collections.emptyMap(), desiredClusterParameters)
                         ),
                         CallbackContext::isParametersApplied, CallbackContext::setParametersApplied))
                 .then(progress -> new ReadHandler().handleRequest(proxy, proxyClient, request, callbackContext));

--- a/aws-rds-dbclusterparametergroup/src/main/java/software/amazon/rds/dbclusterparametergroup/ReadHandler.java
+++ b/aws-rds-dbclusterparametergroup/src/main/java/software/amazon/rds/dbclusterparametergroup/ReadHandler.java
@@ -63,7 +63,7 @@ public class ReadHandler extends BaseHandlerStd {
 
         return progress
                 .then(p -> describeEngineDefaultClusterParameters(proxy, proxyClient, p, null, engineDefaultClusterParameters))
-                .then(p -> describeCurrentDBClusterParameters(proxy, proxyClient, p, null, currentDBClusterParameters))
+                .then(p -> describeDBClusterParameters(proxy, proxyClient, p, null, currentDBClusterParameters))
                 .then(p -> {
                     p.getResourceModel().setParameters(
                             Translator.translateParametersFromSdk(computeModifiedDBParameters(engineDefaultClusterParameters, currentDBClusterParameters))

--- a/aws-rds-dbclusterparametergroup/src/test/java/software/amazon/rds/dbclusterparametergroup/AbstractHandlerTest.java
+++ b/aws-rds-dbclusterparametergroup/src/test/java/software/amazon/rds/dbclusterparametergroup/AbstractHandlerTest.java
@@ -183,11 +183,25 @@ public abstract class AbstractHandlerTest extends AbstractTestBase<DBClusterPara
         };
     }
 
-    protected List<Parameter> translateParamMapToCollection(final Map<String, Object> params) {
+    /**
+     * Translates a map of any such key value pairs to a List of RDS-model Parameters
+     *
+     * The modifiable parameter sets all the parameters in the map to be modifiable or not
+     * See: https://docs.aws.amazon.com/cli/latest/reference/rds/describe-db-parameters.html for modifiable
+     *
+     * This function is needed for unit tests because only modifiable parameters can be modified.
+     * Non modifiable parameters cannot be reset or modified.
+     *
+     * @param params Map of key value pairs, eg. {"client_encoding": "UTF-8"}
+     * @param modifiable Should all the parameters in the map be modifiable
+     * @return List of RDS-model Parameters for DBClusterParameterGroups or DBParameterGroups
+     */
+    protected List<Parameter> translateParamMapToCollection(final Map<String, Object> params, final boolean modifiable) {
         return params.entrySet().stream().map(entry -> Parameter.builder()
                         .parameterName(entry.getKey())
                         .parameterValue((String) entry.getValue())
                         .applyType(ParameterType.Dynamic.toString())
+                        .isModifiable(modifiable)
                         .build())
                 .collect(Collectors.toList());
     }


### PR DESCRIPTION
*Description of changes:*

DBClusterParameterGroup was not correctly resetting parameters.

**The bug**:

Eg. Try creating a DBClusterParameterGroup with:

```
        require_secure_transport: "ON"
        lower_case_table_names: "1"
        collation_server: "utf8_bin"
        time_zone: "US/Eastern"
        character_set_server: "utf8"
        server_audit_events: "CONNECT,QUERY"
        server_audit_logging: "1"
```

Then performing an update with:

```
        lower_case_table_names: "1"
        collation_server: "utf8_bin"
        time_zone: "US/Eastern"
        character_set_server: "utf8"
        server_audit_events: "CONNECT,QUERY"
        server_audit_logging: "1"
```

The parameter *require_secure_transport* does not get reset to its default value.

DBParameterGroup however, does exhibit the correct reset behaviour and resets the parameter if it is removed.

This CR ensures the DBClusterParameterGroup behaves like the DBParameterGroup resource when removing parameters.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
