### PR TITLE
feat(DBCluster): Add CFN support for Deleted Cluster PiTR for automat…

### DIFF
--- a/aws-rds-dbcluster/aws-rds-dbcluster.json
+++ b/aws-rds-dbcluster/aws-rds-dbcluster.json
@@ -252,6 +252,10 @@
       "description": "The identifier of the source DB cluster from which to restore.",
       "type": "string"
     },
+    "SourceDbClusterResourceId": {
+      "description": "The resource ID of the source DB cluster from which to restore.",
+      "type": "string"
+    },
     "SourceRegion": {
       "description": "The AWS Region which contains the source DB cluster when replicating a DB cluster. For example, us-east-1.",
       "type": "string"
@@ -462,6 +466,7 @@
     "/properties/RestoreType",
     "/properties/SnapshotIdentifier",
     "/properties/SourceDBClusterIdentifier",
+    "/properties/SourceDbClusterResourceId",
     "/properties/SourceRegion",
     "/properties/StorageEncrypted",
     "/properties/UseLatestRestorableTime"
@@ -496,6 +501,7 @@
         "rds:CreateDBCluster",
         "rds:CreateDBInstance",
         "rds:DescribeDBClusters",
+        "rds:DescribeDBClusterAutomatedBackups",
         "rds:DescribeEvents",
         "rds:EnableHttpEndpoint",
         "rds:ModifyDBCluster",

--- a/aws-rds-dbcluster/resource-role.yaml
+++ b/aws-rds-dbcluster/resource-role.yaml
@@ -40,6 +40,7 @@ Resources:
                 - "rds:CreateDBInstance"
                 - "rds:DeleteDBCluster"
                 - "rds:DeleteDBInstance"
+                - "rds:DescribeDBClusterAutomatedBackups"
                 - "rds:DescribeDBClusterSnapshots"
                 - "rds:DescribeDBClusters"
                 - "rds:DescribeDBSubnetGroups"

--- a/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/Translator.java
+++ b/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/Translator.java
@@ -24,6 +24,7 @@ import software.amazon.awssdk.services.rds.model.AddRoleToDbClusterRequest;
 import software.amazon.awssdk.services.rds.model.CloudwatchLogsExportConfiguration;
 import software.amazon.awssdk.services.rds.model.CreateDbClusterRequest;
 import software.amazon.awssdk.services.rds.model.DeleteDbClusterRequest;
+import software.amazon.awssdk.services.rds.model.DescribeDbClusterAutomatedBackupsRequest;
 import software.amazon.awssdk.services.rds.model.DescribeDbClusterSnapshotsRequest;
 import software.amazon.awssdk.services.rds.model.DescribeDbClustersRequest;
 import software.amazon.awssdk.services.rds.model.DescribeDbInstancesRequest;
@@ -125,6 +126,7 @@ public class Translator {
                 .scalingConfiguration(translateScalingConfigurationToSdk(model.getScalingConfiguration()))
                 .serverlessV2ScalingConfiguration(translateServerlessV2ScalingConfiguration(model.getServerlessV2ScalingConfiguration()))
                 .sourceDBClusterIdentifier(model.getSourceDBClusterIdentifier())
+                .sourceDbClusterResourceId(model.getSourceDbClusterResourceId())
                 .storageType(model.getStorageType())
                 .restoreType(model.getRestoreType())
                 .tags(Tagging.translateTagsToSdk(tagSet))
@@ -475,6 +477,13 @@ public class Translator {
             .build();
     }
 
+    static DescribeDbClusterAutomatedBackupsRequest describeDbClusterAutomatedBackupsRequest(
+        final ResourceModel model
+    ) {
+        return DescribeDbClusterAutomatedBackupsRequest.builder()
+            .dbClusterResourceId(model.getDBClusterResourceId())
+            .build();
+    }
 
     static EnableHttpEndpointRequest enableHttpEndpointRequest(
             final String clusterArn

--- a/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/util/ResourceModelHelper.java
+++ b/aws-rds-dbcluster/src/main/java/software/amazon/rds/dbcluster/util/ResourceModelHelper.java
@@ -10,7 +10,7 @@ import static software.amazon.rds.common.util.DifferenceUtils.diff;
 public class ResourceModelHelper {
 
     public static boolean isRestoreToPointInTime(final ResourceModel model) {
-        return StringUtils.hasValue(model.getSourceDBClusterIdentifier());
+        return StringUtils.hasValue(model.getSourceDBClusterIdentifier()) || StringUtils.hasValue(model.getSourceDbClusterResourceId());
     }
 
     public static boolean isRestoreFromSnapshot(final ResourceModel model) {

--- a/aws-rds-dbcluster/src/test/java/software/amazon/rds/dbcluster/AbstractHandlerTest.java
+++ b/aws-rds-dbcluster/src/test/java/software/amazon/rds/dbcluster/AbstractHandlerTest.java
@@ -69,6 +69,8 @@ public abstract class AbstractHandlerTest extends AbstractTestBase<DBCluster, Re
     protected static final String SNAPSHOT_IDENTIFIER;
     protected static final String INSTANCE_SNAPSHOT_IDENTIFIER;
     protected static final String SOURCE_IDENTIFIER;
+    protected static final String SOURCE_DB_CLUSTER_RESOURCE_ID;
+    protected static final String RESTORE_TO_TIME;
     protected static final String ENGINE;
     protected static final String ENGINE_AURORA_POSTGRESQL;
     protected static final String ENGINE_MODE;
@@ -141,6 +143,8 @@ public abstract class AbstractHandlerTest extends AbstractTestBase<DBCluster, Re
         SNAPSHOT_IDENTIFIER = "my-sample-dbcluster-snapshot";
         INSTANCE_SNAPSHOT_IDENTIFIER = "arn:aws:rds:us-east-1:123456789012:snapshot:my-db-snapshot";
         SOURCE_IDENTIFIER = "my-source-dbcluster-identifier";
+        SOURCE_DB_CLUSTER_RESOURCE_ID = "my-source-dbcluster-resource-id";
+        RESTORE_TO_TIME = "2025-01-01T12:00:00.000Z";
         ENGINE = "aurora";
         ENGINE_AURORA_POSTGRESQL = "aurora-postgresql";
         ENGINE_MODE = "serverless";


### PR DESCRIPTION
Added support for Point-in-Time Recovery (PiTR) from deleted DB clusters using automated backups by:
- Introducing new `SourceDbClusterResourceId` property to identify source clusters
 - ```SourceDbClusterResouceId``` can be used for PiTR for BOTH existing and deleted clusters whereas ```SourceDBClusterIdentifier```  is limited to only existing clusters.
- Enhancing restore functionality to check automated backups when source cluster is not found, this is to find deleted automated backups
- Expanding restore validation conditions to include `SourceDbClusterResourceId`, just as stated in public doc https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_RestoreDBClusterToPointInTime.html
- Validate `SourceDbClusterResourceId` and `SourceDBClusterIdentifier` requirement of either property needing to be specified not both


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
