### PR TITLE
fix: make requestLogger proper initialized

### DIFF
--- a/aws-rds-customdbengineversion/src/main/java/software/amazon/rds/customdbengineversion/BaseHandlerStd.java
+++ b/aws-rds-customdbengineversion/src/main/java/software/amazon/rds/customdbengineversion/BaseHandlerStd.java
@@ -109,7 +109,8 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
                         proxy,
                         request,
                         callbackContext != null ? callbackContext : new CallbackContext(),
-                        new LoggingProxyClient<>(requestLogger, proxy.newProxy(new ClientProvider()::getClient))
+                        new LoggingProxyClient<>(requestLogger, proxy.newProxy(new ClientProvider()::getClient)),
+                        requestLogger
                 ));
     }
 

--- a/aws-rds-dbclusterendpoint/src/main/java/software/amazon/rds/dbclusterendpoint/BaseHandlerStd.java
+++ b/aws-rds-dbclusterendpoint/src/main/java/software/amazon/rds/dbclusterendpoint/BaseHandlerStd.java
@@ -82,7 +82,7 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
                 requestLogger -> handleRequest(
                         proxy,
                         new LoggingProxyClient<>(requestLogger, proxy.newProxy(new ClientProvider()::getClient)), request,
-                        context
+                        context, requestLogger
                 ));
     }
 

--- a/aws-rds-dbclusterparametergroup/src/main/java/software/amazon/rds/dbclusterparametergroup/BaseHandlerStd.java
+++ b/aws-rds-dbclusterparametergroup/src/main/java/software/amazon/rds/dbclusterparametergroup/BaseHandlerStd.java
@@ -130,7 +130,7 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
                 PARAMETERS_FILTER,
                 requestLogger -> handleRequest(proxy,
                         new LoggingProxyClient<>(requestLogger, proxy.newProxy(new ClientProvider()::getClient)), request,
-                        context
+                        context, requestLogger
                 ));
     }
 

--- a/aws-rds-eventsubscription/src/main/java/software/amazon/rds/eventsubscription/BaseHandlerStd.java
+++ b/aws-rds-eventsubscription/src/main/java/software/amazon/rds/eventsubscription/BaseHandlerStd.java
@@ -67,7 +67,7 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
                 requestLogger -> handleRequest(
                         proxy,
                         new LoggingProxyClient<>(requestLogger, proxy.newProxy(new ClientProvider()::getClient)), request,
-                        callbackContext != null ? callbackContext : new CallbackContext()
+                        callbackContext != null ? callbackContext : new CallbackContext(), requestLogger
                 ));
     }
 

--- a/aws-rds-integration/src/main/java/software/amazon/rds/integration/BaseHandlerStd.java
+++ b/aws-rds-integration/src/main/java/software/amazon/rds/integration/BaseHandlerStd.java
@@ -120,7 +120,7 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
                 requestLogger -> handleRequest(
                         proxy,
                         new LoggingProxyClient<>(requestLogger, proxy.newProxy(new ClientProvider()::getClient)), request,
-                        callbackContext != null ? callbackContext : new CallbackContext()
+                        callbackContext != null ? callbackContext : new CallbackContext(), requestLogger
                 ));
     }
 

--- a/aws-rds-optiongroup/src/main/java/software/amazon/rds/optiongroup/BaseHandlerStd.java
+++ b/aws-rds-optiongroup/src/main/java/software/amazon/rds/optiongroup/BaseHandlerStd.java
@@ -75,7 +75,7 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
                 requestLogger -> handleRequest(
                         proxy,
                         new LoggingProxyClient<>(requestLogger, proxy.newProxy(new ClientBuilder()::getClient)), request,
-                        callbackContext != null ? callbackContext : new CallbackContext()
+                        callbackContext != null ? callbackContext : new CallbackContext(), requestLogger
                 ));
     }
 


### PR DESCRIPTION
*Issue:*
The requestLogger in some resources is not initialized properly, resulting in a NullPointerException under certain circumstances. This causes an internal failure, preventing the customer from seeing the actual error.

*Description of changes:*
This change fix the NullPointerException by making requestLogger proper initialized

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
