### PR TITLE
fix (DBCluster): Perform stabilization again after applying delay to …

### DIFF
--- a/aws-rds-cfn-common/src/main/java/software/amazon/rds/common/util/WaiterHelper.java
+++ b/aws-rds-cfn-common/src/main/java/software/amazon/rds/common/util/WaiterHelper.java
@@ -20,12 +20,16 @@ public class WaiterHelper {
      */
     public static <ResourceT, CallbackT extends DelayContext> ProgressEvent<ResourceT, CallbackT> delay(final ProgressEvent<ResourceT, CallbackT> evt, final int maxSeconds, final int pollSeconds) {
         final CallbackT callbackContext = evt.getCallbackContext();
-        if (callbackContext.getWaitTime() <= maxSeconds) {
+        if (shouldDelay(callbackContext, maxSeconds)) {
             callbackContext.setWaitTime(callbackContext.getWaitTime() + pollSeconds);
             return ProgressEvent.defaultInProgressHandler(callbackContext, pollSeconds, evt.getResourceModel());
         } else {
             return ProgressEvent.progress(evt.getResourceModel(), callbackContext);
         }
+    }
+
+    public static <CallbackT extends DelayContext> boolean shouldDelay(CallbackT callbackContext, int maxSeconds) {
+        return callbackContext.getWaitTime() <= maxSeconds;
     }
 
     public interface DelayContext {

--- a/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/BaseHandlerStd.java
+++ b/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/BaseHandlerStd.java
@@ -12,6 +12,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.BiFunction;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
@@ -198,6 +199,8 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
             .build();
 
     private final JsonPrinter PARAMETERS_FILTER = new FilteredJsonPrinter("MasterUsername", "MasterUserPassword");
+
+    protected static final BiFunction<ResourceModel, ProxyClient<RdsClient>, ResourceModel> NOOP_CALL = (model, proxyClient) -> model;
 
     protected static final ResourceTypeSchema resourceTypeSchema = ResourceTypeSchema.load(new Configuration().resourceSchemaJsonObject());
 

--- a/aws-rds-dbcluster/src/test/java/software/amazon/rds/dbcluster/UpdateHandlerTest.java
+++ b/aws-rds-dbcluster/src/test/java/software/amazon/rds/dbcluster/UpdateHandlerTest.java
@@ -969,7 +969,7 @@ public class UpdateHandlerTest extends AbstractHandlerTest {
 
         ArgumentCaptor<ModifyDbClusterRequest> captor = ArgumentCaptor.forClass(ModifyDbClusterRequest.class);
         verify(rdsProxy.client(), times(1)).modifyDBCluster(captor.capture());
-        verify(rdsProxy.client(), times(3)).describeDBClusters(any(DescribeDbClustersRequest.class));
+        verify(rdsProxy.client(), times(4)).describeDBClusters(any(DescribeDbClustersRequest.class));
         verify(rdsProxy.client(), times(1)).removeTagsFromResource(any(RemoveTagsFromResourceRequest.class));
         verify(rdsProxy.client(), times(1)).addTagsToResource(any(AddTagsToResourceRequest.class));
         verify(rdsProxy.client(), times(1)).describeEvents(any(DescribeEventsRequest.class));


### PR DESCRIPTION
…Aurora Serverless V2 update changes

*Issue #, if available:*

This is a follow-up PR to #609. It introduces a stabilization step after asynchronous workflows occur following the DBCluster resource update, to ensure the cluster is ready for the next step.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
