### PR TITLE
fix(DBClusterParameterGroup): false drift on provided default value

### DIFF
--- a/aws-rds-dbclusterparametergroup/aws-rds-dbclusterparametergroup.json
+++ b/aws-rds-dbclusterparametergroup/aws-rds-dbclusterparametergroup.json
@@ -90,7 +90,6 @@
       "permissions": [
         "rds:DescribeDBClusterParameterGroups",
         "rds:DescribeDBClusterParameters",
-        "rds:DescribeEngineDefaultClusterParameters",
         "rds:ListTagsForResource"
       ]
     },

--- a/aws-rds-dbclusterparametergroup/src/main/java/software/amazon/rds/dbclusterparametergroup/BaseHandlerStd.java
+++ b/aws-rds-dbclusterparametergroup/src/main/java/software/amazon/rds/dbclusterparametergroup/BaseHandlerStd.java
@@ -481,20 +481,13 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
 
     @VisibleForTesting
     static Map<String, Parameter> computeModifiedDBParameters(
-            @NonNull final Map<String, Parameter> engineDefaultParameters,
-            @NonNull final Map<String, Parameter> currentDBParameters
+        @NonNull final Map<String, Parameter> currentDBParameters
     ) {
-        final Map<String, Parameter> modifiedParameters = new HashMap<>();
-        for (final String paramName : currentDBParameters.keySet()) {
-            final Parameter currentParam = currentDBParameters.get(paramName);
-            final Parameter defaultParam = engineDefaultParameters.get(paramName);
-
-            if (defaultParam == null || !Objects.equals(defaultParam.parameterValue(), currentParam.parameterValue())) {
-                modifiedParameters.put(paramName, currentParam);
-            }
-        }
-
-        return modifiedParameters;
+        // Parameter 'source' can either be 'engine-default', 'user' or 'system'
+        // Here, we should only consider parameters modified by the user
+        return currentDBParameters.entrySet().stream()
+            .filter(entry -> "user".equals(entry.getValue().source()))
+            .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
     }
 
     /**

--- a/aws-rds-dbclusterparametergroup/src/main/java/software/amazon/rds/dbclusterparametergroup/ReadHandler.java
+++ b/aws-rds-dbclusterparametergroup/src/main/java/software/amazon/rds/dbclusterparametergroup/ReadHandler.java
@@ -58,15 +58,13 @@ public class ReadHandler extends BaseHandlerStd {
             final ProxyClient<RdsClient> proxyClient,
             final ProgressEvent<ResourceModel, CallbackContext> progress
     ) {
-        final Map<String, Parameter> engineDefaultClusterParameters = new HashMap<>();
         final Map<String, Parameter> currentDBClusterParameters = new HashMap<>();
 
         return progress
-                .then(p -> describeEngineDefaultClusterParameters(proxy, proxyClient, p, null, engineDefaultClusterParameters))
                 .then(p -> describeDBClusterParameters(proxy, proxyClient, p, null, currentDBClusterParameters))
                 .then(p -> {
                     p.getResourceModel().setParameters(
-                            Translator.translateParametersFromSdk(computeModifiedDBParameters(engineDefaultClusterParameters, currentDBClusterParameters))
+                            Translator.translateParametersFromSdk(computeModifiedDBParameters(currentDBClusterParameters))
                     );
                     return p;
                 });

--- a/aws-rds-dbclusterparametergroup/src/test/java/software/amazon/rds/dbclusterparametergroup/ReadHandlerTest.java
+++ b/aws-rds-dbclusterparametergroup/src/test/java/software/amazon/rds/dbclusterparametergroup/ReadHandlerTest.java
@@ -121,21 +121,11 @@ public class ReadHandlerTest extends AbstractHandlerTest {
         when(rdsClient.listTagsForResource(any(ListTagsForResourceRequest.class)))
                 .thenReturn(ListTagsForResourceResponse.builder().build());
 
-        when(rdsClient.describeEngineDefaultClusterParameters(any(DescribeEngineDefaultClusterParametersRequest.class)))
-                .thenReturn(DescribeEngineDefaultClusterParametersResponse.builder()
-                        .engineDefaults(
-                                EngineDefaults.builder().parameters(
-                                        Parameter.builder().parameterName(PARAM_1.parameterName()).parameterValue("default").build(),
-                                        Parameter.builder().parameterName(PARAM_2.parameterName()).parameterValue("default").build()
-                                ).build()
-                        )
-                        .build());
-
         when(rdsClient.describeDBClusterParameters(any(DescribeDbClusterParametersRequest.class)))
                 .thenReturn(DescribeDbClusterParametersResponse.builder()
                         .parameters(
-                                Parameter.builder().parameterName(PARAM_1.parameterName()).parameterValue(PARAM_1.parameterValue()).build(),
-                                Parameter.builder().parameterName(PARAM_2.parameterName()).parameterValue(PARAM_2.parameterValue()).build()
+                                Parameter.builder().parameterName(PARAM_1.parameterName()).parameterValue(PARAM_1.parameterValue()).source("user").build(),
+                                Parameter.builder().parameterName(PARAM_2.parameterName()).parameterValue(PARAM_2.parameterValue()).source("user").build()
                         )
                         .build()
                 );
@@ -158,7 +148,6 @@ public class ReadHandlerTest extends AbstractHandlerTest {
 
         verify(rdsProxy.client(), times(1)).describeDBClusterParameterGroups(any(DescribeDbClusterParameterGroupsRequest.class));
         verify(rdsProxy.client(), times(1)).describeDBClusterParameters(any(DescribeDbClusterParametersRequest.class));
-        verify(rdsProxy.client(), times(1)).describeEngineDefaultClusterParameters(any(DescribeEngineDefaultClusterParametersRequest.class));
         verify(rdsProxy.client(), times(1)).listTagsForResource(any(ListTagsForResourceRequest.class));
     }
 
@@ -166,16 +155,6 @@ public class ReadHandlerTest extends AbstractHandlerTest {
     public void handleRequest_ReadParametersWithDefaultValues() {
         when(rdsClient.listTagsForResource(any(ListTagsForResourceRequest.class)))
                 .thenReturn(ListTagsForResourceResponse.builder().build());
-
-        when(rdsClient.describeEngineDefaultClusterParameters(any(DescribeEngineDefaultClusterParametersRequest.class)))
-                .thenReturn(DescribeEngineDefaultClusterParametersResponse.builder()
-                        .engineDefaults(
-                                EngineDefaults.builder().parameters(
-                                        Parameter.builder().parameterName(PARAM_1.parameterName()).parameterValue("default").build(),
-                                        Parameter.builder().parameterName(PARAM_2.parameterName()).parameterValue("default").build()
-                                ).build()
-                        )
-                        .build());
 
         when(rdsClient.describeDBClusterParameters(any(DescribeDbClusterParametersRequest.class)))
                 .thenReturn(DescribeDbClusterParametersResponse.builder()
@@ -201,7 +180,6 @@ public class ReadHandlerTest extends AbstractHandlerTest {
 
         verify(rdsProxy.client(), times(1)).describeDBClusterParameterGroups(any(DescribeDbClusterParameterGroupsRequest.class));
         verify(rdsProxy.client(), times(1)).describeDBClusterParameters(any(DescribeDbClusterParametersRequest.class));
-        verify(rdsProxy.client(), times(1)).describeEngineDefaultClusterParameters(any(DescribeEngineDefaultClusterParametersRequest.class));
         verify(rdsProxy.client(), times(1)).listTagsForResource(any(ListTagsForResourceRequest.class));
     }
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Workaround for false drift scenario when customer specifies a default parameter value. See: https://github.com/aws-cloudformation/aws-cloudformation-resource-providers-rds/pull/618#discussion_r2174873833

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
