### PR TITLE
[Common] Fix the build failures caused by deprecated Python version

### DIFF
--- a/.github/workflows/maven-verify.yml
+++ b/.github/workflows/maven-verify.yml
@@ -21,9 +21,9 @@ jobs:
     - name: Setup Python
       uses: actions/setup-python@v2.2.2
       with:
-        python-version: 3.7
+        python-version: 3.13
     - name: Install Python packages
-      run: pip install pre-commit cloudformation-cli cloudformation-cli-java-plugin
+      run: pip install pre-commit cloudformation-cli cloudformation-cli-java-plugin setuptools
     - name: Run pre-commit
       run: pre-commit run --all-files
     - name: Verify AWS::RDS::Test::Common


### PR DESCRIPTION
*Issue #, if available:*
See : https://github.com/aws-cloudformation/aws-cloudformation-resource-providers-rds/pull/592/checks

```
Run actions/setup-python@v2.2.2
Version 3.[7](https://github.com/aws-cloudformation/aws-cloudformation-resource-providers-rds/pull/561/checks#step:4:8) was not found in the local cache
Error: Version 3.7 with arch x64 not found
The list of all available versions can be found here: https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json
```

*Description of changes:*

The script uses the latest version of Ubuntu and Python 3.7 is no available in this version. Hence the error. See https://github.com/actions/setup-python/issues/962#issuecomment-2414418045

This PR updates the Python to the latest version and install the relevant missing packages to fix the build issue. 

Testing was performed using the forked git repo to ensure build passes. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
