### PR TITLE
[DBInstance] Introduce ApplyImmediately flag to address unintended reboots and interruptions

### DIFF
--- a/aws-rds-dbinstance/aws-rds-dbinstance.json
+++ b/aws-rds-dbinstance/aws-rds-dbinstance.json
@@ -473,6 +473,10 @@
         "type": "string"
       },
       "description": "A list of the VPC security group IDs to assign to the DB instance. The list can include both the physical IDs of existing VPC security groups and references to AWS::EC2::SecurityGroup resources created in the template."
+    },
+    "ApplyImmediately": {
+      "type": "boolean",
+      "description": "Specifies whether the modifications in this request and any pending modifications are asynchronously applied as soon as possible, regardless of the PreferredMaintenanceWindow setting for the DB instance. By default, this parameter is enabled."
     }
   },
   "additionalProperties": false,
@@ -549,7 +553,8 @@
     "/properties/SourceRegion",
     "/properties/TdeCredentialPassword",
     "/properties/UseDefaultProcessorFeatures",
-    "/properties/UseLatestRestorableTime"
+    "/properties/UseLatestRestorableTime",
+    "/properties/ApplyImmediately"
   ],
   "readOnlyProperties": [
     "/properties/Endpoint",

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/BaseHandlerStd.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/BaseHandlerStd.java
@@ -25,6 +25,7 @@ import software.amazon.rds.common.request.RequestValidationException;
 import software.amazon.rds.common.request.ValidatedRequest;
 import software.amazon.rds.common.request.Validations;
 import software.amazon.rds.dbinstance.client.*;
+import software.amazon.rds.dbinstance.util.ResourceModelHelper;
 
 import java.time.Duration;
 import java.time.Instant;
@@ -596,7 +597,10 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
     ) {
         final DBInstance dbInstance = fetchDBInstance(rdsProxyClient, model);
 
-        return DBInstancePredicates.isDBParameterGroupInSync(dbInstance);
+        if(ResourceModelHelper.shouldApplyImmediately(model)) {
+            return DBInstancePredicates.isDBParameterGroupInSync(dbInstance);
+        }
+        return DBInstancePredicates.isDBParameterGroupNotApplying(dbInstance);
     }
 
     protected boolean isDBClusterParameterGroupStabilized(
@@ -605,7 +609,10 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
     ) {
         final DBCluster dbCluster = fetchDBCluster(rdsProxyClient, model);
 
-        return DBInstancePredicates.isDBClusterParameterGroupInSync(model, dbCluster);
+        if(ResourceModelHelper.shouldApplyImmediately(model)) {
+            return DBInstancePredicates.isDBClusterParameterGroupInSync(model, dbCluster);
+        }
+        return DBInstancePredicates.isDBClusterParameterGroupNotApplying(model, dbCluster);
     }
 
     protected boolean isDBInstanceRoleStabilized(

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/Translator.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/Translator.java
@@ -414,7 +414,7 @@ public class Translator {
     ) {
         final ModifyDbInstanceRequest.Builder builder = ModifyDbInstanceRequest.builder()
                 .allowMajorVersionUpgrade(desiredModel.getAllowMajorVersionUpgrade())
-                .applyImmediately(Boolean.TRUE)
+                .applyImmediately(ResourceModelHelper.shouldApplyImmediately(desiredModel))
                 .autoMinorVersionUpgrade(diff(previousModel.getAutoMinorVersionUpgrade(), desiredModel.getAutoMinorVersionUpgrade()))
                 .backupRetentionPeriod(diff(previousModel.getBackupRetentionPeriod(), desiredModel.getBackupRetentionPeriod()))
                 .dbInstanceClass(diff(previousModel.getDBInstanceClass(), desiredModel.getDBInstanceClass()))
@@ -451,7 +451,7 @@ public class Translator {
     ) {
         final ModifyDbInstanceRequest.Builder builder = ModifyDbInstanceRequest.builder()
                 .allowMajorVersionUpgrade(desiredModel.getAllowMajorVersionUpgrade())
-                .applyImmediately(Boolean.TRUE)
+                .applyImmediately(ResourceModelHelper.shouldApplyImmediately(desiredModel))
                 .autoMinorVersionUpgrade(diff(previousModel.getAutoMinorVersionUpgrade(), desiredModel.getAutoMinorVersionUpgrade()))
                 .backupRetentionPeriod(diff(previousModel.getBackupRetentionPeriod(), desiredModel.getBackupRetentionPeriod()))
                 .copyTagsToSnapshot(diff(previousModel.getCopyTagsToSnapshot(), desiredModel.getCopyTagsToSnapshot()))
@@ -674,7 +674,7 @@ public class Translator {
         return ModifyDbInstanceRequest.builder()
                 .dbInstanceIdentifier(desiredModel.getDBInstanceIdentifier())
                 .allocatedStorage(getAllocatedStorage(desiredModel))
-                .applyImmediately(Boolean.TRUE)
+                .applyImmediately(ResourceModelHelper.shouldApplyImmediately(desiredModel))
                 .build();
     }
 

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/UpdateHandler.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/UpdateHandler.java
@@ -252,8 +252,9 @@ public class UpdateHandler extends BaseHandlerStd {
     ) {
         try {
             final DBInstance dbInstance = fetchDBInstance(proxyClient, progress.getResourceModel());
+            final boolean applyImmediately = ResourceModelHelper.shouldApplyImmediately(progress.getResourceModel());
             if (!CollectionUtils.isNullOrEmpty(dbInstance.dbParameterGroups())) {
-                return DBParameterGroupStatus.PendingReboot.equalsString(dbInstance.dbParameterGroups().get(0).parameterApplyStatus());
+                return applyImmediately && DBParameterGroupStatus.PendingReboot.equalsString(dbInstance.dbParameterGroups().get(0).parameterApplyStatus());
             }
         } catch (DbInstanceNotFoundException e) {
             return false;
@@ -267,10 +268,11 @@ public class UpdateHandler extends BaseHandlerStd {
     ) {
         final String dbInstanceIdentifier = progress.getResourceModel().getDBInstanceIdentifier();
         final DBCluster dbCluster = fetchDBCluster(proxyClient, progress.getResourceModel());
+        final boolean applyImmediately =  ResourceModelHelper.shouldApplyImmediately(progress.getResourceModel());
         if (!CollectionUtils.isNullOrEmpty(dbCluster.dbClusterMembers())) {
             for (final DBClusterMember member : dbCluster.dbClusterMembers()) {
                 if (dbInstanceIdentifier.equalsIgnoreCase(member.dbInstanceIdentifier())) {
-                    return DBParameterGroupStatus.PendingReboot.equalsString(member.dbClusterParameterGroupStatus());
+                    return applyImmediately && DBParameterGroupStatus.PendingReboot.equalsString(member.dbClusterParameterGroupStatus());
                 }
             }
         }

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/util/ResourceModelHelper.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/util/ResourceModelHelper.java
@@ -127,6 +127,12 @@ public final class ResourceModelHelper {
         return StringUtils.hasValue(model.getDBParameterGroupName());
     }
 
+    public static boolean shouldApplyImmediately(final ResourceModel model) {
+        Boolean applyImmediately = model.getApplyImmediately();
+        // default to true
+        return applyImmediately == null || applyImmediately;
+    }
+
     public static Boolean getDefaultMultiAzForEngine(final String engine) {
         if (SQLSERVER_ENGINES_WITH_MIRRORING.contains(engine)) {
             return null;

--- a/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/DBInstancePredicatesTest.java
+++ b/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/DBInstancePredicatesTest.java
@@ -1,0 +1,48 @@
+package software.amazon.rds.dbinstance;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import software.amazon.awssdk.services.rds.model.DBInstance;
+import software.amazon.awssdk.services.rds.model.PendingModifiedValues;
+import software.amazon.rds.common.logging.RequestLogger;
+import software.amazon.rds.dbinstance.status.DBInstanceStatus;
+
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+public class DBInstancePredicatesTest {
+    @Mock
+    RequestLogger requestLogger = Mockito.mock(RequestLogger.class);
+
+    @ParameterizedTest
+    @MethodSource("stabilizeTestCases")
+    public void test_isDBInstanceStabilizedAfterMutate(Boolean applyImmediate, Boolean isStabilized){
+        DBInstance dbInstance = DBInstance.builder()
+            .dbInstanceStatus(DBInstanceStatus.Available.toString())
+            .pendingModifiedValues(PendingModifiedValues.builder()
+                .backupRetentionPeriod(5)
+                .build())
+            .build();
+
+        ResourceModel model = ResourceModel.builder()
+            .applyImmediately(applyImmediate)
+            .build();
+
+        boolean actual = DBInstancePredicates.isDBInstanceStabilizedAfterMutate(dbInstance, model, null, requestLogger);
+
+        assertThat(actual).isEqualTo(isStabilized);
+    }
+
+    private static Stream<Arguments> stabilizeTestCases() {
+        return Stream.of(
+            Arguments.of(null, Boolean.FALSE),
+            Arguments.of(Boolean.TRUE, Boolean.FALSE),
+            Arguments.of(Boolean.FALSE, Boolean.TRUE)
+        );
+    }
+}

--- a/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/TranslatorTest.java
+++ b/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/TranslatorTest.java
@@ -1,14 +1,11 @@
 package software.amazon.rds.dbinstance;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
-import java.time.Instant;
-import java.util.Collection;
-
+import com.google.common.collect.ImmutableList;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-
-import com.google.common.collect.ImmutableList;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import software.amazon.awssdk.services.ec2.Ec2Client;
 import software.amazon.awssdk.services.rds.RdsClient;
 import software.amazon.awssdk.services.rds.model.CreateDbInstanceReadReplicaRequest;
@@ -25,6 +22,12 @@ import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.rds.common.handler.Tagging;
 import software.amazon.rds.test.common.core.HandlerName;
 import software.amazon.rds.test.common.core.TestUtils;
+
+import java.time.Instant;
+import java.util.Collection;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 class TranslatorTest extends AbstractHandlerTest {
 
@@ -1234,6 +1237,40 @@ class TranslatorTest extends AbstractHandlerTest {
         final DBInstance dbInstance = DBInstance.builder().build();
         final ModifyDbInstanceRequest request = Translator.modifyDbInstanceRequest(previous, desired, dbInstance, false);
         assertThat(request.dedicatedLogVolume()).isTrue();
+    }
+
+    private static Stream<Arguments> getApplyImmediatelyTestCases() {
+        return Stream.of(
+            Arguments.of(null, Boolean.TRUE),
+            Arguments.of(Boolean.TRUE, Boolean.TRUE),
+            Arguments.of(Boolean.FALSE, Boolean.FALSE)
+        );
+    }
+
+    @ParameterizedTest()
+    @MethodSource("getApplyImmediatelyTestCases")
+    public void test_modifyDBInstanceV12_ApplyImmediately(Boolean inputValue, Boolean expectedValue) {
+        final ResourceModel previous = ResourceModel.builder()
+            .build();
+        final ResourceModel desired = ResourceModel.builder()
+            .applyImmediately(inputValue)
+            .build();
+
+        final ModifyDbInstanceRequest request = Translator.modifyDbInstanceRequestV12(previous, desired, false);
+        assertThat(request.applyImmediately()).isEqualTo(expectedValue);
+    }
+
+    @ParameterizedTest()
+    @MethodSource("getApplyImmediatelyTestCases")
+    public void test_modifyDBInstance_ApplyImmediately(Boolean inputValue, Boolean expectedValue) {
+        final ResourceModel previous = ResourceModel.builder()
+            .build();
+        final ResourceModel desired = ResourceModel.builder()
+            .applyImmediately(inputValue)
+            .build();
+        final DBInstance dbInstance = DBInstance.builder().build();
+        final ModifyDbInstanceRequest request = Translator.modifyDbInstanceRequest(previous, desired, dbInstance, false);
+        assertThat(request.applyImmediately()).isEqualTo(expectedValue);
     }
 
     // Stub methods to satisfy the interface. This is a 1-time thing.

--- a/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/util/ResourceModelHelperTest.java
+++ b/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/util/ResourceModelHelperTest.java
@@ -1,12 +1,16 @@
 package software.amazon.rds.dbinstance.util;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
-
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import software.amazon.rds.dbinstance.ResourceModel;
+
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
 public class ResourceModelHelperTest {
 
@@ -498,5 +502,24 @@ public class ResourceModelHelperTest {
                 .build();
 
         assertThat(ResourceModelHelper.shouldStopAutomaticBackupReplication(previous, desired)).isTrue();
+    }
+
+    private static Stream<Arguments> getApplyImmediatelyTestCases() {
+        return Stream.of(
+            Arguments.of(null, Boolean.TRUE),
+            Arguments.of(Boolean.TRUE, Boolean.TRUE),
+            Arguments.of(Boolean.FALSE, Boolean.FALSE)
+        );
+    }
+
+    @ParameterizedTest()
+    @MethodSource("getApplyImmediatelyTestCases")
+    public void test_ShouldApplyImmediately(Boolean input, Boolean expected) {
+        final ResourceModel model = ResourceModel.builder()
+            .applyImmediately(input)
+            .build();
+
+        Boolean actualValue = ResourceModelHelper.shouldApplyImmediately(model);
+        Assertions.assertThat(actualValue).isEqualTo(expected);
     }
 }


### PR DESCRIPTION
*Description of changes:*

Introduce ApplyImmediately flag to allow customers to specify whether disruptive changes to the DB instance and any pending modifications are applied immediately, regardless of the PreferredMaintenanceWindow setting. If set to false, changes are applied during the next maintenance window. Until RDS applies the changes, the DB instance remains in a drift state. 

This property also determines whether the DB instance reboots when a static parameter is modified in the associated DB parameter group.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
