### PR TITLE
fix (Integration): Revert the `AWS::RDS::Integration` changes introduced in commit `0b1b251`

### DIFF
--- a/aws-rds-integration/src/main/java/software/amazon/rds/integration/BaseHandlerStd.java
+++ b/aws-rds-integration/src/main/java/software/amazon/rds/integration/BaseHandlerStd.java
@@ -1,7 +1,6 @@
 package software.amazon.rds.integration;
 
 import software.amazon.awssdk.services.rds.RdsClient;
-import software.amazon.awssdk.services.rds.model.Integration;
 import software.amazon.awssdk.services.rds.model.IntegrationAlreadyExistsException;
 import software.amazon.awssdk.services.rds.model.IntegrationConflictOperationException;
 import software.amazon.awssdk.services.rds.model.IntegrationNotFoundException;
@@ -10,7 +9,6 @@ import software.amazon.awssdk.services.rds.model.IntegrationStatus;
 import software.amazon.awssdk.services.rds.model.InvalidIntegrationStateException;
 import software.amazon.awssdk.services.rds.model.KmsKeyNotAccessibleException;
 import software.amazon.awssdk.services.rds.model.Tag;
-import software.amazon.cloudformation.exceptions.CfnNotFoundException;
 import software.amazon.cloudformation.exceptions.CfnNotStabilizedException;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.HandlerErrorCode;
@@ -238,18 +236,5 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
                     context.setIntegrationArn(arn);
                     return ProgressEvent.progress(resourceModel, context);
                 });
-    }
-
-    protected Integration fetchIntegration(final ProxyClient<RdsClient> client, final ResourceModel model) {
-        try {
-            final var response = client.injectCredentialsAndInvokeV2(Translator.describeIntegrationsRequest(model), client.client()::describeIntegrations);
-            if (!response.hasIntegrations() || response.integrations().isEmpty()) {
-                // !!!: integration's PrimaryIdentifier is ARN not name
-                throw new CfnNotFoundException(ResourceModel.TYPE_NAME, model.getIntegrationName());
-            }
-            return response.integrations().get(0);
-        } catch (IntegrationNotFoundException e) {
-            throw new CfnNotFoundException(e);
-        }
     }
 }

--- a/aws-rds-integration/src/main/java/software/amazon/rds/integration/CallbackContext.java
+++ b/aws-rds-integration/src/main/java/software/amazon/rds/integration/CallbackContext.java
@@ -2,14 +2,12 @@ package software.amazon.rds.integration;
 
 import software.amazon.cloudformation.proxy.StdCallbackContext;
 import software.amazon.rds.common.handler.TaggingContext;
-import software.amazon.rds.common.util.IdempotencyHelper;
 
 @lombok.Getter
 @lombok.Setter
 @lombok.ToString
 @lombok.EqualsAndHashCode(callSuper = true)
-public class CallbackContext extends StdCallbackContext implements TaggingContext.Provider, IdempotencyHelper.PreExistenceContext {
-    private Boolean preExistenceCheckDone;
+public class CallbackContext extends StdCallbackContext implements TaggingContext.Provider {
     private String integrationArn;
 
     private TaggingContext taggingContext;

--- a/aws-rds-integration/src/main/java/software/amazon/rds/integration/CreateHandler.java
+++ b/aws-rds-integration/src/main/java/software/amazon/rds/integration/CreateHandler.java
@@ -14,7 +14,6 @@ import software.amazon.rds.common.error.ErrorStatus;
 import software.amazon.rds.common.handler.Commons;
 import software.amazon.rds.common.handler.HandlerConfig;
 import software.amazon.rds.common.handler.Tagging;
-import software.amazon.rds.common.util.IdempotencyHelper;
 import software.amazon.rds.common.util.IdentifierFactory;
 
 import java.util.HashSet;
@@ -81,10 +80,7 @@ public class CreateHandler extends BaseHandlerStd {
 
         return ProgressEvent.progress(model, callbackContext)
                 .then(progress -> setIntegrationNameIfEmpty(request, progress))
-                .then(progress -> IdempotencyHelper.safeCreate(
-                    m -> fetchIntegration(proxyClient, m),
-                    p -> createIntegration(proxy, proxyClient, p, allTags),
-                    ResourceModel.TYPE_NAME, model.getIntegrationName(), progress, requestLogger))
+                .then(progress -> createIntegration(proxy, proxyClient, progress, allTags))
                 .then(progress -> new ReadHandler().handleRequest(proxy, proxyClient, request, callbackContext));
     }
 

--- a/aws-rds-integration/src/test/java/software/amazon/rds/integration/CreateHandlerTest.java
+++ b/aws-rds-integration/src/test/java/software/amazon/rds/integration/CreateHandlerTest.java
@@ -20,7 +20,6 @@ import software.amazon.cloudformation.exceptions.CfnNotStabilizedException;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.HandlerErrorCode;
 import software.amazon.cloudformation.proxy.ProxyClient;
-import software.amazon.rds.common.util.IdempotencyHelper;
 import software.amazon.rds.test.common.core.HandlerName;
 
 import java.time.Duration;
@@ -70,7 +69,6 @@ public class CreateHandlerTest extends AbstractHandlerTest {
         rdsClient = mock(RdsClient.class);
         proxy = new AmazonWebServicesClientProxy(logger, MOCK_CREDENTIALS, () -> Duration.ofSeconds(600).toMillis());
         rdsProxy = MOCK_PROXY(proxy, rdsClient);
-        IdempotencyHelper.setBypass(true);
     }
 
     @AfterEach


### PR DESCRIPTION
*Issue #, if available:*

In commit `0b1b251`, a `DescribeIntegrations` call was added at the start of the create handler for `AWS::RDS::Integration` resource. This call attempts to retrieve the Integration using either the ARN or the integration name—neither of which is available at the time of creation. As a result, the create operation fails whenever it is triggered.

*Description of changes:*

This change revert the `AWS::RDS::Integration` changes introduced in commit `0b1b251`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
