### PR TITLE
feat(DBInstance): add support for read only properties of DBInstance …

### DIFF
--- a/aws-rds-dbinstance/aws-rds-dbinstance.json
+++ b/aws-rds-dbinstance/aws-rds-dbinstance.json
@@ -54,6 +54,28 @@
         "RoleArn"
       ]
     },
+    "DBInstanceStatusInfo": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "Message": {
+          "type": "string",
+          "description": "Details of the error if there is an error for the instance. If the instance isn't in an error state, this value is blank."
+        },
+        "Normal": {
+          "type": "boolean",
+          "description": "Indicates whether the instance is operating normally (TRUE) or is in an error state (FALSE)."
+        },
+        "Status": {
+          "type": "string",
+          "description": "The status of the DB instance. For a StatusType of read replica, the values can be replicating, replication stop point set, replication stop point reached, error, stopped, or terminated."
+        },
+        "StatusType": {
+          "type": "string",
+          "description": "The status type of the DB instance."
+        }
+      }
+    },
     "ProcessorFeature": {
       "type": "object",
       "additionalProperties": false,
@@ -142,6 +164,10 @@
       "type": "integer",
       "minimum": 1,
       "description": "The number of days for which automated cross-region replicated backups are retained. If this value is unset, default to BackupRetentionPeriod."
+    },
+    "AutomaticRestartTime": {
+      "type": "string",
+      "description": "The time when a stopped DB instance is restarted automatically."
     },
     "AvailabilityZone": {
       "type": "string",
@@ -389,6 +415,10 @@
       "type": "string",
       "description": "Indicates that the DB instance should be associated with the specified option group."
     },
+    "PercentProgress": {
+      "type": "string",
+      "description": "The progress of the storage optimization operation as a percentage."
+    },
     "PerformanceInsightsKMSKeyId": {
       "type": "string",
       "description": "The AWS KMS key identifier for encryption of Performance Insights data. The KMS key ID is the Amazon Resource Name (ARN), KMS key identifier, or the KMS key alias for the KMS encryption key."
@@ -449,6 +479,14 @@
       "type": "string",
       "format": "date-time"
     },
+    "ResumeFullAutomationModeTime": {
+      "type": "string",
+      "description": "The duration, in minutes, to pause automation. The valid range is 60 (default) to 1,440 minutes."
+    },
+    "SecondaryAvailabilityZone": {
+      "type": "string",
+      "description": "The name of the secondary Availability Zone for a DB instance with multi-AZ support."
+    },
     "SourceDBClusterIdentifier": {
       "description": "The identifier of the Multi-AZ DB cluster that will act as the source for the read replica. Each DB cluster can have up to 15 read replicas.",
       "type": "string"
@@ -468,6 +506,13 @@
     "SourceRegion": {
       "type": "string",
       "description": "The ID of the region that contains the source DB instance for the Read Replica."
+    },
+    "StatusInfos": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/DBInstanceStatusInfo"
+      },
+      "description": "The status of a read replica. If the DB instance isn't a read replica, the value is blank."
     },
     "StorageEncrypted": {
       "type": "boolean",
@@ -602,6 +647,7 @@
     "/properties/ApplyImmediately"
   ],
   "readOnlyProperties": [
+    "/properties/AutomaticRestartTime",
     "/properties/CertificateDetails",
     "/properties/CertificateDetails/CAIdentifier",
     "/properties/CertificateDetails/ValidTill",
@@ -620,8 +666,12 @@
     "/properties/ListenerEndpoint/Port",
     "/properties/ListenerEndpoint/HostedZoneId",
     "/properties/MasterUserSecret/SecretArn",
+    "/properties/PercentProgress",
     "/properties/ReadReplicaDBClusterIdentifiers",
-    "/properties/ReadReplicaDBInstanceIdentifiers"
+    "/properties/ReadReplicaDBInstanceIdentifiers",
+    "/properties/ResumeFullAutomationModeTime",
+    "/properties/SecondaryAvailabilityZone",
+    "/properties/StatusInfo"
   ],
   "primaryIdentifier": [
     "/properties/DBInstanceIdentifier"

--- a/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/Translator.java
+++ b/aws-rds-dbinstance/src/main/java/software/amazon/rds/dbinstance/Translator.java
@@ -877,6 +877,7 @@ public class Translator {
                 .allocatedStorage(allocatedStorage)
                 .associatedRoles(translateAssociatedRolesFromSdk(dbInstance.associatedRoles()))
                 .automaticBackupReplicationRegion(automatedReplicationRegion)
+                .automaticRestartTime(translateInstantToString(dbInstance.automaticRestartTime()))
                 .autoMinorVersionUpgrade(dbInstance.autoMinorVersionUpgrade())
                 .availabilityZone(dbInstance.availabilityZone())
                 .backupRetentionPeriod(dbInstance.backupRetentionPeriod())
@@ -914,10 +915,10 @@ public class Translator {
                 .engineLifecycleSupport(dbInstance.engineLifecycleSupport())
                 .engineVersion(dbInstance.engineVersion())
                 .iops(dbInstance.iops())
-                .instanceCreateTime(dbInstance.instanceCreateTime() == null ? null : dbInstance.instanceCreateTime().toString())
+                .instanceCreateTime(translateInstantToString(dbInstance.instanceCreateTime()))
                 .isStorageConfigUpgradeAvailable(dbInstance.isStorageConfigUpgradeAvailable())
                 .kmsKeyId(dbInstance.kmsKeyId())
-                .latestRestorableTime(dbInstance.latestRestorableTime() == null ? null : dbInstance.latestRestorableTime().toString())
+                .latestRestorableTime(translateInstantToString(dbInstance.latestRestorableTime()))
                 .licenseModel(dbInstance.licenseModel())
                 .listenerEndpoint(listenerEndpoint)
                 .manageMasterUserPassword(dbInstance.masterUserSecret() != null)
@@ -930,6 +931,7 @@ public class Translator {
                 .ncharCharacterSetName(dbInstance.ncharCharacterSetName())
                 .networkType(dbInstance.networkType())
                 .optionGroupName(optionGroupName)
+                .percentProgress(dbInstance.percentProgress())
                 .performanceInsightsKMSKeyId(dbInstance.performanceInsightsKMSKeyId())
                 .performanceInsightsRetentionPeriod(dbInstance.performanceInsightsRetentionPeriod())
                 .port(port == null ? null : port.toString())
@@ -941,8 +943,11 @@ public class Translator {
                 .sourceDBClusterIdentifier(dbInstance.readReplicaSourceDBClusterIdentifier())
                 .readReplicaDBClusterIdentifiers(translateReadReplicaDBClusterIdentifiers(dbInstance.readReplicaDBClusterIdentifiers()))
                 .readReplicaDBInstanceIdentifiers(translateReadReplicaDBInstanceIdentifiers(dbInstance.readReplicaDBInstanceIdentifiers()))
+                .resumeFullAutomationModeTime(translateInstantToString(dbInstance.resumeFullAutomationModeTime()))
                 .replicaMode(dbInstance.replicaModeAsString())
+                .secondaryAvailabilityZone(dbInstance.secondaryAvailabilityZone())
                 .sourceDBInstanceIdentifier(dbInstance.readReplicaSourceDBInstanceIdentifier())
+                .statusInfos(translateStatusInfosFromSdk(dbInstance.statusInfos()))
                 .storageEncrypted(dbInstance.storageEncrypted())
                 .storageThroughput(dbInstance.storageThroughput())
                 .storageType(dbInstance.storageType())
@@ -974,12 +979,30 @@ public class Translator {
         return enabledCloudwatchLogsExports == null ? null : new ArrayList<>(enabledCloudwatchLogsExports);
     }
 
+    private static String translateInstantToString(final Instant instant) {
+        return instant == null ? null : instant.toString();
+    }
+
     public static List<String> translateReadReplicaDBClusterIdentifiers(final Collection<String> readReplicaDBClusterIdentifiers) {
         return readReplicaDBClusterIdentifiers == null ? null : new ArrayList<>(readReplicaDBClusterIdentifiers);
     }
 
     public static List<String> translateReadReplicaDBInstanceIdentifiers(final Collection<String> readReplicaDBInstanceIdentifiers) {
         return readReplicaDBInstanceIdentifiers == null ? null : new ArrayList<>(readReplicaDBInstanceIdentifiers);
+    }
+
+    public static List<DBInstanceStatusInfo> translateStatusInfosFromSdk(
+            final Collection<software.amazon.awssdk.services.rds.model.DBInstanceStatusInfo> statusInfos
+    ) {
+        return streamOfOrEmpty(statusInfos)
+                .map(statusInfo -> DBInstanceStatusInfo
+                        .builder()
+                        .message(statusInfo.message())
+                        .normal(statusInfo.normal())
+                        .status(statusInfo.status())
+                        .statusType(statusInfo.statusType())
+                        .build())
+                .collect(Collectors.toList());
     }
 
     public static List<String> translateVpcSecurityGroupsFromSdk(

--- a/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/ListHandlerTest.java
+++ b/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/ListHandlerTest.java
@@ -104,6 +104,7 @@ public class ListHandlerTest extends AbstractHandlerTest {
                 .vPCSecurityGroups(Collections.emptyList())
                 .readReplicaDBClusterIdentifiers(Collections.emptyList())
                 .readReplicaDBInstanceIdentifiers(Collections.emptyList())
+                .statusInfos(Collections.emptyList())
                 .dBInstanceIdentifier(DB_INSTANCE_IDENTIFIER)
                 .build();
 

--- a/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/TranslatorTest.java
+++ b/aws-rds-dbinstance/src/test/java/software/amazon/rds/dbinstance/TranslatorTest.java
@@ -1018,6 +1018,30 @@ class TranslatorTest extends AbstractHandlerTest {
     }
 
     @Test
+    public void translateDbInstanceFromSdk_setAutomaticRestartTime() {
+        final Instant automaticRestartTime = Instant.parse("2023-01-09T15:55:37.123Z");
+
+        final DBInstance dbInstance = DBInstance.builder()
+                .automaticRestartTime(automaticRestartTime)
+                .build();
+
+        final ResourceModel model = Translator.translateDbInstanceFromSdk(dbInstance);
+        assertThat(model.getAutomaticRestartTime()).isEqualTo(automaticRestartTime.toString());
+    }
+
+    @Test
+    public void translateDbInstanceFromSdk_setResumeFullAutomationModeTime() {
+        final Instant resumeFullAutomationModeTime = Instant.parse("2023-01-09T15:55:37.123Z");
+
+        final DBInstance dbInstance = DBInstance.builder()
+                .resumeFullAutomationModeTime(resumeFullAutomationModeTime)
+                .build();
+
+        final ResourceModel model = Translator.translateDbInstanceFromSdk(dbInstance);
+        assertThat(model.getResumeFullAutomationModeTime()).isEqualTo(resumeFullAutomationModeTime.toString());
+    }
+
+    @Test
     public void translateDbInstanceFromSdk_setListenerEndpoint() {
         final Endpoint listenerEndpoint = Endpoint.builder()
                 .address("mydb-instance.c123456789.us-east-1.rds.amazonaws.com")
@@ -1054,6 +1078,27 @@ class TranslatorTest extends AbstractHandlerTest {
 
         final ResourceModel model = Translator.translateDbInstanceFromSdk(dbInstance);
         assertThat(model.getReadReplicaDBInstanceIdentifiers()).containsExactly("instance-replica-1", "instance-replica-2");
+    }
+
+    @Test
+    public void translateDbInstanceFromSdk_statusInfos() {
+        final software.amazon.awssdk.services.rds.model.DBInstanceStatusInfo statusInfo =
+                software.amazon.awssdk.services.rds.model.DBInstanceStatusInfo.builder()
+                        .message("test message")
+                        .normal(true)
+                        .status("replicating")
+                        .statusType("read replication")
+                        .build();
+
+        final DBInstance dbInstance = DBInstance.builder()
+                .statusInfos(statusInfo)
+                .build();
+
+        final ResourceModel model = Translator.translateDbInstanceFromSdk(dbInstance);
+        assertThat(model.getStatusInfos().get(0).getMessage()).isEqualTo("test message");
+        assertThat(model.getStatusInfos().get(0).getNormal()).isTrue();
+        assertThat(model.getStatusInfos().get(0).getStatus()).isEqualTo("replicating");
+        assertThat(model.getStatusInfos().get(0).getStatusType()).isEqualTo("read replication");
     }
 
     @Test


### PR DESCRIPTION
This change adds support for the following read only properties for DBInstance Resource including:

```
AutomaticRestartTime: The time when a stopped DB instance is restarted automatically.
PercentProgress: The progress of the storage optimization operation as a percentage.
ResumeFullAutomationModeTime: The duration in minutes to pause automation. Valid values: 60 (default) to 1,440.
SecondaryAvailabilityZone: If present, specifies the name of the secondary Availability Zone for a DB instance with multi-AZ support.
StatusInfos: The status of a read replica. If the DB instance isn't a read replica, the value is blank.

```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
