### PR TITLE
feat(DBInstance): add support for read only properties of DBInstance …

### DIFF
--- a/aws-rds-dbinstance/aws-rds-dbinstance.json
+++ b/aws-rds-dbinstance/aws-rds-dbinstance.json
@@ -206,6 +206,10 @@
       "maxLength": 63,
       "description": "A name for the DB instance. If you specify a name, AWS CloudFormation converts it to lowercase. If you don't specify a name, AWS CloudFormation generates a unique physical ID and uses that ID for the DB instance."
     },
+    "DBInstanceStatus": {
+      "type": "string",
+      "description": "The current state of this DB instance."
+    },
     "DbiResourceId": {
       "type": "string",
       "description": "The AWS Region-unique, immutable identifier for the DB instance. This identifier is found in AWS CloudTrail log entries whenever the AWS KMS key for the DB instance is accessed."
@@ -312,17 +316,35 @@
       "type": "boolean",
       "description": "A value that indicates whether to manage the master user password with AWS Secrets Manager."
     },
+    "InstanceCreateTime": {
+      "type": "string",
+      "description": "The date and time when the DB instance was created.",
+      "format": "date-time"
+    },
     "Iops": {
       "type": "integer",
       "description": "The number of I/O operations per second (IOPS) that the database provisions."
+    },
+    "IsStorageConfigUpgradeAvailable": {
+      "type": "boolean",
+      "description": "Indicates whether an upgrade is recommended for the storage file system configuration on the DB instance."
     },
     "KmsKeyId": {
       "type": "string",
       "description": "The ARN of the AWS Key Management Service (AWS KMS) master key that's used to encrypt the DB instance."
     },
+    "LatestRestorableTime": {
+      "type": "string",
+      "description": "The latest time to which a database in this DB instance can be restored with point-in-time restore.",
+      "format": "date-time"
+    },
     "LicenseModel": {
       "type": "string",
       "description": "License model information for this DB instance."
+    },
+    "ListenerEndpoint": {
+      "$ref": "#/definitions/Endpoint",
+      "description": "The listener connection endpoint for SQL Server Always On."
     },
     "MasterUsername": {
       "type": "string",
@@ -403,6 +425,20 @@
     "PubliclyAccessible": {
       "type": "boolean",
       "description": "Indicates whether the DB instance is an internet-facing instance. If you specify true, AWS CloudFormation creates an instance with a publicly resolvable DNS name, which resolves to a public IP address. If you specify false, AWS CloudFormation creates an internal instance with a DNS name that resolves to a private IP address."
+    },
+    "ReadReplicaDBClusterIdentifiers": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "The identifiers of Aurora DB clusters to which the RDS DB instance is replicated as a read replica."
+    },
+    "ReadReplicaDBInstanceIdentifiers": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "The identifiers of the read replicas associated with this DB instance."
     },
     "ReplicaMode": {
       "description": "The open mode of an Oracle read replica. The default is open-read-only.",
@@ -566,16 +602,26 @@
     "/properties/ApplyImmediately"
   ],
   "readOnlyProperties": [
+    "/properties/CertificateDetails",
+    "/properties/CertificateDetails/CAIdentifier",
+    "/properties/CertificateDetails/ValidTill",
     "/properties/Endpoint",
     "/properties/Endpoint/Address",
     "/properties/Endpoint/Port",
     "/properties/Endpoint/HostedZoneId",
     "/properties/DbiResourceId",
     "/properties/DBInstanceArn",
+    "/properties/DBInstanceStatus",
+    "/properties/InstanceCreateTime",
+    "/properties/IsStorageConfigUpgradeAvailable",
+    "/properties/LatestRestorableTime",
+    "/properties/ListenerEndpoint",
+    "/properties/ListenerEndpoint/Address",
+    "/properties/ListenerEndpoint/Port",
+    "/properties/ListenerEndpoint/HostedZoneId",
     "/properties/MasterUserSecret/SecretArn",
-    "/properties/CertificateDetails",
-    "/properties/CertificateDetails/CAIdentifier",
-    "/properties/CertificateDetails/ValidTill"
+    "/properties/ReadReplicaDBClusterIdentifiers",
+    "/properties/ReadReplicaDBInstanceIdentifiers"
   ],
   "primaryIdentifier": [
     "/properties/DBInstanceIdentifier"

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/Translator.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/Translator.java
@@ -834,6 +834,11 @@ public class Translator {
             endpoint = translateEndpointFromSdk(dbInstance.endpoint());
         }
 
+        Endpoint listenerEndpoint = null;
+        if (dbInstance.listenerEndpoint() != null) {
+            listenerEndpoint = translateEndpointFromSdk(dbInstance.listenerEndpoint());
+        }
+
         final List<Tag> tags = translateTagsFromSdk(dbInstance.tagList());
 
         String allocatedStorage = null;
@@ -886,6 +891,7 @@ public class Translator {
                 .dBInstanceArn(dbInstance.dbInstanceArn())
                 .dBInstanceClass(dbInstance.dbInstanceClass())
                 .dBInstanceIdentifier(dbInstance.dbInstanceIdentifier())
+                .dBInstanceStatus(dbInstance.dbInstanceStatus())
                 .dBName(dbInstance.dbName())
                 .dBParameterGroupName(dbParameterGroupName)
                 .dBSecurityGroups(translateDbSecurityGroupsFromSdk(dbInstance.dbSecurityGroups()))
@@ -908,8 +914,12 @@ public class Translator {
                 .engineLifecycleSupport(dbInstance.engineLifecycleSupport())
                 .engineVersion(dbInstance.engineVersion())
                 .iops(dbInstance.iops())
+                .instanceCreateTime(dbInstance.instanceCreateTime() == null ? null : dbInstance.instanceCreateTime().toString())
+                .isStorageConfigUpgradeAvailable(dbInstance.isStorageConfigUpgradeAvailable())
                 .kmsKeyId(dbInstance.kmsKeyId())
+                .latestRestorableTime(dbInstance.latestRestorableTime() == null ? null : dbInstance.latestRestorableTime().toString())
                 .licenseModel(dbInstance.licenseModel())
+                .listenerEndpoint(listenerEndpoint)
                 .manageMasterUserPassword(dbInstance.masterUserSecret() != null)
                 .masterUserSecret(translateMasterUserSecret(dbInstance.masterUserSecret()))
                 .masterUsername(dbInstance.masterUsername())
@@ -929,6 +939,8 @@ public class Translator {
                 .promotionTier(dbInstance.promotionTier())
                 .publiclyAccessible(dbInstance.publiclyAccessible())
                 .sourceDBClusterIdentifier(dbInstance.readReplicaSourceDBClusterIdentifier())
+                .readReplicaDBClusterIdentifiers(translateReadReplicaDBClusterIdentifiers(dbInstance.readReplicaDBClusterIdentifiers()))
+                .readReplicaDBInstanceIdentifiers(translateReadReplicaDBInstanceIdentifiers(dbInstance.readReplicaDBInstanceIdentifiers()))
                 .replicaMode(dbInstance.replicaModeAsString())
                 .sourceDBInstanceIdentifier(dbInstance.readReplicaSourceDBInstanceIdentifier())
                 .storageEncrypted(dbInstance.storageEncrypted())
@@ -960,6 +972,14 @@ public class Translator {
 
     public static List<String> translateEnableCloudwatchLogsExport(final Collection<String> enabledCloudwatchLogsExports) {
         return enabledCloudwatchLogsExports == null ? null : new ArrayList<>(enabledCloudwatchLogsExports);
+    }
+
+    public static List<String> translateReadReplicaDBClusterIdentifiers(final Collection<String> readReplicaDBClusterIdentifiers) {
+        return readReplicaDBClusterIdentifiers == null ? null : new ArrayList<>(readReplicaDBClusterIdentifiers);
+    }
+
+    public static List<String> translateReadReplicaDBInstanceIdentifiers(final Collection<String> readReplicaDBInstanceIdentifiers) {
+        return readReplicaDBInstanceIdentifiers == null ? null : new ArrayList<>(readReplicaDBInstanceIdentifiers);
     }
 
     public static List<String> translateVpcSecurityGroupsFromSdk(

--- a/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/ListHandlerTest.java
+++ b/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/ListHandlerTest.java
@@ -102,6 +102,8 @@ public class ListHandlerTest extends AbstractHandlerTest {
                 .tags(Collections.emptyList())
                 .dBSecurityGroups(Collections.emptyList())
                 .vPCSecurityGroups(Collections.emptyList())
+                .readReplicaDBClusterIdentifiers(Collections.emptyList())
+                .readReplicaDBInstanceIdentifiers(Collections.emptyList())
                 .dBInstanceIdentifier(DB_INSTANCE_IDENTIFIER)
                 .build();
 

--- a/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/TranslatorTest.java
+++ b/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/TranslatorTest.java
@@ -974,6 +974,89 @@ class TranslatorTest extends AbstractHandlerTest {
     }
 
     @Test
+    public void translateDbInstanceFromSdk_setdBInstanceStatus() {
+        final DBInstance dbInstance = DBInstance.builder()
+                .dbInstanceStatus(DB_INSTANCE_STATUS_AVAILABLE)
+                .build();
+
+        final ResourceModel model = Translator.translateDbInstanceFromSdk(dbInstance);
+        assertThat(model.getDBInstanceStatus()).isEqualTo(DB_INSTANCE_STATUS_AVAILABLE);
+    }
+
+    @Test
+    public void translateDbInstanceFromSdk_setInstanceCreateTime() {
+        final Instant instanceCreateTime = Instant.parse("2023-01-09T15:55:37.123Z");
+
+        final DBInstance dbInstance = DBInstance.builder()
+                .instanceCreateTime(instanceCreateTime)
+                .build();
+
+        final ResourceModel model = Translator.translateDbInstanceFromSdk(dbInstance);
+        assertThat(model.getInstanceCreateTime()).isEqualTo(instanceCreateTime.toString());
+    }
+
+    @Test
+    public void translateDbInstanceFromSdk_setIsStorageConfigUpgradeAvailable() {
+        final DBInstance dbInstance = DBInstance.builder()
+                .isStorageConfigUpgradeAvailable(AUTO_MINOR_VERSION_UPGRADE_NO)
+                .build();
+
+        final ResourceModel model = Translator.translateDbInstanceFromSdk(dbInstance);
+        assertThat(model.getIsStorageConfigUpgradeAvailable()).isEqualTo(AUTO_MINOR_VERSION_UPGRADE_NO);
+    }
+
+    @Test
+    public void translateDbInstanceFromSdk_setLatestRestorableTime() {
+        final Instant latestRestorableTime = Instant.parse("2023-01-09T15:55:37.123Z");
+
+        final DBInstance dbInstance = DBInstance.builder()
+                .latestRestorableTime(latestRestorableTime)
+                .build();
+
+        final ResourceModel model = Translator.translateDbInstanceFromSdk(dbInstance);
+        assertThat(model.getLatestRestorableTime()).isEqualTo(latestRestorableTime.toString());
+    }
+
+    @Test
+    public void translateDbInstanceFromSdk_setListenerEndpoint() {
+        final Endpoint listenerEndpoint = Endpoint.builder()
+                .address("mydb-instance.c123456789.us-east-1.rds.amazonaws.com")
+                .port(3306)
+                .hostedZoneId("Z2R2ITUGPM61AM")
+                .build();
+
+        final DBInstance dbInstance = DBInstance.builder()
+                .listenerEndpoint(listenerEndpoint)
+                .dbInstancePort(0)
+                .build();
+
+        final ResourceModel model = Translator.translateDbInstanceFromSdk(dbInstance);
+        assertThat(model.getListenerEndpoint().getAddress()).isEqualTo("mydb-instance.c123456789.us-east-1.rds.amazonaws.com");
+        assertThat(model.getListenerEndpoint().getPort()).isEqualTo("3306");
+        assertThat(model.getListenerEndpoint().getHostedZoneId()).isEqualTo("Z2R2ITUGPM61AM");
+    }
+
+    @Test
+    public void translateDbInstanceFromSdk_readReplicaDBClusterIdentifiers() {
+        final DBInstance dbInstance = DBInstance.builder()
+                .readReplicaDBClusterIdentifiers("cluster-replica-1", "cluster-replica-2")
+                .build();
+
+        final ResourceModel model = Translator.translateDbInstanceFromSdk(dbInstance);
+        assertThat(model.getReadReplicaDBClusterIdentifiers()).containsExactly("cluster-replica-1", "cluster-replica-2");
+    }
+
+    @Test
+    public void translateDbInstanceFromSdk_readReplicaDBInstanceIdentifiers() {
+        final DBInstance dbInstance = DBInstance.builder()
+                .readReplicaDBInstanceIdentifiers("instance-replica-1", "instance-replica-2")
+                .build();
+
+        final ResourceModel model = Translator.translateDbInstanceFromSdk(dbInstance);
+        assertThat(model.getReadReplicaDBInstanceIdentifiers()).containsExactly("instance-replica-1", "instance-replica-2");
+    }
+
+    @Test
     public void translateDbInstanceFromSdk_port_getFromEndpoint() {
         final DBInstance dbInstance = DBInstance.builder()
                 .endpoint(Endpoint.builder().port(123).build())


### PR DESCRIPTION
This change adds support for the following read only properties for DBInstance Resource including:

    DBInstanceStatus: The current state of this DB instance.
    InstanceCreateTime: The date and time when the DB instance was created.
    IsStorageConfigUpgradeAvailable: Indicates whether an upgrade is recommended for the storage file system configuration on the DB instance.
    LatestRestorableTime: The latest time to which a database in this DB instance can be restored with point-in-time restore.
    ListenerEndpoint: The listener connection endpoint for SQL Server Always On.
    ReadReplicaDBClusterIdentifiers: The identifiers of Aurora DB clusters to which the RDS DB instance is replicated as a read replica.
    ReadReplicaDBInstanceIdentifiers: The identifiers of the read replicas associated with this DB instance.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
