### PR TITLE
[DBInstance] Introduce AutomaticBackupReplicationRetentionPeriod to allow setting of retention period for cross-region replicated backups

### DIFF
--- a/aws-rds-dbinstance/aws-rds-dbinstance.json
+++ b/aws-rds-dbinstance/aws-rds-dbinstance.json
@@ -141,7 +141,6 @@
     "AutomaticBackupReplicationRetentionPeriod": {
       "type": "integer",
       "minimum": 1,
-      "maximum": 35,
       "description": "The number of days for which automated cross-region replicated backups are retained. If this value is unset, default to BackupRetentionPeriod."
     },
     "AvailabilityZone": {
@@ -151,7 +150,6 @@
     "BackupRetentionPeriod": {
       "type": "integer",
       "minimum": 0,
-      "maximum": 35,
       "description": "The number of days for which automated backups are retained. Setting this parameter to a positive number enables backups. Setting this parameter to 0 disables automated backups."
     },
     "CACertificateIdentifier": {

--- a/aws-rds-dbinstance/aws-rds-dbinstance.json
+++ b/aws-rds-dbinstance/aws-rds-dbinstance.json
@@ -138,6 +138,12 @@
       "type": "string",
       "description": "The Amazon Web Services KMS key identifier for encryption of the replicated automated backups. The KMS key ID is the Amazon Resource Name (ARN) for the KMS encryption key in the destination Amazon Web Services Region, for example, `arn:aws:kms:us-east-1:123456789012:key/AKIAIOSFODNN7EXAMPLE` ."
     },
+    "AutomaticBackupReplicationRetentionPeriod": {
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 35,
+      "description": "The number of days for which automated cross-region replicated backups are retained. If this value is unset, default to BackupRetentionPeriod."
+    },
     "AvailabilityZone": {
       "type": "string",
       "description": "The Availability Zone (AZ) where the database will be created. For information on AWS Regions and Availability Zones."
@@ -145,6 +151,7 @@
     "BackupRetentionPeriod": {
       "type": "integer",
       "minimum": 0,
+      "maximum": 35,
       "description": "The number of days for which automated backups are retained. Setting this parameter to a positive number enables backups. Setting this parameter to 0 disables automated backups."
     },
     "CACertificateIdentifier": {
@@ -641,6 +648,7 @@
         "rds:DescribeDBEngineVersions",
         "rds:DescribeDBInstances",
         "rds:DescribeDBParameterGroups",
+        "rds:DescribeDBInstanceAutomatedBackups",
         "rds:DescribeEvents",
         "rds:ModifyDBInstance",
         "rds:PromoteReadReplica",

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/CallbackContext.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/CallbackContext.java
@@ -26,6 +26,7 @@ public class CallbackContext extends StdCallbackContext implements TaggingContex
     private boolean automaticBackupReplicationStopped;
     private boolean automaticBackupReplicationStarted;
     private String dbInstanceArn;
+    private String automaticBackupReplicationArn;
     private String currentRegion;
     private String kmsKeyId;
     private String snapshotIdentifier;

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/ReadHandler.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/ReadHandler.java
@@ -1,14 +1,26 @@
 package software.amazon.rds.dbinstance;
 
+import com.amazonaws.util.StringUtils;
 import software.amazon.awssdk.services.ec2.Ec2Client;
 import software.amazon.awssdk.services.rds.RdsClient;
 import software.amazon.awssdk.services.rds.model.DBInstance;
+import software.amazon.awssdk.services.rds.model.DBInstanceAutomatedBackup;
+import software.amazon.awssdk.services.rds.model.DBInstanceAutomatedBackupsReplication;
+import software.amazon.awssdk.services.rds.model.RdsException;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
+import software.amazon.cloudformation.proxy.HandlerErrorCode;
 import software.amazon.cloudformation.proxy.ProgressEvent;
+import software.amazon.cloudformation.proxy.ProxyClient;
+import software.amazon.rds.common.error.ErrorStatus;
+import software.amazon.rds.common.error.HandlerErrorStatus;
 import software.amazon.rds.common.handler.Commons;
 import software.amazon.rds.common.handler.HandlerConfig;
 import software.amazon.rds.common.request.ValidatedRequest;
+import software.amazon.rds.dbinstance.util.ResourceModelHelper;
+import software.amazon.rds.dbinstance.client.RdsClientProvider;
 import software.amazon.rds.dbinstance.client.VersionedProxyClient;
+
+import java.util.List;
 
 public class ReadHandler extends BaseHandlerStd {
 
@@ -20,6 +32,8 @@ public class ReadHandler extends BaseHandlerStd {
         super(config);
     }
 
+
+
     protected ProgressEvent<ResourceModel, CallbackContext> handleRequest(
             final AmazonWebServicesClientProxy proxy,
             final ValidatedRequest<ResourceModel> request,
@@ -27,21 +41,89 @@ public class ReadHandler extends BaseHandlerStd {
             final VersionedProxyClient<RdsClient> rdsProxyClient,
             final VersionedProxyClient<Ec2Client> ec2ProxyClient
     ) {
-        return proxy.initiate("rds::describe-db-instance", rdsProxyClient.defaultClient(), request.getDesiredResourceState(), callbackContext)
-                .translateToServiceRequest(Translator::describeDbInstancesRequest)
-                .makeServiceCall((describeRequest, proxyInvocation) -> proxyInvocation.injectCredentialsAndInvokeV2(
-                        describeRequest,
-                        proxyInvocation.client()::describeDBInstances
-                ))
-                .handleError((describeRequest, exception, client, model, context) -> Commons.handleException(
-                        ProgressEvent.progress(model, context),
-                        exception,
-                        DEFAULT_DB_INSTANCE_ERROR_RULE_SET,
-                        requestLogger
-                ))
-                .done((describeRequest, describeResponse, proxyInvocation, resourceModel, context) -> {
-                    final DBInstance dbInstance = describeResponse.dbInstances().get(0);
-                    return ProgressEvent.success(Translator.translateDbInstanceFromSdk(dbInstance), context);
-                });
+        return ProgressEvent.progress(request.getDesiredResourceState(), callbackContext)
+            .then(progress -> describeDbInstance(progress, proxy, rdsProxyClient))
+            .then(progress -> {
+                // If replication found for DB instance, we describe it
+                if (!StringUtils.isNullOrEmpty(progress.getCallbackContext().getAutomaticBackupReplicationArn())) {
+                    return describeAutomatedBackupsReplication(progress, proxy);
+                }
+                return progress;
+            })
+            .then(progress -> ProgressEvent.success(progress.getResourceModel(), progress.getCallbackContext()));
+    }
+
+    protected ProgressEvent<ResourceModel, CallbackContext> describeDbInstance(
+            final ProgressEvent<ResourceModel, CallbackContext> progress,
+            final AmazonWebServicesClientProxy proxy,
+            final VersionedProxyClient<RdsClient> rdsProxyClient
+    ) {
+        final CallbackContext callbackContext = progress.getCallbackContext();
+        final ResourceModel resourceModel = progress.getResourceModel();
+
+        return proxy.initiate("rds::describe-db-instance", rdsProxyClient.defaultClient(), resourceModel, callbackContext)
+            .translateToServiceRequest(Translator::describeDbInstancesRequest)
+            .makeServiceCall((describeRequest, proxyInvocation) -> {
+                return proxyInvocation.injectCredentialsAndInvokeV2(
+                    describeRequest,
+                    proxyInvocation.client()::describeDBInstances
+                );
+            })
+            .handleError((describeRequest, exception, client, model, context) -> Commons.handleException(
+                ProgressEvent.progress(model, context),
+                exception,
+                DEFAULT_DB_INSTANCE_ERROR_RULE_SET,
+                requestLogger
+            ))
+            .done((describeRequest, describeResponse, automatedBackupProxyInvocation, model, context) -> {
+                final DBInstance dbInstance = describeResponse.dbInstances().get(0);
+                final ResourceModel currentModel = Translator.translateDbInstanceFromSdk(dbInstance);
+                final List<DBInstanceAutomatedBackupsReplication> replications = dbInstance.dbInstanceAutomatedBackupsReplications();
+                if (replications.isEmpty()) {
+                    context.setAutomaticBackupReplicationStopped(true);
+                    return ProgressEvent.progress(currentModel, context);
+                }
+                context.setAutomaticBackupReplicationArn(replications.get(0).dbInstanceAutomatedBackupsArn());
+
+                return ProgressEvent.progress(currentModel, context);
+            });
+    }
+
+    protected ProgressEvent<ResourceModel, CallbackContext> describeAutomatedBackupsReplication(
+        final ProgressEvent<ResourceModel, CallbackContext> progress,
+        final AmazonWebServicesClientProxy proxy
+    ) {
+        final CallbackContext callbackContext = progress.getCallbackContext();
+        final ResourceModel resourceModel = progress.getResourceModel();
+
+        if (StringUtils.isNullOrEmpty(callbackContext.getAutomaticBackupReplicationArn())) {
+            return ProgressEvent.progress(resourceModel, callbackContext);
+        }
+
+        final String replicationRegion = ResourceModelHelper.getRegionFromArn(callbackContext.getAutomaticBackupReplicationArn());
+        final ProxyClient<RdsClient> replicationRegionProxyClient =
+            proxy.newProxy(() -> new RdsClientProvider().getClientForRegion(replicationRegion));
+
+        return proxy.initiate("rds::describe-db-instance-automated-backups", replicationRegionProxyClient, resourceModel, callbackContext)
+            .translateToServiceRequest(model -> Translator.describeDBInstanceAutomaticBackupRequest(callbackContext.getAutomaticBackupReplicationArn()))
+            .backoffDelay(config.getBackoff())
+            .makeServiceCall((describeRequest, proxyInvocation) -> proxyInvocation.injectCredentialsAndInvokeV2(
+                describeRequest,
+                proxyInvocation.client()::describeDBInstanceAutomatedBackups
+            ))
+            .handleError((describeRequest, exception, client, model, context) ->Commons.handleException(
+                ProgressEvent.progress(model, context),
+                exception,
+                DESCRIBE_AUTOMATED_BACKUPS_SOFTFAIL_ERROR_RULE_SET,
+                requestLogger
+            ))
+            .done((describeRequest, describeResponse, proxyInvocation, model, context) -> {
+                DBInstanceAutomatedBackup dbInstanceAutomatedBackup = describeResponse.dbInstanceAutomatedBackups().get(0);
+                model.setAutomaticBackupReplicationRetentionPeriod(dbInstanceAutomatedBackup.backupRetentionPeriod());
+                model.setAutomaticBackupReplicationRegion(replicationRegion);
+                model.setAutomaticBackupReplicationKmsKeyId(dbInstanceAutomatedBackup.kmsKeyId());
+                context.setAutomaticBackupReplicationStarted(true);
+                return ProgressEvent.progress(model, context);
+            });
     }
 }

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/Translator.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/Translator.java
@@ -90,7 +90,7 @@ public class Translator {
                 .build();
     }
 
-    public static DescribeDbInstanceAutomatedBackupsRequest describeDBInstanceAutomaticBackup(final String automaticBackupArn) {
+    public static DescribeDbInstanceAutomatedBackupsRequest describeDBInstanceAutomaticBackupRequest(final String automaticBackupArn) {
         return DescribeDbInstanceAutomatedBackupsRequest.builder()
                 .dbInstanceAutomatedBackupsArn(automaticBackupArn)
                 .build();
@@ -777,10 +777,12 @@ public class Translator {
 
     public static StartDbInstanceAutomatedBackupsReplicationRequest startDbInstanceAutomatedBackupsReplicationRequest(
             final String dbInstanceArn,
+            final Integer backupRetentionPeriod,
             final String kmsKeyId
     ) {
         return StartDbInstanceAutomatedBackupsReplicationRequest.builder()
                 .sourceDBInstanceArn(dbInstanceArn)
+                .backupRetentionPeriod(backupRetentionPeriod)
                 .kmsKeyId(kmsKeyId)
                 .build();
     }

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/validators/AutomaticBackupReplicationValidator.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/validators/AutomaticBackupReplicationValidator.java
@@ -1,0 +1,23 @@
+package software.amazon.rds.dbinstance.validators;
+
+import com.amazonaws.util.StringUtils;
+import software.amazon.rds.common.request.RequestValidationException;
+import software.amazon.rds.dbinstance.ResourceModel;
+import software.amazon.rds.dbinstance.util.ResourceModelHelper;
+
+public class AutomaticBackupReplicationValidator {
+    public static void validateRequest(final ResourceModel model) throws RequestValidationException {
+        if (StringUtils.isNullOrEmpty(ResourceModelHelper.getAutomaticBackupReplicationRegion(model))) {
+            if (!StringUtils.isNullOrEmpty(ResourceModelHelper.getAutomaticBackupReplicationKmsKeyId(model) )) {
+                throw new RequestValidationException("You must specify the AutomaticBackupReplicationRegion parameter when setting the AutomaticBackupReplicationKmsKeyId parameter.");
+            }
+            if (ResourceModelHelper.getAutomaticBackupReplicationRetentionPeriod(model) != null) {
+                throw new RequestValidationException("You must specify the AutomaticBackupReplicationRegion parameter when setting the AutomaticBackupReplicationRetentionPeriod parameter.");
+            }
+        } else {
+            if (ResourceModelHelper.getBackupRetentionPeriod(model) != null && ResourceModelHelper.getBackupRetentionPeriod(model) == 0) {
+                throw new RequestValidationException("AutomaticBackupReplicationRegion cannot be specified when BackupRetentionPeriod is 0.");
+            }
+        }
+    }
+}

--- a/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/AbstractHandlerTest.java
+++ b/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/AbstractHandlerTest.java
@@ -197,6 +197,7 @@ public abstract class AbstractHandlerTest extends AbstractTestBase<DBInstance, R
     protected static final String MSG_GENERIC_ERR = "Error";
     protected static final String AUTOMATIC_BACKUP_REPLICATION_REGION = "eu-west-1";
     protected static final String AUTOMATIC_BACKUP_REPLICATION_REGION_ALTER = "eu-west-2";
+    protected static final Integer AUTOMATIC_BACKUP_REPLICATION_RETENTION_PERIOD = 1;
     protected static final String CURRENT_REGION = "eu-west-1";
 
 

--- a/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/CreateHandlerTest.java
+++ b/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/CreateHandlerTest.java
@@ -1999,21 +1999,29 @@ public class CreateHandlerTest extends AbstractHandlerTest {
         context.setAutomaticBackupReplicationStarted(false);
 
         proxy = Mockito.spy(proxy);
-
         final RdsClient crossRegionRdsClient = mock(RdsClient.class);
         final ProxyClient<RdsClient> crossRegionRdsProxy = mockProxy(proxy, crossRegionRdsClient);
         doReturn(crossRegionRdsProxy).when(proxy).newProxy(ArgumentMatchers.<Supplier<RdsClient>>any());
 
+        when(crossRegionRdsProxy.client().describeDBInstanceAutomatedBackups(any(DescribeDbInstanceAutomatedBackupsRequest.class)))
+            .thenReturn(DescribeDbInstanceAutomatedBackupsResponse.builder()
+                .dbInstanceAutomatedBackups(Collections.singletonList(DBInstanceAutomatedBackup.builder()
+                    .dbInstanceAutomatedBackupsArn(
+                        getAutomaticBackupArn(AUTOMATIC_BACKUP_REPLICATION_REGION))
+                    .backupRetentionPeriod(AUTOMATIC_BACKUP_REPLICATION_RETENTION_PERIOD).build()))
+                .build());
+
         test_handleRequest_base(
-                context,
-                () -> DB_INSTANCE_ACTIVE.toBuilder().dbInstanceAutomatedBackupsReplications(
-                        Collections.singletonList(DBInstanceAutomatedBackupsReplication.builder()
-                                .dbInstanceAutomatedBackupsArn(
-                                        getAutomaticBackupArn(AUTOMATIC_BACKUP_REPLICATION_REGION)).build())).build(),
-                () -> RESOURCE_MODEL_BLDR()
-                        .automaticBackupReplicationRegion(AUTOMATIC_BACKUP_REPLICATION_REGION)
-                        .build(),
-                expectSuccess()
+            context,
+            () -> DB_INSTANCE_ACTIVE.toBuilder().dbInstanceAutomatedBackupsReplications(
+                Collections.singletonList(DBInstanceAutomatedBackupsReplication.builder()
+                    .dbInstanceAutomatedBackupsArn(
+                        getAutomaticBackupArn(AUTOMATIC_BACKUP_REPLICATION_REGION)).build())).build(),
+            () -> RESOURCE_MODEL_BLDR()
+                .automaticBackupReplicationRegion(AUTOMATIC_BACKUP_REPLICATION_REGION)
+                .automaticBackupReplicationRetentionPeriod(1)
+                .build(),
+            expectSuccess()
         );
 
         verify(crossRegionRdsProxy.client(), times(1)).startDBInstanceAutomatedBackupsReplication(any(StartDbInstanceAutomatedBackupsReplicationRequest.class));
@@ -2031,17 +2039,30 @@ public class CreateHandlerTest extends AbstractHandlerTest {
         context.setUpdatedRoles(true);
         context.setAddTagsComplete(true);
 
+        proxy = Mockito.spy(proxy);
+        final RdsClient crossRegionRdsClient = mock(RdsClient.class);
+        final ProxyClient<RdsClient> crossRegionRdsProxy = mockProxy(proxy, crossRegionRdsClient);
+        doReturn(crossRegionRdsProxy).when(proxy).newProxy(ArgumentMatchers.<Supplier<RdsClient>>any());
+
+        when(crossRegionRdsProxy.client().describeDBInstanceAutomatedBackups(any(DescribeDbInstanceAutomatedBackupsRequest.class)))
+            .thenReturn(DescribeDbInstanceAutomatedBackupsResponse.builder()
+                .dbInstanceAutomatedBackups(Collections.singletonList(DBInstanceAutomatedBackup.builder()
+                    .dbInstanceAutomatedBackupsArn(
+                        getAutomaticBackupArn(AUTOMATIC_BACKUP_REPLICATION_REGION))
+                    .backupRetentionPeriod(AUTOMATIC_BACKUP_REPLICATION_RETENTION_PERIOD).build()))
+                .build());
+
         test_handleRequest_base(
-                context,
-                () -> DB_INSTANCE_ACTIVE.toBuilder().dbInstanceAutomatedBackupsReplications(
-                        Collections.singletonList(DBInstanceAutomatedBackupsReplication.builder()
-                                .dbInstanceAutomatedBackupsArn(
-                                        getAutomaticBackupArn(AUTOMATIC_BACKUP_REPLICATION_REGION)).build())).build(),
-                () -> RESOURCE_MODEL_BLDR()
-                        .automaticBackupReplicationRegion(AUTOMATIC_BACKUP_REPLICATION_REGION)
-                        .backupRetentionPeriod(0)
-                        .build(),
-                expectSuccess()
+            context,
+            () -> DB_INSTANCE_ACTIVE.toBuilder().dbInstanceAutomatedBackupsReplications(
+                Collections.singletonList(DBInstanceAutomatedBackupsReplication.builder()
+                    .dbInstanceAutomatedBackupsArn(
+                        getAutomaticBackupArn(AUTOMATIC_BACKUP_REPLICATION_REGION)).build())).build(),
+            () -> RESOURCE_MODEL_BLDR()
+                .automaticBackupReplicationRegion(null)
+                .backupRetentionPeriod(1)
+                .build(),
+            expectSuccess()
         );
 
         verify(rdsProxy.client(), times(2)).describeDBInstances(any(DescribeDbInstancesRequest.class));

--- a/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/ReadHandlerTest.java
+++ b/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/ReadHandlerTest.java
@@ -2,23 +2,38 @@ package software.amazon.rds.dbinstance;
 
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
 
 import java.time.Duration;
+import java.util.Collections;
+import java.util.function.Supplier;
 
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import lombok.Getter;
+import software.amazon.awssdk.awscore.exception.AwsErrorDetails;
+import software.amazon.awssdk.awscore.exception.AwsServiceException;
+import software.amazon.awssdk.services.cloudwatchlogs.model.AccessDeniedException;
 import software.amazon.awssdk.services.ec2.Ec2Client;
 import software.amazon.awssdk.services.rds.RdsClient;
+import software.amazon.awssdk.services.rds.model.DBInstanceAutomatedBackup;
+import software.amazon.awssdk.services.rds.model.DBInstanceAutomatedBackupsReplication;
+import software.amazon.awssdk.services.rds.model.DbInstanceAutomatedBackupNotFoundException;
+import software.amazon.awssdk.services.rds.model.DescribeDbInstanceAutomatedBackupsRequest;
+import software.amazon.awssdk.services.rds.model.DescribeDbInstanceAutomatedBackupsResponse;
 import software.amazon.awssdk.services.rds.model.DescribeDbInstancesRequest;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.ProxyClient;
@@ -82,5 +97,100 @@ public class ReadHandlerTest extends AbstractHandlerTest {
         );
 
         verify(rdsProxy.client(), times(1)).describeDBInstances(any(DescribeDbInstancesRequest.class));
+    }
+
+    @Test
+    public void handleRequest_ValidAutomaticBackupReplicationArn() {
+        proxy = Mockito.spy(proxy);
+        final RdsClient crossRegionRdsClient = mock(RdsClient.class);
+        final ProxyClient<RdsClient> crossRegionRdsProxy = mockProxy(proxy, crossRegionRdsClient);
+        doReturn(crossRegionRdsProxy).when(proxy).newProxy(ArgumentMatchers.<Supplier<RdsClient>>any());
+
+        final CallbackContext context = new CallbackContext();
+        final String automaticBackupReplicationArn = getAutomaticBackupArn(AUTOMATIC_BACKUP_REPLICATION_REGION);
+
+        when(crossRegionRdsProxy.client().describeDBInstanceAutomatedBackups(any(DescribeDbInstanceAutomatedBackupsRequest.class)))
+            .thenReturn(DescribeDbInstanceAutomatedBackupsResponse.builder()
+                .dbInstanceAutomatedBackups(Collections.singletonList(DBInstanceAutomatedBackup.builder()
+                    .dbInstanceAutomatedBackupsArn(
+                        getAutomaticBackupArn(AUTOMATIC_BACKUP_REPLICATION_REGION))
+                    .backupRetentionPeriod(AUTOMATIC_BACKUP_REPLICATION_RETENTION_PERIOD).build()))
+                .build());
+
+        test_handleRequest_base(
+            context,
+            () -> DB_INSTANCE_ACTIVE.toBuilder()
+                .dbInstanceAutomatedBackupsReplications(Collections.singletonList(DBInstanceAutomatedBackupsReplication.builder()
+                    .dbInstanceAutomatedBackupsArn(automaticBackupReplicationArn).build()))
+                .build(),
+            () -> RESOURCE_MODEL_BLDR().build(),
+            expectSuccess()
+        );
+
+        verify(rdsProxy.client(), times(1)).describeDBInstances(any(DescribeDbInstancesRequest.class));
+        verify(crossRegionRdsProxy.client(), times(1)).describeDBInstanceAutomatedBackups(any(DescribeDbInstanceAutomatedBackupsRequest.class));
+        Assertions.assertThat(context.isAutomaticBackupReplicationStarted()).isTrue();
+    }
+
+    @Test
+    public void handleRequest_AutomaticBackupReplicationNotFound() {
+        // This tests the edge case  where the describe db instance automated backups request returns not found.
+        // In this scenario, the request will fail and simply progress to 'success' without replication parameters.
+        proxy = Mockito.spy(proxy);
+        final RdsClient crossRegionRdsClient = mock(RdsClient.class);
+        final ProxyClient<RdsClient> crossRegionRdsProxy = mockProxy(proxy, crossRegionRdsClient);
+        doReturn(crossRegionRdsProxy).when(proxy).newProxy(ArgumentMatchers.<Supplier<RdsClient>>any());
+
+        final CallbackContext context = new CallbackContext();
+        final String automaticBackupReplicationArn = getAutomaticBackupArn(AUTOMATIC_BACKUP_REPLICATION_REGION);
+
+        when(crossRegionRdsProxy.client().describeDBInstanceAutomatedBackups(any(DescribeDbInstanceAutomatedBackupsRequest.class)))
+            .thenThrow(DbInstanceAutomatedBackupNotFoundException.class);
+
+        test_handleRequest_base(
+            context,
+            () -> DB_INSTANCE_ACTIVE.toBuilder()
+                .dbInstanceAutomatedBackupsReplications(Collections.singletonList(DBInstanceAutomatedBackupsReplication.builder()
+                    .dbInstanceAutomatedBackupsArn(automaticBackupReplicationArn).build()))
+                .build(),
+            () -> RESOURCE_MODEL_BLDR().build(),
+            expectSuccess()
+        );
+
+        verify(rdsProxy.client(), times(1)).describeDBInstances(any(DescribeDbInstancesRequest.class));
+        verify(crossRegionRdsProxy.client(), times(1)).describeDBInstanceAutomatedBackups(any(DescribeDbInstanceAutomatedBackupsRequest.class));
+        Assertions.assertThat(context.isAutomaticBackupReplicationStarted()).isFalse();
+    }
+
+    @Test
+    public void handleRequest_AutomaticBackupReplicationAccessDenied() {
+        // This tests the edge case  where the DB instance has replications, but customer does not have permission to run DescribeDBInstanceAutomatedBackups
+        // In this scenario, the request will fail and simply progress to 'success' without replication parameters.
+        proxy = Mockito.spy(proxy);
+        final RdsClient crossRegionRdsClient = mock(RdsClient.class);
+        final ProxyClient<RdsClient> crossRegionRdsProxy = mockProxy(proxy, crossRegionRdsClient);
+        doReturn(crossRegionRdsProxy).when(proxy).newProxy(ArgumentMatchers.<Supplier<RdsClient>>any());
+
+        final CallbackContext context = new CallbackContext();
+        final String automaticBackupReplicationArn = getAutomaticBackupArn(AUTOMATIC_BACKUP_REPLICATION_REGION);
+
+        when(crossRegionRdsProxy.client().describeDBInstanceAutomatedBackups(any(DescribeDbInstanceAutomatedBackupsRequest.class)))
+            .thenThrow(AwsServiceException.builder()
+                .awsErrorDetails(AwsErrorDetails.builder().errorCode("AccessDenied").build())
+                .build());
+
+        test_handleRequest_base(
+            context,
+            () -> DB_INSTANCE_ACTIVE.toBuilder()
+                .dbInstanceAutomatedBackupsReplications(Collections.singletonList(DBInstanceAutomatedBackupsReplication.builder()
+                    .dbInstanceAutomatedBackupsArn(automaticBackupReplicationArn).build()))
+                .build(),
+            () -> RESOURCE_MODEL_BLDR().build(),
+            expectSuccess()
+        );
+
+        verify(rdsProxy.client(), times(1)).describeDBInstances(any(DescribeDbInstancesRequest.class));
+        verify(crossRegionRdsProxy.client(), times(1)).describeDBInstanceAutomatedBackups(any(DescribeDbInstanceAutomatedBackupsRequest.class));
+        Assertions.assertThat(context.isAutomaticBackupReplicationStarted()).isFalse();
     }
 }

--- a/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/util/ResourceModelHelperTest.java
+++ b/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/util/ResourceModelHelperTest.java
@@ -303,29 +303,12 @@ public class ResourceModelHelperTest {
     }
 
     @Test
-    public void getBackupRetentionPeriod_returnsZeroWhenNotSet() {
-        final ResourceModel model = ResourceModel.builder()
-                .build();
-
-        assertThat(ResourceModelHelper.getBackupRetentionPeriod(model)).isEqualTo(0);
-    }
-
-    @Test
     public void getBackupRetentionPeriod_returnsValueWhenSet() {
         final ResourceModel model = ResourceModel.builder()
                 .backupRetentionPeriod(10)
                 .build();
 
         assertThat(ResourceModelHelper.getBackupRetentionPeriod(model)).isEqualTo(10);
-    }
-
-    @Test
-    public void getAutomaticBackupReplicationRegion_returnsNullWhenBackupReplicationIsZero() {
-        final ResourceModel model = ResourceModel.builder()
-                .automaticBackupReplicationRegion("eu-west-1")
-                .build();
-
-        assertThat(ResourceModelHelper.getAutomaticBackupReplicationRegion(model)).isNull();
     }
 
     @Test
@@ -383,7 +366,7 @@ public class ResourceModelHelperTest {
     }
 
     @Test
-    public void shouldStartAutomaticBackupReplication_returnsFalseWhenBackupRetentionPeriodChangedFromOneToTwo() {
+    public void shouldStartAutomaticBackupReplication_returnsTrueWhenBackupRetentionPeriodChangedFromOneToTwo() {
         final ResourceModel previous = ResourceModel.builder()
                 .automaticBackupReplicationRegion("eu-west-1")
                 .backupRetentionPeriod(1)
@@ -394,7 +377,7 @@ public class ResourceModelHelperTest {
                 .backupRetentionPeriod(2)
                 .build();
 
-        assertThat(ResourceModelHelper.shouldStartAutomaticBackupReplication(previous, desired)).isFalse();
+        assertThat(ResourceModelHelper.shouldStartAutomaticBackupReplication(previous, desired)).isTrue();
     }
 
     @Test
@@ -462,7 +445,7 @@ public class ResourceModelHelperTest {
     }
 
     @Test
-    public void shouldStopAutomaticBackupReplication_returnsTrueWhenBackupRetentionPeriodChangedFromValueToNull() {
+    public void shouldStopAutomaticBackupReplication_returnsFalseWhenBackupRetentionPeriodChangedFromValueToNull() {
         final ResourceModel previous = ResourceModel.builder()
                 .automaticBackupReplicationRegion("eu-west-1")
                 .backupRetentionPeriod(10)
@@ -472,11 +455,11 @@ public class ResourceModelHelperTest {
                 .automaticBackupReplicationRegion("eu-west-1")
                 .build();
 
-        assertThat(ResourceModelHelper.shouldStopAutomaticBackupReplication(previous, desired)).isTrue();
+        assertThat(ResourceModelHelper.shouldStopAutomaticBackupReplication(previous, desired)).isFalse();
     }
 
     @Test
-    public void shouldStopAutomaticBackupReplication_returnsFalseWhenBackupRetentionPeriodChangedFromOneToTwo() {
+    public void shouldStopAutomaticBackupReplication_returnsTrueWhenBackupRetentionPeriodChangedFromOneToTwo() {
         final ResourceModel previous = ResourceModel.builder()
                 .automaticBackupReplicationRegion("eu-west-1")
                 .backupRetentionPeriod(1)
@@ -487,7 +470,7 @@ public class ResourceModelHelperTest {
                 .backupRetentionPeriod(2)
                 .build();
 
-        assertThat(ResourceModelHelper.shouldStopAutomaticBackupReplication(previous, desired)).isFalse();
+        assertThat(ResourceModelHelper.shouldStopAutomaticBackupReplication(previous, desired)).isTrue();
     }
 
     @Test


### PR DESCRIPTION
**Actions**
- Implemented new parameter AutomaticBackupReplicationRetentionPeriod. Allows setting of retention period for cross-region replicated backups and update logic changes to allow modification of replication parameters.

- Added validation for when replication parameters are specified without replication being enabled. This will now fail to prevent stack drift on update/create in these scenarios.

Ref:
[StartDBInstanceAutomatedBackupsReplication](https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_StartDBInstanceAutomatedBackupsReplication.html)

**Testing**
mvn package

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.