### PR TITLE
[Common] Fix CLI version mismatch

### DIFF
--- a/.github/workflows/maven-verify.yml
+++ b/.github/workflows/maven-verify.yml
@@ -23,7 +23,7 @@ jobs:
       with:
         python-version: 3.13
     - name: Install Python packages
-      run: pip install pre-commit cloudformation-cli cloudformation-cli-java-plugin setuptools
+      run: pip install pre-commit cloudformation-cli cloudformation-cli-java-plugin==2.1.1 setuptools
     - name: Run pre-commit
       run: pre-commit run --all-files
     - name: Verify AWS::RDS::Test::Common


### PR DESCRIPTION
*Issue #, if available:*

[The build ](https://github.com/ccmlst/aws-cloudformation-resource-providers-rds/actions/runs/14347180118/job/40219082908) failed  due to `cloudformation-cli` generating
code with `getMaxResults()`, unsupported by Maven’s `2.1.1` plugin.


Pinning the Java plugin to `2.1.1` in the workflow ensures generated code aligns with the
runtime library, resolving the compilation error.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
