### PR TITLE
fix(schema): Missing properties in readOnlyProperties for nested properties

### DIFF
--- a/aws-rds-dbcluster/aws-rds-dbcluster.json
+++ b/aws-rds-dbcluster/aws-rds-dbcluster.json
@@ -439,6 +439,7 @@
     "/properties/Endpoint",
     "/properties/Endpoint/Address",
     "/properties/Endpoint/Port",
+    "/properties/ReadEndpoint",
     "/properties/ReadEndpoint/Address",
     "/properties/MasterUserSecret/SecretArn",
     "/properties/StorageThroughput"

--- a/aws-rds-dbinstance/aws-rds-dbinstance.json
+++ b/aws-rds-dbinstance/aws-rds-dbinstance.json
@@ -552,12 +552,14 @@
     "/properties/UseLatestRestorableTime"
   ],
   "readOnlyProperties": [
+    "/properties/Endpoint",
     "/properties/Endpoint/Address",
     "/properties/Endpoint/Port",
     "/properties/Endpoint/HostedZoneId",
     "/properties/DbiResourceId",
     "/properties/DBInstanceArn",
     "/properties/MasterUserSecret/SecretArn",
+    "/properties/CertificateDetails",
     "/properties/CertificateDetails/CAIdentifier",
     "/properties/CertificateDetails/ValidTill",
     "/properties/DatabaseInsightsMode"


### PR DESCRIPTION
*Description of changes:*

Nested properties in readOnlyProperties require their parents defined otherwise CloudFormation doesn't properly generate templates for IaC Generator: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/generate-IaC.html

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
