### PR TITLE
fix(DBParameterGroup): false drift on provided default value

### DIFF
--- a/aws-rds-dbparametergroup/aws-rds-dbparametergroup.json
+++ b/aws-rds-dbparametergroup/aws-rds-dbparametergroup.json
@@ -89,7 +89,6 @@
       "permissions": [
         "rds:DescribeDBParameterGroups",
         "rds:DescribeDBParameters",
-        "rds:DescribeEngineDefaultParameters",
         "rds:ListTagsForResource"
       ]
     },

--- a/aws-rds-dbparametergroup/src/main/java/software/amazon/rds/dbparametergroup/BaseHandlerStd.java
+++ b/aws-rds-dbparametergroup/src/main/java/software/amazon/rds/dbparametergroup/BaseHandlerStd.java
@@ -591,18 +591,12 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
 
     @VisibleForTesting
     static Map<String, Parameter> computeModifiedDBParameters(
-            @NonNull final Map<String, Parameter> engineDefaultParameters,
-            @NonNull final Map<String, Parameter> currentDBParameters
+        @NonNull final Map<String, Parameter> currentDBParameters
     ) {
-        final Map<String, Parameter> modifiedParameters = new HashMap<>();
-        for (final String paramName : currentDBParameters.keySet()) {
-            final Parameter currentParam = currentDBParameters.get(paramName);
-            final Parameter defaultParam = engineDefaultParameters.get(paramName);
-            if (defaultParam == null || !Objects.equals(defaultParam.parameterValue(), currentParam.parameterValue())) {
-                modifiedParameters.put(paramName, currentParam);
-            }
-        }
-
-        return modifiedParameters;
+        // Parameter 'source' can either be 'engine-default', 'user' or 'system'
+        // Here, we should only consider parameters modified by the user
+        return currentDBParameters.entrySet().stream()
+            .filter(entry -> "user".equals(entry.getValue().source()))
+            .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
     }
 }

--- a/aws-rds-dbparametergroup/src/main/java/software/amazon/rds/dbparametergroup/ReadHandler.java
+++ b/aws-rds-dbparametergroup/src/main/java/software/amazon/rds/dbparametergroup/ReadHandler.java
@@ -77,15 +77,12 @@ public class ReadHandler extends BaseHandlerStd {
             final ProgressEvent<ResourceModel, CallbackContext> progress,
             final RequestLogger logger
     ) {
-        final Map<String, Parameter> engineDefaultParameters = new HashMap<>();
         final Map<String, Parameter> currentDBParameters = new HashMap<>();
-
         return progress
-                .then(p -> describeEngineDefaultParameters(proxy, proxyClient, p, null, engineDefaultParameters, logger))
                 .then(p -> describeCurrentDBParameters(proxy, proxyClient, p, null, currentDBParameters, logger))
                 .then(p -> {
                     p.getResourceModel().setParameters(
-                            Translator.translateParametersFromSdk(computeModifiedDBParameters(engineDefaultParameters, currentDBParameters))
+                            Translator.translateParametersFromSdk(computeModifiedDBParameters(currentDBParameters))
                     );
                     return p;
                 });

--- a/aws-rds-dbparametergroup/src/test/java/software/amazon/rds/dbparametergroup/AbstractTestBase.java
+++ b/aws-rds-dbparametergroup/src/test/java/software/amazon/rds/dbparametergroup/AbstractTestBase.java
@@ -169,8 +169,6 @@ public abstract class AbstractTestBase {
     protected void expectEmptyDescribeParametersResponse(final ProxyClient<RdsClient> proxyClient) {
         when(proxyClient.client().describeDBParameters(any(DescribeDbParametersRequest.class)))
                 .thenReturn(DescribeDbParametersResponse.builder().build());
-        when(proxyClient.client().describeEngineDefaultParameters(any(DescribeEngineDefaultParametersRequest.class)))
-                .thenReturn(DescribeEngineDefaultParametersResponse.builder().build());
     }
 
     void mockDescribeDbParametersResponse(

--- a/aws-rds-dbparametergroup/src/test/java/software/amazon/rds/dbparametergroup/BaseHandlerStdTest.java
+++ b/aws-rds-dbparametergroup/src/test/java/software/amazon/rds/dbparametergroup/BaseHandlerStdTest.java
@@ -12,28 +12,21 @@ class BaseHandlerStdTest {
 
     @Test
     public void test_computeModifiedDBParameters() {
-        final Map<String, Parameter> engineDefaultParameters = ImmutableMap.of(
-                "param1", Parameter.builder().parameterName("param1").parameterValue("value1").build(),
-                "param2", Parameter.builder().parameterName("param2").parameterValue("value2").build(),
-                "param3", Parameter.builder().parameterName("param3").parameterValue("value3").build(),
-                "param4", Parameter.builder().parameterName("param4").build()
-        );
         final Map<String, Parameter> currentDBParameters = ImmutableMap.of(
-                "param1", Parameter.builder().parameterName("param1").parameterValue("value1").build(),
-                "param2", Parameter.builder().parameterName("param2").parameterValue("value1-2").build(),
-                "param4", Parameter.builder().parameterName("param4").build(),
-                "param5", Parameter.builder().parameterName("param5").parameterValue("value5").build()
+                "param1", Parameter.builder().parameterName("param1").parameterValue("value1").source("engine-default").build(),
+                "param2", Parameter.builder().parameterName("param2").parameterValue("value1-2").source("user").build(),
+                "param4", Parameter.builder().parameterName("param4").source("system").build(),
+                "param5", Parameter.builder().parameterName("param5").parameterValue("value5").source("user").build()
         );
 
         final Map<String, Parameter> modifiedParameters = BaseHandlerStd.computeModifiedDBParameters(
-                engineDefaultParameters,
                 currentDBParameters
         );
 
         Assertions.assertThat(modifiedParameters)
                 .isEqualTo(ImmutableMap.of(
-                        "param2", Parameter.builder().parameterName("param2").parameterValue("value1-2").build(),
-                        "param5", Parameter.builder().parameterName("param5").parameterValue("value5").build()
+                        "param2", Parameter.builder().parameterName("param2").parameterValue("value1-2").source("user").build(),
+                        "param5", Parameter.builder().parameterName("param5").parameterValue("value5").source("user").build()
                 ));
     }
 }

--- a/aws-rds-dbparametergroup/src/test/java/software/amazon/rds/dbparametergroup/ReadHandlerTest.java
+++ b/aws-rds-dbparametergroup/src/test/java/software/amazon/rds/dbparametergroup/ReadHandlerTest.java
@@ -113,7 +113,6 @@ public class ReadHandlerTest extends AbstractTestBase {
 
         verify(proxyClient.client()).describeDBParameterGroups(any(DescribeDbParameterGroupsRequest.class));
         verify(proxyClient.client()).listTagsForResource(any(ListTagsForResourceRequest.class));
-        verify(proxyClient.client()).describeEngineDefaultParameters(any(DescribeEngineDefaultParametersRequest.class));
         verify(proxyClient.client()).describeDBParameters(any(DescribeDbParametersRequest.class));
     }
 
@@ -170,23 +169,11 @@ public class ReadHandlerTest extends AbstractTestBase {
         when(proxyClient.client().describeDBParameters(any(DescribeDbParametersRequest.class)))
                 .thenReturn(DescribeDbParametersResponse.builder()
                         .parameters(
-                                Parameter.builder().parameterName("param1").parameterValue("value1").build(),
-                                Parameter.builder().parameterName("param2").parameterValue("value2-modified").build(),
-                                Parameter.builder().parameterName("param3").build()
+                                Parameter.builder().parameterName("param1").parameterValue("value1").source("system").build(),
+                                Parameter.builder().parameterName("param2").parameterValue("value2-modified").source("user").build(),
+                                Parameter.builder().parameterName("param3").source("engine-default").build()
                         )
                         .marker(null)
-                        .build());
-
-        when(proxyClient.client().describeEngineDefaultParameters(any(DescribeEngineDefaultParametersRequest.class)))
-                .thenReturn(DescribeEngineDefaultParametersResponse.builder()
-                        .engineDefaults(EngineDefaults.builder()
-                                .parameters(
-                                        Parameter.builder().parameterName("param1").parameterValue("value1").build(),
-                                        Parameter.builder().parameterName("param2").parameterValue("value2").build(),
-                                        Parameter.builder().parameterName("param3").build()
-                                )
-                                .marker(null)
-                                .build())
                         .build());
 
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
@@ -209,7 +196,6 @@ public class ReadHandlerTest extends AbstractTestBase {
 
         verify(proxyClient.client()).describeDBParameterGroups(any(DescribeDbParameterGroupsRequest.class));
         verify(proxyClient.client()).listTagsForResource(any(ListTagsForResourceRequest.class));
-        verify(proxyClient.client()).describeEngineDefaultParameters(any(DescribeEngineDefaultParametersRequest.class));
         verify(proxyClient.client()).describeDBParameters(any(DescribeDbParametersRequest.class));
     }
 }


### PR DESCRIPTION
This change fixes a bug where false drift would be reported when user specifies parameter value that is equal to engine default value.