### PR TITLE
fix(DBCluster): fix NPE when null capacity specified for Serverless V2

### DIFF
--- a/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/ModelAdapter.java
+++ b/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/ModelAdapter.java
@@ -54,7 +54,10 @@ public class ModelAdapter {
         }
 
         final var serverlessV2ScalingConfiguration = resourceModel.getServerlessV2ScalingConfiguration();
-        if (serverlessV2ScalingConfiguration != null && serverlessV2ScalingConfiguration.getMinCapacity() == 0) {
+        final var isServerlessV2 = serverlessV2ScalingConfiguration != null;
+        final var isAutoPause = isServerlessV2 && serverlessV2ScalingConfiguration.getMinCapacity() != null
+                && serverlessV2ScalingConfiguration.getMinCapacity() == 0;
+        if (isAutoPause) {
             if (serverlessV2ScalingConfiguration.getSecondsUntilAutoPause() == null) {
                 serverlessV2ScalingConfiguration.setSecondsUntilAutoPause(DEFAULT_SECONDS_UNTIL_AUTO_PAUSE_V2);
             }

--- a/aws-rds-dbcluster/src/test/java/software/amazon/rds/dbcluster/UpdateHandlerTest.java
+++ b/aws-rds-dbcluster/src/test/java/software/amazon/rds/dbcluster/UpdateHandlerTest.java
@@ -830,11 +830,12 @@ public class UpdateHandlerTest extends AbstractHandlerTest {
         "1,    , 3,    ,    ", // modify minCapacity
         "1,    , 0, 600, 600", // enable auto-pause with specific seconds until auto-pause
         "1,    , 0,    , 300", // enable auto-pause with default seconds until auto-pause
-        "0, 600, 0,    , 300"  // reset seconds until auto-pause to default
+        "0, 600, 0,    , 300", // reset seconds until auto-pause to default
+        " ,    , 3,    ,    "  // update from null to non-null capacity [CFN-582]
     })
     void handleRequest_ServerlessV2ScalingConfiguration_Success(
-        final double minCapacityBefore, final Integer secondsUntilAutoPauseBefore,
-        final double minCapacityAfter, final Integer secondsUntilAutoPauseAfter,
+        final Double minCapacityBefore, final Integer secondsUntilAutoPauseBefore,
+        final Double minCapacityAfter, final Integer secondsUntilAutoPauseAfter,
         final Integer expectedSecondsUntilAutoPause) {
         when(rdsProxy.client().modifyDBCluster(any(ModifyDbClusterRequest.class)))
                 .thenReturn(ModifyDbClusterResponse.builder().build());


### PR DESCRIPTION
*Description of changes:*

Fixes an issue when null capacity is specified for Serverless V2

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
