### PR TITLE
[DBCluster][DBInstance] never reset to default VPC when both previous and desired security group is null

### DIFF
--- a/aws-rds-cfn-common/src/main/java/software/amazon/rds/common/handler/Vpc.java
+++ b/aws-rds-cfn-common/src/main/java/software/amazon/rds/common/handler/Vpc.java
@@ -1,0 +1,28 @@
+package software.amazon.rds.common.handler;
+
+import com.amazonaws.util.CollectionUtils;
+
+import java.util.List;
+
+public final class Vpc {
+
+    public Vpc() {
+    }
+
+    /**
+     * Is very important that we never reset to default VPC when both previous and desired security group is null,
+     * or we would be potentially doing a modification that is not clearly intended from the model.
+     */
+    public static boolean shouldSetDefaultVpcId(
+        final List<String> previousResourceStateVPCSecurityGroups,
+        final List<String> desiredResourceStateVPCSecurityGroups
+    ) {
+        if (!CollectionUtils.isNullOrEmpty(previousResourceStateVPCSecurityGroups) && CollectionUtils.isNullOrEmpty(desiredResourceStateVPCSecurityGroups)) {
+            // The only condition when we should update the default VPC is when the model is unsetting the securityGroup, and never in any other condition.
+            // For example, when a customer import an existing resource (DBInstance or DBCluster), we should never change the VPC security groups regardless
+            // of what the model says, because is not intuitive from the model definition that we are changing to a default VPC
+            return true;
+        }
+        return false;
+    }
+}

--- a/aws-rds-cfn-common/src/test/java/software/amazon/rds/common/handler/VpcTest.java
+++ b/aws-rds-cfn-common/src/test/java/software/amazon/rds/common/handler/VpcTest.java
@@ -1,0 +1,76 @@
+package software.amazon.rds.common.handler;
+
+import org.junit.jupiter.api.Test;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class VpcTest {
+
+
+    @Test
+    void shouldSetDefaultVpcId_previousNonEmpty_desiredNull_returnsTrue() {
+        List<String> previous = Arrays.asList("sg-123", "sg-456");
+        List<String> desired = null;
+        assertTrue(Vpc.shouldSetDefaultVpcId(previous, desired));
+    }
+
+    @Test
+    void shouldSetDefaultVpcId_previousNonEmpty_desiredEmpty_returnsTrue() {
+        List<String> previous = Arrays.asList("sg-123");
+        List<String> desired = Collections.emptyList();
+        assertTrue(Vpc.shouldSetDefaultVpcId(previous, desired));
+    }
+
+    @Test
+    void shouldSetDefaultVpcId_previousNull_desiredNull_returnsFalse() {
+        List<String> previous = null;
+        List<String> desired = null;
+        assertFalse(Vpc.shouldSetDefaultVpcId(previous, desired));
+    }
+
+    @Test
+    void shouldSetDefaultVpcId_previousEmpty_desiredNull_returnsFalse() {
+        List<String> previous = Collections.emptyList();
+        List<String> desired = null;
+        assertFalse(Vpc.shouldSetDefaultVpcId(previous, desired));
+    }
+
+    @Test
+    void shouldSetDefaultVpcId_previousNull_desiredEmpty_returnsFalse() {
+        List<String> previous = null;
+        List<String> desired = Collections.emptyList();
+        assertFalse(Vpc.shouldSetDefaultVpcId(previous, desired));
+    }
+
+    @Test
+    void shouldSetDefaultVpcId_previousEmpty_desiredEmpty_returnsFalse() {
+        List<String> previous = Collections.emptyList();
+        List<String> desired = Collections.emptyList();
+        assertFalse(Vpc.shouldSetDefaultVpcId(previous, desired));
+    }
+
+    @Test
+    void shouldSetDefaultVpcId_previousNonEmpty_desiredNonEmpty_returnsFalse() {
+        List<String> previous = Arrays.asList("sg-123");
+        List<String> desired = Arrays.asList("sg-789");
+        assertFalse(Vpc.shouldSetDefaultVpcId(previous, desired));
+    }
+
+    @Test
+    void shouldSetDefaultVpcId_previousNull_desiredNonEmpty_returnsFalse() {
+        List<String> previous = null;
+        List<String> desired = Arrays.asList("sg-789");
+        assertFalse(Vpc.shouldSetDefaultVpcId(previous, desired));
+    }
+
+    @Test
+    void shouldSetDefaultVpcId_previousEmpty_desiredNonEmpty_returnsFalse() {
+        List<String> previous = Collections.emptyList();
+        List<String> desired = Arrays.asList("sg-789");
+        assertFalse(Vpc.shouldSetDefaultVpcId(previous, desired));
+    }
+}

--- a/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/BaseHandlerStd.java
+++ b/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/BaseHandlerStd.java
@@ -87,6 +87,7 @@ import software.amazon.rds.common.handler.Commons;
 import software.amazon.rds.common.handler.Events;
 import software.amazon.rds.common.handler.HandlerConfig;
 import software.amazon.rds.common.handler.Tagging;
+import software.amazon.rds.common.handler.Vpc;
 import software.amazon.rds.common.logging.LoggingProxyClient;
 import software.amazon.rds.common.logging.RequestLogger;
 import software.amazon.rds.common.printer.FilteredJsonPrinter;
@@ -780,17 +781,7 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
 
     protected boolean shouldSetDefaultVpcSecurityGroupIds(final ResourceModel previousState,
                                                           final ResourceModel desiredState) {
-        if (previousState != null) {
-            final List<String> previousVpcIds = CollectionUtils.isEmpty(previousState.getVpcSecurityGroupIds()) ?
-                    Collections.emptyList() : previousState.getVpcSecurityGroupIds();
-            final List<String> desiredVpcIds = CollectionUtils.isEmpty(desiredState.getVpcSecurityGroupIds()) ?
-                    Collections.emptyList() : desiredState.getVpcSecurityGroupIds();
-
-            if (CollectionUtils.isEqualCollection(previousVpcIds, desiredVpcIds)) {
-                return false;
-            }
-        }
-        return CollectionUtils.isEmpty(desiredState.getVpcSecurityGroupIds());
+        return Vpc.shouldSetDefaultVpcId(previousState.getVpcSecurityGroupIds(), desiredState.getVpcSecurityGroupIds());
     }
 
     protected boolean shouldUpdateHttpEndpointV2(final ResourceModel previousState, final ResourceModel desiredState) {

--- a/aws-rds-dbcluster/src/test/java/software/amazon/rds/dbcluster/UpdateHandlerTest.java
+++ b/aws-rds-dbcluster/src/test/java/software/amazon/rds/dbcluster/UpdateHandlerTest.java
@@ -441,6 +441,87 @@ public class UpdateHandlerTest extends AbstractHandlerTest {
     }
 
     @Test
+    void handleRequest_WithUpdateToDefaultVPC2_previousNotNull_desiredNotNull() {
+        when(rdsProxy.client().describeEvents(any(DescribeEventsRequest.class)))
+            .thenReturn(DescribeEventsResponse.builder().build());
+
+        final ResourceModel resourceModel = RESOURCE_MODEL_EMPTY_VPC.toBuilder().build();
+        final CallbackContext context = new CallbackContext();
+        context.setModified(true);
+        context.setAddTagsComplete(true);
+
+        // When the previous.vPCSecurityGroups != null && desired.vPCSecurityGroups != null
+        test_handleRequest_base(
+            context,
+            ResourceHandlerRequest.<ResourceModel>builder()
+                .previousResourceTags(Translator.translateTagsToRequest(TAG_LIST))
+                .desiredResourceTags(Translator.translateTagsToRequest(TAG_LIST)),
+            () -> DBCLUSTER_ACTIVE,
+            () -> resourceModel.toBuilder().vpcSecurityGroupIds(ImmutableList.of("group-id")).build(),
+            () -> resourceModel.toBuilder().vpcSecurityGroupIds(ImmutableList.of("group-id")).build(),
+            expectSuccess()
+        );
+
+        // Expect that the security group has NOT been updated
+        verify(rdsProxy.client(), times(1)).describeDBClusters(any(DescribeDbClustersRequest.class));
+        verify(rdsProxy.client(), times(1)).describeEvents(any(DescribeEventsRequest.class));
+    }
+
+    @Test
+    void handleRequest_WithUpdateToDefaultVPC2_previousNull_desiredNotNull() {
+        when(rdsProxy.client().describeEvents(any(DescribeEventsRequest.class)))
+            .thenReturn(DescribeEventsResponse.builder().build());
+
+        final ResourceModel resourceModel = RESOURCE_MODEL_EMPTY_VPC.toBuilder().build();
+        final CallbackContext context = new CallbackContext();
+        context.setModified(true);
+        context.setAddTagsComplete(true);
+
+        // When the previous.vPCSecurityGroups == null && desired.vPCSecurityGroups != null
+        test_handleRequest_base(
+            context,
+            ResourceHandlerRequest.<ResourceModel>builder()
+                .previousResourceTags(Translator.translateTagsToRequest(TAG_LIST))
+                .desiredResourceTags(Translator.translateTagsToRequest(TAG_LIST)),
+            () -> DBCLUSTER_ACTIVE,
+            () -> resourceModel.toBuilder().vpcSecurityGroupIds(ImmutableList.of()).build(),
+            () -> resourceModel.toBuilder().vpcSecurityGroupIds(ImmutableList.of("group-id")).build(),
+            expectSuccess()
+        );
+
+        // Expect that the security group has NOT been updated
+        verify(rdsProxy.client(), times(1)).describeDBClusters(any(DescribeDbClustersRequest.class));
+        verify(rdsProxy.client(), times(1)).describeEvents(any(DescribeEventsRequest.class));
+    }
+
+    @Test
+    void handleRequest_WithUpdateToDefaultVPC2_previousNull_desiredNull() {
+        when(rdsProxy.client().describeEvents(any(DescribeEventsRequest.class)))
+            .thenReturn(DescribeEventsResponse.builder().build());
+
+        final ResourceModel resourceModel = RESOURCE_MODEL_EMPTY_VPC.toBuilder().build();
+        final CallbackContext context = new CallbackContext();
+        context.setModified(true);
+        context.setAddTagsComplete(true);
+
+        // When the previous.vPCSecurityGroups == null && desired.vPCSecurityGroups == null
+        test_handleRequest_base(
+            context,
+            ResourceHandlerRequest.<ResourceModel>builder()
+                .previousResourceTags(Translator.translateTagsToRequest(TAG_LIST))
+                .desiredResourceTags(Translator.translateTagsToRequest(TAG_LIST)),
+            () -> DBCLUSTER_ACTIVE,
+            () -> resourceModel.toBuilder().vpcSecurityGroupIds(ImmutableList.of()).build(),
+            () -> resourceModel.toBuilder().vpcSecurityGroupIds(ImmutableList.of()).build(),
+            expectSuccess()
+        );
+
+        // Expect that the security group has NOT been updated
+        verify(rdsProxy.client(), times(1)).describeDBClusters(any(DescribeDbClustersRequest.class));
+        verify(rdsProxy.client(), times(1)).describeEvents(any(DescribeEventsRequest.class));
+    }
+
+    @Test
     void handleRequest_WithUpdateToDefaultVpcFromDefaultVpc() {
         final ResourceModel resourceModel = RESOURCE_MODEL_EMPTY_VPC.toBuilder().build();
         final CallbackContext context = new CallbackContext();


### PR DESCRIPTION

*Issue #, if available:*

DBSecurity group resets to default during import

*Description of changes:*

This change ensures that we never reset to default VPC when both previous and desired security group is null

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
