### PR TITLE
[Common] Add log4j - fixes missing logs from AWS SDK client

### DIFF
--- a/aws-rds-cfn-common/src/main/resources/log4j2.xml
+++ b/aws-rds-cfn-common/src/main/resources/log4j2.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration xmlns="https://logging.apache.org/xml/ns">
+    <Appenders>
+        <Lambda name="Lambda">
+            <PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss} %X{AWSRequestId} %-5p %c{1} - %m%n"/>
+        </Lambda>
+    </Appenders>
+    <Loggers>
+        <Root level="INFO">
+            <AppenderRef ref="Lambda"/>
+        </Root>
+        <Logger name="software.amazon.awssdk.request" level="DEBUG"/>
+    </Loggers>
+</Configuration>


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This change adds log4j so that we get logs from the AWS SDK, which we have been discarding until now.

We are specifically enabling the software.amazon.awssdk.request logger, which gives us:
- Request IDs
- Retry details


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
