### PR TITLE
[Common] Removed the pinned cli version

### DIFF
--- a/.github/workflows/maven-verify.yml
+++ b/.github/workflows/maven-verify.yml
@@ -23,7 +23,7 @@ jobs:
       with:
         python-version: 3.13
     - name: Install Python packages
-      run: pip install pre-commit cloudformation-cli cloudformation-cli-java-plugin==2.1.1 setuptools
+      run: pip install pre-commit cloudformation-cli cloudformation-cli-java-plugin setuptools
     - name: Run pre-commit
       run: pre-commit run --all-files
     - name: Verify AWS::RDS::Test::Common

--- a/aws-rds-cfn-common/src/main/java/software/amazon/rds/common/request/ValidatedRequest.java
+++ b/aws-rds-cfn-common/src/main/java/software/amazon/rds/common/request/ValidatedRequest.java
@@ -23,6 +23,8 @@ public class ValidatedRequest<T> extends ResourceHandlerRequest<T> {
                 base.getUpdatePolicy(),
                 base.getCreationPolicy(),
                 base.getRegion(),
-                base.getStackId());
+                base.getStackId(),
+                base.getMaxResults()
+                );
     }
 }


### PR DESCRIPTION
Description: 

Due to CLI and Maven version mismatch, we have temporarily pinned the CLI to an older version in the previous [commit](https://github.com/aws-cloudformation/aws-cloudformation-resource-providers-rds/pull/604). 

In this PR, we are : 
1. reverting the temporary fix
2. updating the validator to handle the new property MaxResult. This is to fix the compile error caused by the latest version of cloudformation-cli-java-plugin 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
