### PR TITLE
fix(autoscale): Fix when making CFN update, an autoscaled instance should not fail the CFN deploy

### DIFF
--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/BaseHandlerStd.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/BaseHandlerStd.java
@@ -386,12 +386,14 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
             final AmazonWebServicesClientProxy proxy,
             final ResourceHandlerRequest<ResourceModel> request,
             final ProxyClient<RdsClient> rdsProxyClient,
-            final ProgressEvent<ResourceModel, CallbackContext> progress
+            final ProgressEvent<ResourceModel, CallbackContext> progress,
+            final DBInstance dbInstance
     ) {
         return proxy.initiate("rds::modify-db-instance", rdsProxyClient, progress.getResourceModel(), progress.getCallbackContext())
                 .translateToServiceRequest(resourceModel -> Translator.modifyDbInstanceRequest(
                         request.getPreviousResourceState(),
                         request.getDesiredResourceState(),
+                        dbInstance,
                         BooleanUtils.isTrue(request.getRollback()))
                 )
                 .backoffDelay(config.getBackoff())

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/UpdateHandler.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/UpdateHandler.java
@@ -145,7 +145,10 @@ public class UpdateHandler extends BaseHandlerStd {
                     progress.getCallbackContext().timestampOnce(RESOURCE_UPDATED_AT, Instant.now());
                     return versioned(proxy, rdsProxyClient, progress, null, ImmutableMap.of(
                             ApiVersion.V12, (pxy, pcl, prg, tgs) -> updateDbInstanceV12(pxy, request, pcl, prg),
-                            ApiVersion.DEFAULT, (pxy, pcl, prg, tgs) -> updateDbInstance(pxy, request, pcl, prg)
+                            ApiVersion.DEFAULT, (pxy, pcl, prg, tgs) -> {
+                            final DBInstance dbInstance = fetchDBInstance(rdsProxyClient.defaultClient(), progress.getResourceModel());
+                            return updateDbInstance(pxy, request, pcl, prg, dbInstance);
+                        }
                     )).then(p -> Events.checkFailedEvents(
                             rdsProxyClient.defaultClient(),
                             p.getResourceModel().getDBInstanceIdentifier(),

--- a/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/TranslatorTest.java
+++ b/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/TranslatorTest.java
@@ -36,8 +36,9 @@ class TranslatorTest extends AbstractHandlerTest {
         final ResourceModel desiredModel = RESOURCE_MODEL_BLDR()
                 .allocatedStorage(ALLOCATED_STORAGE_INCR.toString())
                 .build();
+        final DBInstance dbInstance = DBInstance.builder().allocatedStorage(ALLOCATED_STORAGE).build();
         final Boolean isRollback = false;
-        final ModifyDbInstanceRequest request = Translator.modifyDbInstanceRequest(previousModel, desiredModel, isRollback);
+        final ModifyDbInstanceRequest request = Translator.modifyDbInstanceRequest(previousModel, desiredModel, dbInstance, isRollback);
         assertThat(request.allocatedStorage()).isEqualTo(ALLOCATED_STORAGE_INCR);
     }
 
@@ -62,8 +63,9 @@ class TranslatorTest extends AbstractHandlerTest {
         final ResourceModel desiredModel = RESOURCE_MODEL_BLDR()
                 .allocatedStorage(ALLOCATED_STORAGE_DECR.toString())
                 .build();
+        final DBInstance dbInstance = DBInstance.builder().build();
         final Boolean isRollback = false;
-        final ModifyDbInstanceRequest request = Translator.modifyDbInstanceRequest(previousModel, desiredModel, isRollback);
+        final ModifyDbInstanceRequest request = Translator.modifyDbInstanceRequest(previousModel, desiredModel, dbInstance, isRollback);
         assertThat(request.allocatedStorage()).isEqualTo(ALLOCATED_STORAGE_DECR);
     }
 
@@ -88,8 +90,9 @@ class TranslatorTest extends AbstractHandlerTest {
         final ResourceModel desiredModel = RESOURCE_MODEL_BLDR()
                 .allocatedStorage(ALLOCATED_STORAGE_INCR.toString())
                 .build();
+        final DBInstance dbInstance = DBInstance.builder().allocatedStorage(ALLOCATED_STORAGE).build();
         final Boolean isRollback = true;
-        final ModifyDbInstanceRequest request = Translator.modifyDbInstanceRequest(previousModel, desiredModel, isRollback);
+        final ModifyDbInstanceRequest request = Translator.modifyDbInstanceRequest(previousModel, desiredModel, dbInstance, isRollback);
         assertThat(request.allocatedStorage()).isNull();
     }
 
@@ -102,8 +105,9 @@ class TranslatorTest extends AbstractHandlerTest {
                 .allocatedStorage(null)
                 .storageType(STORAGE_TYPE_IO1)
                 .build();
+        final DBInstance dbInstance = DBInstance.builder().build();
         final Boolean isRollback = true;
-        final ModifyDbInstanceRequest request = Translator.modifyDbInstanceRequest(previousModel, desiredModel, isRollback);
+        final ModifyDbInstanceRequest request = Translator.modifyDbInstanceRequest(previousModel, desiredModel, dbInstance, isRollback);
         assertThat(request.allocatedStorage()).isNull();
     }
 
@@ -128,8 +132,9 @@ class TranslatorTest extends AbstractHandlerTest {
         final ResourceModel desiredModel = RESOURCE_MODEL_BLDR()
                 .allocatedStorage(ALLOCATED_STORAGE_DECR.toString())
                 .build();
+        final DBInstance dbInstance = DBInstance.builder().build();
         final Boolean isRollback = true;
-        final ModifyDbInstanceRequest request = Translator.modifyDbInstanceRequest(previousModel, desiredModel, isRollback);
+        final ModifyDbInstanceRequest request = Translator.modifyDbInstanceRequest(previousModel, desiredModel, dbInstance, isRollback);
         assertThat(request.allocatedStorage()).isNull();
     }
 
@@ -154,8 +159,9 @@ class TranslatorTest extends AbstractHandlerTest {
         final ResourceModel desiredModel = RESOURCE_MODEL_BLDR()
                 .iops(IOPS_INCR)
                 .build();
+        final DBInstance dbInstance = DBInstance.builder().build();
         final Boolean isRollback = false;
-        final ModifyDbInstanceRequest request = Translator.modifyDbInstanceRequest(previousModel, desiredModel, isRollback);
+        final ModifyDbInstanceRequest request = Translator.modifyDbInstanceRequest(previousModel, desiredModel, dbInstance, isRollback);
         assertThat(request.iops()).isEqualTo(IOPS_INCR);
     }
 
@@ -180,8 +186,9 @@ class TranslatorTest extends AbstractHandlerTest {
         final ResourceModel desiredModel = RESOURCE_MODEL_BLDR()
                 .iops(IOPS_DECR)
                 .build();
+        final DBInstance dbInstance = DBInstance.builder().build();
         final Boolean isRollback = false;
-        final ModifyDbInstanceRequest request = Translator.modifyDbInstanceRequest(previousModel, desiredModel, isRollback);
+        final ModifyDbInstanceRequest request = Translator.modifyDbInstanceRequest(previousModel, desiredModel, dbInstance, isRollback);
         assertThat(request.iops()).isEqualTo(IOPS_DECR);
     }
 
@@ -206,8 +213,9 @@ class TranslatorTest extends AbstractHandlerTest {
         final ResourceModel desiredModel = RESOURCE_MODEL_BLDR()
                 .iops(IOPS_INCR)
                 .build();
+        final DBInstance dbInstance = DBInstance.builder().build();
         final Boolean isRollback = true;
-        final ModifyDbInstanceRequest request = Translator.modifyDbInstanceRequest(previousModel, desiredModel, isRollback);
+        final ModifyDbInstanceRequest request = Translator.modifyDbInstanceRequest(previousModel, desiredModel, dbInstance, isRollback);
         assertThat(request.iops()).isNull();
     }
 
@@ -232,8 +240,9 @@ class TranslatorTest extends AbstractHandlerTest {
         final ResourceModel desiredModel = RESOURCE_MODEL_BLDR()
                 .iops(IOPS_DECR)
                 .build();
+        final DBInstance dbInstance = DBInstance.builder().build();
         final Boolean isRollback = true;
-        final ModifyDbInstanceRequest request = Translator.modifyDbInstanceRequest(previousModel, desiredModel, isRollback);
+        final ModifyDbInstanceRequest request = Translator.modifyDbInstanceRequest(previousModel, desiredModel, dbInstance, isRollback);
         assertThat(request.iops()).isNull();
     }
 
@@ -258,8 +267,9 @@ class TranslatorTest extends AbstractHandlerTest {
         final ResourceModel desiredModel = RESOURCE_MODEL_BLDR()
                 .useDefaultProcessorFeatures(true)
                 .build();
+        final DBInstance dbInstance = DBInstance.builder().build();
         final Boolean isRollback = false;
-        final ModifyDbInstanceRequest request = Translator.modifyDbInstanceRequest(previousModel, desiredModel, isRollback);
+        final ModifyDbInstanceRequest request = Translator.modifyDbInstanceRequest(previousModel, desiredModel, dbInstance, isRollback);
         assertThat(request.useDefaultProcessorFeatures()).isTrue();
     }
 
@@ -271,8 +281,9 @@ class TranslatorTest extends AbstractHandlerTest {
         final ResourceModel desiredModel = RESOURCE_MODEL_BLDR()
                 .processorFeatures(PROCESSOR_FEATURES_ALTER)
                 .build();
+        final DBInstance dbInstance = DBInstance.builder().build();
         final Boolean isRollback = false;
-        final ModifyDbInstanceRequest request = Translator.modifyDbInstanceRequest(previousModel, desiredModel, isRollback);
+        final ModifyDbInstanceRequest request = Translator.modifyDbInstanceRequest(previousModel, desiredModel, dbInstance, isRollback);
         assertThat(request.processorFeatures()).hasSameElementsAs(Translator.translateProcessorFeaturesToSdk(PROCESSOR_FEATURES_ALTER));
     }
 
@@ -341,8 +352,8 @@ class TranslatorTest extends AbstractHandlerTest {
     @Test
     public void test_modifyReadReplicaRequest_parameterGroupNotSet() {
         final ResourceModel model = RESOURCE_MODEL_BLDR().build();
-
-        final ModifyDbInstanceRequest request = Translator.modifyDbInstanceRequest(ResourceModel.builder().build(), model, false);
+        final DBInstance dbInstance = DBInstance.builder().build();
+        final ModifyDbInstanceRequest request = Translator.modifyDbInstanceRequest(ResourceModel.builder().build(), model, dbInstance,false);
         Assertions.assertEquals("default", request.dbParameterGroupName());
     }
 
@@ -502,8 +513,8 @@ class TranslatorTest extends AbstractHandlerTest {
         final ResourceModel desiredModel = RESOURCE_MODEL_BLDR()
                 .enableCloudwatchLogsExports(ImmutableList.of("config-1", "config-2"))
                 .build();
-
-        final ModifyDbInstanceRequest request = Translator.modifyDbInstanceRequest(previousModel, desiredModel, false);
+        final DBInstance dbInstance = DBInstance.builder().build();
+        final ModifyDbInstanceRequest request = Translator.modifyDbInstanceRequest(previousModel, desiredModel, dbInstance, false);
         assertThat(request.cloudwatchLogsExportConfiguration()).isNull();
     }
 
@@ -515,8 +526,8 @@ class TranslatorTest extends AbstractHandlerTest {
         final ResourceModel desiredModel = RESOURCE_MODEL_BLDR()
                 .enableCloudwatchLogsExports(ImmutableList.of("config-1", "config-3"))
                 .build();
-
-        final ModifyDbInstanceRequest request = Translator.modifyDbInstanceRequest(previousModel, desiredModel, false);
+        final DBInstance dbInstance = DBInstance.builder().build();
+        final ModifyDbInstanceRequest request = Translator.modifyDbInstanceRequest(previousModel, desiredModel, dbInstance, false);
         assertThat(request.cloudwatchLogsExportConfiguration().disableLogTypes()).isEqualTo(ImmutableList.of("config-2"));
         assertThat(request.cloudwatchLogsExportConfiguration().enableLogTypes()).isEqualTo(ImmutableList.of("config-3"));
     }
@@ -529,8 +540,8 @@ class TranslatorTest extends AbstractHandlerTest {
         final ResourceModel desiredModel = RESOURCE_MODEL_BLDR()
                 .enableCloudwatchLogsExports(ImmutableList.of("config-1", "config-2"))
                 .build();
-
-        final ModifyDbInstanceRequest request = Translator.modifyDbInstanceRequest(previousModel, desiredModel, false);
+        final DBInstance dbInstance = DBInstance.builder().build();
+        final ModifyDbInstanceRequest request = Translator.modifyDbInstanceRequest(previousModel, desiredModel, dbInstance, false);
         assertThat(request.cloudwatchLogsExportConfiguration().enableLogTypes()).isEqualTo(ImmutableList.of("config-1", "config-2"));
     }
 
@@ -635,8 +646,8 @@ class TranslatorTest extends AbstractHandlerTest {
         final ResourceModel desired = RESOURCE_MODEL_BLDR()
                 .masterUserPassword("password")
                 .build();
-
-        final ModifyDbInstanceRequest request = Translator.modifyDbInstanceRequest(prev, desired, false);
+        final DBInstance dbInstance = DBInstance.builder().build();
+        final ModifyDbInstanceRequest request = Translator.modifyDbInstanceRequest(prev, desired, dbInstance, false);
 
         assertThat(request.manageMasterUserPassword()).isNull();
         assertThat(request.masterUserSecretKmsKeyId()).isNull();
@@ -651,8 +662,8 @@ class TranslatorTest extends AbstractHandlerTest {
                 .build();
         final ResourceModel desired = RESOURCE_MODEL_BLDR()
                 .build();
-
-        final ModifyDbInstanceRequest request = Translator.modifyDbInstanceRequest(prev, desired, false);
+        final DBInstance dbInstance = DBInstance.builder().build();
+        final ModifyDbInstanceRequest request = Translator.modifyDbInstanceRequest(prev, desired, dbInstance, false);
 
         assertThat(request.manageMasterUserPassword()).isFalse();
         assertThat(request.masterUserSecretKmsKeyId()).isNull();
@@ -668,8 +679,8 @@ class TranslatorTest extends AbstractHandlerTest {
                 .manageMasterUserPassword(false)
                 .masterUserSecret(MasterUserSecret.builder().kmsKeyId("key1").build())
                 .build();
-
-        final ModifyDbInstanceRequest request = Translator.modifyDbInstanceRequest(prev, desired, false);
+        final DBInstance dbInstance = DBInstance.builder().build();
+        final ModifyDbInstanceRequest request = Translator.modifyDbInstanceRequest(prev, desired, dbInstance, false);
 
         assertThat(request.manageMasterUserPassword()).isFalse();
         assertThat(request.masterUserSecretKmsKeyId()).isNull();
@@ -684,8 +695,8 @@ class TranslatorTest extends AbstractHandlerTest {
                 .manageMasterUserPassword(true)
                 .masterUserSecret(MasterUserSecret.builder().kmsKeyId(null).build())
                 .build();
-
-        final ModifyDbInstanceRequest request = Translator.modifyDbInstanceRequest(prev, desired, false);
+        final DBInstance dbInstance = DBInstance.builder().build();
+        final ModifyDbInstanceRequest request = Translator.modifyDbInstanceRequest(prev, desired, dbInstance,false);
 
         assertThat(request.manageMasterUserPassword()).isTrue();
         assertThat(request.masterUserSecretKmsKeyId()).isNull();
@@ -700,8 +711,8 @@ class TranslatorTest extends AbstractHandlerTest {
                 .manageMasterUserPassword(true)
                 .masterUserSecret(null)
                 .build();
-
-        final ModifyDbInstanceRequest request = Translator.modifyDbInstanceRequest(prev, desired, false);
+        final DBInstance dbInstance = DBInstance.builder().build();
+        final ModifyDbInstanceRequest request = Translator.modifyDbInstanceRequest(prev, desired, dbInstance, false);
 
         assertThat(request.manageMasterUserPassword()).isTrue();
         assertThat(request.masterUserSecretKmsKeyId()).isNull();
@@ -718,10 +729,9 @@ class TranslatorTest extends AbstractHandlerTest {
                 .manageMasterUserPassword(false)
                 .masterUserPassword("password")
                 .masterUserSecret(MasterUserSecret.builder().kmsKeyId("key").build())
-
                 .build();
-
-        final ModifyDbInstanceRequest request = Translator.modifyDbInstanceRequest(prev, desired, false);
+        final DBInstance dbInstance = DBInstance.builder().build();
+        final ModifyDbInstanceRequest request = Translator.modifyDbInstanceRequest(prev, desired, dbInstance, false);
 
         assertThat(request.manageMasterUserPassword()).isNull();
         assertThat(request.masterUserSecretKmsKeyId()).isNull();
@@ -736,8 +746,8 @@ class TranslatorTest extends AbstractHandlerTest {
                 .manageMasterUserPassword(true)
                 .masterUserSecret(MasterUserSecret.builder().kmsKeyId("myKey").build())
                 .build();
-
-        final ModifyDbInstanceRequest request = Translator.modifyDbInstanceRequest(prev, desired, false);
+        final DBInstance dbInstance = DBInstance.builder().build();
+        final ModifyDbInstanceRequest request = Translator.modifyDbInstanceRequest(prev, desired, dbInstance, false);
 
         assertThat(request.manageMasterUserPassword()).isTrue();
         assertThat(request.masterUserSecretKmsKeyId()).isEqualTo("myKey");
@@ -793,7 +803,8 @@ class TranslatorTest extends AbstractHandlerTest {
                 .enablePerformanceInsights(true)
                 .performanceInsightsKMSKeyId(kmsKeyId)
                 .build();
-        final ModifyDbInstanceRequest request = Translator.modifyDbInstanceRequest(previousModel, desiredModel, false);
+        final DBInstance dbInstance = DBInstance.builder().build();
+        final ModifyDbInstanceRequest request = Translator.modifyDbInstanceRequest(previousModel, desiredModel, dbInstance, false);
         assertThat(request.enablePerformanceInsights()).isNull();
         assertThat(request.performanceInsightsKMSKeyId()).isNull();
     }
@@ -809,7 +820,8 @@ class TranslatorTest extends AbstractHandlerTest {
                 .enablePerformanceInsights(true)
                 .performanceInsightsKMSKeyId(kmsKeyId)
                 .build();
-        final ModifyDbInstanceRequest request = Translator.modifyDbInstanceRequest(previousModel, desiredModel, false);
+        final DBInstance dbInstance = DBInstance.builder().build();
+        final ModifyDbInstanceRequest request = Translator.modifyDbInstanceRequest(previousModel, desiredModel, dbInstance, false);
         assertThat(request.enablePerformanceInsights()).isTrue();
         assertThat(request.performanceInsightsKMSKeyId()).isEqualTo(kmsKeyId);
     }
@@ -825,7 +837,8 @@ class TranslatorTest extends AbstractHandlerTest {
                 .enablePerformanceInsights(false)
                 .performanceInsightsKMSKeyId(kmsKeyId)
                 .build();
-        final ModifyDbInstanceRequest request = Translator.modifyDbInstanceRequest(previousModel, desiredModel, false);
+        final DBInstance dbInstance = DBInstance.builder().build();
+        final ModifyDbInstanceRequest request = Translator.modifyDbInstanceRequest(previousModel, desiredModel, dbInstance, false);
         assertThat(request.enablePerformanceInsights()).isFalse();
         assertThat(request.performanceInsightsKMSKeyId()).isNull();
     }
@@ -841,7 +854,8 @@ class TranslatorTest extends AbstractHandlerTest {
                 .enablePerformanceInsights(true)
                 .performanceInsightsRetentionPeriod(NEW_RETENTION_PERIOD)
                 .build();
-        final ModifyDbInstanceRequest request = Translator.modifyDbInstanceRequest(previousModel, desiredModel, false);
+        final DBInstance dbInstance = DBInstance.builder().build();
+        final ModifyDbInstanceRequest request = Translator.modifyDbInstanceRequest(previousModel, desiredModel, dbInstance, false);
         assertThat(request.enablePerformanceInsights()).isTrue();
         assertThat(request.performanceInsightsRetentionPeriod()).isEqualTo(NEW_RETENTION_PERIOD);
     }
@@ -857,7 +871,8 @@ class TranslatorTest extends AbstractHandlerTest {
                 .enablePerformanceInsights(false)
                 .performanceInsightsRetentionPeriod(NEW_RETENTION_PERIOD)
                 .build();
-        final ModifyDbInstanceRequest request = Translator.modifyDbInstanceRequest(previousModel, desiredModel, false);
+        final DBInstance dbInstance = DBInstance.builder().build();
+        final ModifyDbInstanceRequest request = Translator.modifyDbInstanceRequest(previousModel, desiredModel, dbInstance, false);
         assertThat(request.enablePerformanceInsights()).isFalse();
         assertThat(request.performanceInsightsRetentionPeriod()).isEqualTo(NEW_RETENTION_PERIOD);
     }
@@ -874,7 +889,8 @@ class TranslatorTest extends AbstractHandlerTest {
                 .enablePerformanceInsights(true)
                 .performanceInsightsKMSKeyId(kmsKeyId2)
                 .build();
-        final ModifyDbInstanceRequest request = Translator.modifyDbInstanceRequest(previousModel, desiredModel, false);
+        final DBInstance dbInstance = DBInstance.builder().build();
+        final ModifyDbInstanceRequest request = Translator.modifyDbInstanceRequest(previousModel, desiredModel, dbInstance, false);
         assertThat(request.enablePerformanceInsights()).isTrue();
         assertThat(request.performanceInsightsKMSKeyId()).isEqualTo(kmsKeyId2);
     }
@@ -891,7 +907,8 @@ class TranslatorTest extends AbstractHandlerTest {
                 .enablePerformanceInsights(false)
                 .performanceInsightsKMSKeyId(kmsKeyId2)
                 .build();
-        final ModifyDbInstanceRequest request = Translator.modifyDbInstanceRequest(previousModel, desiredModel, false);
+        final DBInstance dbInstance = DBInstance.builder().build();
+        final ModifyDbInstanceRequest request = Translator.modifyDbInstanceRequest(previousModel, desiredModel, dbInstance, false);
         assertThat(request.enablePerformanceInsights()).isFalse();
         assertThat(request.performanceInsightsKMSKeyId()).isEqualTo(kmsKeyId2);
     }
@@ -908,7 +925,8 @@ class TranslatorTest extends AbstractHandlerTest {
                 .enablePerformanceInsights(false)
                 .performanceInsightsKMSKeyId(kmsKeyId2)
                 .build();
-        final ModifyDbInstanceRequest request = Translator.modifyDbInstanceRequest(previousModel, desiredModel, false);
+        final DBInstance dbInstance = DBInstance.builder().build();
+        final ModifyDbInstanceRequest request = Translator.modifyDbInstanceRequest(previousModel, desiredModel, dbInstance, false);
         assertThat(request.enablePerformanceInsights()).isFalse();
         assertThat(request.performanceInsightsKMSKeyId()).isEqualTo(kmsKeyId2);
     }
@@ -925,7 +943,8 @@ class TranslatorTest extends AbstractHandlerTest {
                 .enablePerformanceInsights(true)
                 .performanceInsightsKMSKeyId(kmsKeyId2)
                 .build();
-        final ModifyDbInstanceRequest request = Translator.modifyDbInstanceRequest(previousModel, desiredModel, false);
+        final DBInstance dbInstance = DBInstance.builder().build();
+        final ModifyDbInstanceRequest request = Translator.modifyDbInstanceRequest(previousModel, desiredModel, dbInstance, false);
         assertThat(request.enablePerformanceInsights()).isTrue();
         assertThat(request.performanceInsightsKMSKeyId()).isEqualTo(kmsKeyId2);
     }
@@ -966,8 +985,8 @@ class TranslatorTest extends AbstractHandlerTest {
     public void modifyDbInstanceRequest_shouldIncludeAllocatedStorage_ifStorageTypeIsIo1_andIopsOnlyChanged() {
         final ResourceModel previous = RESOURCE_MODEL_BLDR().storageType("io1").iops(1000).build();
         final ResourceModel desired = RESOURCE_MODEL_BLDR().storageType("io1").iops(1200).build();
-
-        final ModifyDbInstanceRequest request = Translator.modifyDbInstanceRequest(previous, desired, false);
+        final DBInstance dbInstance = DBInstance.builder().allocatedStorage(ALLOCATED_STORAGE).build();
+        final ModifyDbInstanceRequest request = Translator.modifyDbInstanceRequest(previous, desired, dbInstance, false);
 
         assertThat(request.iops()).isEqualTo(1200);
         assertThat(request.allocatedStorage()).isEqualTo(ALLOCATED_STORAGE);
@@ -977,8 +996,8 @@ class TranslatorTest extends AbstractHandlerTest {
     public void modifyDbInstanceRequest_shouldIncludeAllocatedStorageANdIops_ifStorageTypeIsIo1_andStorageTypeChangedToIo2() {
         final ResourceModel previous = RESOURCE_MODEL_BLDR().storageType("io1").iops(1000).allocatedStorage("100").build();
         final ResourceModel desired = RESOURCE_MODEL_BLDR().storageType("io2").iops(1000).allocatedStorage("100").build();
-
-        final ModifyDbInstanceRequest request = Translator.modifyDbInstanceRequest(previous, desired, false);
+        final DBInstance dbInstance = DBInstance.builder().allocatedStorage(ALLOCATED_STORAGE).build();
+        final ModifyDbInstanceRequest request = Translator.modifyDbInstanceRequest(previous, desired, dbInstance, false);
 
         assertThat(request.iops()).isEqualTo(1000);
         assertThat(request.allocatedStorage()).isEqualTo(100);
@@ -988,8 +1007,8 @@ class TranslatorTest extends AbstractHandlerTest {
     public void modifyDbInstanceRequest_shouldIncludeAllocatedStorage_ifStorageTypeIsImplicitIo1_andIopsOnlyChanged() {
         final ResourceModel previous = RESOURCE_MODEL_BLDR().storageType(null).iops(1000).build();
         final ResourceModel desired = RESOURCE_MODEL_BLDR().storageType(null).iops(1200).build();
-
-        final ModifyDbInstanceRequest request = Translator.modifyDbInstanceRequest(previous, desired, false);
+        final DBInstance dbInstance = DBInstance.builder().allocatedStorage(ALLOCATED_STORAGE).build();
+        final ModifyDbInstanceRequest request = Translator.modifyDbInstanceRequest(previous, desired, dbInstance,false);
 
         assertThat(request.iops()).isEqualTo(1200);
         assertThat(request.allocatedStorage()).isEqualTo(ALLOCATED_STORAGE);
@@ -999,8 +1018,8 @@ class TranslatorTest extends AbstractHandlerTest {
     public void modifyDbInstanceRequest_shouldIncludeAllocatedStorage_ifStorageTypeIsGp3_andIopsOnlyChanged() {
         final ResourceModel previous = RESOURCE_MODEL_BLDR().storageType("gp3").iops(1000).build();
         final ResourceModel desired = RESOURCE_MODEL_BLDR().storageType("gp3").iops(1200).build();
-
-        final ModifyDbInstanceRequest request = Translator.modifyDbInstanceRequest(previous, desired, false);
+        final DBInstance dbInstance = DBInstance.builder().allocatedStorage(ALLOCATED_STORAGE).build();
+        final ModifyDbInstanceRequest request = Translator.modifyDbInstanceRequest(previous, desired, dbInstance, false);
 
         assertThat(request.iops()).isEqualTo(1200);
         assertThat(request.allocatedStorage()).isEqualTo(ALLOCATED_STORAGE);
@@ -1010,8 +1029,8 @@ class TranslatorTest extends AbstractHandlerTest {
     public void modifyDbInstanceRequest_shouldIncludeIops_ifStorageTypeIsGp3_andAllocatedStorageOnlyChanged() {
         final ResourceModel previous = RESOURCE_MODEL_BLDR().storageType("gp3").allocatedStorage(ALLOCATED_STORAGE.toString()).build();
         final ResourceModel desired = RESOURCE_MODEL_BLDR().storageType("gp3").allocatedStorage(ALLOCATED_STORAGE_INCR.toString()).build();
-
-        final ModifyDbInstanceRequest request = Translator.modifyDbInstanceRequest(previous, desired, false);
+        final DBInstance dbInstance = DBInstance.builder().allocatedStorage(ALLOCATED_STORAGE).build();
+        final ModifyDbInstanceRequest request = Translator.modifyDbInstanceRequest(previous, desired, dbInstance,false);
 
         assertThat(request.iops()).isEqualTo(IOPS_DEFAULT);
         assertThat(request.allocatedStorage()).isEqualTo(ALLOCATED_STORAGE_INCR);
@@ -1021,8 +1040,8 @@ class TranslatorTest extends AbstractHandlerTest {
     public void modifyDbInstanceRequest_shouldNotIncludeAllocatedStorage_ifStorageTypeIsGP2_andIopsOnlyChanged() {
         final ResourceModel previous = RESOURCE_MODEL_BLDR().iops(1000).build();
         final ResourceModel desired = RESOURCE_MODEL_BLDR().iops(1200).build();
-
-        final ModifyDbInstanceRequest request = Translator.modifyDbInstanceRequest(previous, desired, false);
+        final DBInstance dbInstance = DBInstance.builder().build();
+        final ModifyDbInstanceRequest request = Translator.modifyDbInstanceRequest(previous, desired, dbInstance,false);
 
         assertThat(request.iops()).isEqualTo(1200);
         assertThat(request.allocatedStorage()).isNull();
@@ -1073,9 +1092,9 @@ class TranslatorTest extends AbstractHandlerTest {
                 .iops(IOPS_DECR)
                 .allocatedStorage(ALLOCATED_STORAGE_DECR.toString())
                 .build();
-
+        final DBInstance dbInstance = DBInstance.builder().allocatedStorage(ALLOCATED_STORAGE).build();
         final boolean isRollback = true;
-        final ModifyDbInstanceRequest request = Translator.modifyDbInstanceRequest(previous, desired, isRollback);
+        final ModifyDbInstanceRequest request = Translator.modifyDbInstanceRequest(previous, desired, dbInstance, isRollback);
 
         assertThat(request.allocatedStorage()).isEqualTo(ALLOCATED_STORAGE_INCR);
         assertThat(request.iops()).isEqualTo(IOPS_DECR);
@@ -1093,9 +1112,9 @@ class TranslatorTest extends AbstractHandlerTest {
                 .iops(IOPS_DECR)
                 .allocatedStorage(ALLOCATED_STORAGE_INCR.toString())
                 .build();
-
+        final DBInstance dbInstance = DBInstance.builder().allocatedStorage(ALLOCATED_STORAGE_INCR).build();
         final boolean isRollback = true;
-        final ModifyDbInstanceRequest request = Translator.modifyDbInstanceRequest(previous, desired, isRollback);
+        final ModifyDbInstanceRequest request = Translator.modifyDbInstanceRequest(previous, desired, dbInstance, isRollback);
 
         assertThat(request.allocatedStorage()).isEqualTo(ALLOCATED_STORAGE_INCR);
         assertThat(request.iops()).isEqualTo(IOPS_DECR);
@@ -1113,9 +1132,9 @@ class TranslatorTest extends AbstractHandlerTest {
                 .iops(IOPS_DECR)
                 .allocatedStorage(null)
                 .build();
-
+        final DBInstance dbInstance = DBInstance.builder().allocatedStorage(ALLOCATED_STORAGE).build();
         final boolean isRollback = true;
-        final ModifyDbInstanceRequest request = Translator.modifyDbInstanceRequest(previous, desired, isRollback);
+        final ModifyDbInstanceRequest request = Translator.modifyDbInstanceRequest(previous, desired, dbInstance, isRollback);
 
         assertThat(request.allocatedStorage()).isEqualTo(ALLOCATED_STORAGE_INCR);
         assertThat(request.iops()).isEqualTo(IOPS_DECR);
@@ -1212,8 +1231,8 @@ class TranslatorTest extends AbstractHandlerTest {
         final ResourceModel desired = ResourceModel.builder()
                 .dedicatedLogVolume(true)
                 .build();
-
-        final ModifyDbInstanceRequest request = Translator.modifyDbInstanceRequest(previous, desired, false);
+        final DBInstance dbInstance = DBInstance.builder().build();
+        final ModifyDbInstanceRequest request = Translator.modifyDbInstanceRequest(previous, desired, dbInstance, false);
         assertThat(request.dedicatedLogVolume()).isTrue();
     }
 

--- a/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/UpdateHandlerTest.java
+++ b/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/UpdateHandlerTest.java
@@ -200,7 +200,7 @@ public class UpdateHandlerTest extends AbstractHandlerTest {
                 expectSuccess()
         );
 
-        verify(rdsProxy.client(), times(3)).describeDBInstances(any(DescribeDbInstancesRequest.class));
+        verify(rdsProxy.client(), times(4)).describeDBInstances(any(DescribeDbInstancesRequest.class));
         verify(rdsProxy.client()).modifyDBInstance(any(ModifyDbInstanceRequest.class));
         verify(rdsProxy.client()).addTagsToResource(any(AddTagsToResourceRequest.class));
         verify(rdsProxy.client()).removeTagsFromResource(any(RemoveTagsFromResourceRequest.class));
@@ -284,7 +284,7 @@ public class UpdateHandlerTest extends AbstractHandlerTest {
         verify(rdsProxy.client(), times(1)).modifyDBInstance(argument.capture());
         Assertions.assertThat(argument.getValue().maxAllocatedStorage()).isEqualTo(ALLOCATED_STORAGE);
 
-        verify(rdsProxy.client(), times(3)).describeDBInstances(any(DescribeDbInstancesRequest.class));
+        verify(rdsProxy.client(), times(4)).describeDBInstances(any(DescribeDbInstancesRequest.class));
         verify(rdsProxy.client(), times(1)).describeEvents(any(DescribeEventsRequest.class));
     }
 
@@ -1218,7 +1218,7 @@ public class UpdateHandlerTest extends AbstractHandlerTest {
                 expectSuccess()
         );
 
-        verify(rdsProxy.client(), times(3)).describeDBInstances(any(DescribeDbInstancesRequest.class));
+        verify(rdsProxy.client(), times(4)).describeDBInstances(any(DescribeDbInstancesRequest.class));
 
         ArgumentCaptor<ModifyDbInstanceRequest> captor = ArgumentCaptor.forClass(ModifyDbInstanceRequest.class);
         verify(rdsProxy.client(), times(1)).modifyDBInstance(captor.capture());
@@ -1248,6 +1248,10 @@ public class UpdateHandlerTest extends AbstractHandlerTest {
             final Object requestException,
             final HandlerErrorCode expectResponseCode
     ) {
+        final DBInstance fakeDBInstance = DBInstance.builder().build();
+        when(rdsProxy.client().describeDBInstances(any(DescribeDbInstancesRequest.class)))
+            .thenReturn(DescribeDbInstancesResponse.builder().dbInstances(fakeDBInstance).build());
+
         final CallbackContext context = new CallbackContext();
         context.setStorageAllocated(true);
 
@@ -1359,7 +1363,7 @@ public class UpdateHandlerTest extends AbstractHandlerTest {
                 expectSuccess()
         );
 
-        verify(rdsProxy.client(), times(3)).describeDBInstances(any(DescribeDbInstancesRequest.class));
+        verify(rdsProxy.client(), times(4)).describeDBInstances(any(DescribeDbInstancesRequest.class));
 
         final ArgumentCaptor<ModifyDbInstanceRequest> argumentCaptor = ArgumentCaptor.forClass(ModifyDbInstanceRequest.class);
         verify(rdsProxy.client(), times(1)).modifyDBInstance(argumentCaptor.capture());
@@ -1390,7 +1394,7 @@ public class UpdateHandlerTest extends AbstractHandlerTest {
                 expectSuccess()
         );
 
-        verify(rdsProxy.client(), times(3)).describeDBInstances(any(DescribeDbInstancesRequest.class));
+        verify(rdsProxy.client(), times(4)).describeDBInstances(any(DescribeDbInstancesRequest.class));
 
         final ArgumentCaptor<ModifyDbInstanceRequest> argumentCaptor = ArgumentCaptor.forClass(ModifyDbInstanceRequest.class);
         verify(rdsProxy.client(), times(1)).modifyDBInstance(argumentCaptor.capture());
@@ -1605,7 +1609,7 @@ public class UpdateHandlerTest extends AbstractHandlerTest {
         verify(rdsProxy.client(), times(1)).modifyDBInstance(any(ModifyDbInstanceRequest.class));
         ArgumentCaptor<DescribeEventsRequest> describeEventsCaptor = ArgumentCaptor.forClass(DescribeEventsRequest.class);
         verify(rdsProxy.client(), times(1)).describeEvents(describeEventsCaptor.capture());
-        verify(rdsProxy.client(), times(3)).describeDBInstances(any(DescribeDbInstancesRequest.class));
+        verify(rdsProxy.client(), times(4)).describeDBInstances(any(DescribeDbInstancesRequest.class));
 
         Assertions.assertThat(describeEventsCaptor.getValue().startTime()).isEqualTo(updatedAt);
     }
@@ -1738,7 +1742,7 @@ public class UpdateHandlerTest extends AbstractHandlerTest {
 
         verify(rdsProxy.client(), times(1)).modifyDBInstance(any(ModifyDbInstanceRequest.class));
         verify(rdsProxy.client(), times(1)).describeEvents(any(DescribeEventsRequest.class));
-        verify(rdsProxy.client(), times(2)).describeDBInstances(any(DescribeDbInstancesRequest.class));
+        verify(rdsProxy.client(), times(3)).describeDBInstances(any(DescribeDbInstancesRequest.class));
     }
 
     @Test
@@ -1850,7 +1854,7 @@ public class UpdateHandlerTest extends AbstractHandlerTest {
                 expectSuccess()
         );
 
-        verify(rdsProxy.client(), times(3)).describeDBInstances(any(DescribeDbInstancesRequest.class));
+        verify(rdsProxy.client(), times(4)).describeDBInstances(any(DescribeDbInstancesRequest.class));
 
         final ArgumentCaptor<ModifyDbInstanceRequest> argumentCaptor = ArgumentCaptor.forClass(ModifyDbInstanceRequest.class);
         verify(rdsProxy.client()).modifyDBInstance(argumentCaptor.capture());


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-cloudformation/cloudformation-coverage-roadmap/issues/430

*Description of changes:*

When an instance is autoscaled out, the template no longer matches the real instance's AllocatedStorage.

For example:

Given a template:
```
Resource:
  DBInstance:
    Type: AWS::RDS::DBInstance
      AllocatedStorage: 100
      MaxAllocatedStorage: 500
```

When the DBInstance reaches high storage utilization, it scales from AllocatedStorage 100 => AllocatedStorage 120

On template update, the ModifyDBInstance call, for ProvisionedIOPS volumes (gp3/io1/io2), will pass the template's AllocatedStorage into the ModifyDBInstance call.

This surfaces as an exception similar to:

```
Resource handler returned message: "Invalid storage size for engine name mysql and storage type gp3: 100 (Service: Rds, Status Code: 400, Request ID: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx)" (RequestToken: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx, HandlerErrorCode: InvalidRequest)
```

This PR ensures that on template update, the CloudFormation stack on update will succeed despite the autoscaled out instance.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
