### PR TITLE
[DBCluster] Support restore for Aurora Limitless Cluster

### DIFF
--- a/.github/workflows/maven-verify.yml
+++ b/.github/workflows/maven-verify.yml
@@ -23,7 +23,7 @@ jobs:
       with:
         python-version: 3.13
     - name: Install Python packages
-      run: pip install pre-commit cloudformation-cli cloudformation-cli-java-plugin setuptools
+      run: pip install pre-commit cloudformation-cli cloudformation-cli-java-plugin==2.1.1 setuptools
     - name: Run pre-commit
       run: pre-commit run --all-files
     - name: Verify AWS::RDS::Test::Common

--- a/aws-rds-cfn-common/src/main/java/software/amazon/rds/common/handler/Commons.java
+++ b/aws-rds-cfn-common/src/main/java/software/amazon/rds/common/handler/Commons.java
@@ -54,6 +54,14 @@ public final class Commons {
                     SdkClientException.class)
             .build();
 
+    public static final ErrorRuleSet ACCESS_DENIED_RULE_SET =  ErrorRuleSet.extend(ErrorRuleSet.EMPTY_RULE_SET)
+        .withErrorCodes(ErrorStatus.failWith(HandlerErrorCode.AccessDenied),
+            ErrorCode.AccessDenied,
+            ErrorCode.AccessDeniedException,
+            ErrorCode.NotAuthorized,
+            ErrorCode.UnauthorizedOperation)
+        .build();
+
     private Commons() {
     }
 

--- a/aws-rds-cfn-common/src/main/java/software/amazon/rds/common/util/ArnHelper.java
+++ b/aws-rds-cfn-common/src/main/java/software/amazon/rds/common/util/ArnHelper.java
@@ -1,0 +1,67 @@
+package software.amazon.rds.common.util;
+
+import com.amazonaws.arn.Arn;
+import com.amazonaws.arn.ArnResource;
+import com.amazonaws.util.StringUtils;
+
+
+public final class ArnHelper {
+    private static String RDS_SERVICE = "rds";
+    public enum ResourceType {
+        DB_INSTANCE_SNAPSHOT("snapshot"),
+        DB_CLUSTER_SNAPSHOT("cluster-snapshot");
+
+        private String value;
+
+        ResourceType(String value) {
+            this.value = value;
+        }
+
+        public static ResourceType fromString(final String resourceString) {
+            if (!StringUtils.isNullOrEmpty(resourceString)) {
+                for (final ResourceType type : ResourceType.values()) {
+                    if (type.value.equals(resourceString)) {
+                        return type;
+                    }
+                }
+            }
+            return null;
+        }
+    }
+
+    public static boolean isValidArn(final String arn) {
+        if (StringUtils.isNullOrEmpty(arn)) {
+            return false;
+        }
+        try {
+            Arn.fromString(arn);
+            return true;
+        } catch (IllegalArgumentException e) {
+            return false;
+        }
+    }
+
+    public static String getRegionFromArn(final String arn) {
+        return Arn.fromString(arn).getRegion();
+    }
+
+    public static String getResourceNameFromArn(final String arn) {
+        return Arn.fromString(arn).getResource().getResource();
+    }
+
+    public static String getAccountIdFromArn(final String arn) {
+        return Arn.fromString(arn).getAccountId();
+    }
+
+    public static ResourceType getResourceType(String potentialArn) {
+        if (isValidArn(potentialArn)) {
+            final Arn arn = Arn.fromString(potentialArn);
+            if (!RDS_SERVICE.equalsIgnoreCase(arn.getService())) {
+                return null;
+            }
+            final ArnResource resource = arn.getResource();
+            return ResourceType.fromString(resource.getResourceType());
+        }
+        return null;
+    }
+}

--- a/aws-rds-cfn-common/src/main/java/software/amazon/rds/common/validation/ValidationAccessException.java
+++ b/aws-rds-cfn-common/src/main/java/software/amazon/rds/common/validation/ValidationAccessException.java
@@ -1,0 +1,6 @@
+package software.amazon.rds.common.validation;
+
+@SuppressWarnings("serial")
+public class ValidationAccessException extends Exception {
+    public ValidationAccessException(final String message) { super(message); }
+}

--- a/aws-rds-cfn-common/src/main/java/software/amazon/rds/common/validation/ValidationUtils.java
+++ b/aws-rds-cfn-common/src/main/java/software/amazon/rds/common/validation/ValidationUtils.java
@@ -1,0 +1,30 @@
+package software.amazon.rds.common.validation;
+
+import com.google.common.collect.ImmutableMap;
+import software.amazon.cloudformation.proxy.HandlerErrorCode;
+import software.amazon.rds.common.error.ErrorStatus;
+import software.amazon.rds.common.error.HandlerErrorStatus;
+import software.amazon.rds.common.handler.Commons;
+import software.amazon.rds.common.logging.RequestLogger;
+
+import java.util.function.Supplier;
+
+public class ValidationUtils {
+    private final static String MISSING_PERMISSION = "MissingPermission";
+    public static <T> T fetchResourceForValidation(Supplier<T> supplier, String requiredPermission) throws ValidationAccessException {
+        try {
+            return supplier.get();
+        } catch (Exception ex) {
+            final ErrorStatus error = Commons.ACCESS_DENIED_RULE_SET.handle(ex);
+            if (error instanceof HandlerErrorStatus &&
+                    ((HandlerErrorStatus)error).getHandlerErrorCode() == HandlerErrorCode.AccessDenied ){
+                throw new ValidationAccessException(requiredPermission);
+            }
+            throw ex;
+        }
+    }
+
+    public static void emitMetric(final RequestLogger logger, final String validationMetric, ValidationAccessException ex) {
+        logger.log(validationMetric, ImmutableMap.of(MISSING_PERMISSION, ex.getMessage()));
+    }
+}

--- a/aws-rds-cfn-common/src/test/java/software/amazon/rds/common/util/ArnHelperTests.java
+++ b/aws-rds-cfn-common/src/test/java/software/amazon/rds/common/util/ArnHelperTests.java
@@ -1,0 +1,47 @@
+package software.amazon.rds.common.util;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+public class ArnHelperTests {
+    @Test
+    public void isValidArn_returnsFalseWhenNull() {
+        assertThat(ArnHelper.isValidArn(null)).isFalse();
+    }
+
+    @Test
+    public void isValidArn_returnsFalseWhenInvalid() {
+        assertThat(ArnHelper.isValidArn("invalid")).isFalse();
+    }
+
+    @Test
+    public void isValidArn_returnsTrueWhenValid() {
+        assertThat(ArnHelper.isValidArn("arn:aws:rds:us-east-1:1234567890:cluster-snapshot:mysnapshot")).isTrue();
+    }
+
+    @Test
+    public void getResourceType_returnsClusterSnapshot() {
+        assertThat(ArnHelper.getResourceType("arn:aws:rds:us-east-1:1234567890:cluster-snapshot:mysnapshot")).isEqualTo(ArnHelper.ResourceType.DB_CLUSTER_SNAPSHOT);
+    }
+
+    @Test
+    public void getResourceType_returnsNullForNonRdsService() {
+        assertThat(ArnHelper.getResourceType("arn:aws:someservice:us-east-1:1234567890:cluster-snapshot:mysnapshot")).isNull();
+    }
+
+    @Test
+    public void getResourceType_returnsInstanceSnapshot() {
+        assertThat(ArnHelper.getResourceType("arn:aws:rds:us-east-1:1234567890:snapshot:mysnapshot")).isEqualTo(ArnHelper.ResourceType.DB_INSTANCE_SNAPSHOT);
+    }
+
+    @Test
+    public void getRegionFromArn_returnsRegion() {
+        assertThat(ArnHelper.getRegionFromArn("arn:aws:rds:us-east-1:1234567890:snapshot:mysnapshot")).isEqualTo("us-east-1");
+    }
+
+    @Test
+    public void getResourceName_returnsResourceName() {
+        assertThat(ArnHelper.getResourceNameFromArn("arn:aws:rds:us-east-1:1234567890:snapshot:mysnapshot")).isEqualTo("mysnapshot");
+    }
+}

--- a/aws-rds-dbcluster/aws-rds-dbcluster.json
+++ b/aws-rds-dbcluster/aws-rds-dbcluster.json
@@ -496,6 +496,7 @@
         "rds:ModifyDBCluster",
         "rds:RestoreDBClusterFromSnapshot",
         "rds:RestoreDBClusterToPointInTime",
+        "rds:DescribeDBClusterSnapshots",
         "secretsmanager:CreateSecret",
         "secretsmanager:TagResource"
       ],

--- a/aws-rds-dbcluster/resource-role.yaml
+++ b/aws-rds-dbcluster/resource-role.yaml
@@ -40,6 +40,7 @@ Resources:
                 - "rds:CreateDBInstance"
                 - "rds:DeleteDBCluster"
                 - "rds:DeleteDBInstance"
+                - "rds:DescribeDBClusterSnapshots"
                 - "rds:DescribeDBClusters"
                 - "rds:DescribeDBSubnetGroups"
                 - "rds:DescribeEvents"

--- a/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/CallbackContext.java
+++ b/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/CallbackContext.java
@@ -5,6 +5,7 @@ import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
 
+import software.amazon.awssdk.services.rds.model.ClusterScalabilityType;
 import software.amazon.cloudformation.proxy.StdCallbackContext;
 import software.amazon.rds.common.handler.ProbingContext;
 import software.amazon.rds.common.handler.TaggingContext;
@@ -18,6 +19,7 @@ public class CallbackContext extends StdCallbackContext implements TaggingContex
     private boolean modified;
     private boolean rebooted;
     private boolean deleting;
+    private ClusterScalabilityType clusterScalabilityType;
 
     private Map<String, Long> timestamps;
     private Map<String, Double> timeDelta;

--- a/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/CreateHandler.java
+++ b/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/CreateHandler.java
@@ -8,8 +8,15 @@ import org.apache.commons.lang3.BooleanUtils;
 import com.amazonaws.util.StringUtils;
 import software.amazon.awssdk.services.ec2.Ec2Client;
 import software.amazon.awssdk.services.rds.RdsClient;
+import software.amazon.awssdk.services.rds.model.ClusterScalabilityType;
+import software.amazon.awssdk.services.rds.model.DBCluster;
+import software.amazon.awssdk.services.rds.model.DBClusterSnapshot;
+import software.amazon.awssdk.services.rds.model.ModifyDbClusterRequest;
+import software.amazon.awssdk.services.rds.model.RestoreDbClusterFromSnapshotRequest;
+import software.amazon.awssdk.services.rds.model.RestoreDbClusterToPointInTimeRequest;
 import software.amazon.awssdk.services.rds.model.SourceType;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
+import software.amazon.cloudformation.proxy.CallChain;
 import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
@@ -21,8 +28,13 @@ import software.amazon.rds.common.request.RequestValidationException;
 import software.amazon.rds.common.request.ValidatedRequest;
 import software.amazon.rds.common.request.Validations;
 import software.amazon.rds.common.util.IdentifierFactory;
+import software.amazon.rds.dbcluster.util.ResourceModelHelper;
+import software.amazon.rds.dbcluster.validators.ClusterScalabilityTypeValidator;
 
 public class CreateHandler extends BaseHandlerStd {
+
+    public final static String LIMITLESS_ENGINE_VERSION_SUFFIX = "limitless";
+    public final static String ENGINE_VERSION_SEPERATOR = "-";
 
     private static final IdentifierFactory dbClusterIdentifierFactory = new IdentifierFactory(
             STACK_NAME,
@@ -44,6 +56,7 @@ public class CreateHandler extends BaseHandlerStd {
     protected void validateRequest(final ResourceHandlerRequest<ResourceModel> request) throws RequestValidationException {
         super.validateRequest(request);
         Validations.validateTimestamp(request.getDesiredResourceState().getRestoreToTime());
+        ClusterScalabilityTypeValidator.validateRequest(request.getDesiredResourceState());
     }
 
     @Override
@@ -70,11 +83,20 @@ public class CreateHandler extends BaseHandlerStd {
                 .resourceTags(new HashSet<>(Translator.translateTagsToSdk(request.getDesiredResourceState().getTags())))
                 .build();
 
+        if(ResourceModelHelper.isRestoreFromSnapshot(model)) {
+            ClusterScalabilityType clusterScalabilityType = getClusterScalabilityTypeFromSnapshot(rdsProxyClient, model);
+            callbackContext.setClusterScalabilityType(clusterScalabilityType);
+        }
+        if(ResourceModelHelper.isRestoreToPointInTime(model)) {
+            ClusterScalabilityType clusterScalabilityType = getClusterScalabilityTypeFromSourceDBCluster(extractAwsAccountId(request), rdsProxyClient, model);
+            callbackContext.setClusterScalabilityType(clusterScalabilityType);
+        }
+
         return ProgressEvent.progress(model, callbackContext)
                 .then(progress -> {
-                    if (isRestoreToPointInTime(model)) {
-                        return Tagging.createWithTaggingFallback(proxy, rdsProxyClient, this::restoreDbClusterToPointInTime, progress, allTags);
-                    } else if (isRestoreFromSnapshot(model)) {
+                    if (ResourceModelHelper.isRestoreToPointInTime(model)) {
+                      return Tagging.createWithTaggingFallback(proxy, rdsProxyClient, this::restoreDbClusterToPointInTime, progress, allTags);
+                    } else if (ResourceModelHelper.isRestoreFromSnapshot(model)) {
                         return Tagging.createWithTaggingFallback(proxy, rdsProxyClient, this::restoreDbClusterFromSnapshot, progress, allTags);
                     }
                     return Tagging.createWithTaggingFallback(proxy, rdsProxyClient, this::createDbCluster, progress, allTags);
@@ -87,14 +109,14 @@ public class CreateHandler extends BaseHandlerStd {
                     return updateTags(proxy, rdsProxyClient, progress, Tagging.TagSet.emptySet(), extraTags);
                 }, CallbackContext::isAddTagsComplete, CallbackContext::setAddTagsComplete))
                 .then(progress -> {
-                    if (shouldUpdateAfterCreate(progress.getResourceModel())) {
+                    if (ResourceModelHelper.shouldUpdateAfterCreate(progress.getResourceModel())) {
                         return Commons.execOnce(
                                 progress,
                                 () -> {
                                     progress.getCallbackContext().timestampOnce(RESOURCE_UPDATED_AT, Instant.now());
                                     return modifyDBCluster(proxy, rdsProxyClient, progress)
                                             .then(p -> {
-                                                if (shouldEnableHttpEndpointV2AfterCreate(progress.getResourceModel())) {
+                                                if (ResourceModelHelper.shouldEnableHttpEndpointV2AfterCreate(progress.getResourceModel())) {
                                                     return enableHttpEndpointV2(proxy, rdsProxyClient, progress);
                                                 }
                                                 return p;
@@ -159,9 +181,14 @@ public class CreateHandler extends BaseHandlerStd {
             final ProgressEvent<ResourceModel, CallbackContext> progress,
             final Tagging.TagSet tagSet
     ) {
-        return proxy.initiate("rds::restore-dbcluster-to-point-in-time", proxyClient, progress.getResourceModel(), progress.getCallbackContext())
-                .translateToServiceRequest(model -> Translator.restoreDbClusterToPointInTimeRequest(model, tagSet))
-                .backoffDelay(config.getBackoff())
+        CallChain.RequestMaker<RdsClient, ResourceModel, CallbackContext> requestMaker = proxy.initiate("rds::restore-dbcluster-to-point-in-time", proxyClient, progress.getResourceModel(), progress.getCallbackContext());
+        CallChain.Caller<RestoreDbClusterToPointInTimeRequest, RdsClient, ResourceModel, CallbackContext> caller = null;
+        if(progress.getCallbackContext().getClusterScalabilityType().equals(ClusterScalabilityType.LIMITLESS)) {
+            caller = requestMaker.translateToServiceRequest(model -> Translator.restoreLimitlessDbClusterToPointInTimeRequest(model, tagSet));
+        } else {
+            caller = requestMaker.translateToServiceRequest(model -> Translator.restoreDbClusterToPointInTimeRequest(model, tagSet));
+        }
+        return caller.backoffDelay(config.getBackoff())
                 .makeServiceCall((dbClusterRequest, proxyInvocation) -> proxyInvocation.injectCredentialsAndInvokeV2(
                         dbClusterRequest,
                         proxyInvocation.client()::restoreDBClusterToPointInTime
@@ -184,9 +211,15 @@ public class CreateHandler extends BaseHandlerStd {
             final ProgressEvent<ResourceModel, CallbackContext> progress,
             final Tagging.TagSet tagSet
     ) {
-        return proxy.initiate("rds::restore-dbcluster-from-snapshot", proxyClient, progress.getResourceModel(), progress.getCallbackContext())
-                .translateToServiceRequest(model -> Translator.restoreDbClusterFromSnapshotRequest(model, tagSet))
-                .backoffDelay(config.getBackoff())
+        CallChain.RequestMaker<RdsClient, ResourceModel ,CallbackContext> requestMaker = proxy.initiate("rds::restore-dbcluster-from-snapshot", proxyClient, progress.getResourceModel(), progress.getCallbackContext());
+        CallChain.Caller<RestoreDbClusterFromSnapshotRequest, RdsClient, ResourceModel, CallbackContext> caller = null;
+        if(progress.getCallbackContext().getClusterScalabilityType().equals(ClusterScalabilityType.LIMITLESS)) {
+            caller = requestMaker.translateToServiceRequest(model -> Translator.restoreLimitlessDbClusterFromSnapshotRequest(model, tagSet));
+        } else {
+            caller = requestMaker.translateToServiceRequest(model -> Translator.restoreDbClusterFromSnapshotRequest(model, tagSet));
+        }
+
+        return caller.backoffDelay(config.getBackoff())
                 .makeServiceCall((dbClusterRequest, proxyInvocation) -> proxyInvocation.injectCredentialsAndInvokeV2(
                         dbClusterRequest,
                         proxyInvocation.client()::restoreDBClusterFromSnapshot
@@ -208,9 +241,18 @@ public class CreateHandler extends BaseHandlerStd {
             final ProxyClient<RdsClient> proxyClient,
             final ProgressEvent<ResourceModel, CallbackContext> progress
     ) {
-        return proxy.initiate("rds::modify-dbcluster", proxyClient, progress.getResourceModel(), progress.getCallbackContext())
-                .translateToServiceRequest(Translator::modifyDbClusterAfterCreateRequest)
-                .backoffDelay(config.getBackoff())
+        ClusterScalabilityType clusterScalabilityType = progress.getCallbackContext().getClusterScalabilityType();
+        CallChain.RequestMaker<RdsClient, ResourceModel, CallbackContext> callContext = proxy.initiate("rds::modify-dbcluster", proxyClient, progress.getResourceModel(), progress.getCallbackContext());
+        CallChain.Caller<ModifyDbClusterRequest, RdsClient, ResourceModel, CallbackContext> caller = null;
+
+        if (clusterScalabilityType.equals(ClusterScalabilityType.LIMITLESS)) {
+            caller = callContext.translateToServiceRequest(Translator::modifyLimitlessDbClusterAfterCreateRequest);
+        }
+        else {
+            caller = callContext.translateToServiceRequest(Translator::modifyDbClusterAfterCreateRequest);
+        }
+
+        return caller.backoffDelay(config.getBackoff())
                 .makeServiceCall((dbClusterModifyRequest, proxyInvocation) -> proxyInvocation.injectCredentialsAndInvokeV2(
                         dbClusterModifyRequest,
                         proxyInvocation.client()::modifyDBCluster
@@ -227,19 +269,32 @@ public class CreateHandler extends BaseHandlerStd {
                 .progress();
     }
 
-    private boolean isRestoreToPointInTime(final ResourceModel model) {
-        return StringUtils.hasValue(model.getSourceDBClusterIdentifier());
+    private String extractAwsAccountId(ValidatedRequest<ResourceModel> request) {
+        if (request != null && StringUtils.hasValue(request.getAwsAccountId())) {
+            return request.getAwsAccountId();
+        }
+        return null;
     }
 
-    private boolean isRestoreFromSnapshot(final ResourceModel model) {
-        return StringUtils.hasValue(model.getSnapshotIdentifier());
+
+    protected ClusterScalabilityType getClusterScalabilityTypeFromSnapshot(final ProxyClient<RdsClient> rdsProxyClient, final ResourceModel resourceModel) {
+        DBClusterSnapshot snapshot = fetchDBClusterSnapshot(rdsProxyClient, resourceModel);
+        String snapshotEngineVersion = snapshot.engineVersion();
+
+        if (StringUtils.isNullOrEmpty(snapshotEngineVersion)) {
+            return ClusterScalabilityType.STANDARD;
+        }
+        // we are using the engine version suffix until clusterScalabilityType is returned as part of describe snapshot API - https://jira.rds.a2z.com/browse/KER-23223
+        String[] snapshotEngineVersionParts = snapshotEngineVersion.split(ENGINE_VERSION_SEPERATOR);
+        if(snapshotEngineVersionParts.length > 1 && snapshotEngineVersionParts[1].equals(LIMITLESS_ENGINE_VERSION_SUFFIX)) {
+            return ClusterScalabilityType.LIMITLESS;
+        }
+
+        return ClusterScalabilityType.STANDARD;
     }
 
-    private boolean shouldUpdateAfterCreate(final ResourceModel model) {
-        return isRestoreFromSnapshot(model) || isRestoreToPointInTime(model);
-    }
-
-    private boolean shouldEnableHttpEndpointV2AfterCreate(final ResourceModel model) {
-        return BooleanUtils.isTrue(model.getEnableHttpEndpoint()) && !EngineMode.Serverless.equals(EngineMode.fromString(model.getEngineMode()))  ;
+    protected ClusterScalabilityType getClusterScalabilityTypeFromSourceDBCluster(final String AwsAccountId, final ProxyClient<RdsClient> rdsProxyClient, final ResourceModel resourceModel) {
+        DBCluster cluster = fetchSourceDBCluster(AwsAccountId, rdsProxyClient, resourceModel);
+        return cluster.clusterScalabilityType() != null ? cluster.clusterScalabilityType() : ClusterScalabilityType.STANDARD;
     }
 }

--- a/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/util/ResourceModelHelper.java
+++ b/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/util/ResourceModelHelper.java
@@ -1,0 +1,25 @@
+package software.amazon.rds.dbcluster.util;
+
+import com.amazonaws.util.StringUtils;
+import org.apache.commons.lang3.BooleanUtils;
+import software.amazon.rds.dbcluster.EngineMode;
+import software.amazon.rds.dbcluster.ResourceModel;
+
+public class ResourceModelHelper {
+
+    public static boolean isRestoreToPointInTime(final ResourceModel model) {
+        return StringUtils.hasValue(model.getSourceDBClusterIdentifier());
+    }
+
+    public static boolean isRestoreFromSnapshot(final ResourceModel model) {
+        return StringUtils.hasValue(model.getSnapshotIdentifier());
+    }
+
+    public static boolean shouldUpdateAfterCreate(final ResourceModel model) {
+        return isRestoreFromSnapshot(model) || isRestoreToPointInTime(model);
+    }
+
+    public static boolean shouldEnableHttpEndpointV2AfterCreate(final ResourceModel model) {
+        return BooleanUtils.isTrue(model.getEnableHttpEndpoint()) && !EngineMode.Serverless.equals(EngineMode.fromString(model.getEngineMode()));
+    }
+}

--- a/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/validators/ClusterScalabilityTypeValidator.java
+++ b/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/validators/ClusterScalabilityTypeValidator.java
@@ -1,0 +1,18 @@
+package software.amazon.rds.dbcluster.validators;
+
+import software.amazon.rds.common.request.RequestValidationException;
+import software.amazon.rds.dbcluster.ResourceModel;
+import software.amazon.rds.dbcluster.util.ResourceModelHelper;
+
+public class ClusterScalabilityTypeValidator {
+    public static void validateRequest(final ResourceModel model) throws RequestValidationException {
+        if (ResourceModelHelper.isRestoreToPointInTime(model) && model.getClusterScalabilityType() != null) {
+            throw new RequestValidationException("The ClusterScalabilityType parameter is not allowed when creating a cluster from a point-in-time restore. This value is automatically inherited from the source DB cluster.");
+        }
+
+        if (ResourceModelHelper.isRestoreFromSnapshot(model) && model.getClusterScalabilityType() != null) {
+            throw new RequestValidationException("The ClusterScalabilityType parameter is not allowed when creating a DB cluster from a snapshot restore. This value is automatically inherited from the snapshot.");
+        }
+
+    }
+}

--- a/aws-rds-dbcluster/src/test/java/software/amazon/rds/dbcluster/AbstractHandlerTest.java
+++ b/aws-rds-dbcluster/src/test/java/software/amazon/rds/dbcluster/AbstractHandlerTest.java
@@ -67,6 +67,7 @@ public abstract class AbstractHandlerTest extends AbstractTestBase<DBCluster, Re
     protected static final String DOMAIN_NON_EMPTY;
     protected static final String DOMAIN_IAM_ROLE_NAME_NON_EMPTY;
     protected static final String SNAPSHOT_IDENTIFIER;
+    protected static final String INSTANCE_SNAPSHOT_IDENTIFIER;
     protected static final String SOURCE_IDENTIFIER;
     protected static final String ENGINE;
     protected static final String ENGINE_AURORA_POSTGRESQL;
@@ -93,6 +94,7 @@ public abstract class AbstractHandlerTest extends AbstractTestBase<DBCluster, Re
     protected static final ResourceModel RESOURCE_MODEL_EMPTY_VPC;
     protected static final ResourceModel RESOURCE_MODEL_ON_RESTORE;
     protected static final ResourceModel RESOURCE_MODEL_ON_RESTORE_WITH_PIEM;
+    protected static final ResourceModel RESOURCE_MODEL_ON_RESTORE_SNAPSHOT_WITH_PIEM;
     protected static final ResourceModel RESOURCE_MODEL_ON_RESTORE_IN_TIME;
     protected static final ResourceModel RESOURCE_MODEL_ON_RESTORE_IN_TIME_WITH_PIEM;
     protected static final ResourceModel RESOURCE_MODEL_WITH_GLOBAL_CLUSTER;
@@ -137,6 +139,7 @@ public abstract class AbstractHandlerTest extends AbstractTestBase<DBCluster, Re
         DOMAIN_NON_EMPTY = "domain-name";
         DOMAIN_IAM_ROLE_NAME_NON_EMPTY = "domain-iam-role-name";
         SNAPSHOT_IDENTIFIER = "my-sample-dbcluster-snapshot";
+        INSTANCE_SNAPSHOT_IDENTIFIER = "arn:aws:rds:us-east-1:123456789012:snapshot:my-db-snapshot";
         SOURCE_IDENTIFIER = "my-source-dbcluster-identifier";
         ENGINE = "aurora";
         ENGINE_AURORA_POSTGRESQL = "aurora-postgresql";
@@ -235,6 +238,22 @@ public abstract class AbstractHandlerTest extends AbstractTestBase<DBCluster, Re
                 .performanceInsightsRetentionPeriod(PERFORMANCE_INSIGHTS_RETENTION_PERIOD)
                 .performanceInsightsKmsKeyId(PERFORMANCE_INSIGHTS_KMS_KEY_ID)
                 .build();
+
+        RESOURCE_MODEL_ON_RESTORE_SNAPSHOT_WITH_PIEM = ResourceModel.builder()
+            .dBClusterIdentifier(DBCLUSTER_IDENTIFIER)
+            .dBClusterParameterGroupName(DBCLUSTER_PARAMETER_GROUP_NAME)
+            .snapshotIdentifier(INSTANCE_SNAPSHOT_IDENTIFIER)
+            .engineMode(ENGINE_MODE)
+            .masterUsername(USER_NAME)
+            .masterUserPassword(USER_PASSWORD)
+            .scalingConfiguration(SCALING_CONFIGURATION)
+            .vpcSecurityGroupIds(VPC_SG_IDS)
+            .monitoringRoleArn(ROLE_ARN)
+            .monitoringInterval(MONITORING_INTERVAL)
+            .performanceInsightsEnabled(ENABLE_PERFORMANCE_INSIGHTS)
+            .performanceInsightsRetentionPeriod(PERFORMANCE_INSIGHTS_RETENTION_PERIOD)
+            .performanceInsightsKmsKeyId(PERFORMANCE_INSIGHTS_KMS_KEY_ID)
+            .build();
 
         RESOURCE_MODEL_ON_RESTORE_IN_TIME = ResourceModel.builder()
                 .dBClusterIdentifier(null)

--- a/aws-rds-dbcluster/src/test/java/software/amazon/rds/dbcluster/TranslatorTest.java
+++ b/aws-rds-dbcluster/src/test/java/software/amazon/rds/dbcluster/TranslatorTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Test;
 import com.google.common.collect.ImmutableList;
 import software.amazon.awssdk.services.ec2.Ec2Client;
 import software.amazon.awssdk.services.rds.RdsClient;
+import software.amazon.awssdk.services.rds.model.ClusterScalabilityType;
 import software.amazon.awssdk.services.rds.model.CreateDbClusterRequest;
 import software.amazon.awssdk.services.rds.model.DBCluster;
 import software.amazon.awssdk.services.rds.model.DomainMembership;
@@ -30,6 +31,11 @@ public class TranslatorTest extends AbstractHandlerTest {
     private final static String STORAGE_TYPE_GP3 = "gp3";
     private final static boolean IS_NOT_ROLLBACK = false;
     private final static boolean IS_ROLLBACK = true;
+    private final static String MONITORING_ROLE_ARN = "arn:aws:iam::999999999999:role/emaaccess";
+    private final static int MONITORING_INTERVAL = 30;
+    private final static boolean ENABLE_PERFORMANCE_INSIGHTS= true;
+    private final static int PERFORMANCE_INSIGHTS_RETENTION_PERIOD = 31;
+    private final static String PERFORMANCE_INSIGHTS_KMS_KEY_ID = "arn:aws:kms:999999999999:key/key";
 
 
     @Test
@@ -87,6 +93,44 @@ public class TranslatorTest extends AbstractHandlerTest {
         final RestoreDbClusterToPointInTimeRequest request = Translator.restoreDbClusterToPointInTimeRequest(model, Tagging.TagSet.emptySet());
         assertThat(request.storageType()).isEqualTo(STORAGE_TYPE_GP3);
         assertThat(request.iops()).isEqualTo(100);
+    }
+
+    @Test
+    public void restoreDbClusterToPointInTimeRequest_validatePiEmParams_StandardPath() {
+        final ResourceModel model = ResourceModel.builder()
+                .monitoringRoleArn(MONITORING_ROLE_ARN)
+                .monitoringInterval(MONITORING_INTERVAL)
+                .performanceInsightsEnabled(ENABLE_PERFORMANCE_INSIGHTS)
+                .performanceInsightsRetentionPeriod(PERFORMANCE_INSIGHTS_RETENTION_PERIOD)
+                .performanceInsightsKmsKeyId(PERFORMANCE_INSIGHTS_KMS_KEY_ID)
+                .clusterScalabilityType(ClusterScalabilityType.STANDARD.toString())
+                .build();
+
+        final RestoreDbClusterToPointInTimeRequest request = Translator.restoreDbClusterToPointInTimeRequest(model, Tagging.TagSet.emptySet());
+        assertThat(request.monitoringRoleArn()).isNull();
+        assertThat(request.monitoringInterval()).isNull();
+        assertThat(request.enablePerformanceInsights()).isNull();
+        assertThat(request.performanceInsightsRetentionPeriod()).isNull();
+        assertThat(request.performanceInsightsKMSKeyId()).isNull();
+    }
+
+    @Test
+    public void restoreDbClusterToPointInTimeRequest_validatePiEmParams_LimitlessPath() {
+        final ResourceModel model = ResourceModel.builder()
+            .monitoringRoleArn(MONITORING_ROLE_ARN)
+            .monitoringInterval(MONITORING_INTERVAL)
+            .performanceInsightsEnabled(ENABLE_PERFORMANCE_INSIGHTS)
+            .performanceInsightsRetentionPeriod(PERFORMANCE_INSIGHTS_RETENTION_PERIOD)
+            .performanceInsightsKmsKeyId(PERFORMANCE_INSIGHTS_KMS_KEY_ID)
+            .clusterScalabilityType(ClusterScalabilityType.LIMITLESS.toString())
+            .build();
+
+        final RestoreDbClusterToPointInTimeRequest request = Translator.restoreLimitlessDbClusterToPointInTimeRequest(model, Tagging.TagSet.emptySet());
+        assertThat(request.monitoringRoleArn()).isEqualTo(MONITORING_ROLE_ARN);
+        assertThat(request.monitoringInterval()).isEqualTo(MONITORING_INTERVAL);
+        assertThat(request.enablePerformanceInsights()).isEqualTo(ENABLE_PERFORMANCE_INSIGHTS);
+        assertThat(request.performanceInsightsRetentionPeriod()).isEqualTo(PERFORMANCE_INSIGHTS_RETENTION_PERIOD);
+        assertThat(request.performanceInsightsKMSKeyId()).isEqualTo(PERFORMANCE_INSIGHTS_KMS_KEY_ID);
     }
 
     @Test
@@ -592,6 +636,44 @@ public class TranslatorTest extends AbstractHandlerTest {
 
         final ModifyDbClusterRequest modifyRequest = Translator.modifyDbClusterAfterCreateRequest(model);
         assertThat(modifyRequest.serverlessV2ScalingConfiguration()).isNull();
+    }
+
+    @Test
+    public void restoreDbClusterFromSnapshot_validatePiEmParams_LimitlessPath() {
+        final ResourceModel model = ResourceModel.builder()
+                .monitoringRoleArn(MONITORING_ROLE_ARN)
+                .monitoringInterval(MONITORING_INTERVAL)
+                .performanceInsightsEnabled(ENABLE_PERFORMANCE_INSIGHTS)
+                .performanceInsightsRetentionPeriod(PERFORMANCE_INSIGHTS_RETENTION_PERIOD)
+                .performanceInsightsKmsKeyId(PERFORMANCE_INSIGHTS_KMS_KEY_ID)
+                .clusterScalabilityType(ClusterScalabilityType.LIMITLESS.toString())
+                .build();
+
+        final RestoreDbClusterFromSnapshotRequest request = Translator.restoreLimitlessDbClusterFromSnapshotRequest(model, Tagging.TagSet.emptySet());
+        assertThat(request.monitoringRoleArn()).isEqualTo(MONITORING_ROLE_ARN);
+        assertThat(request.monitoringInterval()).isEqualTo(MONITORING_INTERVAL);
+        assertThat(request.enablePerformanceInsights()).isEqualTo(ENABLE_PERFORMANCE_INSIGHTS);
+        assertThat(request.performanceInsightsRetentionPeriod()).isEqualTo(PERFORMANCE_INSIGHTS_RETENTION_PERIOD);
+        assertThat(request.performanceInsightsKMSKeyId()).isEqualTo(PERFORMANCE_INSIGHTS_KMS_KEY_ID);
+    }
+
+    @Test
+    public void restoreDbClusterFromSnapshot_validatePiEmParams_StandardPath() {
+        final ResourceModel model = ResourceModel.builder()
+            .monitoringRoleArn(MONITORING_ROLE_ARN)
+            .monitoringInterval(MONITORING_INTERVAL)
+            .performanceInsightsEnabled(ENABLE_PERFORMANCE_INSIGHTS)
+            .performanceInsightsRetentionPeriod(PERFORMANCE_INSIGHTS_RETENTION_PERIOD)
+            .performanceInsightsKmsKeyId(PERFORMANCE_INSIGHTS_KMS_KEY_ID)
+            .clusterScalabilityType(ClusterScalabilityType.STANDARD.toString())
+            .build();
+
+        final RestoreDbClusterFromSnapshotRequest request = Translator.restoreDbClusterFromSnapshotRequest(model, Tagging.TagSet.emptySet());
+        assertThat(request.monitoringRoleArn()).isNull();
+        assertThat(request.monitoringInterval()).isNull();
+        assertThat(request.enablePerformanceInsights()).isNull();
+        assertThat(request.performanceInsightsRetentionPeriod()).isNull();
+        assertThat(request.performanceInsightsKMSKeyId()).isNull();
     }
 
     @Test

--- a/aws-rds-dbcluster/src/test/java/software/amazon/rds/dbcluster/util/ResourceModelHelperTest.java
+++ b/aws-rds-dbcluster/src/test/java/software/amazon/rds/dbcluster/util/ResourceModelHelperTest.java
@@ -1,0 +1,100 @@
+package software.amazon.rds.dbcluster.util;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import software.amazon.rds.dbcluster.EngineMode;
+import software.amazon.rds.dbcluster.ResourceModel;
+
+public class ResourceModelHelperTest {
+
+    private ResourceModel model;
+
+    @BeforeEach
+    void setUp() {
+        model = new ResourceModel();
+    }
+
+    @Test
+    void isRestoreToPointInTime_withSourceDBClusterIdentifier_returnsTrue() {
+        model.setSourceDBClusterIdentifier("source-cluster-id");
+        Assertions.assertTrue(ResourceModelHelper.isRestoreToPointInTime(model));
+    }
+
+    @Test
+    void isRestoreToPointInTime_withNullSourceDBClusterIdentifier_returnsFalse() {
+        model.setSourceDBClusterIdentifier(null);
+        Assertions.assertFalse(ResourceModelHelper.isRestoreToPointInTime(model));
+    }
+
+    @Test
+    void isRestoreToPointInTime_withEmptySourceDBClusterIdentifier_returnsFalse() {
+        model.setSourceDBClusterIdentifier("");
+        Assertions.assertFalse(ResourceModelHelper.isRestoreToPointInTime(model));
+    }
+
+    @Test
+    void isRestoreFromSnapshot_withSnapshotIdentifier_returnsTrue() {
+        model.setSnapshotIdentifier("snapshot-id");
+        Assertions.assertTrue(ResourceModelHelper.isRestoreFromSnapshot(model));
+    }
+
+    @Test
+    void isRestoreFromSnapshot_withNullSnapshotIdentifier_returnsFalse() {
+        model.setSnapshotIdentifier(null);
+        Assertions.assertFalse(ResourceModelHelper.isRestoreFromSnapshot(model));
+    }
+
+    @Test
+    void isRestoreFromSnapshot_withEmptySnapshotIdentifier_returnsFalse() {
+        model.setSnapshotIdentifier("");
+        Assertions.assertFalse(ResourceModelHelper.isRestoreFromSnapshot(model));
+    }
+
+    @Test
+    void shouldUpdateAfterCreate_withSnapshotRestore_returnsTrue() {
+        model.setSnapshotIdentifier("snapshot-id");
+        Assertions.assertTrue(ResourceModelHelper.shouldUpdateAfterCreate(model));
+    }
+
+    @Test
+    void shouldUpdateAfterCreate_withPointInTimeRestore_returnsTrue() {
+        model.setSourceDBClusterIdentifier("source-cluster-id");
+        Assertions.assertTrue(ResourceModelHelper.shouldUpdateAfterCreate(model));
+    }
+
+    @Test
+    void shouldUpdateAfterCreate_withNoRestore_returnsFalse() {
+        model.setSnapshotIdentifier(null);
+        model.setSourceDBClusterIdentifier(null);
+        Assertions.assertFalse(ResourceModelHelper.shouldUpdateAfterCreate(model));
+    }
+
+    @Test
+    void shouldEnableHttpEndpointV2AfterCreate_withEnabledHttpAndNotServerless_returnsTrue() {
+        model.setEnableHttpEndpoint(true);
+        model.setEngineMode(EngineMode.Provisioned.toString());
+        Assertions.assertTrue(ResourceModelHelper.shouldEnableHttpEndpointV2AfterCreate(model));
+    }
+
+    @Test
+    void shouldEnableHttpEndpointV2AfterCreate_withDisabledHttp_returnsFalse() {
+        model.setEnableHttpEndpoint(false);
+        model.setEngineMode(EngineMode.Provisioned.toString());
+        Assertions.assertFalse(ResourceModelHelper.shouldEnableHttpEndpointV2AfterCreate(model));
+    }
+
+    @Test
+    void shouldEnableHttpEndpointV2AfterCreate_withNullHttpEndpoint_returnsFalse() {
+        model.setEnableHttpEndpoint(null);
+        model.setEngineMode(EngineMode.Provisioned.toString());
+        Assertions.assertFalse(ResourceModelHelper.shouldEnableHttpEndpointV2AfterCreate(model));
+    }
+
+    @Test
+    void shouldEnableHttpEndpointV2AfterCreate_withServerlessEngineMode_returnsFalse() {
+        model.setEnableHttpEndpoint(true);
+        model.setEngineMode(EngineMode.Serverless.toString());
+        Assertions.assertFalse(ResourceModelHelper.shouldEnableHttpEndpointV2AfterCreate(model));
+    }
+}

--- a/aws-rds-dbcluster/src/test/java/software/amazon/rds/dbcluster/validators/ClusterScalabilityTypeValidatorTest.java
+++ b/aws-rds-dbcluster/src/test/java/software/amazon/rds/dbcluster/validators/ClusterScalabilityTypeValidatorTest.java
@@ -1,0 +1,71 @@
+package software.amazon.rds.dbcluster.validators;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import software.amazon.rds.common.request.RequestValidationException;
+import software.amazon.rds.dbcluster.ResourceModel;
+
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class ClusterScalabilityTypeValidatorTest {
+
+    private ResourceModel model;
+
+    @BeforeEach
+    void setUp() {
+        model = new ResourceModel();
+    }
+
+    @Test
+    void validateRequest_withPointInTimeRestoreAndScalabilityType_throwsException() {
+        model.setSourceDBClusterIdentifier("source-cluster-id");
+        model.setClusterScalabilityType("STANDARD");
+
+        assertThatThrownBy(() -> ClusterScalabilityTypeValidator.validateRequest(model))
+            .isInstanceOf(RequestValidationException.class);
+        }
+
+    @Test
+    void validateRequest_withPointInTimeRestoreAndNoScalabilityType_doesNotThrow() {
+        model.setSourceDBClusterIdentifier("source-cluster-id");
+        model.setClusterScalabilityType(null);
+
+        assertThatNoException().isThrownBy(() -> ClusterScalabilityTypeValidator.validateRequest(model));
+    }
+
+    @Test
+    void validateRequest_withSnapshotRestoreAndScalabilityType_throwsException() {
+        model.setSnapshotIdentifier("snapshot-id");
+        model.setClusterScalabilityType("STANDARD");
+
+        assertThatThrownBy(() -> ClusterScalabilityTypeValidator.validateRequest(model))
+            .isInstanceOf(RequestValidationException.class);
+    }
+
+    @Test
+    void validateRequest_withSnapshotRestoreAndNoScalabilityType_doesNotThrow() {
+        model.setSnapshotIdentifier("snapshot-id");
+        model.setClusterScalabilityType(null);
+
+        assertThatNoException().isThrownBy(() -> ClusterScalabilityTypeValidator.validateRequest(model));
+    }
+
+    @Test
+    void validateRequest_withNoRestoreAndScalabilityType_doesNotThrow() {
+        model.setSourceDBClusterIdentifier(null);
+        model.setSnapshotIdentifier(null);
+        model.setClusterScalabilityType("STANDARD");
+
+        assertThatNoException().isThrownBy(() -> ClusterScalabilityTypeValidator.validateRequest(model));
+    }
+
+    @Test
+    void validateRequest_withNoRestoreAndNoScalabilityType_doesNotThrow() {
+        model.setSourceDBClusterIdentifier(null);
+        model.setSnapshotIdentifier(null);
+        model.setClusterScalabilityType(null);
+
+        assertThatNoException().isThrownBy(() -> ClusterScalabilityTypeValidator.validateRequest(model));
+    }
+}

--- a/aws-rds-dbshardgroup/src/main/java/software/amazon/rds/dbshardgroup/DeleteHandler.java
+++ b/aws-rds-dbshardgroup/src/main/java/software/amazon/rds/dbshardgroup/DeleteHandler.java
@@ -123,7 +123,6 @@ public class DeleteHandler extends BaseHandlerStd {
 
             if (CollectionUtils.isEmpty(dbClusters)) {
                 // For an empty response, we assume the same behavior for a DbClusterNotFoundException
-                // https://jira.rds.a2z.com/browse/WS-6673
                 return true;
             } else {
                 return isDBClusterAvailable(dbClusters.get(0));


### PR DESCRIPTION
Description of changes:

Add New Parameters onto restore-db-cluster-from-snapshot And restore-db-cluster-to-point-in-time in order to support restore for Limitless Clusters.

GetClusterScalabilityTypeFromSnapshot returns default when instance snapshot is provided and when AccessException is thrown

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.