### PR TITLE
fix (DBInstance): Handle throttling error for DBInstance resource

### DIFF
--- a/aws-rds-cfn-common/src/main/java/software/amazon/rds/common/error/ErrorStatus.java
+++ b/aws-rds-cfn-common/src/main/java/software/amazon/rds/common/error/ErrorStatus.java
@@ -20,7 +20,11 @@ public interface ErrorStatus {
     }
 
     static ErrorStatus retry(final int callbackDelay) {
-        return new RetryErrorStatus(OperationStatus.IN_PROGRESS, callbackDelay);
+        return retry(callbackDelay, null);
+    }
+
+    static ErrorStatus retry(final int callbackDelay, final HandlerErrorCode handlerErrorCode) {
+        return new RetryErrorStatus(OperationStatus.IN_PROGRESS, callbackDelay, handlerErrorCode);
     }
 
     static ErrorStatus conditional(Function<Exception, ErrorStatus> condition) {

--- a/aws-rds-cfn-common/src/main/java/software/amazon/rds/common/error/RetryErrorStatus.java
+++ b/aws-rds-cfn-common/src/main/java/software/amazon/rds/common/error/RetryErrorStatus.java
@@ -1,6 +1,7 @@
 package software.amazon.rds.common.error;
 
 import lombok.Getter;
+import software.amazon.cloudformation.proxy.HandlerErrorCode;
 import software.amazon.cloudformation.proxy.OperationStatus;
 
 public class RetryErrorStatus implements ErrorStatus {
@@ -10,8 +11,12 @@ public class RetryErrorStatus implements ErrorStatus {
     @Getter
     private final int callbackDelay;
 
-    public RetryErrorStatus(final OperationStatus status, int callbackDelay) {
+    @Getter
+    HandlerErrorCode handlerErrorCode;
+
+    public RetryErrorStatus(final OperationStatus status, int callbackDelay, final HandlerErrorCode handlerErrorCode) {
         this.status = status;
         this.callbackDelay = callbackDelay;
+        this.handlerErrorCode = handlerErrorCode;
     }
 }

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/BaseHandlerStd.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/BaseHandlerStd.java
@@ -75,6 +75,8 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
 
     protected static final String DB_INSTANCE_STABILIZATION_TIME = "dbinstance-stabilization-time";
 
+    protected static final int CALLBACK_DELAY = 6;
+
     protected final HandlerConfig config;
 
     protected RequestLogger requestLogger;
@@ -115,6 +117,9 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
                     ErrorCode.InsufficientDBInstanceCapacity,
                     ErrorCode.SnapshotQuotaExceeded,
                     ErrorCode.StorageQuotaExceeded)
+            .withErrorCodes(ErrorStatus.retry(CALLBACK_DELAY, HandlerErrorCode.Throttling),
+                    ErrorCode.ThrottlingException,
+                    ErrorCode.Throttling)
             .withErrorCodes(ErrorStatus.failWith(HandlerErrorCode.InvalidRequest),
                     ErrorCode.DBSubnetGroupNotAllowedFault,
                     ErrorCode.InvalidParameterCombination,
@@ -167,8 +172,16 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
                     InvalidSubnetException.class)
             .build();
 
-    protected static final ErrorRuleSet DESCRIBE_AUTOMATED_BACKUPS_SOFTFAIL_ERROR_RULE_SET = ErrorRuleSet
+
+    protected static final ErrorRuleSet READ_HANDLER_ERROR_RULE_SET = ErrorRuleSet
         .extend(DEFAULT_DB_INSTANCE_ERROR_RULE_SET)
+        .withErrorCodes(ErrorStatus.failWith(HandlerErrorCode.Throttling),
+            ErrorCode.ThrottlingException,
+            ErrorCode.Throttling)
+        .build();
+
+    protected static final ErrorRuleSet DESCRIBE_AUTOMATED_BACKUPS_SOFTFAIL_ERROR_RULE_SET = ErrorRuleSet
+        .extend(READ_HANDLER_ERROR_RULE_SET)
         .withErrorClasses(ErrorStatus.ignore(OperationStatus.IN_PROGRESS),
             DbInstanceAutomatedBackupNotFoundException.class)
         .withErrorCodes(ErrorStatus.ignore(OperationStatus.IN_PROGRESS),

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/ReadHandler.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/ReadHandler.java
@@ -72,7 +72,7 @@ public class ReadHandler extends BaseHandlerStd {
             .handleError((describeRequest, exception, client, model, context) -> Commons.handleException(
                 ProgressEvent.progress(model, context),
                 exception,
-                DEFAULT_DB_INSTANCE_ERROR_RULE_SET,
+                READ_HANDLER_ERROR_RULE_SET,
                 requestLogger
             ))
             .done((describeRequest, describeResponse, automatedBackupProxyInvocation, model, context) -> {

--- a/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/AbstractHandlerTest.java
+++ b/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/AbstractHandlerTest.java
@@ -9,8 +9,12 @@ import java.time.Duration;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.function.Supplier;
+import java.util.stream.Stream;
 
 import org.json.JSONObject;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.mockito.stubbing.OngoingStubbing;
@@ -42,6 +46,7 @@ import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 import software.amazon.cloudformation.proxy.delay.Constant;
+import software.amazon.rds.common.error.ErrorCode;
 import software.amazon.rds.common.handler.Tagging;
 import software.amazon.rds.common.logging.RequestLogger;
 import software.amazon.rds.common.printer.FilteredJsonPrinter;
@@ -200,6 +205,7 @@ public abstract class AbstractHandlerTest extends AbstractTestBase<DBInstance, R
     protected static final Integer AUTOMATIC_BACKUP_REPLICATION_RETENTION_PERIOD = 1;
     protected static final String CURRENT_REGION = "eu-west-1";
 
+    protected static final int CALLBACK_DELAY = 6;
 
     protected static final ResourceModel RESOURCE_MODEL_NO_IDENTIFIER;
     protected static final ResourceModel RESOURCE_MODEL_ALTER;
@@ -888,5 +894,15 @@ public abstract class AbstractHandlerTest extends AbstractTestBase<DBInstance, R
 
     protected static String getAutomaticBackupArn(final String region) {
         return String.format("arn:aws:rds:%s:1234567890:auto-backup:ab-test", region);
+    }
+
+    static class ThrottleExceptionArgumentsProvider implements ArgumentsProvider {
+        @Override
+        public Stream<? extends Arguments> provideArguments(ExtensionContext extensionContext) throws Exception {
+            return Stream.of(
+                Arguments.of(ErrorCode.ThrottlingException),
+                Arguments.of(ErrorCode.Throttling)
+            );
+        }
     }
 }

--- a/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/DeleteHandlerTest.java
+++ b/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/DeleteHandlerTest.java
@@ -445,4 +445,36 @@ public class DeleteHandlerTest extends AbstractHandlerTest {
                 expectResponseCode
         );
     }
+
+    @ParameterizedTest
+    @ArgumentsSource(ThrottleExceptionArgumentsProvider.class)
+    public void handleRequest_DeleteDBInstance_HandleThrottleExceptionInDelete(
+        final Object requestException
+    ) {
+        when(rdsProxy.client().describeDBInstances(any(DescribeDbInstancesRequest.class)))
+            .thenReturn(DescribeDbInstancesResponse.builder().dbInstances(DB_INSTANCE_ACTIVE).build());
+
+        test_handleRequest_throttle(
+            expectDeleteDBInstanceCall(),
+            new CallbackContext(),
+            () -> RESOURCE_MODEL_BLDR().build(),
+            requestException,
+            CALLBACK_DELAY
+        );
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(ThrottleExceptionArgumentsProvider.class)
+    public void handleRequest_DeleteDBInstance_HandleThrottleExceptionInDescribe(
+        final Object requestException
+    ) {
+        expectServiceInvocation = false;
+        test_handleRequest_throttle(
+            expectDescribeDBInstancesCall(),
+            new CallbackContext(),
+            () -> RESOURCE_MODEL_BLDR().build(),
+            requestException,
+            CALLBACK_DELAY
+        );
+    }
 }

--- a/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/ReadHandlerTest.java
+++ b/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/ReadHandlerTest.java
@@ -18,6 +18,8 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ArgumentsSource;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
 import org.mockito.Mockito;
@@ -36,6 +38,7 @@ import software.amazon.awssdk.services.rds.model.DescribeDbInstanceAutomatedBack
 import software.amazon.awssdk.services.rds.model.DescribeDbInstanceAutomatedBackupsResponse;
 import software.amazon.awssdk.services.rds.model.DescribeDbInstancesRequest;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
+import software.amazon.cloudformation.proxy.HandlerErrorCode;
 import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.rds.test.common.core.HandlerName;
 
@@ -192,5 +195,19 @@ public class ReadHandlerTest extends AbstractHandlerTest {
         verify(rdsProxy.client(), times(1)).describeDBInstances(any(DescribeDbInstancesRequest.class));
         verify(crossRegionRdsProxy.client(), times(1)).describeDBInstanceAutomatedBackups(any(DescribeDbInstanceAutomatedBackupsRequest.class));
         Assertions.assertThat(context.isAutomaticBackupReplicationStarted()).isFalse();
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(ThrottleExceptionArgumentsProvider.class)
+    public void handleRequest_DescribeDBInstance_HandleThrottleException(
+        final Object requestException
+    ) {
+        test_handleRequest_error(
+            expectDescribeDBInstancesCall(),
+            new CallbackContext(),
+            () -> RESOURCE_MODEL_BLDR().build(),
+            requestException,
+            HandlerErrorCode.Throttling
+        );
     }
 }

--- a/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/UpdateHandlerTest.java
+++ b/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/UpdateHandlerTest.java
@@ -1979,4 +1979,26 @@ public class UpdateHandlerTest extends AbstractHandlerTest {
                 expectFailed(HandlerErrorCode.InvalidRequest)
         );
     }
+
+    @ParameterizedTest
+    @ArgumentsSource(ThrottleExceptionArgumentsProvider.class)
+    public void handleRequest_ModifyDBInstance_HandleThrottleException(
+        final Object requestException
+    ) {
+        final DBInstance fakeDBInstance = DBInstance.builder().build();
+        when(rdsProxy.client().describeDBInstances(any(DescribeDbInstancesRequest.class)))
+            .thenReturn(DescribeDbInstancesResponse.builder().dbInstances(fakeDBInstance).build());
+
+        final CallbackContext context = new CallbackContext();
+        context.setStorageAllocated(true);
+
+        test_handleRequest_throttle(
+            expectModifyDBInstanceCall(),
+            context,
+            () -> RESOURCE_MODEL_BLDR().build(),
+            () -> RESOURCE_MODEL_ALTER,
+            requestException,
+            CALLBACK_DELAY
+        );
+    }
 }


### PR DESCRIPTION
*Description of changes:*

Enhanced error handling for DBInstance to return an 'In-progress' status instead of 'Fail' upon encountering throttling errors, enabling automatic retries.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
