### PR TITLE
fix (DBCluster): Add support for automatic backup retention on delete

### DIFF
--- a/aws-rds-dbcluster/aws-rds-dbcluster.json
+++ b/aws-rds-dbcluster/aws-rds-dbcluster.json
@@ -102,6 +102,10 @@
       "description": "A DB subnet group that you want to associate with this DB cluster.",
       "type": "string"
     },
+    "DeleteAutomatedBackups": {
+      "type": "boolean",
+      "description": "Specifies whether to remove automated backups immediately after the DB cluster is deleted. This parameter isn't case-sensitive. The default is to remove automated backups immediately after the DB cluster is deleted, unless the AWS Backup policy specifies a point-in-time restore rule."
+    },
     "DeletionProtection": {
       "description": "A value that indicates whether the DB cluster has deletion protection enabled. The database can't be deleted when deletion protection is enabled. By default, deletion protection is disabled.",
       "type": "boolean"
@@ -473,6 +477,7 @@
   "writeOnlyProperties": [
     "/properties/ClusterScalabilityType",
     "/properties/DBInstanceParameterGroupName",
+    "/properties/DeleteAutomatedBackups",
     "/properties/MasterUserPassword",
     "/properties/RestoreToTime",
     "/properties/RestoreType",

--- a/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/Translator.java
+++ b/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/Translator.java
@@ -422,7 +422,8 @@ public class Translator {
             final String finalDBSnapshotIdentifier
     ) {
         final DeleteDbClusterRequest.Builder builder = DeleteDbClusterRequest.builder()
-                .dbClusterIdentifier(model.getDBClusterIdentifier());
+                .dbClusterIdentifier(model.getDBClusterIdentifier())
+                .deleteAutomatedBackups(model.getDeleteAutomatedBackups());
         if (StringUtils.isNullOrEmpty(finalDBSnapshotIdentifier)) {
             builder.skipFinalSnapshot(true);
         } else {


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-cloudformation/cloudformation-coverage-roadmap/issues/1848

*Description of changes:*
This change add support for automatic backup retention on delete for DBCluster

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
